### PR TITLE
tests: Add `FeatureRequirements` class

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ buildtools/
 depot_tools/
 testing/
 tools/
+
+scripts/*.args.json
+scripts/*.pyproj

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -397,6 +397,8 @@ source_set("vulkan_layer_utils") {
     "layers/vulkan/generated/error_location_helper.cpp",
     "layers/vulkan/generated/error_location_helper.h",
     "layers/vulkan/generated/layer_chassis_dispatch.h",
+    "layers/vulkan/generated/feature_requirements_helper.cpp",
+    "layers/vulkan/generated/feature_requirements_helper.h",
     "layers/vulkan/generated/pnext_chain_extraction.cpp",
     "layers/vulkan/generated/pnext_chain_extraction.h",
     "layers/vulkan/generated/vk_api_version.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -31,6 +31,8 @@ target_sources(VkLayer_utils PRIVATE
     external/xxhash.h
     ${API_TYPE}/generated/error_location_helper.cpp
     ${API_TYPE}/generated/error_location_helper.h
+    ${API_TYPE}/generated/feature_requirements_helper.cpp
+    ${API_TYPE}/generated/feature_requirements_helper.h
     ${API_TYPE}/generated/pnext_chain_extraction.cpp
     ${API_TYPE}/generated/pnext_chain_extraction.h
     ${API_TYPE}/generated/vk_function_pointers.cpp

--- a/layers/vulkan/generated/feature_requirements_helper.cpp
+++ b/layers/vulkan/generated/feature_requirements_helper.cpp
@@ -1,0 +1,6126 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See feature_requirements.py for modifications
+
+/***************************************************************************
+ *
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+// NOLINTBEGIN
+
+#include "generated/feature_requirements_helper.h"
+
+#include "generated/pnext_chain_extraction.h"
+
+#include <vulkan/utility/vk_struct_helper.hpp>
+
+namespace vkt {
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain) {
+    switch (feature) {
+        case Feature::storageBuffer16BitAccess:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageBuffer16BitAccess, "VkPhysicalDeviceVulkan11Features::storageBuffer16BitAccess"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice16BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageBuffer16BitAccess, "VkPhysicalDevice16BitStorageFeatures::storageBuffer16BitAccess"};
+            }
+        case Feature::storageInputOutput16:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageInputOutput16, "VkPhysicalDeviceVulkan11Features::storageInputOutput16"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice16BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageInputOutput16, "VkPhysicalDevice16BitStorageFeatures::storageInputOutput16"};
+            }
+        case Feature::storagePushConstant16:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storagePushConstant16, "VkPhysicalDeviceVulkan11Features::storagePushConstant16"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice16BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storagePushConstant16, "VkPhysicalDevice16BitStorageFeatures::storagePushConstant16"};
+            }
+        case Feature::uniformAndStorageBuffer16BitAccess:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformAndStorageBuffer16BitAccess,
+                        "VkPhysicalDeviceVulkan11Features::uniformAndStorageBuffer16BitAccess"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice16BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice16BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice16BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformAndStorageBuffer16BitAccess,
+                        "VkPhysicalDevice16BitStorageFeatures::uniformAndStorageBuffer16BitAccess"};
+            }
+        case Feature::formatA4B4G4R4: {
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->formatA4B4G4R4, "VkPhysicalDevice4444FormatsFeaturesEXT::formatA4B4G4R4"};
+        }
+        case Feature::formatA4R4G4B4: {
+            auto vk_struct = const_cast<VkPhysicalDevice4444FormatsFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevice4444FormatsFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevice4444FormatsFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->formatA4R4G4B4, "VkPhysicalDevice4444FormatsFeaturesEXT::formatA4R4G4B4"};
+        }
+
+        case Feature::storageBuffer8BitAccess:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageBuffer8BitAccess, "VkPhysicalDeviceVulkan12Features::storageBuffer8BitAccess"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice8BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storageBuffer8BitAccess, "VkPhysicalDevice8BitStorageFeatures::storageBuffer8BitAccess"};
+            }
+        case Feature::storagePushConstant8:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storagePushConstant8, "VkPhysicalDeviceVulkan12Features::storagePushConstant8"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice8BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->storagePushConstant8, "VkPhysicalDevice8BitStorageFeatures::storagePushConstant8"};
+            }
+        case Feature::uniformAndStorageBuffer8BitAccess:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformAndStorageBuffer8BitAccess,
+                        "VkPhysicalDeviceVulkan12Features::uniformAndStorageBuffer8BitAccess"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevice8BitStorageFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevice8BitStorageFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevice8BitStorageFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformAndStorageBuffer8BitAccess,
+                        "VkPhysicalDevice8BitStorageFeatures::uniformAndStorageBuffer8BitAccess"};
+            }
+        case Feature::decodeModeSharedExponent: {
+            auto vk_struct = const_cast<VkPhysicalDeviceASTCDecodeFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceASTCDecodeFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceASTCDecodeFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->decodeModeSharedExponent, "VkPhysicalDeviceASTCDecodeFeaturesEXT::decodeModeSharedExponent"};
+        }
+        case Feature::accelerationStructure: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->accelerationStructure, "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure"};
+        }
+        case Feature::accelerationStructureCaptureReplay: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->accelerationStructureCaptureReplay,
+                    "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureCaptureReplay"};
+        }
+        case Feature::accelerationStructureHostCommands: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->accelerationStructureHostCommands,
+                    "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureHostCommands"};
+        }
+        case Feature::accelerationStructureIndirectBuild: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->accelerationStructureIndirectBuild,
+                    "VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructureIndirectBuild"};
+        }
+        case Feature::descriptorBindingAccelerationStructureUpdateAfterBind: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAccelerationStructureFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAccelerationStructureFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorBindingAccelerationStructureUpdateAfterBind,
+                    "VkPhysicalDeviceAccelerationStructureFeaturesKHR::descriptorBindingAccelerationStructureUpdateAfterBind"};
+        }
+        case Feature::reportAddressBinding: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAddressBindingReportFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAddressBindingReportFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->reportAddressBinding, "VkPhysicalDeviceAddressBindingReportFeaturesEXT::reportAddressBinding"};
+        }
+        case Feature::amigoProfiling: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAmigoProfilingFeaturesSEC>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAmigoProfilingFeaturesSEC;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->amigoProfiling, "VkPhysicalDeviceAmigoProfilingFeaturesSEC::amigoProfiling"};
+        }
+        case Feature::attachmentFeedbackLoopDynamicState: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->attachmentFeedbackLoopDynamicState,
+                    "VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT::attachmentFeedbackLoopDynamicState"};
+        }
+        case Feature::attachmentFeedbackLoopLayout: {
+            auto vk_struct = const_cast<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->attachmentFeedbackLoopLayout,
+                    "VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT::attachmentFeedbackLoopLayout"};
+        }
+        case Feature::advancedBlendCoherentOperations: {
+            auto vk_struct = const_cast<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->advancedBlendCoherentOperations,
+                    "VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT::advancedBlendCoherentOperations"};
+        }
+        case Feature::borderColorSwizzle: {
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->borderColorSwizzle, "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::borderColorSwizzle"};
+        }
+        case Feature::borderColorSwizzleFromImage: {
+            auto vk_struct = const_cast<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceBorderColorSwizzleFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceBorderColorSwizzleFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->borderColorSwizzleFromImage,
+                    "VkPhysicalDeviceBorderColorSwizzleFeaturesEXT::borderColorSwizzleFromImage"};
+        }
+
+        case Feature::bufferDeviceAddress:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddress, "VkPhysicalDeviceVulkan12Features::bufferDeviceAddress"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddress, "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress"};
+            }
+        case Feature::bufferDeviceAddressCaptureReplay:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddressCaptureReplay,
+                        "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressCaptureReplay"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddressCaptureReplay,
+                        "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressCaptureReplay"};
+            }
+        case Feature::bufferDeviceAddressMultiDevice:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddressMultiDevice,
+                        "VkPhysicalDeviceVulkan12Features::bufferDeviceAddressMultiDevice"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceBufferDeviceAddressFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->bufferDeviceAddressMultiDevice,
+                        "VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddressMultiDevice"};
+            }
+        case Feature::clustercullingShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->clustercullingShader, "VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI::clustercullingShader"};
+        }
+        case Feature::multiviewClusterCullingShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multiviewClusterCullingShader,
+                    "VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI::multiviewClusterCullingShader"};
+        }
+        case Feature::deviceCoherentMemory: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCoherentMemoryFeaturesAMD>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCoherentMemoryFeaturesAMD;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceCoherentMemory, "VkPhysicalDeviceCoherentMemoryFeaturesAMD::deviceCoherentMemory"};
+        }
+        case Feature::colorWriteEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceColorWriteEnableFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceColorWriteEnableFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->colorWriteEnable, "VkPhysicalDeviceColorWriteEnableFeaturesEXT::colorWriteEnable"};
+        }
+        case Feature::computeDerivativeGroupLinear: {
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->computeDerivativeGroupLinear,
+                    "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupLinear"};
+        }
+        case Feature::computeDerivativeGroupQuads: {
+            auto vk_struct = const_cast<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceComputeShaderDerivativesFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceComputeShaderDerivativesFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->computeDerivativeGroupQuads,
+                    "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupQuads"};
+        }
+        case Feature::conditionalRendering: {
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->conditionalRendering, "VkPhysicalDeviceConditionalRenderingFeaturesEXT::conditionalRendering"};
+        }
+        case Feature::inheritedConditionalRendering: {
+            auto vk_struct = const_cast<VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceConditionalRenderingFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->inheritedConditionalRendering,
+                    "VkPhysicalDeviceConditionalRenderingFeaturesEXT::inheritedConditionalRendering"};
+        }
+        case Feature::cooperativeMatrix: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->cooperativeMatrix, "VkPhysicalDeviceCooperativeMatrixFeaturesKHR::cooperativeMatrix"};
+        }
+        case Feature::cooperativeMatrixRobustBufferAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCooperativeMatrixFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCooperativeMatrixFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->cooperativeMatrixRobustBufferAccess,
+                    "VkPhysicalDeviceCooperativeMatrixFeaturesKHR::cooperativeMatrixRobustBufferAccess"};
+        }
+        case Feature::indirectCopy: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCopyMemoryIndirectFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCopyMemoryIndirectFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->indirectCopy, "VkPhysicalDeviceCopyMemoryIndirectFeaturesNV::indirectCopy"};
+        }
+        case Feature::cornerSampledImage: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCornerSampledImageFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCornerSampledImageFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCornerSampledImageFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->cornerSampledImage, "VkPhysicalDeviceCornerSampledImageFeaturesNV::cornerSampledImage"};
+        }
+        case Feature::coverageReductionMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCoverageReductionModeFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCoverageReductionModeFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->coverageReductionMode, "VkPhysicalDeviceCoverageReductionModeFeaturesNV::coverageReductionMode"};
+        }
+        case Feature::cubicRangeClamp: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicClampFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCubicClampFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCubicClampFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->cubicRangeClamp, "VkPhysicalDeviceCubicClampFeaturesQCOM::cubicRangeClamp"};
+        }
+        case Feature::selectableCubicWeights: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCubicWeightsFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCubicWeightsFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->selectableCubicWeights, "VkPhysicalDeviceCubicWeightsFeaturesQCOM::selectableCubicWeights"};
+        }
+        case Feature::cudaKernelLaunchFeatures: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCudaKernelLaunchFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCudaKernelLaunchFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->cudaKernelLaunchFeatures, "VkPhysicalDeviceCudaKernelLaunchFeaturesNV::cudaKernelLaunchFeatures"};
+        }
+        case Feature::customBorderColorWithoutFormat: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->customBorderColorWithoutFormat,
+                    "VkPhysicalDeviceCustomBorderColorFeaturesEXT::customBorderColorWithoutFormat"};
+        }
+        case Feature::customBorderColors: {
+            auto vk_struct = const_cast<VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceCustomBorderColorFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceCustomBorderColorFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->customBorderColors, "VkPhysicalDeviceCustomBorderColorFeaturesEXT::customBorderColors"};
+        }
+        case Feature::dedicatedAllocationImageAliasing: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->dedicatedAllocationImageAliasing,
+                    "VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV::dedicatedAllocationImageAliasing"};
+        }
+        case Feature::depthBiasControl: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->depthBiasControl, "VkPhysicalDeviceDepthBiasControlFeaturesEXT::depthBiasControl"};
+        }
+        case Feature::depthBiasExact: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->depthBiasExact, "VkPhysicalDeviceDepthBiasControlFeaturesEXT::depthBiasExact"};
+        }
+        case Feature::floatRepresentation: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->floatRepresentation, "VkPhysicalDeviceDepthBiasControlFeaturesEXT::floatRepresentation"};
+        }
+        case Feature::leastRepresentableValueForceUnormRepresentation: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthBiasControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthBiasControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->leastRepresentableValueForceUnormRepresentation,
+                    "VkPhysicalDeviceDepthBiasControlFeaturesEXT::leastRepresentableValueForceUnormRepresentation"};
+        }
+        case Feature::depthClampZeroOne: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClampZeroOneFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthClampZeroOneFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthClampZeroOneFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->depthClampZeroOne, "VkPhysicalDeviceDepthClampZeroOneFeaturesEXT::depthClampZeroOne"};
+        }
+        case Feature::depthClipControl: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthClipControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->depthClipControl, "VkPhysicalDeviceDepthClipControlFeaturesEXT::depthClipControl"};
+        }
+        case Feature::depthClipEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipEnableFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDepthClipEnableFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->depthClipEnable, "VkPhysicalDeviceDepthClipEnableFeaturesEXT::depthClipEnable"};
+        }
+        case Feature::descriptorBuffer: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorBuffer, "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBuffer"};
+        }
+        case Feature::descriptorBufferCaptureReplay: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorBufferCaptureReplay,
+                    "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBufferCaptureReplay"};
+        }
+        case Feature::descriptorBufferImageLayoutIgnored: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorBufferImageLayoutIgnored,
+                    "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBufferImageLayoutIgnored"};
+        }
+        case Feature::descriptorBufferPushDescriptors: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorBufferPushDescriptors,
+                    "VkPhysicalDeviceDescriptorBufferFeaturesEXT::descriptorBufferPushDescriptors"};
+        }
+
+        case Feature::descriptorBindingPartiallyBound:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingPartiallyBound,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingPartiallyBound"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingPartiallyBound,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingPartiallyBound"};
+            }
+        case Feature::descriptorBindingSampledImageUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingSampledImageUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingSampledImageUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingSampledImageUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingSampledImageUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingStorageBufferUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageBufferUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageBufferUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageBufferUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageBufferUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingStorageImageUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageImageUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageImageUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageImageUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageImageUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingStorageTexelBufferUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageTexelBufferUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingStorageTexelBufferUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingStorageTexelBufferUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingStorageTexelBufferUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingUniformBufferUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUniformBufferUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformBufferUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUniformBufferUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingUniformBufferUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingUniformTexelBufferUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUniformTexelBufferUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingUniformTexelBufferUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUniformTexelBufferUpdateAfterBind,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingUniformTexelBufferUpdateAfterBind"};
+            }
+        case Feature::descriptorBindingUpdateUnusedWhilePending:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUpdateUnusedWhilePending,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingUpdateUnusedWhilePending"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingUpdateUnusedWhilePending,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingUpdateUnusedWhilePending"};
+            }
+        case Feature::descriptorBindingVariableDescriptorCount:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingVariableDescriptorCount,
+                        "VkPhysicalDeviceVulkan12Features::descriptorBindingVariableDescriptorCount"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingVariableDescriptorCount,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::descriptorBindingVariableDescriptorCount"};
+            }
+        case Feature::runtimeDescriptorArray:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->runtimeDescriptorArray, "VkPhysicalDeviceVulkan12Features::runtimeDescriptorArray"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->runtimeDescriptorArray, "VkPhysicalDeviceDescriptorIndexingFeatures::runtimeDescriptorArray"};
+            }
+        case Feature::shaderInputAttachmentArrayDynamicIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInputAttachmentArrayDynamicIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayDynamicIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInputAttachmentArrayDynamicIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderInputAttachmentArrayDynamicIndexing"};
+            }
+        case Feature::shaderInputAttachmentArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInputAttachmentArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderInputAttachmentArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInputAttachmentArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderInputAttachmentArrayNonUniformIndexing"};
+            }
+        case Feature::shaderSampledImageArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSampledImageArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderSampledImageArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSampledImageArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderSampledImageArrayNonUniformIndexing"};
+            }
+        case Feature::shaderStorageBufferArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderStorageBufferArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderStorageBufferArrayNonUniformIndexing"};
+            }
+        case Feature::shaderStorageImageArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageImageArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderStorageImageArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageImageArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderStorageImageArrayNonUniformIndexing"};
+            }
+        case Feature::shaderStorageTexelBufferArrayDynamicIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageTexelBufferArrayDynamicIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayDynamicIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageTexelBufferArrayDynamicIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderStorageTexelBufferArrayDynamicIndexing"};
+            }
+        case Feature::shaderStorageTexelBufferArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageTexelBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderStorageTexelBufferArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderStorageTexelBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderStorageTexelBufferArrayNonUniformIndexing"};
+            }
+        case Feature::shaderUniformBufferArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderUniformBufferArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderUniformBufferArrayNonUniformIndexing"};
+            }
+        case Feature::shaderUniformTexelBufferArrayDynamicIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformTexelBufferArrayDynamicIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayDynamicIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformTexelBufferArrayDynamicIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderUniformTexelBufferArrayDynamicIndexing"};
+            }
+        case Feature::shaderUniformTexelBufferArrayNonUniformIndexing:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformTexelBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceVulkan12Features::shaderUniformTexelBufferArrayNonUniformIndexing"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDescriptorIndexingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorIndexingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDescriptorIndexingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderUniformTexelBufferArrayNonUniformIndexing,
+                        "VkPhysicalDeviceDescriptorIndexingFeatures::shaderUniformTexelBufferArrayNonUniformIndexing"};
+            }
+        case Feature::descriptorPoolOverallocation: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorPoolOverallocation,
+                    "VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV::descriptorPoolOverallocation"};
+        }
+        case Feature::descriptorSetHostMapping: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorSetHostMapping,
+                    "VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE::descriptorSetHostMapping"};
+        }
+        case Feature::deviceGeneratedCompute: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceGeneratedCompute,
+                    "VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV::deviceGeneratedCompute"};
+        }
+        case Feature::deviceGeneratedComputeCaptureReplay: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceGeneratedComputeCaptureReplay,
+                    "VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV::deviceGeneratedComputeCaptureReplay"};
+        }
+        case Feature::deviceGeneratedComputePipelines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceGeneratedComputePipelines,
+                    "VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV::deviceGeneratedComputePipelines"};
+        }
+        case Feature::deviceGeneratedCommands: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceGeneratedCommands,
+                    "VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV::deviceGeneratedCommands"};
+        }
+        case Feature::deviceMemoryReport: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDeviceMemoryReportFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDeviceMemoryReportFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceMemoryReport, "VkPhysicalDeviceDeviceMemoryReportFeaturesEXT::deviceMemoryReport"};
+        }
+        case Feature::diagnosticsConfig: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDiagnosticsConfigFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDiagnosticsConfigFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->diagnosticsConfig, "VkPhysicalDeviceDiagnosticsConfigFeaturesNV::diagnosticsConfig"};
+        }
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::displacementMicromap: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDisplacementMicromapFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDisplacementMicromapFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->displacementMicromap, "VkPhysicalDeviceDisplacementMicromapFeaturesNV::displacementMicromap"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+
+        case Feature::dynamicRendering:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->dynamicRendering, "VkPhysicalDeviceVulkan13Features::dynamicRendering"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceDynamicRenderingFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->dynamicRendering, "VkPhysicalDeviceDynamicRenderingFeatures::dynamicRendering"};
+            }
+        case Feature::dynamicRenderingUnusedAttachments: {
+            auto vk_struct = const_cast<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->dynamicRenderingUnusedAttachments,
+                    "VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT::dynamicRenderingUnusedAttachments"};
+        }
+        case Feature::exclusiveScissor: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExclusiveScissorFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExclusiveScissorFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExclusiveScissorFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->exclusiveScissor, "VkPhysicalDeviceExclusiveScissorFeaturesNV::exclusiveScissor"};
+        }
+        case Feature::extendedDynamicState2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState2, "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::extendedDynamicState2"};
+        }
+        case Feature::extendedDynamicState2LogicOp: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState2LogicOp,
+                    "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::extendedDynamicState2LogicOp"};
+        }
+        case Feature::extendedDynamicState2PatchControlPoints: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState2PatchControlPoints,
+                    "VkPhysicalDeviceExtendedDynamicState2FeaturesEXT::extendedDynamicState2PatchControlPoints"};
+        }
+        case Feature::extendedDynamicState3AlphaToCoverageEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3AlphaToCoverageEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3AlphaToCoverageEnable"};
+        }
+        case Feature::extendedDynamicState3AlphaToOneEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3AlphaToOneEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3AlphaToOneEnable"};
+        }
+        case Feature::extendedDynamicState3ColorBlendAdvanced: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ColorBlendAdvanced,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ColorBlendAdvanced"};
+        }
+        case Feature::extendedDynamicState3ColorBlendEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ColorBlendEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ColorBlendEnable"};
+        }
+        case Feature::extendedDynamicState3ColorBlendEquation: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ColorBlendEquation,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ColorBlendEquation"};
+        }
+        case Feature::extendedDynamicState3ColorWriteMask: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ColorWriteMask,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ColorWriteMask"};
+        }
+        case Feature::extendedDynamicState3ConservativeRasterizationMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ConservativeRasterizationMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ConservativeRasterizationMode"};
+        }
+        case Feature::extendedDynamicState3CoverageModulationMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageModulationMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageModulationMode"};
+        }
+        case Feature::extendedDynamicState3CoverageModulationTable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageModulationTable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageModulationTable"};
+        }
+        case Feature::extendedDynamicState3CoverageModulationTableEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageModulationTableEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageModulationTableEnable"};
+        }
+        case Feature::extendedDynamicState3CoverageReductionMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageReductionMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageReductionMode"};
+        }
+        case Feature::extendedDynamicState3CoverageToColorEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageToColorEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageToColorEnable"};
+        }
+        case Feature::extendedDynamicState3CoverageToColorLocation: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3CoverageToColorLocation,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3CoverageToColorLocation"};
+        }
+        case Feature::extendedDynamicState3DepthClampEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3DepthClampEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3DepthClampEnable"};
+        }
+        case Feature::extendedDynamicState3DepthClipEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3DepthClipEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3DepthClipEnable"};
+        }
+        case Feature::extendedDynamicState3DepthClipNegativeOneToOne: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3DepthClipNegativeOneToOne,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3DepthClipNegativeOneToOne"};
+        }
+        case Feature::extendedDynamicState3ExtraPrimitiveOverestimationSize: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ExtraPrimitiveOverestimationSize,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ExtraPrimitiveOverestimationSize"};
+        }
+        case Feature::extendedDynamicState3LineRasterizationMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3LineRasterizationMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3LineRasterizationMode"};
+        }
+        case Feature::extendedDynamicState3LineStippleEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3LineStippleEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3LineStippleEnable"};
+        }
+        case Feature::extendedDynamicState3LogicOpEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3LogicOpEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3LogicOpEnable"};
+        }
+        case Feature::extendedDynamicState3PolygonMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3PolygonMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3PolygonMode"};
+        }
+        case Feature::extendedDynamicState3ProvokingVertexMode: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ProvokingVertexMode,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ProvokingVertexMode"};
+        }
+        case Feature::extendedDynamicState3RasterizationSamples: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3RasterizationSamples,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3RasterizationSamples"};
+        }
+        case Feature::extendedDynamicState3RasterizationStream: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3RasterizationStream,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3RasterizationStream"};
+        }
+        case Feature::extendedDynamicState3RepresentativeFragmentTestEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3RepresentativeFragmentTestEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3RepresentativeFragmentTestEnable"};
+        }
+        case Feature::extendedDynamicState3SampleLocationsEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3SampleLocationsEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3SampleLocationsEnable"};
+        }
+        case Feature::extendedDynamicState3SampleMask: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3SampleMask,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3SampleMask"};
+        }
+        case Feature::extendedDynamicState3ShadingRateImageEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ShadingRateImageEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ShadingRateImageEnable"};
+        }
+        case Feature::extendedDynamicState3TessellationDomainOrigin: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3TessellationDomainOrigin,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3TessellationDomainOrigin"};
+        }
+        case Feature::extendedDynamicState3ViewportSwizzle: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ViewportSwizzle,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ViewportSwizzle"};
+        }
+        case Feature::extendedDynamicState3ViewportWScalingEnable: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicState3FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicState3FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState3ViewportWScalingEnable,
+                    "VkPhysicalDeviceExtendedDynamicState3FeaturesEXT::extendedDynamicState3ViewportWScalingEnable"};
+        }
+        case Feature::extendedDynamicState: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedDynamicStateFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedDynamicStateFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedDynamicState, "VkPhysicalDeviceExtendedDynamicStateFeaturesEXT::extendedDynamicState"};
+        }
+        case Feature::extendedSparseAddressSpace: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->extendedSparseAddressSpace,
+                    "VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV::extendedSparseAddressSpace"};
+        }
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+        case Feature::externalFormatResolve: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExternalFormatResolveFeaturesANDROID>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExternalFormatResolveFeaturesANDROID;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->externalFormatResolve,
+                    "VkPhysicalDeviceExternalFormatResolveFeaturesANDROID::externalFormatResolve"};
+        }
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+        case Feature::externalMemoryRDMA: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryRDMAFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExternalMemoryRDMAFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->externalMemoryRDMA, "VkPhysicalDeviceExternalMemoryRDMAFeaturesNV::externalMemoryRDMA"};
+        }
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+        case Feature::screenBufferImport: {
+            auto vk_struct = const_cast<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->screenBufferImport, "VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX::screenBufferImport"};
+        }
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
+        case Feature::deviceFault: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceFault, "VkPhysicalDeviceFaultFeaturesEXT::deviceFault"};
+        }
+        case Feature::deviceFaultVendorBinary: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFaultFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFaultFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFaultFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->deviceFaultVendorBinary, "VkPhysicalDeviceFaultFeaturesEXT::deviceFaultVendorBinary"};
+        }
+        case Feature::fragmentDensityMapDeferred: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMap2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentDensityMap2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentDensityMapDeferred,
+                    "VkPhysicalDeviceFragmentDensityMap2FeaturesEXT::fragmentDensityMapDeferred"};
+        }
+        case Feature::fragmentDensityMap: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentDensityMap, "VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMap"};
+        }
+        case Feature::fragmentDensityMapDynamic: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentDensityMapDynamic,
+                    "VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMapDynamic"};
+        }
+        case Feature::fragmentDensityMapNonSubsampledImages: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentDensityMapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentDensityMapNonSubsampledImages,
+                    "VkPhysicalDeviceFragmentDensityMapFeaturesEXT::fragmentDensityMapNonSubsampledImages"};
+        }
+        case Feature::fragmentDensityMapOffset: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentDensityMapOffset,
+                    "VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM::fragmentDensityMapOffset"};
+        }
+        case Feature::fragmentShaderBarycentric: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentShaderBarycentric,
+                    "VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR::fragmentShaderBarycentric"};
+        }
+        case Feature::fragmentShaderPixelInterlock: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentShaderPixelInterlock,
+                    "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderPixelInterlock"};
+        }
+        case Feature::fragmentShaderSampleInterlock: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentShaderSampleInterlock,
+                    "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderSampleInterlock"};
+        }
+        case Feature::fragmentShaderShadingRateInterlock: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentShaderShadingRateInterlock,
+                    "VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT::fragmentShaderShadingRateInterlock"};
+        }
+        case Feature::fragmentShadingRateEnums: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->fragmentShadingRateEnums,
+                    "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::fragmentShadingRateEnums"};
+        }
+        case Feature::noInvocationFragmentShadingRates: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->noInvocationFragmentShadingRates,
+                    "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::noInvocationFragmentShadingRates"};
+        }
+        case Feature::supersampleFragmentShadingRates: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->supersampleFragmentShadingRates,
+                    "VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV::supersampleFragmentShadingRates"};
+        }
+        case Feature::attachmentFragmentShadingRate: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->attachmentFragmentShadingRate,
+                    "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate"};
+        }
+        case Feature::pipelineFragmentShadingRate: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelineFragmentShadingRate,
+                    "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::pipelineFragmentShadingRate"};
+        }
+        case Feature::primitiveFragmentShadingRate: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFragmentShadingRateFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFragmentShadingRateFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitiveFragmentShadingRate,
+                    "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::primitiveFragmentShadingRate"};
+        }
+        case Feature::frameBoundary: {
+            auto vk_struct = const_cast<VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceFrameBoundaryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceFrameBoundaryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->frameBoundary, "VkPhysicalDeviceFrameBoundaryFeaturesEXT::frameBoundary"};
+        }
+        case Feature::globalPriorityQuery: {
+            auto vk_struct = const_cast<VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->globalPriorityQuery, "VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR::globalPriorityQuery"};
+        }
+        case Feature::graphicsPipelineLibrary: {
+            auto vk_struct = const_cast<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->graphicsPipelineLibrary,
+                    "VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT::graphicsPipelineLibrary"};
+        }
+        case Feature::hostImageCopy: {
+            auto vk_struct = const_cast<VkPhysicalDeviceHostImageCopyFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceHostImageCopyFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceHostImageCopyFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->hostImageCopy, "VkPhysicalDeviceHostImageCopyFeaturesEXT::hostImageCopy"};
+        }
+
+        case Feature::hostQueryReset:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->hostQueryReset, "VkPhysicalDeviceVulkan12Features::hostQueryReset"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceHostQueryResetFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceHostQueryResetFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceHostQueryResetFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->hostQueryReset, "VkPhysicalDeviceHostQueryResetFeatures::hostQueryReset"};
+            }
+        case Feature::image2DViewOf3D: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->image2DViewOf3D, "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::image2DViewOf3D"};
+        }
+        case Feature::sampler2DViewOf3D: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImage2DViewOf3DFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImage2DViewOf3DFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->sampler2DViewOf3D, "VkPhysicalDeviceImage2DViewOf3DFeaturesEXT::sampler2DViewOf3D"};
+        }
+        case Feature::imageCompressionControl: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageCompressionControlFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageCompressionControl,
+                    "VkPhysicalDeviceImageCompressionControlFeaturesEXT::imageCompressionControl"};
+        }
+        case Feature::imageCompressionControlSwapchain: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageCompressionControlSwapchain,
+                    "VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT::imageCompressionControlSwapchain"};
+        }
+        case Feature::textureBlockMatch2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessing2FeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageProcessing2FeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->textureBlockMatch2, "VkPhysicalDeviceImageProcessing2FeaturesQCOM::textureBlockMatch2"};
+        }
+        case Feature::textureBlockMatch: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->textureBlockMatch, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureBlockMatch"};
+        }
+        case Feature::textureBoxFilter: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->textureBoxFilter, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureBoxFilter"};
+        }
+        case Feature::textureSampleWeighted: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageProcessingFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageProcessingFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageProcessingFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->textureSampleWeighted, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureSampleWeighted"};
+        }
+
+        case Feature::robustImageAccess:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->robustImageAccess, "VkPhysicalDeviceVulkan13Features::robustImageAccess"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceImageRobustnessFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceImageRobustnessFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceImageRobustnessFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->robustImageAccess, "VkPhysicalDeviceImageRobustnessFeatures::robustImageAccess"};
+            }
+        case Feature::imageSlicedViewOf3D: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageSlicedViewOf3D, "VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT::imageSlicedViewOf3D"};
+        }
+        case Feature::minLod: {
+            auto vk_struct = const_cast<VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceImageViewMinLodFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceImageViewMinLodFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->minLod, "VkPhysicalDeviceImageViewMinLodFeaturesEXT::minLod"};
+        }
+
+        case Feature::imagelessFramebuffer:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->imagelessFramebuffer, "VkPhysicalDeviceVulkan12Features::imagelessFramebuffer"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceImagelessFramebufferFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceImagelessFramebufferFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceImagelessFramebufferFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->imagelessFramebuffer, "VkPhysicalDeviceImagelessFramebufferFeatures::imagelessFramebuffer"};
+            }
+        case Feature::indexTypeUint8: {
+            auto vk_struct = const_cast<VkPhysicalDeviceIndexTypeUint8FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceIndexTypeUint8FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceIndexTypeUint8FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->indexTypeUint8, "VkPhysicalDeviceIndexTypeUint8FeaturesEXT::indexTypeUint8"};
+        }
+        case Feature::inheritedViewportScissor2D: {
+            auto vk_struct = const_cast<VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceInheritedViewportScissorFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceInheritedViewportScissorFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->inheritedViewportScissor2D,
+                    "VkPhysicalDeviceInheritedViewportScissorFeaturesNV::inheritedViewportScissor2D"};
+        }
+
+        case Feature::descriptorBindingInlineUniformBlockUpdateAfterBind:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingInlineUniformBlockUpdateAfterBind,
+                        "VkPhysicalDeviceVulkan13Features::descriptorBindingInlineUniformBlockUpdateAfterBind"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->descriptorBindingInlineUniformBlockUpdateAfterBind,
+                        "VkPhysicalDeviceInlineUniformBlockFeatures::descriptorBindingInlineUniformBlockUpdateAfterBind"};
+            }
+        case Feature::inlineUniformBlock:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceVulkan13Features::inlineUniformBlock"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceInlineUniformBlockFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceInlineUniformBlockFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceInlineUniformBlockFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->inlineUniformBlock, "VkPhysicalDeviceInlineUniformBlockFeatures::inlineUniformBlock"};
+            }
+        case Feature::invocationMask: {
+            auto vk_struct = const_cast<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceInvocationMaskFeaturesHUAWEI>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceInvocationMaskFeaturesHUAWEI;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->invocationMask, "VkPhysicalDeviceInvocationMaskFeaturesHUAWEI::invocationMask"};
+        }
+        case Feature::legacyDithering: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLegacyDitheringFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLegacyDitheringFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->legacyDithering, "VkPhysicalDeviceLegacyDitheringFeaturesEXT::legacyDithering"};
+        }
+        case Feature::bresenhamLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->bresenhamLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::bresenhamLines"};
+        }
+        case Feature::rectangularLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rectangularLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::rectangularLines"};
+        }
+        case Feature::smoothLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->smoothLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::smoothLines"};
+        }
+        case Feature::stippledBresenhamLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->stippledBresenhamLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::stippledBresenhamLines"};
+        }
+        case Feature::stippledRectangularLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->stippledRectangularLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::stippledRectangularLines"};
+        }
+        case Feature::stippledSmoothLines: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLineRasterizationFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLineRasterizationFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->stippledSmoothLines, "VkPhysicalDeviceLineRasterizationFeaturesEXT::stippledSmoothLines"};
+        }
+        case Feature::linearColorAttachment: {
+            auto vk_struct = const_cast<VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceLinearColorAttachmentFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceLinearColorAttachmentFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->linearColorAttachment, "VkPhysicalDeviceLinearColorAttachmentFeaturesNV::linearColorAttachment"};
+        }
+
+        case Feature::maintenance4:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->maintenance4, "VkPhysicalDeviceVulkan13Features::maintenance4"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceMaintenance4Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance4Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceMaintenance4Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->maintenance4, "VkPhysicalDeviceMaintenance4Features::maintenance4"};
+            }
+        case Feature::maintenance5: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMaintenance5FeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance5FeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMaintenance5FeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->maintenance5, "VkPhysicalDeviceMaintenance5FeaturesKHR::maintenance5"};
+        }
+        case Feature::memoryDecompression: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryDecompressionFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMemoryDecompressionFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMemoryDecompressionFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->memoryDecompression, "VkPhysicalDeviceMemoryDecompressionFeaturesNV::memoryDecompression"};
+        }
+        case Feature::memoryPriority: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMemoryPriorityFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMemoryPriorityFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->memoryPriority, "VkPhysicalDeviceMemoryPriorityFeaturesEXT::memoryPriority"};
+        }
+        case Feature::meshShaderQueries: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->meshShaderQueries, "VkPhysicalDeviceMeshShaderFeaturesEXT::meshShaderQueries"};
+        }
+        case Feature::multiviewMeshShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multiviewMeshShader, "VkPhysicalDeviceMeshShaderFeaturesEXT::multiviewMeshShader"};
+        }
+        case Feature::primitiveFragmentShadingRateMeshShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitiveFragmentShadingRateMeshShader,
+                    "VkPhysicalDeviceMeshShaderFeaturesEXT::primitiveFragmentShadingRateMeshShader"};
+        }
+        case Feature::meshShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->meshShader, "VkPhysicalDeviceMeshShaderFeaturesEXT::meshShader"};
+        }
+        case Feature::taskShader: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMeshShaderFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMeshShaderFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMeshShaderFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->taskShader, "VkPhysicalDeviceMeshShaderFeaturesEXT::taskShader"};
+        }
+        case Feature::multiDraw: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiDrawFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMultiDrawFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMultiDrawFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multiDraw, "VkPhysicalDeviceMultiDrawFeaturesEXT::multiDraw"};
+        }
+        case Feature::multisampledRenderToSingleSampled: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multisampledRenderToSingleSampled,
+                    "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT::multisampledRenderToSingleSampled"};
+        }
+
+        case Feature::multiview:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiview, "VkPhysicalDeviceVulkan11Features::multiview"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceMultiviewFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiview, "VkPhysicalDeviceMultiviewFeatures::multiview"};
+            }
+        case Feature::multiviewGeometryShader:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiviewGeometryShader, "VkPhysicalDeviceVulkan11Features::multiviewGeometryShader"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceMultiviewFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiviewGeometryShader, "VkPhysicalDeviceMultiviewFeatures::multiviewGeometryShader"};
+            }
+        case Feature::multiviewTessellationShader:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceVulkan11Features::multiviewTessellationShader"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceMultiviewFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceMultiviewFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->multiviewTessellationShader, "VkPhysicalDeviceMultiviewFeatures::multiviewTessellationShader"};
+            }
+        case Feature::multiviewPerViewRenderAreas: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multiviewPerViewRenderAreas,
+                    "VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM::multiviewPerViewRenderAreas"};
+        }
+        case Feature::multiviewPerViewViewports: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multiviewPerViewViewports,
+                    "VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM::multiviewPerViewViewports"};
+        }
+        case Feature::mutableDescriptorType: {
+            auto vk_struct = const_cast<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->mutableDescriptorType, "VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT::mutableDescriptorType"};
+        }
+        case Feature::nestedCommandBuffer: {
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->nestedCommandBuffer, "VkPhysicalDeviceNestedCommandBufferFeaturesEXT::nestedCommandBuffer"};
+        }
+        case Feature::nestedCommandBufferRendering: {
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->nestedCommandBufferRendering,
+                    "VkPhysicalDeviceNestedCommandBufferFeaturesEXT::nestedCommandBufferRendering"};
+        }
+        case Feature::nestedCommandBufferSimultaneousUse: {
+            auto vk_struct = const_cast<VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceNestedCommandBufferFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceNestedCommandBufferFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->nestedCommandBufferSimultaneousUse,
+                    "VkPhysicalDeviceNestedCommandBufferFeaturesEXT::nestedCommandBufferSimultaneousUse"};
+        }
+        case Feature::nonSeamlessCubeMap: {
+            auto vk_struct = const_cast<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->nonSeamlessCubeMap, "VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT::nonSeamlessCubeMap"};
+        }
+        case Feature::micromap: {
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->micromap, "VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromap"};
+        }
+        case Feature::micromapCaptureReplay: {
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->micromapCaptureReplay, "VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromapCaptureReplay"};
+        }
+        case Feature::micromapHostCommands: {
+            auto vk_struct = const_cast<VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceOpacityMicromapFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceOpacityMicromapFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->micromapHostCommands, "VkPhysicalDeviceOpacityMicromapFeaturesEXT::micromapHostCommands"};
+        }
+        case Feature::opticalFlow: {
+            auto vk_struct = const_cast<VkPhysicalDeviceOpticalFlowFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceOpticalFlowFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceOpticalFlowFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->opticalFlow, "VkPhysicalDeviceOpticalFlowFeaturesNV::opticalFlow"};
+        }
+        case Feature::pageableDeviceLocalMemory: {
+            auto vk_struct = const_cast<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pageableDeviceLocalMemory,
+                    "VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT::pageableDeviceLocalMemory"};
+        }
+        case Feature::performanceCounterMultipleQueryPools: {
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->performanceCounterMultipleQueryPools,
+                    "VkPhysicalDevicePerformanceQueryFeaturesKHR::performanceCounterMultipleQueryPools"};
+        }
+        case Feature::performanceCounterQueryPools: {
+            auto vk_struct = const_cast<VkPhysicalDevicePerformanceQueryFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePerformanceQueryFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePerformanceQueryFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->performanceCounterQueryPools,
+                    "VkPhysicalDevicePerformanceQueryFeaturesKHR::performanceCounterQueryPools"};
+        }
+
+        case Feature::pipelineCreationCacheControl:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->pipelineCreationCacheControl, "VkPhysicalDeviceVulkan13Features::pipelineCreationCacheControl"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevicePipelineCreationCacheControlFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevicePipelineCreationCacheControlFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevicePipelineCreationCacheControlFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->pipelineCreationCacheControl,
+                        "VkPhysicalDevicePipelineCreationCacheControlFeatures::pipelineCreationCacheControl"};
+            }
+        case Feature::pipelineExecutableInfo: {
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelineExecutableInfo,
+                    "VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR::pipelineExecutableInfo"};
+        }
+        case Feature::pipelineLibraryGroupHandles: {
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelineLibraryGroupHandles,
+                    "VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT::pipelineLibraryGroupHandles"};
+        }
+        case Feature::pipelinePropertiesIdentifier: {
+            auto vk_struct = const_cast<VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePipelinePropertiesFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePipelinePropertiesFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelinePropertiesIdentifier,
+                    "VkPhysicalDevicePipelinePropertiesFeaturesEXT::pipelinePropertiesIdentifier"};
+        }
+        case Feature::pipelineProtectedAccess: {
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineProtectedAccessFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePipelineProtectedAccessFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePipelineProtectedAccessFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelineProtectedAccess,
+                    "VkPhysicalDevicePipelineProtectedAccessFeaturesEXT::pipelineProtectedAccess"};
+        }
+        case Feature::pipelineRobustness: {
+            auto vk_struct = const_cast<VkPhysicalDevicePipelineRobustnessFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePipelineRobustnessFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePipelineRobustnessFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pipelineRobustness, "VkPhysicalDevicePipelineRobustnessFeaturesEXT::pipelineRobustness"};
+        }
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::constantAlphaColorBlendFactors: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->constantAlphaColorBlendFactors,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::constantAlphaColorBlendFactors"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::events: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->events, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::events"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::imageView2DOn3DImage: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageView2DOn3DImage, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::imageView2DOn3DImage"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::imageViewFormatReinterpretation: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageViewFormatReinterpretation,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::imageViewFormatReinterpretation"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::imageViewFormatSwizzle: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageViewFormatSwizzle, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::imageViewFormatSwizzle"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::multisampleArrayImage: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->multisampleArrayImage, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::multisampleArrayImage"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::mutableComparisonSamplers: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->mutableComparisonSamplers,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::mutableComparisonSamplers"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::pointPolygons: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->pointPolygons, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::pointPolygons"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::samplerMipLodBias: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->samplerMipLodBias, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::samplerMipLodBias"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::separateStencilMaskRef: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->separateStencilMaskRef, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::separateStencilMaskRef"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::shaderSampleRateInterpolationFunctions: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSampleRateInterpolationFunctions,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::shaderSampleRateInterpolationFunctions"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::tessellationIsolines: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->tessellationIsolines, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::tessellationIsolines"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::tessellationPointMode: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->tessellationPointMode, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::tessellationPointMode"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::triangleFans: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->triangleFans, "VkPhysicalDevicePortabilitySubsetFeaturesKHR::triangleFans"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::vertexAttributeAccessBeyondStride: {
+            auto vk_struct = const_cast<VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePortabilitySubsetFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePortabilitySubsetFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->vertexAttributeAccessBeyondStride,
+                    "VkPhysicalDevicePortabilitySubsetFeaturesKHR::vertexAttributeAccessBeyondStride"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case Feature::presentBarrier: {
+            auto vk_struct = const_cast<VkPhysicalDevicePresentBarrierFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePresentBarrierFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePresentBarrierFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->presentBarrier, "VkPhysicalDevicePresentBarrierFeaturesNV::presentBarrier"};
+        }
+        case Feature::presentId: {
+            auto vk_struct = const_cast<VkPhysicalDevicePresentIdFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePresentIdFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePresentIdFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->presentId, "VkPhysicalDevicePresentIdFeaturesKHR::presentId"};
+        }
+        case Feature::presentWait: {
+            auto vk_struct = const_cast<VkPhysicalDevicePresentWaitFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePresentWaitFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePresentWaitFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->presentWait, "VkPhysicalDevicePresentWaitFeaturesKHR::presentWait"};
+        }
+        case Feature::primitiveTopologyListRestart: {
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitiveTopologyListRestart,
+                    "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::primitiveTopologyListRestart"};
+        }
+        case Feature::primitiveTopologyPatchListRestart: {
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitiveTopologyPatchListRestart,
+                    "VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT::primitiveTopologyPatchListRestart"};
+        }
+        case Feature::primitivesGeneratedQuery: {
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitivesGeneratedQuery,
+                    "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::primitivesGeneratedQuery"};
+        }
+        case Feature::primitivesGeneratedQueryWithNonZeroStreams: {
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitivesGeneratedQueryWithNonZeroStreams,
+                    "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::primitivesGeneratedQueryWithNonZeroStreams"};
+        }
+        case Feature::primitivesGeneratedQueryWithRasterizerDiscard: {
+            auto vk_struct = const_cast<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->primitivesGeneratedQueryWithRasterizerDiscard,
+                    "VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT::primitivesGeneratedQueryWithRasterizerDiscard"};
+        }
+
+        case Feature::privateData:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->privateData, "VkPhysicalDeviceVulkan13Features::privateData"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDevicePrivateDataFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDevicePrivateDataFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDevicePrivateDataFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->privateData, "VkPhysicalDevicePrivateDataFeatures::privateData"};
+            }
+        case Feature::protectedMemory:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->protectedMemory, "VkPhysicalDeviceVulkan11Features::protectedMemory"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceProtectedMemoryFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceProtectedMemoryFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceProtectedMemoryFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->protectedMemory, "VkPhysicalDeviceProtectedMemoryFeatures::protectedMemory"};
+            }
+        case Feature::provokingVertexLast: {
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->provokingVertexLast, "VkPhysicalDeviceProvokingVertexFeaturesEXT::provokingVertexLast"};
+        }
+        case Feature::transformFeedbackPreservesProvokingVertex: {
+            auto vk_struct = const_cast<VkPhysicalDeviceProvokingVertexFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceProvokingVertexFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceProvokingVertexFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->transformFeedbackPreservesProvokingVertex,
+                    "VkPhysicalDeviceProvokingVertexFeaturesEXT::transformFeedbackPreservesProvokingVertex"};
+        }
+        case Feature::formatRgba10x6WithoutYCbCrSampler: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->formatRgba10x6WithoutYCbCrSampler,
+                    "VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT::formatRgba10x6WithoutYCbCrSampler"};
+        }
+        case Feature::rasterizationOrderColorAttachmentAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rasterizationOrderColorAttachmentAccess,
+                    "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT::rasterizationOrderColorAttachmentAccess"};
+        }
+        case Feature::rasterizationOrderDepthAttachmentAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rasterizationOrderDepthAttachmentAccess,
+                    "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT::rasterizationOrderDepthAttachmentAccess"};
+        }
+        case Feature::rasterizationOrderStencilAttachmentAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rasterizationOrderStencilAttachmentAccess,
+                    "VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT::rasterizationOrderStencilAttachmentAccess"};
+        }
+        case Feature::rayQuery: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayQueryFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayQueryFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayQuery, "VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery"};
+        }
+        case Feature::rayTracingInvocationReorder: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingInvocationReorder,
+                    "VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV::rayTracingInvocationReorder"};
+        }
+        case Feature::rayTracingMaintenance1: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingMaintenance1,
+                    "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR::rayTracingMaintenance1"};
+        }
+        case Feature::rayTracingPipelineTraceRaysIndirect2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPipelineTraceRaysIndirect2,
+                    "VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR::rayTracingPipelineTraceRaysIndirect2"};
+        }
+        case Feature::rayTracingMotionBlur: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingMotionBlur, "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::rayTracingMotionBlur"};
+        }
+        case Feature::rayTracingMotionBlurPipelineTraceRaysIndirect: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingMotionBlurFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingMotionBlurFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingMotionBlurPipelineTraceRaysIndirect,
+                    "VkPhysicalDeviceRayTracingMotionBlurFeaturesNV::rayTracingMotionBlurPipelineTraceRaysIndirect"};
+        }
+        case Feature::rayTracingPipeline: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPipeline, "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipeline"};
+        }
+        case Feature::rayTracingPipelineShaderGroupHandleCaptureReplay: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPipelineShaderGroupHandleCaptureReplay,
+                    "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplay"};
+        }
+        case Feature::rayTracingPipelineShaderGroupHandleCaptureReplayMixed: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPipelineShaderGroupHandleCaptureReplayMixed,
+                    "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineShaderGroupHandleCaptureReplayMixed"};
+        }
+        case Feature::rayTracingPipelineTraceRaysIndirect: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPipelineTraceRaysIndirect,
+                    "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTracingPipelineTraceRaysIndirect"};
+        }
+        case Feature::rayTraversalPrimitiveCulling: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPipelineFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPipelineFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTraversalPrimitiveCulling,
+                    "VkPhysicalDeviceRayTracingPipelineFeaturesKHR::rayTraversalPrimitiveCulling"};
+        }
+        case Feature::rayTracingPositionFetch: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->rayTracingPositionFetch,
+                    "VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR::rayTracingPositionFetch"};
+        }
+        case Feature::relaxedLineRasterization: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->relaxedLineRasterization,
+                    "VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG::relaxedLineRasterization"};
+        }
+        case Feature::renderPassStriped: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRenderPassStripedFeaturesARM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRenderPassStripedFeaturesARM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRenderPassStripedFeaturesARM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->renderPassStriped, "VkPhysicalDeviceRenderPassStripedFeaturesARM::renderPassStriped"};
+        }
+        case Feature::representativeFragmentTest: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->representativeFragmentTest,
+                    "VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV::representativeFragmentTest"};
+        }
+        case Feature::nullDescriptor: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRobustness2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->nullDescriptor, "VkPhysicalDeviceRobustness2FeaturesEXT::nullDescriptor"};
+        }
+        case Feature::robustBufferAccess2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRobustness2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->robustBufferAccess2, "VkPhysicalDeviceRobustness2FeaturesEXT::robustBufferAccess2"};
+        }
+        case Feature::robustImageAccess2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceRobustness2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceRobustness2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->robustImageAccess2, "VkPhysicalDeviceRobustness2FeaturesEXT::robustImageAccess2"};
+        }
+
+        case Feature::samplerYcbcrConversion:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->samplerYcbcrConversion, "VkPhysicalDeviceVulkan11Features::samplerYcbcrConversion"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceSamplerYcbcrConversionFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceSamplerYcbcrConversionFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->samplerYcbcrConversion,
+                        "VkPhysicalDeviceSamplerYcbcrConversionFeatures::samplerYcbcrConversion"};
+            }
+        case Feature::scalarBlockLayout:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceVulkan12Features::scalarBlockLayout"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceScalarBlockLayoutFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceScalarBlockLayoutFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceScalarBlockLayoutFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->scalarBlockLayout, "VkPhysicalDeviceScalarBlockLayoutFeatures::scalarBlockLayout"};
+            }
+        case Feature::schedulingControls: {
+            auto vk_struct = const_cast<VkPhysicalDeviceSchedulingControlsFeaturesARM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceSchedulingControlsFeaturesARM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceSchedulingControlsFeaturesARM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->schedulingControls, "VkPhysicalDeviceSchedulingControlsFeaturesARM::schedulingControls"};
+        }
+
+        case Feature::separateDepthStencilLayouts:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->separateDepthStencilLayouts, "VkPhysicalDeviceVulkan12Features::separateDepthStencilLayouts"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->separateDepthStencilLayouts,
+                        "VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures::separateDepthStencilLayouts"};
+            }
+        case Feature::shaderBufferFloat16AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat16AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat16AtomicAdd"};
+        }
+        case Feature::shaderBufferFloat16AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat16AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat16AtomicMinMax"};
+        }
+        case Feature::shaderBufferFloat16Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat16Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat16Atomics"};
+        }
+        case Feature::shaderBufferFloat32AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat32AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat32AtomicMinMax"};
+        }
+        case Feature::shaderBufferFloat64AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat64AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderBufferFloat64AtomicMinMax"};
+        }
+        case Feature::shaderImageFloat32AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderImageFloat32AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderImageFloat32AtomicMinMax"};
+        }
+        case Feature::shaderSharedFloat16AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat16AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderSharedFloat16AtomicAdd"};
+        }
+        case Feature::shaderSharedFloat16AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat16AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderSharedFloat16AtomicMinMax"};
+        }
+        case Feature::shaderSharedFloat16Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat16Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderSharedFloat16Atomics"};
+        }
+        case Feature::shaderSharedFloat32AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat32AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderSharedFloat32AtomicMinMax"};
+        }
+        case Feature::shaderSharedFloat64AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat64AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::shaderSharedFloat64AtomicMinMax"};
+        }
+        case Feature::sparseImageFloat32AtomicMinMax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->sparseImageFloat32AtomicMinMax,
+                    "VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT::sparseImageFloat32AtomicMinMax"};
+        }
+        case Feature::shaderBufferFloat32AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat32AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32AtomicAdd"};
+        }
+        case Feature::shaderBufferFloat32Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat32Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat32Atomics"};
+        }
+        case Feature::shaderBufferFloat64AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat64AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat64AtomicAdd"};
+        }
+        case Feature::shaderBufferFloat64Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderBufferFloat64Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderBufferFloat64Atomics"};
+        }
+        case Feature::shaderImageFloat32AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderImageFloat32AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderImageFloat32AtomicAdd"};
+        }
+        case Feature::shaderImageFloat32Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderImageFloat32Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderImageFloat32Atomics"};
+        }
+        case Feature::shaderSharedFloat32AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat32AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat32AtomicAdd"};
+        }
+        case Feature::shaderSharedFloat32Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat32Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat32Atomics"};
+        }
+        case Feature::shaderSharedFloat64AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat64AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat64AtomicAdd"};
+        }
+        case Feature::shaderSharedFloat64Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSharedFloat64Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::shaderSharedFloat64Atomics"};
+        }
+        case Feature::sparseImageFloat32AtomicAdd: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->sparseImageFloat32AtomicAdd,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::sparseImageFloat32AtomicAdd"};
+        }
+        case Feature::sparseImageFloat32Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicFloatFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderAtomicFloatFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->sparseImageFloat32Atomics,
+                    "VkPhysicalDeviceShaderAtomicFloatFeaturesEXT::sparseImageFloat32Atomics"};
+        }
+
+        case Feature::shaderBufferInt64Atomics:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderBufferInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderBufferInt64Atomics"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderBufferInt64Atomics,
+                        "VkPhysicalDeviceShaderAtomicInt64Features::shaderBufferInt64Atomics"};
+            }
+        case Feature::shaderSharedInt64Atomics:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSharedInt64Atomics, "VkPhysicalDeviceVulkan12Features::shaderSharedInt64Atomics"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderAtomicInt64Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderAtomicInt64Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderAtomicInt64Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSharedInt64Atomics,
+                        "VkPhysicalDeviceShaderAtomicInt64Features::shaderSharedInt64Atomics"};
+            }
+        case Feature::shaderDeviceClock: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderDeviceClock, "VkPhysicalDeviceShaderClockFeaturesKHR::shaderDeviceClock"};
+        }
+        case Feature::shaderSubgroupClock: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderClockFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderClockFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderClockFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSubgroupClock, "VkPhysicalDeviceShaderClockFeaturesKHR::shaderSubgroupClock"};
+        }
+        case Feature::shaderCoreBuiltins: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderCoreBuiltins, "VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM::shaderCoreBuiltins"};
+        }
+
+        case Feature::shaderDemoteToHelperInvocation:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderDemoteToHelperInvocation,
+                        "VkPhysicalDeviceVulkan13Features::shaderDemoteToHelperInvocation"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderDemoteToHelperInvocation,
+                        "VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures::shaderDemoteToHelperInvocation"};
+            }
+        case Feature::shaderDrawParameters:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceVulkan11Features::shaderDrawParameters"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderDrawParametersFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderDrawParametersFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderDrawParametersFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderDrawParameters, "VkPhysicalDeviceShaderDrawParametersFeatures::shaderDrawParameters"};
+            }
+        case Feature::shaderEarlyAndLateFragmentTests: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderEarlyAndLateFragmentTests,
+                    "VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD::shaderEarlyAndLateFragmentTests"};
+        }
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case Feature::shaderEnqueue: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderEnqueueFeaturesAMDX;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderEnqueue, "VkPhysicalDeviceShaderEnqueueFeaturesAMDX::shaderEnqueue"};
+        }
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+
+        case Feature::shaderFloat16:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderFloat16, "VkPhysicalDeviceVulkan12Features::shaderFloat16"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderFloat16, "VkPhysicalDeviceShaderFloat16Int8Features::shaderFloat16"};
+            }
+        case Feature::shaderInt8:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInt8, "VkPhysicalDeviceVulkan12Features::shaderInt8"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderFloat16Int8Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderFloat16Int8Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderFloat16Int8Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderInt8, "VkPhysicalDeviceShaderFloat16Int8Features::shaderInt8"};
+            }
+        case Feature::shaderImageInt64Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderImageInt64Atomics,
+                    "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::shaderImageInt64Atomics"};
+        }
+        case Feature::sparseImageInt64Atomics: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->sparseImageInt64Atomics,
+                    "VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT::sparseImageInt64Atomics"};
+        }
+        case Feature::imageFootprint: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderImageFootprintFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderImageFootprintFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->imageFootprint, "VkPhysicalDeviceShaderImageFootprintFeaturesNV::imageFootprint"};
+        }
+
+        case Feature::shaderIntegerDotProduct:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderIntegerDotProduct, "VkPhysicalDeviceVulkan13Features::shaderIntegerDotProduct"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerDotProductFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerDotProductFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderIntegerDotProductFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderIntegerDotProduct,
+                        "VkPhysicalDeviceShaderIntegerDotProductFeatures::shaderIntegerDotProduct"};
+            }
+        case Feature::shaderIntegerFunctions2: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderIntegerFunctions2,
+                    "VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL::shaderIntegerFunctions2"};
+        }
+        case Feature::shaderModuleIdentifier: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderModuleIdentifier,
+                    "VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT::shaderModuleIdentifier"};
+        }
+        case Feature::shaderObject: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderObjectFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderObjectFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderObjectFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderObject, "VkPhysicalDeviceShaderObjectFeaturesEXT::shaderObject"};
+        }
+        case Feature::shaderSMBuiltins: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderSMBuiltinsFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderSMBuiltinsFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSMBuiltins, "VkPhysicalDeviceShaderSMBuiltinsFeaturesNV::shaderSMBuiltins"};
+        }
+
+        case Feature::shaderSubgroupExtendedTypes:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSubgroupExtendedTypes, "VkPhysicalDeviceVulkan12Features::shaderSubgroupExtendedTypes"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderSubgroupExtendedTypes,
+                        "VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures::shaderSubgroupExtendedTypes"};
+            }
+        case Feature::shaderSubgroupUniformControlFlow: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderSubgroupUniformControlFlow,
+                    "VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR::shaderSubgroupUniformControlFlow"};
+        }
+
+        case Feature::shaderTerminateInvocation:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderTerminateInvocation, "VkPhysicalDeviceVulkan13Features::shaderTerminateInvocation"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceShaderTerminateInvocationFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceShaderTerminateInvocationFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceShaderTerminateInvocationFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderTerminateInvocation,
+                        "VkPhysicalDeviceShaderTerminateInvocationFeatures::shaderTerminateInvocation"};
+            }
+        case Feature::shaderTileImageColorReadAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderTileImageColorReadAccess,
+                    "VkPhysicalDeviceShaderTileImageFeaturesEXT::shaderTileImageColorReadAccess"};
+        }
+        case Feature::shaderTileImageDepthReadAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderTileImageDepthReadAccess,
+                    "VkPhysicalDeviceShaderTileImageFeaturesEXT::shaderTileImageDepthReadAccess"};
+        }
+        case Feature::shaderTileImageStencilReadAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShaderTileImageFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShaderTileImageFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShaderTileImageFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderTileImageStencilReadAccess,
+                    "VkPhysicalDeviceShaderTileImageFeaturesEXT::shaderTileImageStencilReadAccess"};
+        }
+        case Feature::shadingRateCoarseSampleOrder: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shadingRateCoarseSampleOrder,
+                    "VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateCoarseSampleOrder"};
+        }
+        case Feature::shadingRateImage: {
+            auto vk_struct = const_cast<VkPhysicalDeviceShadingRateImageFeaturesNV *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceShadingRateImageFeaturesNV;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shadingRateImage, "VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage"};
+        }
+
+        case Feature::computeFullSubgroups:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->computeFullSubgroups, "VkPhysicalDeviceVulkan13Features::computeFullSubgroups"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->computeFullSubgroups, "VkPhysicalDeviceSubgroupSizeControlFeatures::computeFullSubgroups"};
+            }
+        case Feature::subgroupSizeControl:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceVulkan13Features::subgroupSizeControl"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceSubgroupSizeControlFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceSubgroupSizeControlFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceSubgroupSizeControlFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->subgroupSizeControl, "VkPhysicalDeviceSubgroupSizeControlFeatures::subgroupSizeControl"};
+            }
+        case Feature::subpassMergeFeedback: {
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->subpassMergeFeedback, "VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT::subpassMergeFeedback"};
+        }
+        case Feature::subpassShading: {
+            auto vk_struct = const_cast<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceSubpassShadingFeaturesHUAWEI>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceSubpassShadingFeaturesHUAWEI;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->subpassShading, "VkPhysicalDeviceSubpassShadingFeaturesHUAWEI::subpassShading"};
+        }
+        case Feature::swapchainMaintenance1: {
+            auto vk_struct = const_cast<VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->swapchainMaintenance1, "VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT::swapchainMaintenance1"};
+        }
+
+        case Feature::synchronization2:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->synchronization2, "VkPhysicalDeviceVulkan13Features::synchronization2"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceSynchronization2Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceSynchronization2Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceSynchronization2Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->synchronization2, "VkPhysicalDeviceSynchronization2Features::synchronization2"};
+            }
+        case Feature::texelBufferAlignment: {
+            auto vk_struct = const_cast<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->texelBufferAlignment, "VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT::texelBufferAlignment"};
+        }
+
+        case Feature::textureCompressionASTC_HDR:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->textureCompressionASTC_HDR, "VkPhysicalDeviceVulkan13Features::textureCompressionASTC_HDR"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceTextureCompressionASTCHDRFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceTextureCompressionASTCHDRFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->textureCompressionASTC_HDR,
+                        "VkPhysicalDeviceTextureCompressionASTCHDRFeatures::textureCompressionASTC_HDR"};
+            }
+        case Feature::tileProperties: {
+            auto vk_struct = const_cast<VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceTilePropertiesFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceTilePropertiesFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->tileProperties, "VkPhysicalDeviceTilePropertiesFeaturesQCOM::tileProperties"};
+        }
+
+        case Feature::timelineSemaphore:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceVulkan12Features::timelineSemaphore"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceTimelineSemaphoreFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceTimelineSemaphoreFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceTimelineSemaphoreFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->timelineSemaphore, "VkPhysicalDeviceTimelineSemaphoreFeatures::timelineSemaphore"};
+            }
+        case Feature::geometryStreams: {
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->geometryStreams, "VkPhysicalDeviceTransformFeedbackFeaturesEXT::geometryStreams"};
+        }
+        case Feature::transformFeedback: {
+            auto vk_struct = const_cast<VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceTransformFeedbackFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceTransformFeedbackFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->transformFeedback, "VkPhysicalDeviceTransformFeedbackFeaturesEXT::transformFeedback"};
+        }
+
+        case Feature::uniformBufferStandardLayout:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformBufferStandardLayout, "VkPhysicalDeviceVulkan12Features::uniformBufferStandardLayout"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceUniformBufferStandardLayoutFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceUniformBufferStandardLayoutFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->uniformBufferStandardLayout,
+                        "VkPhysicalDeviceUniformBufferStandardLayoutFeatures::uniformBufferStandardLayout"};
+            }
+        case Feature::variablePointers:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->variablePointers, "VkPhysicalDeviceVulkan11Features::variablePointers"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->variablePointers, "VkPhysicalDeviceVariablePointersFeatures::variablePointers"};
+            }
+        case Feature::variablePointersStorageBuffer:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan11Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan11Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->variablePointersStorageBuffer,
+                        "VkPhysicalDeviceVulkan11Features::variablePointersStorageBuffer"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceVariablePointersFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVariablePointersFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVariablePointersFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->variablePointersStorageBuffer,
+                        "VkPhysicalDeviceVariablePointersFeatures::variablePointersStorageBuffer"};
+            }
+        case Feature::vertexAttributeInstanceRateDivisor: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->vertexAttributeInstanceRateDivisor,
+                    "VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR::vertexAttributeInstanceRateDivisor"};
+        }
+        case Feature::vertexAttributeInstanceRateZeroDivisor: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->vertexAttributeInstanceRateZeroDivisor,
+                    "VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR::vertexAttributeInstanceRateZeroDivisor"};
+        }
+        case Feature::vertexInputDynamicState: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->vertexInputDynamicState,
+                    "VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT::vertexInputDynamicState"};
+        }
+        case Feature::descriptorIndexing: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->descriptorIndexing, "VkPhysicalDeviceVulkan12Features::descriptorIndexing"};
+        }
+        case Feature::drawIndirectCount: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->drawIndirectCount, "VkPhysicalDeviceVulkan12Features::drawIndirectCount"};
+        }
+        case Feature::samplerFilterMinmax: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->samplerFilterMinmax, "VkPhysicalDeviceVulkan12Features::samplerFilterMinmax"};
+        }
+        case Feature::samplerMirrorClampToEdge: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->samplerMirrorClampToEdge, "VkPhysicalDeviceVulkan12Features::samplerMirrorClampToEdge"};
+        }
+        case Feature::shaderOutputLayer: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderOutputLayer, "VkPhysicalDeviceVulkan12Features::shaderOutputLayer"};
+        }
+        case Feature::shaderOutputViewportIndex: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->shaderOutputViewportIndex, "VkPhysicalDeviceVulkan12Features::shaderOutputViewportIndex"};
+        }
+        case Feature::subgroupBroadcastDynamicId: {
+            auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceVulkan12Features;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->subgroupBroadcastDynamicId, "VkPhysicalDeviceVulkan12Features::subgroupBroadcastDynamicId"};
+        }
+
+        case Feature::vulkanMemoryModel:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModel, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModel"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModel, "VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModel"};
+            }
+        case Feature::vulkanMemoryModelAvailabilityVisibilityChains:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModelAvailabilityVisibilityChains,
+                        "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelAvailabilityVisibilityChains"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModelAvailabilityVisibilityChains,
+                        "VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModelAvailabilityVisibilityChains"};
+            }
+        case Feature::vulkanMemoryModelDeviceScope:
+            if (api_version >= VK_API_VERSION_1_2) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan12Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan12Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModelDeviceScope, "VkPhysicalDeviceVulkan12Features::vulkanMemoryModelDeviceScope"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkanMemoryModelFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkanMemoryModelFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkanMemoryModelFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->vulkanMemoryModelDeviceScope,
+                        "VkPhysicalDeviceVulkanMemoryModelFeatures::vulkanMemoryModelDeviceScope"};
+            }
+        case Feature::shaderZeroInitializeWorkgroupMemory:
+            if (api_version >= VK_API_VERSION_1_3) {
+                auto vk_struct = const_cast<VkPhysicalDeviceVulkan13Features *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceVulkan13Features>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceVulkan13Features;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderZeroInitializeWorkgroupMemory,
+                        "VkPhysicalDeviceVulkan13Features::shaderZeroInitializeWorkgroupMemory"};
+            } else {
+                auto vk_struct = const_cast<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(
+                    vku::FindStructInPNextChain<VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures>(*inout_pnext_chain));
+                if (!vk_struct) {
+                    vk_struct = new VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures;
+                    *vk_struct = vku::InitStructHelper();
+                    if (*inout_pnext_chain) {
+                        vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                    } else {
+                        *inout_pnext_chain = vk_struct;
+                    }
+                }
+                return {&vk_struct->shaderZeroInitializeWorkgroupMemory,
+                        "VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures::shaderZeroInitializeWorkgroupMemory"};
+            }
+        case Feature::workgroupMemoryExplicitLayout: {
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->workgroupMemoryExplicitLayout,
+                    "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayout"};
+        }
+        case Feature::workgroupMemoryExplicitLayout16BitAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->workgroupMemoryExplicitLayout16BitAccess,
+                    "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayout16BitAccess"};
+        }
+        case Feature::workgroupMemoryExplicitLayout8BitAccess: {
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->workgroupMemoryExplicitLayout8BitAccess,
+                    "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayout8BitAccess"};
+        }
+        case Feature::workgroupMemoryExplicitLayoutScalarBlockLayout: {
+            auto vk_struct = const_cast<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->workgroupMemoryExplicitLayoutScalarBlockLayout,
+                    "VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR::workgroupMemoryExplicitLayoutScalarBlockLayout"};
+        }
+        case Feature::ycbcr2plane444Formats: {
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->ycbcr2plane444Formats, "VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT::ycbcr2plane444Formats"};
+        }
+        case Feature::ycbcrDegamma: {
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrDegammaFeaturesQCOM>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceYcbcrDegammaFeaturesQCOM;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->ycbcrDegamma, "VkPhysicalDeviceYcbcrDegammaFeaturesQCOM::ycbcrDegamma"};
+        }
+        case Feature::ycbcrImageArrays: {
+            auto vk_struct = const_cast<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceYcbcrImageArraysFeaturesEXT>(*inout_pnext_chain));
+            if (!vk_struct) {
+                vk_struct = new VkPhysicalDeviceYcbcrImageArraysFeaturesEXT;
+                *vk_struct = vku::InitStructHelper();
+                if (*inout_pnext_chain) {
+                    vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                } else {
+                    *inout_pnext_chain = vk_struct;
+                }
+            }
+            return {&vk_struct->ycbcrImageArrays, "VkPhysicalDeviceYcbcrImageArraysFeaturesEXT::ycbcrImageArrays"};
+        }
+        default:
+            assert(false);
+            return {nullptr, ""};
+    }
+}
+}  // namespace vkt
+// NOLINTEND

--- a/layers/vulkan/generated/feature_requirements_helper.h
+++ b/layers/vulkan/generated/feature_requirements_helper.h
@@ -1,0 +1,848 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See feature_requirements.py for modifications
+
+/***************************************************************************
+ *
+ * Copyright (c) 2023 The Khronos Group Inc.
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+// NOLINTBEGIN
+
+#include "vk_api_version.h"
+
+#include <vulkan/vulkan.h>
+
+namespace vkt {
+enum class Feature {
+    // VkPhysicalDevice16BitStorageFeatures, VkPhysicalDeviceVulkan11Features
+    storageBuffer16BitAccess,
+    // VkPhysicalDevice16BitStorageFeatures, VkPhysicalDeviceVulkan11Features
+    storageInputOutput16,
+    // VkPhysicalDevice16BitStorageFeatures, VkPhysicalDeviceVulkan11Features
+    storagePushConstant16,
+    // VkPhysicalDevice16BitStorageFeatures, VkPhysicalDeviceVulkan11Features
+    uniformAndStorageBuffer16BitAccess,
+    // VkPhysicalDevice4444FormatsFeaturesEXT
+    formatA4B4G4R4,
+    // VkPhysicalDevice4444FormatsFeaturesEXT
+    formatA4R4G4B4,
+    // VkPhysicalDevice8BitStorageFeatures, VkPhysicalDeviceVulkan12Features
+    storageBuffer8BitAccess,
+    // VkPhysicalDevice8BitStorageFeatures, VkPhysicalDeviceVulkan12Features
+    storagePushConstant8,
+    // VkPhysicalDevice8BitStorageFeatures, VkPhysicalDeviceVulkan12Features
+    uniformAndStorageBuffer8BitAccess,
+    // VkPhysicalDeviceASTCDecodeFeaturesEXT
+    decodeModeSharedExponent,
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR
+    accelerationStructure,
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR
+    accelerationStructureCaptureReplay,
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR
+    accelerationStructureHostCommands,
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR
+    accelerationStructureIndirectBuild,
+    // VkPhysicalDeviceAccelerationStructureFeaturesKHR
+    descriptorBindingAccelerationStructureUpdateAfterBind,
+    // VkPhysicalDeviceAddressBindingReportFeaturesEXT
+    reportAddressBinding,
+    // VkPhysicalDeviceAmigoProfilingFeaturesSEC
+    amigoProfiling,
+    // VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT
+    attachmentFeedbackLoopDynamicState,
+    // VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT
+    attachmentFeedbackLoopLayout,
+    // VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT
+    advancedBlendCoherentOperations,
+    // VkPhysicalDeviceBorderColorSwizzleFeaturesEXT
+    borderColorSwizzle,
+    // VkPhysicalDeviceBorderColorSwizzleFeaturesEXT
+    borderColorSwizzleFromImage,
+    // VkPhysicalDeviceBufferDeviceAddressFeatures, VkPhysicalDeviceVulkan12Features
+    bufferDeviceAddress,
+    // VkPhysicalDeviceBufferDeviceAddressFeatures, VkPhysicalDeviceVulkan12Features
+    bufferDeviceAddressCaptureReplay,
+    // VkPhysicalDeviceBufferDeviceAddressFeatures, VkPhysicalDeviceVulkan12Features
+    bufferDeviceAddressMultiDevice,
+    // VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI
+    clustercullingShader,
+    // VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI
+    multiviewClusterCullingShader,
+    // VkPhysicalDeviceCoherentMemoryFeaturesAMD
+    deviceCoherentMemory,
+    // VkPhysicalDeviceColorWriteEnableFeaturesEXT
+    colorWriteEnable,
+    // VkPhysicalDeviceComputeShaderDerivativesFeaturesNV
+    computeDerivativeGroupLinear,
+    // VkPhysicalDeviceComputeShaderDerivativesFeaturesNV
+    computeDerivativeGroupQuads,
+    // VkPhysicalDeviceConditionalRenderingFeaturesEXT
+    conditionalRendering,
+    // VkPhysicalDeviceConditionalRenderingFeaturesEXT
+    inheritedConditionalRendering,
+    // VkPhysicalDeviceCooperativeMatrixFeaturesKHR, VkPhysicalDeviceCooperativeMatrixFeaturesNV
+    cooperativeMatrix,
+    // VkPhysicalDeviceCooperativeMatrixFeaturesKHR, VkPhysicalDeviceCooperativeMatrixFeaturesNV
+    cooperativeMatrixRobustBufferAccess,
+    // VkPhysicalDeviceCopyMemoryIndirectFeaturesNV
+    indirectCopy,
+    // VkPhysicalDeviceCornerSampledImageFeaturesNV
+    cornerSampledImage,
+    // VkPhysicalDeviceCoverageReductionModeFeaturesNV
+    coverageReductionMode,
+    // VkPhysicalDeviceCubicClampFeaturesQCOM
+    cubicRangeClamp,
+    // VkPhysicalDeviceCubicWeightsFeaturesQCOM
+    selectableCubicWeights,
+    // VkPhysicalDeviceCudaKernelLaunchFeaturesNV
+    cudaKernelLaunchFeatures,
+    // VkPhysicalDeviceCustomBorderColorFeaturesEXT
+    customBorderColorWithoutFormat,
+    // VkPhysicalDeviceCustomBorderColorFeaturesEXT
+    customBorderColors,
+    // VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV
+    dedicatedAllocationImageAliasing,
+    // VkPhysicalDeviceDepthBiasControlFeaturesEXT
+    depthBiasControl,
+    // VkPhysicalDeviceDepthBiasControlFeaturesEXT
+    depthBiasExact,
+    // VkPhysicalDeviceDepthBiasControlFeaturesEXT
+    floatRepresentation,
+    // VkPhysicalDeviceDepthBiasControlFeaturesEXT
+    leastRepresentableValueForceUnormRepresentation,
+    // VkPhysicalDeviceDepthClampZeroOneFeaturesEXT
+    depthClampZeroOne,
+    // VkPhysicalDeviceDepthClipControlFeaturesEXT
+    depthClipControl,
+    // VkPhysicalDeviceDepthClipEnableFeaturesEXT
+    depthClipEnable,
+    // VkPhysicalDeviceDescriptorBufferFeaturesEXT
+    descriptorBuffer,
+    // VkPhysicalDeviceDescriptorBufferFeaturesEXT
+    descriptorBufferCaptureReplay,
+    // VkPhysicalDeviceDescriptorBufferFeaturesEXT
+    descriptorBufferImageLayoutIgnored,
+    // VkPhysicalDeviceDescriptorBufferFeaturesEXT
+    descriptorBufferPushDescriptors,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingPartiallyBound,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingSampledImageUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingStorageBufferUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingStorageImageUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingStorageTexelBufferUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingUniformBufferUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingUniformTexelBufferUpdateAfterBind,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingUpdateUnusedWhilePending,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    descriptorBindingVariableDescriptorCount,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    runtimeDescriptorArray,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderInputAttachmentArrayDynamicIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderInputAttachmentArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderSampledImageArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderStorageBufferArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderStorageImageArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderStorageTexelBufferArrayDynamicIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderStorageTexelBufferArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderUniformBufferArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderUniformTexelBufferArrayDynamicIndexing,
+    // VkPhysicalDeviceDescriptorIndexingFeatures, VkPhysicalDeviceVulkan12Features
+    shaderUniformTexelBufferArrayNonUniformIndexing,
+    // VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV
+    descriptorPoolOverallocation,
+    // VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE
+    descriptorSetHostMapping,
+    // VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV
+    deviceGeneratedCompute,
+    // VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV
+    deviceGeneratedComputeCaptureReplay,
+    // VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV
+    deviceGeneratedComputePipelines,
+    // VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV
+    deviceGeneratedCommands,
+    // VkPhysicalDeviceDeviceMemoryReportFeaturesEXT
+    deviceMemoryReport,
+    // VkPhysicalDeviceDiagnosticsConfigFeaturesNV
+    diagnosticsConfig,
+    // VkPhysicalDeviceDisplacementMicromapFeaturesNV
+    displacementMicromap,
+    // VkPhysicalDeviceDynamicRenderingFeatures, VkPhysicalDeviceVulkan13Features
+    dynamicRendering,
+    // VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT
+    dynamicRenderingUnusedAttachments,
+    // VkPhysicalDeviceExclusiveScissorFeaturesNV
+    exclusiveScissor,
+    // VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
+    extendedDynamicState2,
+    // VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
+    extendedDynamicState2LogicOp,
+    // VkPhysicalDeviceExtendedDynamicState2FeaturesEXT
+    extendedDynamicState2PatchControlPoints,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3AlphaToCoverageEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3AlphaToOneEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ColorBlendAdvanced,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ColorBlendEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ColorBlendEquation,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ColorWriteMask,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ConservativeRasterizationMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageModulationMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageModulationTable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageModulationTableEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageReductionMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageToColorEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3CoverageToColorLocation,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3DepthClampEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3DepthClipEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3DepthClipNegativeOneToOne,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ExtraPrimitiveOverestimationSize,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3LineRasterizationMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3LineStippleEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3LogicOpEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3PolygonMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ProvokingVertexMode,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3RasterizationSamples,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3RasterizationStream,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3RepresentativeFragmentTestEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3SampleLocationsEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3SampleMask,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ShadingRateImageEnable,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3TessellationDomainOrigin,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ViewportSwizzle,
+    // VkPhysicalDeviceExtendedDynamicState3FeaturesEXT
+    extendedDynamicState3ViewportWScalingEnable,
+    // VkPhysicalDeviceExtendedDynamicStateFeaturesEXT
+    extendedDynamicState,
+    // VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV
+    extendedSparseAddressSpace,
+    // VkPhysicalDeviceExternalFormatResolveFeaturesANDROID
+    externalFormatResolve,
+    // VkPhysicalDeviceExternalMemoryRDMAFeaturesNV
+    externalMemoryRDMA,
+    // VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX
+    screenBufferImport,
+    // VkPhysicalDeviceFaultFeaturesEXT
+    deviceFault,
+    // VkPhysicalDeviceFaultFeaturesEXT
+    deviceFaultVendorBinary,
+    // VkPhysicalDeviceFeatures
+    alphaToOne,
+    // VkPhysicalDeviceFeatures
+    depthBiasClamp,
+    // VkPhysicalDeviceFeatures
+    depthBounds,
+    // VkPhysicalDeviceFeatures
+    depthClamp,
+    // VkPhysicalDeviceFeatures
+    drawIndirectFirstInstance,
+    // VkPhysicalDeviceFeatures
+    dualSrcBlend,
+    // VkPhysicalDeviceFeatures
+    fillModeNonSolid,
+    // VkPhysicalDeviceFeatures
+    fragmentStoresAndAtomics,
+    // VkPhysicalDeviceFeatures
+    fullDrawIndexUint32,
+    // VkPhysicalDeviceFeatures
+    geometryShader,
+    // VkPhysicalDeviceFeatures
+    imageCubeArray,
+    // VkPhysicalDeviceFeatures
+    independentBlend,
+    // VkPhysicalDeviceFeatures
+    inheritedQueries,
+    // VkPhysicalDeviceFeatures
+    largePoints,
+    // VkPhysicalDeviceFeatures
+    logicOp,
+    // VkPhysicalDeviceFeatures
+    multiDrawIndirect,
+    // VkPhysicalDeviceFeatures
+    multiViewport,
+    // VkPhysicalDeviceFeatures
+    occlusionQueryPrecise,
+    // VkPhysicalDeviceFeatures
+    pipelineStatisticsQuery,
+    // VkPhysicalDeviceFeatures
+    robustBufferAccess,
+    // VkPhysicalDeviceFeatures
+    sampleRateShading,
+    // VkPhysicalDeviceFeatures
+    samplerAnisotropy,
+    // VkPhysicalDeviceFeatures
+    shaderClipDistance,
+    // VkPhysicalDeviceFeatures
+    shaderCullDistance,
+    // VkPhysicalDeviceFeatures
+    shaderFloat64,
+    // VkPhysicalDeviceFeatures
+    shaderImageGatherExtended,
+    // VkPhysicalDeviceFeatures
+    shaderInt16,
+    // VkPhysicalDeviceFeatures
+    shaderInt64,
+    // VkPhysicalDeviceFeatures
+    shaderResourceMinLod,
+    // VkPhysicalDeviceFeatures
+    shaderResourceResidency,
+    // VkPhysicalDeviceFeatures
+    shaderSampledImageArrayDynamicIndexing,
+    // VkPhysicalDeviceFeatures
+    shaderStorageBufferArrayDynamicIndexing,
+    // VkPhysicalDeviceFeatures
+    shaderStorageImageArrayDynamicIndexing,
+    // VkPhysicalDeviceFeatures
+    shaderStorageImageExtendedFormats,
+    // VkPhysicalDeviceFeatures
+    shaderStorageImageMultisample,
+    // VkPhysicalDeviceFeatures
+    shaderStorageImageReadWithoutFormat,
+    // VkPhysicalDeviceFeatures
+    shaderStorageImageWriteWithoutFormat,
+    // VkPhysicalDeviceFeatures
+    shaderTessellationAndGeometryPointSize,
+    // VkPhysicalDeviceFeatures
+    shaderUniformBufferArrayDynamicIndexing,
+    // VkPhysicalDeviceFeatures
+    sparseBinding,
+    // VkPhysicalDeviceFeatures
+    sparseResidency16Samples,
+    // VkPhysicalDeviceFeatures
+    sparseResidency2Samples,
+    // VkPhysicalDeviceFeatures
+    sparseResidency4Samples,
+    // VkPhysicalDeviceFeatures
+    sparseResidency8Samples,
+    // VkPhysicalDeviceFeatures
+    sparseResidencyAliased,
+    // VkPhysicalDeviceFeatures
+    sparseResidencyBuffer,
+    // VkPhysicalDeviceFeatures
+    sparseResidencyImage2D,
+    // VkPhysicalDeviceFeatures
+    sparseResidencyImage3D,
+    // VkPhysicalDeviceFeatures
+    tessellationShader,
+    // VkPhysicalDeviceFeatures
+    textureCompressionASTC_LDR,
+    // VkPhysicalDeviceFeatures
+    textureCompressionBC,
+    // VkPhysicalDeviceFeatures
+    textureCompressionETC2,
+    // VkPhysicalDeviceFeatures
+    variableMultisampleRate,
+    // VkPhysicalDeviceFeatures
+    vertexPipelineStoresAndAtomics,
+    // VkPhysicalDeviceFeatures
+    wideLines,
+    // VkPhysicalDeviceFragmentDensityMap2FeaturesEXT
+    fragmentDensityMapDeferred,
+    // VkPhysicalDeviceFragmentDensityMapFeaturesEXT
+    fragmentDensityMap,
+    // VkPhysicalDeviceFragmentDensityMapFeaturesEXT
+    fragmentDensityMapDynamic,
+    // VkPhysicalDeviceFragmentDensityMapFeaturesEXT
+    fragmentDensityMapNonSubsampledImages,
+    // VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM
+    fragmentDensityMapOffset,
+    // VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR
+    fragmentShaderBarycentric,
+    // VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
+    fragmentShaderPixelInterlock,
+    // VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
+    fragmentShaderSampleInterlock,
+    // VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT
+    fragmentShaderShadingRateInterlock,
+    // VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV
+    fragmentShadingRateEnums,
+    // VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV
+    noInvocationFragmentShadingRates,
+    // VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV
+    supersampleFragmentShadingRates,
+    // VkPhysicalDeviceFragmentShadingRateFeaturesKHR
+    attachmentFragmentShadingRate,
+    // VkPhysicalDeviceFragmentShadingRateFeaturesKHR
+    pipelineFragmentShadingRate,
+    // VkPhysicalDeviceFragmentShadingRateFeaturesKHR
+    primitiveFragmentShadingRate,
+    // VkPhysicalDeviceFrameBoundaryFeaturesEXT
+    frameBoundary,
+    // VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR
+    globalPriorityQuery,
+    // VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT
+    graphicsPipelineLibrary,
+    // VkPhysicalDeviceHostImageCopyFeaturesEXT
+    hostImageCopy,
+    // VkPhysicalDeviceHostQueryResetFeatures, VkPhysicalDeviceVulkan12Features
+    hostQueryReset,
+    // VkPhysicalDeviceImage2DViewOf3DFeaturesEXT
+    image2DViewOf3D,
+    // VkPhysicalDeviceImage2DViewOf3DFeaturesEXT
+    sampler2DViewOf3D,
+    // VkPhysicalDeviceImageCompressionControlFeaturesEXT
+    imageCompressionControl,
+    // VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT
+    imageCompressionControlSwapchain,
+    // VkPhysicalDeviceImageProcessing2FeaturesQCOM
+    textureBlockMatch2,
+    // VkPhysicalDeviceImageProcessingFeaturesQCOM
+    textureBlockMatch,
+    // VkPhysicalDeviceImageProcessingFeaturesQCOM
+    textureBoxFilter,
+    // VkPhysicalDeviceImageProcessingFeaturesQCOM
+    textureSampleWeighted,
+    // VkPhysicalDeviceImageRobustnessFeatures, VkPhysicalDeviceVulkan13Features
+    robustImageAccess,
+    // VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT
+    imageSlicedViewOf3D,
+    // VkPhysicalDeviceImageViewMinLodFeaturesEXT
+    minLod,
+    // VkPhysicalDeviceImagelessFramebufferFeatures, VkPhysicalDeviceVulkan12Features
+    imagelessFramebuffer,
+    // VkPhysicalDeviceIndexTypeUint8FeaturesEXT
+    indexTypeUint8,
+    // VkPhysicalDeviceInheritedViewportScissorFeaturesNV
+    inheritedViewportScissor2D,
+    // VkPhysicalDeviceInlineUniformBlockFeatures, VkPhysicalDeviceVulkan13Features
+    descriptorBindingInlineUniformBlockUpdateAfterBind,
+    // VkPhysicalDeviceInlineUniformBlockFeatures, VkPhysicalDeviceVulkan13Features
+    inlineUniformBlock,
+    // VkPhysicalDeviceInvocationMaskFeaturesHUAWEI
+    invocationMask,
+    // VkPhysicalDeviceLegacyDitheringFeaturesEXT
+    legacyDithering,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    bresenhamLines,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    rectangularLines,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    smoothLines,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    stippledBresenhamLines,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    stippledRectangularLines,
+    // VkPhysicalDeviceLineRasterizationFeaturesEXT
+    stippledSmoothLines,
+    // VkPhysicalDeviceLinearColorAttachmentFeaturesNV
+    linearColorAttachment,
+    // VkPhysicalDeviceMaintenance4Features, VkPhysicalDeviceVulkan13Features
+    maintenance4,
+    // VkPhysicalDeviceMaintenance5FeaturesKHR
+    maintenance5,
+    // VkPhysicalDeviceMemoryDecompressionFeaturesNV
+    memoryDecompression,
+    // VkPhysicalDeviceMemoryPriorityFeaturesEXT
+    memoryPriority,
+    // VkPhysicalDeviceMeshShaderFeaturesEXT
+    meshShaderQueries,
+    // VkPhysicalDeviceMeshShaderFeaturesEXT
+    multiviewMeshShader,
+    // VkPhysicalDeviceMeshShaderFeaturesEXT
+    primitiveFragmentShadingRateMeshShader,
+    // VkPhysicalDeviceMeshShaderFeaturesEXT, VkPhysicalDeviceMeshShaderFeaturesNV
+    meshShader,
+    // VkPhysicalDeviceMeshShaderFeaturesEXT, VkPhysicalDeviceMeshShaderFeaturesNV
+    taskShader,
+    // VkPhysicalDeviceMultiDrawFeaturesEXT
+    multiDraw,
+    // VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT
+    multisampledRenderToSingleSampled,
+    // VkPhysicalDeviceMultiviewFeatures, VkPhysicalDeviceVulkan11Features
+    multiview,
+    // VkPhysicalDeviceMultiviewFeatures, VkPhysicalDeviceVulkan11Features
+    multiviewGeometryShader,
+    // VkPhysicalDeviceMultiviewFeatures, VkPhysicalDeviceVulkan11Features
+    multiviewTessellationShader,
+    // VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM
+    multiviewPerViewRenderAreas,
+    // VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM
+    multiviewPerViewViewports,
+    // VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT
+    mutableDescriptorType,
+    // VkPhysicalDeviceNestedCommandBufferFeaturesEXT
+    nestedCommandBuffer,
+    // VkPhysicalDeviceNestedCommandBufferFeaturesEXT
+    nestedCommandBufferRendering,
+    // VkPhysicalDeviceNestedCommandBufferFeaturesEXT
+    nestedCommandBufferSimultaneousUse,
+    // VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT
+    nonSeamlessCubeMap,
+    // VkPhysicalDeviceOpacityMicromapFeaturesEXT
+    micromap,
+    // VkPhysicalDeviceOpacityMicromapFeaturesEXT
+    micromapCaptureReplay,
+    // VkPhysicalDeviceOpacityMicromapFeaturesEXT
+    micromapHostCommands,
+    // VkPhysicalDeviceOpticalFlowFeaturesNV
+    opticalFlow,
+    // VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT
+    pageableDeviceLocalMemory,
+    // VkPhysicalDevicePerformanceQueryFeaturesKHR
+    performanceCounterMultipleQueryPools,
+    // VkPhysicalDevicePerformanceQueryFeaturesKHR
+    performanceCounterQueryPools,
+    // VkPhysicalDevicePipelineCreationCacheControlFeatures, VkPhysicalDeviceVulkan13Features
+    pipelineCreationCacheControl,
+    // VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR
+    pipelineExecutableInfo,
+    // VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT
+    pipelineLibraryGroupHandles,
+    // VkPhysicalDevicePipelinePropertiesFeaturesEXT
+    pipelinePropertiesIdentifier,
+    // VkPhysicalDevicePipelineProtectedAccessFeaturesEXT
+    pipelineProtectedAccess,
+    // VkPhysicalDevicePipelineRobustnessFeaturesEXT
+    pipelineRobustness,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    constantAlphaColorBlendFactors,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    events,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    imageView2DOn3DImage,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    imageViewFormatReinterpretation,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    imageViewFormatSwizzle,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    multisampleArrayImage,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    mutableComparisonSamplers,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    pointPolygons,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    samplerMipLodBias,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    separateStencilMaskRef,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    shaderSampleRateInterpolationFunctions,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    tessellationIsolines,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    tessellationPointMode,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    triangleFans,
+    // VkPhysicalDevicePortabilitySubsetFeaturesKHR
+    vertexAttributeAccessBeyondStride,
+    // VkPhysicalDevicePresentBarrierFeaturesNV
+    presentBarrier,
+    // VkPhysicalDevicePresentIdFeaturesKHR
+    presentId,
+    // VkPhysicalDevicePresentWaitFeaturesKHR
+    presentWait,
+    // VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT
+    primitiveTopologyListRestart,
+    // VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT
+    primitiveTopologyPatchListRestart,
+    // VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT
+    primitivesGeneratedQuery,
+    // VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT
+    primitivesGeneratedQueryWithNonZeroStreams,
+    // VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT
+    primitivesGeneratedQueryWithRasterizerDiscard,
+    // VkPhysicalDevicePrivateDataFeatures, VkPhysicalDeviceVulkan13Features
+    privateData,
+    // VkPhysicalDeviceProtectedMemoryFeatures, VkPhysicalDeviceVulkan11Features
+    protectedMemory,
+    // VkPhysicalDeviceProvokingVertexFeaturesEXT
+    provokingVertexLast,
+    // VkPhysicalDeviceProvokingVertexFeaturesEXT
+    transformFeedbackPreservesProvokingVertex,
+    // VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT
+    formatRgba10x6WithoutYCbCrSampler,
+    // VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT
+    rasterizationOrderColorAttachmentAccess,
+    // VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT
+    rasterizationOrderDepthAttachmentAccess,
+    // VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT
+    rasterizationOrderStencilAttachmentAccess,
+    // VkPhysicalDeviceRayQueryFeaturesKHR
+    rayQuery,
+    // VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV
+    rayTracingInvocationReorder,
+    // VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR
+    rayTracingMaintenance1,
+    // VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR
+    rayTracingPipelineTraceRaysIndirect2,
+    // VkPhysicalDeviceRayTracingMotionBlurFeaturesNV
+    rayTracingMotionBlur,
+    // VkPhysicalDeviceRayTracingMotionBlurFeaturesNV
+    rayTracingMotionBlurPipelineTraceRaysIndirect,
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR
+    rayTracingPipeline,
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR
+    rayTracingPipelineShaderGroupHandleCaptureReplay,
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR
+    rayTracingPipelineShaderGroupHandleCaptureReplayMixed,
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR
+    rayTracingPipelineTraceRaysIndirect,
+    // VkPhysicalDeviceRayTracingPipelineFeaturesKHR
+    rayTraversalPrimitiveCulling,
+    // VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR
+    rayTracingPositionFetch,
+    // VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG
+    relaxedLineRasterization,
+    // VkPhysicalDeviceRenderPassStripedFeaturesARM
+    renderPassStriped,
+    // VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV
+    representativeFragmentTest,
+    // VkPhysicalDeviceRobustness2FeaturesEXT
+    nullDescriptor,
+    // VkPhysicalDeviceRobustness2FeaturesEXT
+    robustBufferAccess2,
+    // VkPhysicalDeviceRobustness2FeaturesEXT
+    robustImageAccess2,
+    // VkPhysicalDeviceSamplerYcbcrConversionFeatures, VkPhysicalDeviceVulkan11Features
+    samplerYcbcrConversion,
+    // VkPhysicalDeviceScalarBlockLayoutFeatures, VkPhysicalDeviceVulkan12Features
+    scalarBlockLayout,
+    // VkPhysicalDeviceSchedulingControlsFeaturesARM
+    schedulingControls,
+    // VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures, VkPhysicalDeviceVulkan12Features
+    separateDepthStencilLayouts,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderBufferFloat16AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderBufferFloat16AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderBufferFloat16Atomics,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderBufferFloat32AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderBufferFloat64AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderImageFloat32AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderSharedFloat16AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderSharedFloat16AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderSharedFloat16Atomics,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderSharedFloat32AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    shaderSharedFloat64AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT
+    sparseImageFloat32AtomicMinMax,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderBufferFloat32AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderBufferFloat32Atomics,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderBufferFloat64AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderBufferFloat64Atomics,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderImageFloat32AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderImageFloat32Atomics,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderSharedFloat32AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderSharedFloat32Atomics,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderSharedFloat64AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    shaderSharedFloat64Atomics,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    sparseImageFloat32AtomicAdd,
+    // VkPhysicalDeviceShaderAtomicFloatFeaturesEXT
+    sparseImageFloat32Atomics,
+    // VkPhysicalDeviceShaderAtomicInt64Features, VkPhysicalDeviceVulkan12Features
+    shaderBufferInt64Atomics,
+    // VkPhysicalDeviceShaderAtomicInt64Features, VkPhysicalDeviceVulkan12Features
+    shaderSharedInt64Atomics,
+    // VkPhysicalDeviceShaderClockFeaturesKHR
+    shaderDeviceClock,
+    // VkPhysicalDeviceShaderClockFeaturesKHR
+    shaderSubgroupClock,
+    // VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM
+    shaderCoreBuiltins,
+    // VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures, VkPhysicalDeviceVulkan13Features
+    shaderDemoteToHelperInvocation,
+    // VkPhysicalDeviceShaderDrawParametersFeatures, VkPhysicalDeviceVulkan11Features
+    shaderDrawParameters,
+    // VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD
+    shaderEarlyAndLateFragmentTests,
+    // VkPhysicalDeviceShaderEnqueueFeaturesAMDX
+    shaderEnqueue,
+    // VkPhysicalDeviceShaderFloat16Int8Features, VkPhysicalDeviceVulkan12Features
+    shaderFloat16,
+    // VkPhysicalDeviceShaderFloat16Int8Features, VkPhysicalDeviceVulkan12Features
+    shaderInt8,
+    // VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT
+    shaderImageInt64Atomics,
+    // VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT
+    sparseImageInt64Atomics,
+    // VkPhysicalDeviceShaderImageFootprintFeaturesNV
+    imageFootprint,
+    // VkPhysicalDeviceShaderIntegerDotProductFeatures, VkPhysicalDeviceVulkan13Features
+    shaderIntegerDotProduct,
+    // VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL
+    shaderIntegerFunctions2,
+    // VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT
+    shaderModuleIdentifier,
+    // VkPhysicalDeviceShaderObjectFeaturesEXT
+    shaderObject,
+    // VkPhysicalDeviceShaderSMBuiltinsFeaturesNV
+    shaderSMBuiltins,
+    // VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures, VkPhysicalDeviceVulkan12Features
+    shaderSubgroupExtendedTypes,
+    // VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR
+    shaderSubgroupUniformControlFlow,
+    // VkPhysicalDeviceShaderTerminateInvocationFeatures, VkPhysicalDeviceVulkan13Features
+    shaderTerminateInvocation,
+    // VkPhysicalDeviceShaderTileImageFeaturesEXT
+    shaderTileImageColorReadAccess,
+    // VkPhysicalDeviceShaderTileImageFeaturesEXT
+    shaderTileImageDepthReadAccess,
+    // VkPhysicalDeviceShaderTileImageFeaturesEXT
+    shaderTileImageStencilReadAccess,
+    // VkPhysicalDeviceShadingRateImageFeaturesNV
+    shadingRateCoarseSampleOrder,
+    // VkPhysicalDeviceShadingRateImageFeaturesNV
+    shadingRateImage,
+    // VkPhysicalDeviceSubgroupSizeControlFeatures, VkPhysicalDeviceVulkan13Features
+    computeFullSubgroups,
+    // VkPhysicalDeviceSubgroupSizeControlFeatures, VkPhysicalDeviceVulkan13Features
+    subgroupSizeControl,
+    // VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT
+    subpassMergeFeedback,
+    // VkPhysicalDeviceSubpassShadingFeaturesHUAWEI
+    subpassShading,
+    // VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT
+    swapchainMaintenance1,
+    // VkPhysicalDeviceSynchronization2Features, VkPhysicalDeviceVulkan13Features
+    synchronization2,
+    // VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT
+    texelBufferAlignment,
+    // VkPhysicalDeviceTextureCompressionASTCHDRFeatures, VkPhysicalDeviceVulkan13Features
+    textureCompressionASTC_HDR,
+    // VkPhysicalDeviceTilePropertiesFeaturesQCOM
+    tileProperties,
+    // VkPhysicalDeviceTimelineSemaphoreFeatures, VkPhysicalDeviceVulkan12Features
+    timelineSemaphore,
+    // VkPhysicalDeviceTransformFeedbackFeaturesEXT
+    geometryStreams,
+    // VkPhysicalDeviceTransformFeedbackFeaturesEXT
+    transformFeedback,
+    // VkPhysicalDeviceUniformBufferStandardLayoutFeatures, VkPhysicalDeviceVulkan12Features
+    uniformBufferStandardLayout,
+    // VkPhysicalDeviceVariablePointersFeatures, VkPhysicalDeviceVulkan11Features
+    variablePointers,
+    // VkPhysicalDeviceVariablePointersFeatures, VkPhysicalDeviceVulkan11Features
+    variablePointersStorageBuffer,
+    // VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR
+    vertexAttributeInstanceRateDivisor,
+    // VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR
+    vertexAttributeInstanceRateZeroDivisor,
+    // VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT
+    vertexInputDynamicState,
+    // VkPhysicalDeviceVulkan12Features
+    descriptorIndexing,
+    // VkPhysicalDeviceVulkan12Features
+    drawIndirectCount,
+    // VkPhysicalDeviceVulkan12Features
+    samplerFilterMinmax,
+    // VkPhysicalDeviceVulkan12Features
+    samplerMirrorClampToEdge,
+    // VkPhysicalDeviceVulkan12Features
+    shaderOutputLayer,
+    // VkPhysicalDeviceVulkan12Features
+    shaderOutputViewportIndex,
+    // VkPhysicalDeviceVulkan12Features
+    subgroupBroadcastDynamicId,
+    // VkPhysicalDeviceVulkan12Features, VkPhysicalDeviceVulkanMemoryModelFeatures
+    vulkanMemoryModel,
+    // VkPhysicalDeviceVulkan12Features, VkPhysicalDeviceVulkanMemoryModelFeatures
+    vulkanMemoryModelAvailabilityVisibilityChains,
+    // VkPhysicalDeviceVulkan12Features, VkPhysicalDeviceVulkanMemoryModelFeatures
+    vulkanMemoryModelDeviceScope,
+    // VkPhysicalDeviceVulkan13Features, VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures
+    shaderZeroInitializeWorkgroupMemory,
+    // VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
+    workgroupMemoryExplicitLayout,
+    // VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
+    workgroupMemoryExplicitLayout16BitAccess,
+    // VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
+    workgroupMemoryExplicitLayout8BitAccess,
+    // VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR
+    workgroupMemoryExplicitLayoutScalarBlockLayout,
+    // VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT
+    ycbcr2plane444Formats,
+    // VkPhysicalDeviceYcbcrDegammaFeaturesQCOM
+    ycbcrDegamma,
+    // VkPhysicalDeviceYcbcrImageArraysFeaturesEXT
+    ycbcrImageArrays,
+};
+
+struct FeatureAndName {
+    VkBool32 *feature;
+    const char *name;
+};
+
+// Find or add the correct VkPhysicalDeviceFeature struct in `pnext_chain` based on `feature`,
+// a vkt::Feature enum value, and set feature to VK_TRUE
+FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain);
+
+}  // namespace vkt
+
+// NOLINTEND

--- a/layers/vulkan/generated/pnext_chain_extraction.cpp
+++ b/layers/vulkan/generated/pnext_chain_extraction.cpp
@@ -51,6 +51,2788 @@ void PnextChainRemoveLast(void *chain) {
     prev->pNext = nullptr;
 }
 
+void PnextChainFree(void *chain) {
+    if (!chain) return;
+    auto header = reinterpret_cast<VkBaseOutStructure *>(chain);
+    switch (header->sType) {
+        case VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkShaderModuleCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_16BIT_STORAGE_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevice16BitStorageFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_REQUIREMENTS:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryDedicatedRequirements *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_DEDICATED_ALLOCATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryDedicatedAllocateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_FLAGS_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryAllocateFlagsInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_RENDER_PASS_BEGIN_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupRenderPassBeginInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupCommandBufferBeginInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_SUBMIT_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupSubmitInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_BIND_SPARSE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupBindSparseInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_DEVICE_GROUP_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBindBufferMemoryDeviceGroupInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_DEVICE_GROUP_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBindImageMemoryDeviceGroupInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_DEVICE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupDeviceCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFeatures2 *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_POINT_CLIPPING_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePointClippingProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_INPUT_ATTACHMENT_ASPECT_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassInputAttachmentAspectCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_USAGE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageViewUsageCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_DOMAIN_ORIGIN_STATE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineTessellationDomainOriginStateCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_MULTIVIEW_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassMultiviewCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VARIABLE_POINTERS_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVariablePointersFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROTECTED_MEMORY_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceProtectedMemoryProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PROTECTED_SUBMIT_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkProtectedSubmitInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerYcbcrConversionInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BIND_IMAGE_PLANE_MEMORY_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBindImagePlaneMemoryInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_PLANE_MEMORY_REQUIREMENTS_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImagePlaneMemoryRequirementsInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_YCBCR_CONVERSION_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerYcbcrConversionFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_IMAGE_FORMAT_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerYcbcrConversionImageFormatProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_IMAGE_FORMAT_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalImageFormatInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_IMAGE_FORMAT_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalImageFormatProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceIDProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_BUFFER_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalMemoryBufferCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMemoryAllocateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportFenceCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportSemaphoreCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_3_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance3Properties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DRAW_PARAMETERS_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDrawParametersFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_1_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan11Properties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan12Properties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_FORMAT_LIST_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageFormatListCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_8BIT_STORAGE_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevice8BitStorageFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRIVER_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDriverProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_INT64_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicInt64Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_FLOAT16_INT8_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderFloat16Int8Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FLOAT_CONTROLS_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFloatControlsProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDescriptorSetLayoutBindingFlagsCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorIndexingProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountAllocateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_LAYOUT_SUPPORT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDescriptorSetVariableDescriptorCountLayoutSupport *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_DEPTH_STENCIL_RESOLVE:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSubpassDescriptionDepthStencilResolve *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_STENCIL_RESOLVE_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDepthStencilResolveProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCALAR_BLOCK_LAYOUT_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceScalarBlockLayoutFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_STENCIL_USAGE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageStencilUsageCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerReductionModeCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLER_FILTER_MINMAX_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSamplerFilterMinmaxProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_MEMORY_MODEL_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkanMemoryModelFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGELESS_FRAMEBUFFER_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImagelessFramebufferFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkFramebufferAttachmentsCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_ATTACHMENT_BEGIN_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassAttachmentBeginInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_UNIFORM_BUFFER_STANDARD_LAYOUT_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceUniformBufferStandardLayoutFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_EXTENDED_TYPES_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupExtendedTypesFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SEPARATE_DEPTH_STENCIL_LAYOUTS_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSeparateDepthStencilLayoutsFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_STENCIL_LAYOUT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAttachmentReferenceStencilLayout *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_STENCIL_LAYOUT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAttachmentDescriptionStencilLayout *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_QUERY_RESET_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceHostQueryResetFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TIMELINE_SEMAPHORE_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTimelineSemaphoreProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SEMAPHORE_TYPE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSemaphoreTypeCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_TIMELINE_SEMAPHORE_SUBMIT_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkTimelineSemaphoreSubmitInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BUFFER_OPAQUE_CAPTURE_ADDRESS_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBufferOpaqueCaptureAddressCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_OPAQUE_CAPTURE_ADDRESS_ALLOCATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryOpaqueCaptureAddressAllocateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVulkan13Properties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_CREATION_FEEDBACK_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCreationFeedbackCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TERMINATE_INVOCATION_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTerminateInvocationFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_DEMOTE_TO_HELPER_INVOCATION_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderDemoteToHelperInvocationFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIVATE_DATA_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePrivateDataFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_PRIVATE_DATA_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDevicePrivateDataCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_CREATION_CACHE_CONTROL_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineCreationCacheControlFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_BARRIER_2:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryBarrier2 *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SYNCHRONIZATION_2_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSynchronization2Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ZERO_INITIALIZE_WORKGROUP_MEMORY_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceZeroInitializeWorkgroupMemoryFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_ROBUSTNESS_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageRobustnessFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBGROUP_SIZE_CONTROL_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubgroupSizeControlProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_REQUIRED_SUBGROUP_SIZE_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineShaderStageRequiredSubgroupSizeCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INLINE_UNIFORM_BLOCK_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceInlineUniformBlockProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_INLINE_UNIFORM_BLOCK:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkWriteDescriptorSetInlineUniformBlock *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_INLINE_UNIFORM_BLOCK_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDescriptorPoolInlineUniformBlockCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXTURE_COMPRESSION_ASTC_HDR_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTextureCompressionASTCHDRFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRenderingCreateInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderingInfo *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductFeatures *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_DOT_PRODUCT_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerDotProductProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentProperties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_3:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkFormatProperties3 *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_FEATURES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Features *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_4_PROPERTIES:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance4Properties *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_SWAPCHAIN_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageSwapchainCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_SWAPCHAIN_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBindImageMemorySwapchainInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupPresentInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_GROUP_SWAPCHAIN_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceGroupSwapchainCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DISPLAY_PRESENT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDisplayPresentInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_QUERY_RESULT_STATUS_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueueFamilyQueryResultStatusPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_VIDEO_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueueFamilyVideoPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoProfileInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_PROFILE_LIST_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoProfileListInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeCapabilitiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_USAGE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeUsageInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PROFILE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264ProfileInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264CapabilitiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersAddInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264SessionParametersCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_PICTURE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264PictureInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_DPB_SLOT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH264DpbSlotInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderingFragmentShadingRateAttachmentInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDERING_FRAGMENT_DENSITY_MAP_ATTACHMENT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderingFragmentDensityMapAttachmentInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ATTACHMENT_SAMPLE_COUNT_INFO_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAttachmentSampleCountInfoAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_ATTRIBUTES_INFO_NVX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMultiviewPerViewAttributesInfoNVX *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoKHR *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_FD_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryFdInfoKHR *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportSemaphoreWin32HandleInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_D3D12_FENCE_SUBMIT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkD3D12FenceSubmitInfoKHR *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PUSH_DESCRIPTOR_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePushDescriptorPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PRESENT_REGIONS_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPresentRegionsKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SHARED_PRESENT_SURFACE_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSharedPresentSurfaceCapabilitiesKHR *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_EXPORT_FENCE_WIN32_HANDLE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportFenceWin32HandleInfoKHR *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PERFORMANCE_QUERY_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePerformanceQueryPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueryPoolPerformanceCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PERFORMANCE_QUERY_SUBMIT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPerformanceQuerySubmitInfoKHR *>(header);
+            break;
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PORTABILITY_SUBSET_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePortabilitySubsetPropertiesKHR *>(header);
+            break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CLOCK_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderClockFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PROFILE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265ProfileInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265CapabilitiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersAddInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265SessionParametersCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_PICTURE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265PictureInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_DPB_SLOT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoDecodeH265DpbSlotInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_QUEUE_GLOBAL_PRIORITY_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceQueueGlobalPriorityCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GLOBAL_PRIORITY_QUERY_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceGlobalPriorityQueryFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_GLOBAL_PRIORITY_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueueFamilyGlobalPriorityPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_FRAGMENT_SHADING_RATE_ATTACHMENT_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkFragmentShadingRateAttachmentInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_STATE_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateStateCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRatePropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_PROTECTED_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfaceProtectedCapabilitiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_WAIT_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePresentWaitFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_EXECUTABLE_PROPERTIES_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineExecutablePropertiesFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineLibraryCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PRESENT_ID_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPresentIdKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_ID_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePresentIdFeaturesKHR *>(header);
+            break;
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_CAPABILITIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeCapabilitiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUERY_POOL_VIDEO_ENCODE_FEEDBACK_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueryPoolVideoEncodeFeedbackCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_USAGE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeUsageInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeRateControlInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeQualityLevelInfoKHR *>(header);
+            break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_2_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueueFamilyCheckpointProperties2NV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderBarycentricPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SUBGROUP_UNIFORM_CONTROL_FLOW_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSubgroupUniformControlFlowFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_WORKGROUP_MEMORY_EXPLICIT_LAYOUT_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceWorkgroupMemoryExplicitLayoutFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MAINTENANCE_1_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5FeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MAINTENANCE_5_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMaintenance5PropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_CREATE_FLAGS_2_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCreateFlags2CreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBufferUsageFlags2CreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_POSITION_FETCH_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPositionFetchFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_DIVISOR_STATE_CREATE_INFO_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineVertexInputDivisorStateCreateInfoKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDebugReportCallbackCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationStateRasterizationOrderAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_IMAGE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDedicatedAllocationImageCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_BUFFER_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDedicatedAllocationBufferCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDedicatedAllocationMemoryAllocateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TRANSFORM_FEEDBACK_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTransformFeedbackPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationStateStreamCreateInfoEXT *>(header);
+            break;
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_CAPABILITIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264CapabilitiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_QUALITY_LEVEL_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264QualityLevelPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264SessionCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersAddInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_GET_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersGetInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_FEEDBACK_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264SessionParametersFeedbackInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264PictureInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_DPB_SLOT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264DpbSlotInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PROFILE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264ProfileInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_RATE_CONTROL_LAYER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264RateControlLayerInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_GOP_REMAINING_FRAME_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH264GopRemainingFrameInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_CAPABILITIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265CapabilitiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265SessionCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_QUALITY_LEVEL_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265QualityLevelPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersAddInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_GET_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersGetInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_FEEDBACK_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265SessionParametersFeedbackInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PICTURE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265PictureInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_DPB_SLOT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265DpbSlotInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_PROFILE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265ProfileInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_RATE_CONTROL_LAYER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265RateControlLayerInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_GOP_REMAINING_FRAME_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkVideoEncodeH265GopRemainingFrameInfoEXT *>(header);
+            break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_TEXTURE_LOD_GATHER_FORMAT_PROPERTIES_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkTextureLODGatherFormatPropertiesAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CORNER_SAMPLED_IMAGE_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCornerSampledImageFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_IMAGE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalMemoryImageCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_ALLOCATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMemoryAllocateInfoNV *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_WIN32_HANDLE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryWin32HandleInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_MEMORY_WIN32_HANDLE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMemoryWin32HandleInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_WIN32_KEYED_MUTEX_ACQUIRE_RELEASE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkWin32KeyedMutexAcquireReleaseInfoNV *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_VALIDATION_FLAGS_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkValidationFlagsEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_ASTC_DECODE_MODE_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageViewASTCDecodeModeEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ASTC_DECODE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceASTCDecodeFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_ROBUSTNESS_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineRobustnessPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_ROBUSTNESS_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRobustnessCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONDITIONAL_RENDERING_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceConditionalRenderingFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_CONDITIONAL_RENDERING_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkCommandBufferInheritanceConditionalRenderingInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_W_SCALING_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportWScalingStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_COUNTER_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainCounterCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PRESENT_TIMES_INFO_GOOGLE:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPresentTimesInfoGOOGLE *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_ATTRIBUTES_PROPERTIES_NVX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewAttributesPropertiesNVX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SWIZZLE_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportSwizzleStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISCARD_RECTANGLE_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDiscardRectanglePropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_DISCARD_RECTANGLE_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineDiscardRectangleStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CONSERVATIVE_RASTERIZATION_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceConservativeRasterizationPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationConservativeStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_ENABLE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipEnableFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationDepthClipStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RELAXED_LINE_RASTERIZATION_FEATURES_IMG:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRelaxedLineRasterizationFeaturesIMG *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDebugUtilsObjectNameInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDebugUtilsMessengerCreateInfoEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_USAGE_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAndroidHardwareBufferUsageANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatPropertiesANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_ANDROID_HARDWARE_BUFFER_INFO_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportAndroidHardwareBufferInfoANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalFormatANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_PROPERTIES_2_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatProperties2ANDROID *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_FEATURES_AMDX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueueFeaturesAMDX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ENQUEUE_PROPERTIES_AMDX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEnqueuePropertiesAMDX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineShaderStageNodeCreateInfoAMDX *>(header);
+            break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSampleLocationsInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_SAMPLE_LOCATIONS_BEGIN_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassSampleLocationsBeginInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_SAMPLE_LOCATIONS_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineSampleLocationsStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SAMPLE_LOCATIONS_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSampleLocationsPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BLEND_OPERATION_ADVANCED_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_ADVANCED_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineColorBlendAdvancedStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_TO_COLOR_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCoverageToColorStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_MODULATION_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCoverageModulationStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_SM_BUILTINS_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderSMBuiltinsFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesListEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_DRM_FORMAT_MODIFIER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageDrmFormatModifierInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_LIST_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageDrmFormatModifierListCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_EXPLICIT_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageDrmFormatModifierExplicitCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DRM_FORMAT_MODIFIER_PROPERTIES_LIST_2_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDrmFormatModifierPropertiesList2EXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SHADER_MODULE_VALIDATION_CACHE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkShaderModuleValidationCacheCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_SHADING_RATE_IMAGE_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportShadingRateImageStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImageFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADING_RATE_IMAGE_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShadingRateImagePropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_COARSE_SAMPLE_ORDER_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportCoarseSampleOrderStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_REPRESENTATIVE_FRAGMENT_TEST_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRepresentativeFragmentTestFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_REPRESENTATIVE_FRAGMENT_TEST_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRepresentativeFragmentTestStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_IMAGE_FORMAT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewImageFormatInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_FILTER_CUBIC_IMAGE_VIEW_IMAGE_FORMAT_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkFilterCubicImageViewImageFormatPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_HOST_POINTER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryHostPointerInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_HOST_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryHostPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COMPILER_CONTROL_CREATE_INFO_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCompilerControlCreateInfoAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_MEMORY_OVERALLOCATION_CREATE_INFO_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceMemoryOverallocationCreateInfoAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_ATTRIBUTE_DIVISOR_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_GGP
+        case VK_STRUCTURE_TYPE_PRESENT_FRAME_TOKEN_GGP:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPresentFrameTokenGGP *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_GGP
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COMPUTE_SHADER_DERIVATIVES_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceComputeShaderDerivativesFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_FOOTPRINT_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageFootprintFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_EXCLUSIVE_SCISSOR_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportExclusiveScissorStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXCLUSIVE_SCISSOR_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExclusiveScissorFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUEUE_FAMILY_CHECKPOINT_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueueFamilyCheckpointPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_INTEGER_FUNCTIONS_2_FEATURES_INTEL:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderIntegerFunctions2FeaturesINTEL *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_QUERY_CREATE_INFO_INTEL:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueryPoolPerformanceQueryCreateInfoINTEL *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PCI_BUS_INFO_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePCIBusInfoPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DISPLAY_NATIVE_HDR_SURFACE_CAPABILITIES_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDisplayNativeHdrSurfaceCapabilitiesAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_DISPLAY_NATIVE_HDR_CREATE_INFO_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainDisplayNativeHdrCreateInfoAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_FRAGMENT_DENSITY_MAP_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassFragmentDensityMapCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_2_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreProperties2AMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COHERENT_MEMORY_FEATURES_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCoherentMemoryFeaturesAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_IMAGE_ATOMIC_INT64_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderImageAtomicInt64FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_BUDGET_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryBudgetPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PRIORITY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryPriorityFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MEMORY_PRIORITY_ALLOCATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMemoryPriorityAllocateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEDICATED_ALLOCATION_IMAGE_ALIASING_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDedicatedAllocationImageAliasingFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BUFFER_DEVICE_ADDRESS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceBufferDeviceAddressFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBufferDeviceAddressCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkValidationFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COOPERATIVE_MATRIX_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCooperativeMatrixPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COVERAGE_REDUCTION_MODE_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCoverageReductionModeFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COVERAGE_REDUCTION_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineCoverageReductionStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_INTERLOCK_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShaderInterlockFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_IMAGE_ARRAYS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrImageArraysFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROVOKING_VERTEX_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceProvokingVertexPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationProvokingVertexStateCreateInfoEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_FULL_SCREEN_EXCLUSIVE_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfaceCapabilitiesFullScreenExclusiveEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfaceFullScreenExclusiveWin32InfoEXT *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_WIN32_KHR
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINE_RASTERIZATION_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceLineRasterizationPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineRasterizationLineStateCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloatFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INDEX_TYPE_UINT8_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceIndexTypeUint8FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicStateFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_HOST_IMAGE_COPY_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceHostImageCopyPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SUBRESOURCE_HOST_MEMCPY_SIZE_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSubresourceHostMemcpySizeEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_HOST_IMAGE_COPY_DEVICE_PERFORMANCE_QUERY_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkHostImageCopyDevicePerformanceQueryEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_ATOMIC_FLOAT_2_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderAtomicFloat2FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfacePresentModeEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_SCALING_CAPABILITIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfacePresentScalingCapabilitiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_PRESENT_MODE_COMPATIBILITY_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfacePresentModeCompatibilityEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SWAPCHAIN_MAINTENANCE_1_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSwapchainMaintenance1FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_FENCE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainPresentFenceInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODES_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainPresentModesCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_MODE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainPresentModeInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_SCALING_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainPresentScalingCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_SHADER_GROUPS_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkGraphicsPipelineShaderGroupsCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INHERITED_VIEWPORT_SCISSOR_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceInheritedViewportScissorFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_VIEWPORT_SCISSOR_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkCommandBufferInheritanceViewportScissorInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TEXEL_BUFFER_ALIGNMENT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTexelBufferAlignmentFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_TRANSFORM_BEGIN_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassTransformBeginInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDER_PASS_TRANSFORM_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkCommandBufferInheritanceRenderPassTransformInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_BIAS_CONTROL_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDepthBiasControlFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDepthBiasRepresentationInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_MEMORY_REPORT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceMemoryReportFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_DEVICE_MEMORY_REPORT_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceDeviceMemoryReportCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ROBUSTNESS_2_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRobustness2PropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_CUSTOM_BORDER_COLOR_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerCustomBorderColorCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUSTOM_BORDER_COLOR_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCustomBorderColorFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRESENT_BARRIER_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePresentBarrierFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_PRESENT_BARRIER_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSurfaceCapabilitiesPresentBarrierNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_PRESENT_BARRIER_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainPresentBarrierCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DIAGNOSTICS_CONFIG_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDiagnosticsConfigFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_DIAGNOSTICS_CONFIG_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceDiagnosticsConfigCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUDA_KERNEL_LAUNCH_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCudaKernelLaunchPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_QUERY_LOW_LATENCY_SUPPORT_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkQueryLowLatencySupportNV *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_METAL_EXT
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalObjectCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_DEVICE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalDeviceInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_COMMAND_QUEUE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalCommandQueueInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalBufferInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_BUFFER_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMetalBufferInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_TEXTURE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalTextureInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_TEXTURE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMetalTextureInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_IO_SURFACE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMetalIOSurfaceInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXPORT_METAL_SHARED_EVENT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExportMetalSharedEventInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_METAL_SHARED_EVENT_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMetalSharedEventInfoEXT *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_METAL_EXT
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_DENSITY_MAP_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorBufferFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_PUSH_DESCRIPTOR_BUFFER_HANDLE_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDescriptorBufferBindingPushDescriptorBufferHandleEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_OPAQUE_CAPTURE_DESCRIPTOR_DATA_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkOpaqueCaptureDescriptorDataCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GRAPHICS_PIPELINE_LIBRARY_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceGraphicsPipelineLibraryPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_LIBRARY_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkGraphicsPipelineLibraryCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_EARLY_AND_LATE_FRAGMENT_TESTS_FEATURES_AMD:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderEarlyAndLateFragmentTestsFeaturesAMD *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_ENUMS_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentShadingRateEnumsPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_FRAGMENT_SHADING_RATE_ENUM_STATE_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineFragmentShadingRateEnumStateCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_MOTION_TRIANGLES_DATA_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAccelerationStructureGeometryMotionTrianglesDataNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MOTION_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAccelerationStructureMotionInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_MOTION_BLUR_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingMotionBlurFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_2_PLANE_444_FORMATS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcr2Plane444FormatsFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_2_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMap2PropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_COPY_COMMAND_TRANSFORM_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkCopyCommandTransformInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_CONTROL_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageCompressionControlEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageCompressionPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_LAYOUT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopLayoutFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_4444_FORMATS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevice4444FormatsFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FAULT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFaultFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRasterizationOrderAttachmentAccessFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RGBA10X6_FORMATS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRGBA10X6FormatsFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MUTABLE_DESCRIPTOR_TYPE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMutableDescriptorTypeFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MUTABLE_DESCRIPTOR_TYPE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMutableDescriptorTypeCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VERTEX_INPUT_DYNAMIC_STATE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceVertexInputDynamicStateFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDrmPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ADDRESS_BINDING_REPORT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAddressBindingReportFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_ADDRESS_BINDING_CALLBACK_DATA_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceAddressBindingCallbackDataEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLIP_CONTROL_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClipControlFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_DEPTH_CLIP_CONTROL_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineViewportDepthClipControlCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVE_TOPOLOGY_LIST_RESTART_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_FUCHSIA
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_ZIRCON_HANDLE_INFO_FUCHSIA:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryZirconHandleInfoFUCHSIA *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_MEMORY_BUFFER_COLLECTION_FUCHSIA:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportMemoryBufferCollectionFUCHSIA *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBufferCollectionImageCreateInfoFUCHSIA *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBufferCollectionBufferCreateInfoFUCHSIA *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_FUCHSIA
+        case VK_STRUCTURE_TYPE_SUBPASS_SHADING_PIPELINE_CREATE_INFO_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSubpassShadingPipelineCreateInfoHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_FEATURES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingFeaturesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_SHADING_PROPERTIES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassShadingPropertiesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_INVOCATION_MASK_FEATURES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceInvocationMaskFeaturesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_RDMA_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryRDMAFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROPERTIES_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelinePropertiesFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAME_BOUNDARY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFrameBoundaryFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkFrameBoundaryEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SUBPASS_RESOLVE_PERFORMANCE_QUERY_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSubpassResolvePerformanceQueryEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMultisampledRenderToSingleSampledInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_2_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState2FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COLOR_WRITE_ENABLE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceColorWriteEnableFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_COLOR_WRITE_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineColorWriteCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PRIMITIVES_GENERATED_QUERY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePrimitivesGeneratedQueryFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_VIEW_MIN_LOD_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageViewMinLodFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_MIN_LOD_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageViewMinLodCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTI_DRAW_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiDrawPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_2D_VIEW_OF_3D_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImage2DViewOf3DFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImageFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_TILE_IMAGE_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderTileImagePropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceOpacityMicromapPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesOpacityMicromapEXT *>(header);
+            break;
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DISPLACEMENT_MICROMAP_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDisplacementMicromapPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_DISPLACEMENT_MICROMAP_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAccelerationStructureTrianglesDisplacementMicromapNV *>(header);
+            break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_FEATURES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderFeaturesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_PROPERTIES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderPropertiesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CLUSTER_CULLING_SHADER_VRS_FEATURES_HUAWEI:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceClusterCullingShaderVrsFeaturesHUAWEI *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_BORDER_COLOR_SWIZZLE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceBorderColorSwizzleFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_BORDER_COLOR_COMPONENT_MAPPING_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerBorderColorComponentMappingCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PAGEABLE_DEVICE_LOCAL_MEMORY_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePageableDeviceLocalMemoryFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_PROPERTIES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCorePropertiesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DEVICE_QUEUE_SHADER_CORE_CONTROL_CREATE_INFO_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDeviceQueueShaderCoreControlCreateInfoARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_FEATURES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsFeaturesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SCHEDULING_CONTROLS_PROPERTIES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSchedulingControlsPropertiesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_SLICED_VIEW_OF_3D_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_SLICED_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageViewSlicedCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_SET_HOST_MAPPING_FEATURES_VALVE:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorSetHostMappingFeaturesVALVE *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEPTH_CLAMP_ZERO_ONE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDepthClampZeroOneFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NON_SEAMLESS_CUBE_MAP_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceNonSeamlessCubeMapFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_FEATURES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedFeaturesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RENDER_PASS_STRIPED_PROPERTIES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRenderPassStripedPropertiesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_BEGIN_INFO_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassStripeBeginInfoARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_SUBMIT_INFO_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassStripeSubmitInfoARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_DENSITY_MAP_OFFSET_PROPERTIES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceFragmentDensityMapOffsetPropertiesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SUBPASS_FRAGMENT_DENSITY_MAP_OFFSET_END_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSubpassFragmentDensityMapOffsetEndInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_COPY_MEMORY_INDIRECT_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCopyMemoryIndirectPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_DECOMPRESSION_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMemoryDecompressionPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DEVICE_GENERATED_COMMANDS_COMPUTE_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDeviceGeneratedCommandsComputeFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LINEAR_COLOR_ATTACHMENT_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceLinearColorAttachmentFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_COMPRESSION_CONTROL_SWAPCHAIN_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageCompressionControlSwapchainFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMAGE_VIEW_SAMPLE_WEIGHT_CREATE_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImageViewSampleWeightCreateInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_PROPERTIES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessingPropertiesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_NESTED_COMMAND_BUFFER_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceNestedCommandBufferPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_MEMORY_ACQUIRE_UNMODIFIED_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalMemoryAcquireUnmodifiedEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3FeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_DYNAMIC_STATE_3_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedDynamicState3PropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SUBPASS_MERGE_FEEDBACK_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceSubpassMergeFeedbackFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_CONTROL_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassCreationControlEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_CREATION_FEEDBACK_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassCreationFeedbackCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_RENDER_PASS_SUBPASS_FEEDBACK_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkRenderPassSubpassFeedbackCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_LIST_LUNARG:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkDirectDriverLoadingListLUNARG *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_MODULE_IDENTIFIER_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderModuleIdentifierPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_MODULE_IDENTIFIER_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPipelineShaderStageModuleIdentifierCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPTICAL_FLOW_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceOpticalFlowPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkOpticalFlowImageFormatInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_PRIVATE_DATA_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkOpticalFlowSessionCreatePrivateDataInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LEGACY_DITHERING_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceLegacyDitheringFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_PROTECTED_ACCESS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineProtectedAccessFeaturesEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_FEATURES_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolveFeaturesANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FORMAT_RESOLVE_PROPERTIES_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalFormatResolvePropertiesANDROID *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_FORMAT_RESOLVE_PROPERTIES_ANDROID:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAndroidHardwareBufferFormatResolvePropertiesANDROID *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_OBJECT_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderObjectPropertiesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TILE_PROPERTIES_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceTilePropertiesFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_AMIGO_PROFILING_FEATURES_SEC:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAmigoProfilingFeaturesSEC *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_AMIGO_PROFILING_SUBMIT_INFO_SEC:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkAmigoProfilingSubmitInfoSEC *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_VIEWPORTS_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewViewportsFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderPropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_INVOCATION_REORDER_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingInvocationReorderFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpaceFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTENDED_SPARSE_ADDRESS_SPACE_PROPERTIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExtendedSparseAddressSpacePropertiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkLayerSettingsCreateInfoEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_FEATURES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SHADER_CORE_BUILTINS_PROPERTIES_ARM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceShaderCoreBuiltinsPropertiesARM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PIPELINE_LIBRARY_GROUP_HANDLES_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DYNAMIC_RENDERING_UNUSED_ATTACHMENTS_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDynamicRenderingUnusedAttachmentsFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_LATENCY_SUBMISSION_PRESENT_ID_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkLatencySubmissionPresentIdNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SWAPCHAIN_LATENCY_CREATE_INFO_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSwapchainLatencyCreateInfoNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_LATENCY_SURFACE_CAPABILITIES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkLatencySurfaceCapabilitiesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MULTIVIEW_PER_VIEW_RENDER_AREAS_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMultiviewPerViewRenderAreasFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_MULTIVIEW_PER_VIEW_RENDER_AREAS_RENDER_PASS_BEGIN_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkMultiviewPerViewRenderAreasRenderPassBeginInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2FeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_PROCESSING_2_PROPERTIES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceImageProcessing2PropertiesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_BLOCK_MATCH_WINDOW_CREATE_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerBlockMatchWindowCreateInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_WEIGHTS_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCubicWeightsFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_CUBIC_WEIGHTS_CREATE_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerCubicWeightsCreateInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkBlitImageCubicWeightsInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_YCBCR_DEGAMMA_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceYcbcrDegammaFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_YCBCR_DEGAMMA_CREATE_INFO_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkSamplerYcbcrConversionYcbcrDegammaCreateInfoQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_CUBIC_CLAMP_FEATURES_QCOM:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceCubicClampFeaturesQCOM *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ATTACHMENT_FEEDBACK_LOOP_DYNAMIC_STATE_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAttachmentFeedbackLoopDynamicStateFeaturesEXT *>(header);
+            break;
+#ifdef VK_USE_PLATFORM_SCREEN_QNX
+        case VK_STRUCTURE_TYPE_SCREEN_BUFFER_FORMAT_PROPERTIES_QNX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkScreenBufferFormatPropertiesQNX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_IMPORT_SCREEN_BUFFER_INFO_QNX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkImportScreenBufferInfoQNX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_EXTERNAL_FORMAT_QNX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkExternalFormatQNX *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_MEMORY_SCREEN_BUFFER_FEATURES_QNX:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceExternalMemoryScreenBufferFeaturesQNX *>(header);
+            break;
+#endif  // VK_USE_PLATFORM_SCREEN_QNX
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_LAYERED_DRIVER_PROPERTIES_MSFT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceLayeredDriverPropertiesMSFT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_POOL_OVERALLOCATION_FEATURES_NV:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceDescriptorPoolOverallocationFeaturesNV *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET_ACCELERATION_STRUCTURE_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkWriteDescriptorSetAccelerationStructureKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructureFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceAccelerationStructurePropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelineFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayTracingPipelinePropertiesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_QUERY_FEATURES_KHR:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceRayQueryFeaturesKHR *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderFeaturesEXT *>(header);
+            break;
+        case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT:
+            PnextChainFree(header->pNext);
+            header->pNext = nullptr;
+            delete reinterpret_cast<const VkPhysicalDeviceMeshShaderPropertiesEXT *>(header);
+            break;
+        default:
+            assert(false);
+            break;
+    }
+}
+
 template <>
 void *PnextChainExtract(const void *in_pnext_chain, PnextChainVkPhysicalDeviceImageFormatInfo2 &out) {
     void *chain_begin = nullptr;

--- a/layers/vulkan/generated/pnext_chain_extraction.h
+++ b/layers/vulkan/generated/pnext_chain_extraction.h
@@ -37,6 +37,9 @@ void *PnextChainAdd(void *chain, void *new_struct);
 // Remove last element from a pNext chain
 void PnextChainRemoveLast(void *chain);
 
+// Free dynamically allocated pnext chain structs
+void PnextChainFree(void *chain);
+
 // Helper class relying on RAII to help with adding and removing an element from a pNext chain
 class PnextChainScopedAdd {
   public:

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -70,6 +70,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
     from generators.error_location_helper_generator import ErrorLocationHelperOutputGenerator
     from generators.pnext_chain_extraction_generator import PnextChainExtractionGenerator
     from generators.state_tracker_helper_generator import StateTrackerHelperOutputGenerator
+    from generators.feature_requirements import FeatureRequirementsGenerator
 
     # These set fields that are needed by both OutputGenerator and BaseGenerator,
     # but are uniform and don't need to be set at a per-generated file level
@@ -276,6 +277,14 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
         },
         'state_tracker_helper.cpp' : {
             'generator' : StateTrackerHelperOutputGenerator,
+            'genCombined': True,
+        },
+        'feature_requirements_helper.h' : {
+            'generator' : FeatureRequirementsGenerator,
+            'genCombined': True,
+        },
+        'feature_requirements_helper.cpp' : {
+            'generator' : FeatureRequirementsGenerator,
             'genCombined': True,
         },
     }

--- a/scripts/generators/feature_requirements.py
+++ b/scripts/generators/feature_requirements.py
@@ -1,0 +1,220 @@
+#!/usr/bin/python3 -i
+#
+# Copyright (c) 2015-2023 The Khronos Group Inc.
+# Copyright (c) 2015-2023 Valve Corporation
+# Copyright (c) 2015-2023 LunarG, Inc.
+# Copyright (c) 2015-2023 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from generators.base_generator import BaseGenerator
+from generators.generator_utils import PlatformGuardHelper
+
+class FeatureRequirementsGenerator(BaseGenerator):
+    def __init__(self):
+        BaseGenerator.__init__(self)
+        
+        # Features of the VkPhysicalDeviceBufferDeviceAddressFeaturesEXT have
+        # the same name as Vulkan 1.2 and
+        # VkPhysicalDeviceBufferDeviceAddressFeaturesKHR features, but are
+        # semantically different.  They are given a suffix to be distinguished.
+        self.identical_but_different_features = {
+            'VkPhysicalDeviceBufferDeviceAddressFeaturesEXT',
+        }
+        
+    def generate(self):
+        out = []
+        out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+            // See {os.path.basename(__file__)} for modifications
+
+            /***************************************************************************
+            *
+            * Copyright (c) 2023 The Khronos Group Inc.
+            * Copyright (c) 2023 Valve Corporation
+            * Copyright (c) 2023 LunarG, Inc.
+            *
+            * Licensed under the Apache License, Version 2.0 (the "License");
+            * you may not use this file except in compliance with the License.
+            * You may obtain a copy of the License at
+            *
+            *     http://www.apache.org/licenses/LICENSE-2.0
+            *
+            * Unless required by applicable law or agreed to in writing, software
+            * distributed under the License is distributed on an "AS IS" BASIS,
+            * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+            * See the License for the specific language governing permissions and
+            * limitations under the License.
+            ****************************************************************************/\n\n''')
+        out.append('// NOLINTBEGIN\n\n') # Wrap for clang-tidy to ignore
+
+        if self.filename == 'feature_requirements_helper.h':
+            out.append(self.generateHeader())
+        elif self.filename == 'feature_requirements_helper.cpp':
+            out.append(self.generateSource())
+        else:
+            out.append(f'\nFile name {self.filename} has no code to generate\n')
+
+        out.append('\n// NOLINTEND') # Wrap for clang-tidy to ignore
+        self.write("".join(out))
+        
+    def getFeaturesAndOrigins(self) -> dict:
+        # Get all Vulkan Physical Device Features 
+        featureMap = dict()
+        feature_structs = self.vk.structs['VkPhysicalDeviceFeatures2'].extendedBy
+        feature_structs.append('VkPhysicalDeviceFeatures')
+        for extending_struct_name in feature_structs:
+            if extending_struct_name in self.identical_but_different_features:
+                continue
+            extending_struct = self.vk.structs[extending_struct_name]
+            
+            for feature in extending_struct.members:
+                if feature.type == 'VkBool32':
+                    if feature.name not in featureMap:
+                        featureMap[feature.name] = set()
+                    featureMap[feature.name].add(extending_struct_name)
+
+        # Generate a comment for every feature regarding where it may be coming from, then sort the
+        # features by that comment.  That ensures features of the same struct end up together.
+        featuresAndOrigins = sorted([(sorted(structs), feature)
+                                     for feature, structs in featureMap.items()])
+        
+        return featuresAndOrigins
+
+    def generateHeader(self):
+        out = []
+        out.append('''
+            #include "vk_api_version.h"
+
+            #include <vulkan/vulkan.h>   
+
+            namespace vkt {                                                      
+        ''')
+
+        # Physical device features enum
+        out.append('enum class Feature {\n')
+        for origins, feature in self.getFeaturesAndOrigins():
+            out.append(f'// {", ".join(origins)}\n')
+            out.append(f'{feature},\n')
+        out.append('};\n')
+        
+        # Functions declarations
+        out.append('''
+            struct FeatureAndName {
+                VkBool32 *feature;
+                const char *name;
+            };
+                   
+            // Find or add the correct VkPhysicalDeviceFeature struct in `pnext_chain` based on `feature`, 
+            // a vkt::Feature enum value, and set feature to VK_TRUE
+            FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain);
+            
+            }// namespace vkt
+        ''')
+        return "".join(out)
+    
+    # Find the Vulkan version in a VkPhysicalDeviceVulkan<N>Features struct
+    def getApiVersion(self, structs):
+        if structs.find('11') != -1:
+            return 'VK_API_VERSION_1_2'
+        if structs.find('12') != -1:
+            return 'VK_API_VERSION_1_2'
+        if structs.find('13') != -1:
+            return 'VK_API_VERSION_1_3'
+        else:
+            assert False 
+
+    def generateSource(self):
+        out = []
+        out.append('#include "generated/feature_requirements_helper.h"\n\n')
+        out.append('#include "generated/pnext_chain_extraction.h"\n\n')
+        out.append('#include <vulkan/utility/vk_struct_helper.hpp>\n\n')
+        out.append('namespace vkt {')
+
+        # AddFeature
+        guard_helper = PlatformGuardHelper()
+        out.append('FeatureAndName AddFeature(APIVersion api_version, vkt::Feature feature, void **inout_pnext_chain) {\n')
+        out.append('switch(feature) {\n')
+        for origins, feature in self.getFeaturesAndOrigins():
+            # Skip VkPhysicalDeviceFeatures, handled by hand
+            if len(origins) == 1 and origins[0] == 'VkPhysicalDeviceFeatures':
+                continue
+            vulkan_feature_struct_i = -1
+            for i,s in enumerate(origins):
+                if s.find('Vulkan') != -1:
+                    vulkan_feature_struct_i = i
+                    break
+            if len(origins) == 1 or vulkan_feature_struct_i == -1:
+                    feature_struct_name = origins[0]    
+                    out.extend(guard_helper.add_guard(self.vk.structs[feature_struct_name].protect))
+                    out.append(f''' case Feature::{feature}: {{
+                        auto vk_struct = const_cast<{feature_struct_name} *>(vku::FindStructInPNextChain<{feature_struct_name}>(*inout_pnext_chain));
+                        if (!vk_struct) {{
+                            vk_struct = new {feature_struct_name};
+                            *vk_struct = vku::InitStructHelper();
+                            if (*inout_pnext_chain) {{
+                                vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+                            }} else {{
+                                *inout_pnext_chain = vk_struct;
+                            }} 
+                        }}
+                        return {{&vk_struct->{feature}, "{feature_struct_name}::{feature}"}};
+                        }}
+                        ''')
+                    out.extend(guard_helper.add_guard(None))
+            else:
+                assert len(origins) == 2
+                api_struct_name = origins[vulkan_feature_struct_i]
+                feature_struct_name = origins[1 - vulkan_feature_struct_i]
+                ref_api_version = self.getApiVersion(api_struct_name)
+                out.extend(guard_helper.add_guard(self.vk.structs[feature_struct_name].protect))
+                out.append(f'''
+case Feature::{feature}: 
+    if (api_version >= {ref_api_version}) {{
+        auto vk_struct = const_cast<{api_struct_name} *>(vku::FindStructInPNextChain<{api_struct_name}>(*inout_pnext_chain));
+        if (!vk_struct) {{
+            vk_struct = new {api_struct_name};
+            *vk_struct = vku::InitStructHelper();
+            if (*inout_pnext_chain) {{
+                vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+            }} else {{
+                *inout_pnext_chain = vk_struct;
+            }} 
+        }}
+        return {{&vk_struct->{feature}, "{api_struct_name}::{feature}"}};
+    }} else {{
+        auto vk_struct = const_cast<{feature_struct_name} *>(vku::FindStructInPNextChain<{feature_struct_name}>(*inout_pnext_chain));
+        if (!vk_struct) {{
+            vk_struct = new {feature_struct_name};
+            *vk_struct = vku::InitStructHelper();
+            if (*inout_pnext_chain) {{
+                vvl::PnextChainAdd(*inout_pnext_chain, vk_struct);
+            }} else {{
+                *inout_pnext_chain = vk_struct;
+            }} 
+        }}
+        return {{&vk_struct->{feature}, "{feature_struct_name}::{feature}"}};
+    }}''')
+                out.extend(guard_helper.add_guard(None))
+
+        out.append('''default:
+            assert(false);
+            return {nullptr, ""};
+            }''')
+        
+        out.append('}\n')
+            
+        out.append('}// namespace vkt')
+
+        return "".join(out)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     framework/gpu_av_helper.h
     framework/render_pass_helper.h
     framework/render_pass_helper.cpp
+    framework/feature_requirements.h
+    framework/feature_requirements.cpp
     framework/queue_submit_context.h
     framework/queue_submit_context.cpp
     unit/amd_best_practices.cpp

--- a/tests/framework/feature_requirements.cpp
+++ b/tests/framework/feature_requirements.cpp
@@ -1,0 +1,370 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/feature_requirements.h"
+
+#include "generated/pnext_chain_extraction.h"
+
+#include <vulkan/utility/vk_struct_helper.hpp>
+
+namespace vkt {
+
+FeatureRequirements::~FeatureRequirements() {
+    vvl::PnextChainFree(feature_chain_);
+    feature_chain_ = nullptr;
+}
+
+void FeatureRequirements::AddRequiredFeature(APIVersion api_version, vkt::Feature feature) {
+    SetFeature(api_version, feature, VK_TRUE);
+}
+
+void FeatureRequirements::AddDisabledFeature(APIVersion api_version, vkt::Feature feature) {
+    SetFeature(api_version, feature, VK_FALSE);
+}
+
+vkt::FeatureAndName FeatureRequirements::SetFeature(APIVersion api_version, vkt::Feature feature, VkBool32 value) {
+    switch (feature) {
+        case vkt::Feature::robustBufferAccess: {
+            phys_dev_features_.features.robustBufferAccess = value;
+            FeatureAndName f{&phys_dev_features_.features.robustBufferAccess, "VkPhysicalDeviceFeatures::robustBufferAccess"};
+            return f;
+        }
+        case vkt::Feature::fullDrawIndexUint32: {
+            phys_dev_features_.features.fullDrawIndexUint32 = value;
+            FeatureAndName f{&phys_dev_features_.features.fullDrawIndexUint32, "VkPhysicalDeviceFeatures::fullDrawIndexUint32"};
+            return f;
+        }
+        case vkt::Feature::imageCubeArray: {
+            phys_dev_features_.features.imageCubeArray = value;
+            FeatureAndName f{&phys_dev_features_.features.imageCubeArray, "VkPhysicalDeviceFeatures::imageCubeArray"};
+            return f;
+        }
+        case vkt::Feature::independentBlend: {
+            phys_dev_features_.features.independentBlend = value;
+            FeatureAndName f{&phys_dev_features_.features.independentBlend, "VkPhysicalDeviceFeatures::independentBlend"};
+            return f;
+        }
+        case vkt::Feature::geometryShader: {
+            phys_dev_features_.features.geometryShader = value;
+            FeatureAndName f{&phys_dev_features_.features.geometryShader, "VkPhysicalDeviceFeatures::geometryShader"};
+            return f;
+        }
+        case vkt::Feature::tessellationShader: {
+            phys_dev_features_.features.tessellationShader = value;
+            FeatureAndName f{&phys_dev_features_.features.tessellationShader, "VkPhysicalDeviceFeatures::tessellationShader"};
+            return f;
+        }
+        case vkt::Feature::sampleRateShading: {
+            phys_dev_features_.features.sampleRateShading = value;
+            FeatureAndName f{&phys_dev_features_.features.sampleRateShading, "VkPhysicalDeviceFeatures::sampleRateShading"};
+            return f;
+        }
+        case vkt::Feature::dualSrcBlend: {
+            phys_dev_features_.features.dualSrcBlend = value;
+            FeatureAndName f{&phys_dev_features_.features.dualSrcBlend, "VkPhysicalDeviceFeatures::dualSrcBlend"};
+            return f;
+        }
+        case vkt::Feature::logicOp: {
+            phys_dev_features_.features.logicOp = value;
+            FeatureAndName f{&phys_dev_features_.features.logicOp, "VkPhysicalDeviceFeatures::logicOp"};
+            return f;
+        }
+        case vkt::Feature::multiDrawIndirect: {
+            phys_dev_features_.features.multiDrawIndirect = value;
+            FeatureAndName f{&phys_dev_features_.features.multiDrawIndirect, "VkPhysicalDeviceFeatures::multiDrawIndirect"};
+            return f;
+        }
+        case vkt::Feature::drawIndirectFirstInstance: {
+            phys_dev_features_.features.drawIndirectFirstInstance = value;
+            FeatureAndName f{&phys_dev_features_.features.drawIndirectFirstInstance,
+                             "VkPhysicalDeviceFeatures::drawIndirectFirstInstance"};
+            return f;
+        }
+        case vkt::Feature::depthClamp: {
+            phys_dev_features_.features.depthClamp = value;
+            FeatureAndName f{&phys_dev_features_.features.depthClamp, "VkPhysicalDeviceFeatures::depthClamp"};
+            return f;
+        }
+        case vkt::Feature::depthBiasClamp: {
+            phys_dev_features_.features.depthBiasClamp = value;
+            FeatureAndName f{&phys_dev_features_.features.depthBiasClamp, "VkPhysicalDeviceFeatures::depthBiasClamp"};
+            return f;
+        }
+        case vkt::Feature::fillModeNonSolid: {
+            phys_dev_features_.features.fillModeNonSolid = value;
+            FeatureAndName f{&phys_dev_features_.features.fillModeNonSolid, "VkPhysicalDeviceFeatures::fillModeNonSolid"};
+            return f;
+        }
+        case vkt::Feature::depthBounds: {
+            phys_dev_features_.features.depthBounds = value;
+            FeatureAndName f{&phys_dev_features_.features.depthBounds, "VkPhysicalDeviceFeatures::depthBounds"};
+            return f;
+        }
+        case vkt::Feature::wideLines: {
+            phys_dev_features_.features.wideLines = value;
+            FeatureAndName f{&phys_dev_features_.features.wideLines, "VkPhysicalDeviceFeatures::wideLines"};
+            return f;
+        }
+        case vkt::Feature::largePoints: {
+            phys_dev_features_.features.largePoints = value;
+            FeatureAndName f{&phys_dev_features_.features.largePoints, "VkPhysicalDeviceFeatures::largePoints"};
+            return f;
+        }
+        case vkt::Feature::alphaToOne: {
+            phys_dev_features_.features.alphaToOne = value;
+            FeatureAndName f{&phys_dev_features_.features.alphaToOne, "VkPhysicalDeviceFeatures::alphaToOne"};
+            return f;
+        }
+        case vkt::Feature::multiViewport: {
+            phys_dev_features_.features.multiViewport = value;
+            FeatureAndName f{&phys_dev_features_.features.multiViewport, "VkPhysicalDeviceFeatures::multiViewport"};
+            return f;
+        }
+        case vkt::Feature::samplerAnisotropy: {
+            phys_dev_features_.features.samplerAnisotropy = value;
+            FeatureAndName f{&phys_dev_features_.features.samplerAnisotropy, "VkPhysicalDeviceFeatures::samplerAnisotropy"};
+            return f;
+        }
+        case vkt::Feature::textureCompressionETC2: {
+            phys_dev_features_.features.textureCompressionETC2 = value;
+            FeatureAndName f{&phys_dev_features_.features.textureCompressionETC2,
+                             "VkPhysicalDeviceFeatures::textureCompressionETC2"};
+            return f;
+        }
+        case vkt::Feature::textureCompressionASTC_LDR: {
+            phys_dev_features_.features.textureCompressionASTC_LDR = value;
+            FeatureAndName f{&phys_dev_features_.features.textureCompressionASTC_LDR,
+                             "VkPhysicalDeviceFeatures::textureCompressionASTC_LDR"};
+            return f;
+        }
+        case vkt::Feature::textureCompressionBC: {
+            phys_dev_features_.features.textureCompressionBC = value;
+            FeatureAndName f{&phys_dev_features_.features.textureCompressionBC, "VkPhysicalDeviceFeatures::textureCompressionBC"};
+            return f;
+        }
+        case vkt::Feature::occlusionQueryPrecise: {
+            phys_dev_features_.features.occlusionQueryPrecise = value;
+            FeatureAndName f{&phys_dev_features_.features.occlusionQueryPrecise, "VkPhysicalDeviceFeatures::occlusionQueryPrecise"};
+            return f;
+        }
+        case vkt::Feature::pipelineStatisticsQuery: {
+            phys_dev_features_.features.pipelineStatisticsQuery = value;
+            FeatureAndName f{&phys_dev_features_.features.pipelineStatisticsQuery,
+                             "VkPhysicalDeviceFeatures::pipelineStatisticsQuery"};
+            return f;
+        }
+        case vkt::Feature::vertexPipelineStoresAndAtomics: {
+            phys_dev_features_.features.vertexPipelineStoresAndAtomics = value;
+            FeatureAndName f{&phys_dev_features_.features.vertexPipelineStoresAndAtomics,
+                             "VkPhysicalDeviceFeatures::vertexPipelineStoresAndAtomics"};
+            return f;
+        }
+        case vkt::Feature::fragmentStoresAndAtomics: {
+            phys_dev_features_.features.fragmentStoresAndAtomics = value;
+            FeatureAndName f{&phys_dev_features_.features.fragmentStoresAndAtomics,
+                             "VkPhysicalDeviceFeatures::fragmentStoresAndAtomics"};
+            return f;
+        }
+        case vkt::Feature::shaderTessellationAndGeometryPointSize: {
+            phys_dev_features_.features.shaderTessellationAndGeometryPointSize = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderTessellationAndGeometryPointSize,
+                             "VkPhysicalDeviceFeatures::shaderTessellationAndGeometryPointSize"};
+            return f;
+        }
+        case vkt::Feature::shaderImageGatherExtended: {
+            phys_dev_features_.features.shaderImageGatherExtended = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderImageGatherExtended,
+                             "VkPhysicalDeviceFeatures::shaderImageGatherExtended"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageImageExtendedFormats: {
+            phys_dev_features_.features.shaderStorageImageExtendedFormats = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageImageExtendedFormats,
+                             "VkPhysicalDeviceFeatures::shaderStorageImageExtendedFormats"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageImageMultisample: {
+            phys_dev_features_.features.shaderStorageImageMultisample = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageImageMultisample,
+                             "VkPhysicalDeviceFeatures::shaderStorageImageMultisample"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageImageReadWithoutFormat: {
+            phys_dev_features_.features.shaderStorageImageReadWithoutFormat = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageImageReadWithoutFormat,
+                             "VkPhysicalDeviceFeatures::shaderStorageImageReadWithoutFormat"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageImageWriteWithoutFormat: {
+            phys_dev_features_.features.shaderStorageImageWriteWithoutFormat = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageImageWriteWithoutFormat,
+                             "VkPhysicalDeviceFeatures::shaderStorageImageWriteWithoutFormat"};
+            return f;
+        }
+        case vkt::Feature::shaderUniformBufferArrayDynamicIndexing: {
+            phys_dev_features_.features.shaderUniformBufferArrayDynamicIndexing = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderUniformBufferArrayDynamicIndexing,
+                             "VkPhysicalDeviceFeatures::shaderUniformBufferArrayDynamicIndexing"};
+            return f;
+        }
+        case vkt::Feature::shaderSampledImageArrayDynamicIndexing: {
+            phys_dev_features_.features.shaderSampledImageArrayDynamicIndexing = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderSampledImageArrayDynamicIndexing,
+                             "VkPhysicalDeviceFeatures::shaderSampledImageArrayDynamicIndexing"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageBufferArrayDynamicIndexing: {
+            phys_dev_features_.features.shaderStorageBufferArrayDynamicIndexing = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageBufferArrayDynamicIndexing,
+                             "VkPhysicalDeviceFeatures::shaderStorageBufferArrayDynamicIndexing"};
+            return f;
+        }
+        case vkt::Feature::shaderStorageImageArrayDynamicIndexing: {
+            phys_dev_features_.features.shaderStorageImageArrayDynamicIndexing = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderStorageImageArrayDynamicIndexing,
+                             "VkPhysicalDeviceFeatures::shaderStorageImageArrayDynamicIndexing"};
+            return f;
+        }
+        case vkt::Feature::shaderClipDistance: {
+            phys_dev_features_.features.shaderClipDistance = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderClipDistance, "VkPhysicalDeviceFeatures::shaderClipDistance"};
+            return f;
+        }
+        case vkt::Feature::shaderCullDistance: {
+            phys_dev_features_.features.shaderCullDistance = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderCullDistance, "VkPhysicalDeviceFeatures::shaderCullDistance"};
+            return f;
+        }
+        case vkt::Feature::shaderFloat64: {
+            phys_dev_features_.features.shaderFloat64 = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderFloat64, "VkPhysicalDeviceFeatures::shaderFloat64"};
+            return f;
+        }
+        case vkt::Feature::shaderInt64: {
+            phys_dev_features_.features.shaderInt64 = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderInt64, "VkPhysicalDeviceFeatures::shaderInt64"};
+            return f;
+        }
+        case vkt::Feature::shaderInt16: {
+            phys_dev_features_.features.shaderInt16 = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderInt16, "VkPhysicalDeviceFeatures::shaderInt16"};
+            return f;
+        }
+        case vkt::Feature::shaderResourceResidency: {
+            phys_dev_features_.features.shaderResourceResidency = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderResourceResidency,
+                             "VkPhysicalDeviceFeatures::shaderResourceResidency"};
+            return f;
+        }
+        case vkt::Feature::shaderResourceMinLod: {
+            phys_dev_features_.features.shaderResourceMinLod = value;
+            FeatureAndName f{&phys_dev_features_.features.shaderResourceMinLod, "VkPhysicalDeviceFeatures::shaderResourceMinLod"};
+            return f;
+        }
+        case vkt::Feature::sparseBinding: {
+            phys_dev_features_.features.sparseBinding = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseBinding, "VkPhysicalDeviceFeatures::sparseBinding"};
+            return f;
+        }
+        case vkt::Feature::sparseResidencyBuffer: {
+            phys_dev_features_.features.sparseResidencyBuffer = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidencyBuffer, "VkPhysicalDeviceFeatures::sparseResidencyBuffer"};
+            return f;
+        }
+        case vkt::Feature::sparseResidencyImage2D: {
+            phys_dev_features_.features.sparseResidencyImage2D = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidencyImage2D,
+                             "VkPhysicalDeviceFeatures::sparseResidencyImage2D"};
+            return f;
+        }
+        case vkt::Feature::sparseResidencyImage3D: {
+            phys_dev_features_.features.sparseResidencyImage3D = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidencyImage3D,
+                             "VkPhysicalDeviceFeatures::sparseResidencyImage3D"};
+            return f;
+        }
+        case vkt::Feature::sparseResidency2Samples: {
+            phys_dev_features_.features.sparseResidency2Samples = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidency2Samples,
+                             "VkPhysicalDeviceFeatures::sparseResidency2Samples"};
+            return f;
+        }
+        case vkt::Feature::sparseResidency4Samples: {
+            phys_dev_features_.features.sparseResidency4Samples = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidency4Samples,
+                             "VkPhysicalDeviceFeatures::sparseResidency4Samples"};
+            return f;
+        }
+        case vkt::Feature::sparseResidency8Samples: {
+            phys_dev_features_.features.sparseResidency8Samples = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidency8Samples,
+                             "VkPhysicalDeviceFeatures::sparseResidency8Samples"};
+            return f;
+        }
+        case vkt::Feature::sparseResidency16Samples: {
+            phys_dev_features_.features.sparseResidency16Samples = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidency16Samples,
+                             "VkPhysicalDeviceFeatures::sparseResidency16Samples"};
+            return f;
+        }
+        case vkt::Feature::sparseResidencyAliased: {
+            phys_dev_features_.features.sparseResidencyAliased = value;
+            FeatureAndName f{&phys_dev_features_.features.sparseResidencyAliased,
+                             "VkPhysicalDeviceFeatures::sparseResidencyAliased"};
+            return f;
+        }
+        case vkt::Feature::variableMultisampleRate: {
+            phys_dev_features_.features.variableMultisampleRate = value;
+            FeatureAndName f{&phys_dev_features_.features.variableMultisampleRate,
+                             "VkPhysicalDeviceFeatures::variableMultisampleRate"};
+            return f;
+        }
+        case vkt::Feature::inheritedQueries: {
+            phys_dev_features_.features.inheritedQueries = value;
+            FeatureAndName f{&phys_dev_features_.features.inheritedQueries, "VkPhysicalDeviceFeatures::inheritedQueries"};
+            return f;
+        }
+        default:
+            FeatureAndName f = vkt::AddFeature(api_version, feature, &feature_chain_);
+            if (value == VK_TRUE) {
+                *f.feature = VK_TRUE;
+                required_features_.emplace_back(f);
+                return f;
+            } else {
+                *f.feature = VK_FALSE;
+                disabled_features_.emplace_back(f.feature);
+            }
+            return f;
+    }
+}
+
+VkPhysicalDeviceFeatures2* FeatureRequirements::GetFeatures2() {
+    phys_dev_features_.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
+    phys_dev_features_.pNext = feature_chain_;
+    return &phys_dev_features_;
+}
+
+const char* FeatureRequirements::AnyRequiredFeatureDisabled() const {
+    for (const auto [feature, name] : required_features_) {
+        if (*feature == VK_FALSE) {
+            return name;
+        }
+    }
+    return nullptr;
+}
+
+void FeatureRequirements::EnforceDisableFeatures() {
+    for (auto feature : disabled_features_) {
+        *feature = VK_FALSE;
+    }
+}
+
+}  // namespace vkt

--- a/tests/framework/feature_requirements.h
+++ b/tests/framework/feature_requirements.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+
+#include "generated/feature_requirements_helper.h"
+
+#include <vector>
+#include <vulkan/vulkan.h>
+
+namespace vkt {
+
+class FeatureRequirements {
+  public:
+    ~FeatureRequirements();
+    // Add a feature required for the test to be executed
+    void AddRequiredFeature(APIVersion api_version, vkt::Feature feature);
+    // Add a feature that will be disabled when creating the device
+    void AddDisabledFeature(APIVersion api_version, vkt::Feature feature);
+
+    bool HasFeatures2() const { return feature_chain_ != nullptr; }
+    VkPhysicalDeviceFeatures* GetFeatures() { return &phys_dev_features_.features; };
+    VkPhysicalDeviceFeatures2* GetFeatures2();
+    // Return nullptr if all required feature are enabled, else return the name of the first disabled feature
+    const char* AnyRequiredFeatureDisabled() const;
+    void EnforceDisableFeatures();
+
+  private:
+    FeatureAndName SetFeature(APIVersion api_version, vkt::Feature feature, VkBool32 value);
+
+    void* feature_chain_ = nullptr;
+    VkPhysicalDeviceFeatures2 phys_dev_features_{};
+    std::vector<FeatureAndName> required_features_{};
+    std::vector<VkBool32*> disabled_features_{};
+};
+
+}  // namespace vkt

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -476,8 +476,10 @@ class PositiveQuery : public QueryTest {};
 
 class RayTracingTest : public virtual VkLayerTest {
   public:
-    void InitFrameworkForRayTracingTest(bool is_khr, VkPhysicalDeviceFeatures2KHR *features2 = nullptr,
-                                        VkValidationFeaturesEXT *enabled_features = nullptr);
+    void InitFrameworkForRayTracingTest(VkValidationFeaturesEXT *enabled_features = nullptr);
+
+    void NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR *features2 = nullptr,
+                                          VkValidationFeaturesEXT *enabled_features = nullptr);
 
     void OOBRayTracingShadersTestBody(bool gpu_assisted);
 };

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -21,6 +21,7 @@
 #include "generated/vk_function_pointers.h"
 #include "error_monitor.h"
 #include "test_framework.h"
+#include "feature_requirements.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/log.h>
@@ -116,7 +117,7 @@ class VkRenderFramework : public VkTestFramework {
     // default to CommandPool Reset flag to allow recording multiple command buffers simpler
     void InitState(VkPhysicalDeviceFeatures *features = nullptr, void *create_device_pnext = nullptr,
                    const VkCommandPoolCreateFlags flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-
+    void InitStateWithRequirements(vkt::FeatureRequirements &feature_requirements);
     bool DeviceExtensionSupported(const char *extension_name, uint32_t spec_version = 0) const;
     bool DeviceExtensionSupported(VkPhysicalDevice, const char *, const char *name,
                                   uint32_t spec_version = 0) const {  // deprecated
@@ -139,6 +140,11 @@ class VkRenderFramework : public VkTestFramework {
     // By default, requested extensions that are promoted to the effective API version (and thus are redundant)
     // are not enabled, but this can be overridden for individual test cases that explicitly test such use cases.
     void AllowPromotedExtensions() { allow_promoted_extensions_ = true; }
+
+    // Add a feature required for the test to be executed
+    void AddRequiredFeature(vkt::Feature feature);
+    // Add a feature that will be disabled when creating the device
+    void AddDisabledFeature(vkt::Feature feature);
 
     void *SetupValidationSettings(void *first_pnext);
 
@@ -181,6 +187,7 @@ class VkRenderFramework : public VkTestFramework {
     VkInstance instance_;
     VkPhysicalDevice gpu_ = VK_NULL_HANDLE;
     VkPhysicalDeviceProperties physDevProps_;
+    vkt::FeatureRequirements feature_requirements_;
 
     uint32_t m_gpu_index;
     vkt::Device *m_device;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1206,7 +1206,7 @@ TEST_F(NegativeRayTracing, DescriptorBindingUpdateAfterBindWithAccelerationStruc
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     VkDescriptorSetLayoutBinding binding = {};
@@ -1508,7 +1508,7 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceAccelerationStructureFeaturesKHR as_features = vku::InitStructHelper();
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&as_features);
@@ -1628,16 +1628,15 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate CmdCopyMemoryToAccelerationStructureKHR with dst buffer not bound to memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    RETURN_IF_SKIP(InitState());
 
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
@@ -1835,13 +1834,12 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure creation.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper(&ray_query_features);
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&acc_struct_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     VkAccelerationStructureKHR as;
     VkAccelerationStructureCreateInfoKHR as_create_info = vku::InitStructHelper();
@@ -1923,13 +1921,13 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     TEST_DESCRIPTION("Validate acceleration structure creation replay feature.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR acc_struct_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&acc_struct_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
 
-    acc_struct_features.accelerationStructureCaptureReplay = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+
+    AddDisabledFeature(vkt::Feature::accelerationStructureCaptureReplay);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
@@ -1961,15 +1959,11 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&bda_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_tracing_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    if (IsPlatformMockICD()) {
-        GTEST_SKIP() << "Test not supported by MockICD";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Create ray tracing pipeline
     VkPipeline raytracing_pipeline = VK_NULL_HANDLE;
@@ -2035,10 +2029,8 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
 
     const VkDeviceAddress device_address = buffer.address();
 
-    VkStridedDeviceAddressRegionKHR stridebufregion = {};
-    stridebufregion.deviceAddress = device_address;
-    stridebufregion.stride = ray_tracing_properties.shaderGroupHandleAlignment;
-    stridebufregion.size = stridebufregion.stride;
+    const VkStridedDeviceAddressRegionKHR stridebufregion = {device_address, ray_tracing_properties.shaderGroupHandleAlignment,
+                                                             ray_tracing_properties.shaderGroupHandleAlignment};
 
     m_commandBuffer->begin();
 
@@ -2094,19 +2086,21 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, raytracing_pipeline);
 
     // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
-    vkt::Buffer buffer_missing_flag;
-    buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-    buffer_missing_flag.init_no_mem(*m_device, buffer_ci);
-    vk::BindBufferMemory(device(), buffer_missing_flag.handle(), mem.handle(), 0);
-    const VkDeviceAddress device_address_missing_flag = buffer_missing_flag.address();
-
-    // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
     {
-        VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
-        // This address is the same as the one from the first (valid) buffer, so no validation error
-        invalid_stride.deviceAddress = device_address_missing_flag;
-        vk::CmdTraceRaysKHR(m_commandBuffer->handle(), &invalid_stride, &stridebufregion, &stridebufregion, &stridebufregion, 100,
-                            100, 1);
+        vkt::Buffer buffer_missing_flag;
+        buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+        buffer_missing_flag.init_no_mem(*m_device, buffer_ci);
+        vk::BindBufferMemory(device(), buffer_missing_flag.handle(), mem.handle(), 0);
+        const VkDeviceAddress device_address_missing_flag = buffer_missing_flag.address();
+
+        // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
+        if (device_address_missing_flag == device_address) {
+            VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
+            // This address is the same as the one from the first (valid) buffer, so no validation error
+            invalid_stride.deviceAddress = device_address_missing_flag;
+            vk::CmdTraceRaysKHR(m_commandBuffer->handle(), &invalid_stride, &stridebufregion, &stridebufregion, &stridebufregion,
+                                100, 100, 1);
+        }
     }
 
     // pRayGenShaderBindingTable address range and stride are invalid
@@ -2114,7 +2108,6 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
         invalid_stride.stride = 8128;
         invalid_stride.size = 8128;
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03681");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkStridedDeviceAddressRegionKHR-size-04631");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkStridedDeviceAddressRegionKHR-size-04632");
         vk::CmdTraceRaysKHR(m_commandBuffer->handle(), &invalid_stride, &stridebufregion, &stridebufregion, &stridebufregion, 100,
@@ -2154,15 +2147,11 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysIndirectKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
 
-    if (ray_tracing_features.rayTracingPipelineTraceRaysIndirect == VK_FALSE) {
-        GTEST_SKIP() << "rayTracingIndirectTraceRays not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayTracingPipelineTraceRaysIndirect);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     VkBufferCreateInfo buf_info = vku::InitStructHelper();
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -2248,11 +2237,11 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-    // VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR maintenance1_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddDisabledFeature(vkt::Feature::rayTracingPipelineTraceRaysIndirect2);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     VkBufferCreateInfo buffer_info = vku::InitStructHelper();
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -2281,15 +2270,11 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
-    VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR maintenance1_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&maintenance1_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    if (maintenance1_features.rayTracingPipelineTraceRaysIndirect2 == VK_FALSE) {
-        GTEST_SKIP() << "rayTracingPipelineTraceRaysIndirect2 not supported";
-    }
 
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayTracingPipelineTraceRaysIndirect2);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     VkBufferCreateInfo buffer_info = vku::InitStructHelper();
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
@@ -2316,7 +2301,7 @@ TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
     TEST_DESCRIPTION("Validate VkAccelerationStructureVersionInfoKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
@@ -2346,22 +2331,58 @@ TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
     }
 }
 
+TEST_F(NegativeRayTracing, IndirectCmdBuildAccelerationStructuresKHR) {
+    TEST_DESCRIPTION("Validate acceleration structure indirect builds.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::accelerationStructureIndirectBuild);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    // Command buffer indirect build
+    auto build_info_null_dst = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull());
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                         "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03800");
+    build_info_null_dst.BuildCmdBufferIndirect(*m_device, m_commandBuffer->handle());
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeRayTracing, HostCmdBuildAccelerationStructuresKHR) {
+    TEST_DESCRIPTION("Validate acceleration structure indirect builds.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::accelerationStructureHostCommands);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    // Host build
+    auto build_info_null_dst = vkt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(*m_device);
+    build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull());
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBuildAccelerationStructuresKHR-dstAccelerationStructure-03800");
+    build_info_null_dst.BuildHost(instance(), *m_device);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
 
     AddOptionalExtensions(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    ray_query_features.rayQuery = VK_TRUE;
-    accel_features.accelerationStructureIndirectBuild = VK_TRUE;
-    accel_features.accelerationStructureHostCommands = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     const bool index_type_uint8 = IsExtensionsEnabled(VK_EXT_INDEX_TYPE_UINT8_EXTENSION_NAME);
 
@@ -2386,25 +2407,6 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                                  "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03800");
             build_info_null_dst.BuildCmdBuffer(*m_device, m_commandBuffer->handle());
-            m_errorMonitor->VerifyFound();
-        }
-
-        // Command buffer indirect build
-        if (accel_features.accelerationStructureIndirectBuild == VK_TRUE) {
-            auto build_info_null_dst = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-            build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull());
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
-                                                 "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-dstAccelerationStructure-03800");
-            build_info_null_dst.BuildCmdBufferIndirect(*m_device, m_commandBuffer->handle());
-            m_errorMonitor->VerifyFound();
-        }
-
-        // Host build
-        if (accel_features.accelerationStructureHostCommands == VK_TRUE) {
-            auto build_info_null_dst = vkt::as::blueprint::BuildGeometryInfoSimpleOnHostBottomLevel(*m_device);
-            build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull());
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBuildAccelerationStructuresKHR-dstAccelerationStructure-03800");
-            build_info_null_dst.BuildHost(instance(), *m_device);
             m_errorMonitor->VerifyFound();
         }
     }
@@ -2653,16 +2655,12 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         "Validate acceleration structure building when source/destination acceleration structures and scratch buffers overlap.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     constexpr size_t build_info_count = 3;
 
@@ -2912,12 +2910,12 @@ TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&bda_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     vkt::as::BuildGeometryInfoKHR build_geometry_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     m_commandBuffer->begin();
@@ -2941,7 +2939,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     TEST_DESCRIPTION("Validate CmdCopyAccelerationStructureToMemoryKHR.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&ray_tracing_features);
@@ -2993,7 +2991,7 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     TEST_DESCRIPTION("Test for updating an acceleration structure without a srcAccelerationStructure");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_address_features = vku::InitStructHelper(&ray_tracing_features);
@@ -3028,12 +3026,12 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
         "as long as valid buffers are correctly removed from the internal buffer device addresses to buffers mapping.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR buffer_addr_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&buffer_addr_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Allocate common buffer memory
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
@@ -3304,16 +3302,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidMode) {
     TEST_DESCRIPTION("Build an acceleration structure with an invalid mode");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     build_info.SetMode(static_cast<VkBuildAccelerationStructureModeKHR>(42));
@@ -3329,16 +3323,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTy
         "Build a list of destination acceleration structures, then do an update build on that same list changing geometry type");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to geometry type
     m_commandBuffer->begin();
@@ -3365,16 +3355,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryFl
         "geometry flag");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to geometry flags
     m_commandBuffer->begin();
@@ -3400,16 +3386,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
         "vertex format for the triangles");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles vertex format
     m_commandBuffer->begin();
@@ -3435,16 +3417,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
         "maxVertex for triangles");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles max vertex
     m_commandBuffer->begin();
@@ -3470,16 +3448,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
         "type for the triangles");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles index type
     m_commandBuffer->begin();
@@ -3505,16 +3479,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
         "pointer for the transform data");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles transform data
     m_commandBuffer->begin();
@@ -3540,16 +3510,12 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometry) 
         "transform data going from non NULL to NULL");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_features = vku::InitStructHelper();
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_features);
-    VkPhysicalDeviceRayQueryFeaturesKHR ray_query_features = vku::InitStructHelper(&bda_features);
-    accel_features.accelerationStructure = VK_TRUE;
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    ray_query_features.rayQuery = VK_TRUE;
 
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_query_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles transform data
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
@@ -3583,12 +3549,11 @@ TEST_F(NegativeRayTracing, DynamicRayTracingPipelineStack) {
         "but do not set size before tracing rays");
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&bda_features);
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_struct_features = vku::InitStructHelper(&ray_tracing_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&accel_struct_features);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
 
     vkt::rt::Pipeline pipeline(*this, m_device);
     pipeline.SetRayGenShader(kRayTracingMinimalGlsl);

--- a/tests/unit/ray_tracing_gpu.cpp
+++ b/tests/unit/ray_tracing_gpu.cpp
@@ -29,18 +29,14 @@ TEST_F(NegativeGpuAVRayTracing, CmdTraceRaysIndirectKHR) {
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
 
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper();
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&bda_features);
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&ray_tracing_features);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
     VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2, &validation_features))
-
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(&validation_features));
     if (IsPlatformMockICD()) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2))
+    RETURN_IF_SKIP(InitState());
 
     // Create ray tracing pipeline
     std::vector<VkDescriptorSetLayoutBinding> bindings(1);

--- a/tests/unit/ray_tracing_gpu_nv.cpp
+++ b/tests/unit/ray_tracing_gpu_nv.cpp
@@ -25,7 +25,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationInvalidHan
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest(nullptr, &validation_features));
 
     if (!CanEnableGpuAV(*this)) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
@@ -101,7 +101,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationBottomLeve
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest(nullptr, &validation_features));
 
     if (!CanEnableGpuAV(*this)) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
@@ -186,7 +186,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationBottomLeve
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest(nullptr, &validation_features));
 
     if (!CanEnableGpuAV(*this)) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";
@@ -287,7 +287,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationRestoresSt
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_PUSH_DESCRIPTOR_EXTENSION_NAME);
     VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false, nullptr, &validation_features));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest(nullptr, &validation_features));
 
     if (!CanEnableGpuAV(*this)) {
         GTEST_SKIP() << "Requirements for GPU-AV are not met";

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -18,9 +18,23 @@
 #include "../framework/descriptor_helper.h"
 #include "../layers/utils/vk_layer_utils.h"
 
+void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR *features2 /*= nullptr*/,
+                                                      VkValidationFeaturesEXT *enabled_features /*= nullptr*/) {
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
+
+    RETURN_IF_SKIP(InitFramework(enabled_features));
+
+    if (features2) {
+        // extension enabled as dependency of RT extension
+        vk::GetPhysicalDeviceFeatures2KHR(gpu(), features2);
+    }
+}
+
 TEST_F(NegativeRayTracingNV, AccelerationStructureBindings) {
     TEST_DESCRIPTION("Use more bindings with a descriptorType of VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV than allowed");
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_props);
@@ -65,7 +79,7 @@ TEST_F(NegativeRayTracingNV, AccelerationStructureBindings) {
 TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     TEST_DESCRIPTION("Validate acceleration structure geometries.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -317,7 +331,7 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
 TEST_F(NegativeRayTracingNV, ValidateCreateAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure creation.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -424,7 +438,7 @@ TEST_F(NegativeRayTracingNV, ValidateCreateAccelerationStructure) {
 TEST_F(NegativeRayTracingNV, ValidateBindAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure binding.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -572,7 +586,7 @@ TEST_F(NegativeRayTracingNV, ValidateBindAccelerationStructure) {
 TEST_F(NegativeRayTracingNV, ValidateWriteDescriptorSetAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure descriptor writing.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     OneOffDescriptorSet ds(m_device,
@@ -604,7 +618,7 @@ TEST_F(NegativeRayTracingNV, ValidateWriteDescriptorSetAccelerationStructure) {
 TEST_F(NegativeRayTracingNV, ValidateCmdBuildAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure building.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -726,7 +740,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdBuildAccelerationStructure) {
 TEST_F(NegativeRayTracingNV, ObjInUseCmdBuildAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure building tracks the objects used.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -773,7 +787,7 @@ TEST_F(NegativeRayTracingNV, ObjInUseCmdBuildAccelerationStructure) {
 TEST_F(NegativeRayTracingNV, ValidateGetAccelerationStructureHandle) {
     TEST_DESCRIPTION("Validate acceleration structure handle querying.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;
@@ -812,7 +826,7 @@ TEST_F(NegativeRayTracingNV, ValidateGetAccelerationStructureHandle) {
 TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
     TEST_DESCRIPTION("Validate acceleration structure copying.");
 
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer vbo;

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -18,7 +18,7 @@
 
 TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
     TEST_DESCRIPTION("Validate vkCreateRayTracingPipelinesNV and CreateInfo parameters during ray-tracing pipeline creation");
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
 
     VkPhysicalDevicePipelineCreationCacheControlFeaturesEXT pipleline_features = vku::InitStructHelper();
     auto features2 = GetPhysicalDeviceFeatures2(pipleline_features);
@@ -171,7 +171,7 @@ TEST_F(NegativeRayTracingPipelineNV, BindPoint) {
 
 TEST_F(NegativeRayTracingPipelineNV, ShaderGroups) {
     TEST_DESCRIPTION("Validate shader groups during ray-tracing pipeline creation");
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     const vkt::PipelineLayout empty_pipeline_layout(*m_device, {});
@@ -641,7 +641,7 @@ TEST_F(NegativeRayTracingPipelineNV, StageCreationFeedbackCount) {
     TEST_DESCRIPTION("Test NV ray tracing pipeline feedback stage count check.");
 
     AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_FEEDBACK_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPropertiesNV rtnv_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(rtnv_props);
@@ -672,7 +672,7 @@ TEST_F(NegativeRayTracingPipelineNV, StageCreationFeedbackCount) {
 TEST_F(NegativeRayTracingPipelineNV, MissingEntrypoint) {
     TEST_DESCRIPTION("Test NV ray tracing pipeline with missing entrypoint.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
     char const missShaderText[] = R"glsl(

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -19,7 +19,7 @@ TEST_F(PositiveRayTracingPipeline, ShaderGroupsKHR) {
     TEST_DESCRIPTION("Test that no warning is produced when a library is referenced in the raytracing shader groups.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(ray_tracing_features);
@@ -113,7 +113,7 @@ TEST_F(PositiveRayTracingPipeline, CacheControl) {
     TEST_DESCRIPTION("Create ray tracing pipeline with VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT_EXT.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true));
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
     VkPhysicalDeviceRayTracingPipelineFeaturesKHR ray_tracing_features = vku::InitStructHelper(&features13);
@@ -161,34 +161,17 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
         "Regression test for issue 6282: make sure that when validating vkGetRayTracingCaptureReplayShaderGroupHandlesKHR on a "
         "pipeline created using pipeline libraries, the total shader group count is computed using info from the libraries.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
-
-    VkPhysicalDeviceAccelerationStructureFeaturesKHR accel_struct_features = vku::InitStructHelper();
-    accel_struct_features.accelerationStructure = VK_TRUE;
-    VkPhysicalDeviceBufferDeviceAddressFeaturesKHR bda_features = vku::InitStructHelper(&accel_struct_features);
-    bda_features.bufferDeviceAddress = VK_TRUE;
-    VkPhysicalDeviceRayTracingPipelineFeaturesKHR rt_pipeline_features = vku::InitStructHelper(&bda_features);
-    rt_pipeline_features.rayTracingPipelineShaderGroupHandleCaptureReplay = VK_TRUE;
-    VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT gpl_features = vku::InitStructHelper(&rt_pipeline_features);
-    gpl_features.graphicsPipelineLibrary = VK_TRUE;
-    VkPhysicalDevicePipelineLibraryGroupHandlesFeaturesEXT pipeline_group_handle_features = vku::InitStructHelper(&gpl_features);
-    pipeline_group_handle_features.pipelineLibraryGroupHandles = VK_TRUE;
-    VkPhysicalDeviceFeatures2KHR features2 = vku::InitStructHelper(&pipeline_group_handle_features);
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_PIPELINE_LIBRARY_GROUP_HANDLES_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(true, &features2));
 
-    features2 = GetPhysicalDeviceFeatures2(pipeline_group_handle_features);
-    if (!gpl_features.graphicsPipelineLibrary) {
-        GTEST_SKIP() << "graphicsPipelineLibrary feature not supported, skipping test";
-    }
-    if (!pipeline_group_handle_features.pipelineLibraryGroupHandles) {
-        GTEST_SKIP() << "pipelineLibraryGroupHandles feature not supported, skipping test";
-    }
-    if (!rt_pipeline_features.rayTracingPipelineShaderGroupHandleCaptureReplay) {
-        GTEST_SKIP() << "rayTracingShaderGroupHandleCaptureReplay not supported, skipping test";
-    }
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::graphicsPipelineLibrary);
+    AddRequiredFeature(vkt::Feature::pipelineLibraryGroupHandles);
+    AddRequiredFeature(vkt::Feature::rayTracingPipelineShaderGroupHandleCaptureReplay);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
 
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    RETURN_IF_SKIP(InitState());
 
     vkt::rt::Pipeline rt_pipe_lib(*this, m_device);
     rt_pipe_lib.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR);

--- a/tests/unit/ray_tracing_pipeline_positive_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive_nv.cpp
@@ -17,7 +17,7 @@
 
 TEST_F(PositiveRayTracingPipelineNV, BasicUsage) {
     TEST_DESCRIPTION("Test VK_NV_ray_tracing.");
-    RETURN_IF_SKIP(InitFrameworkForRayTracingTest(false));
+    RETURN_IF_SKIP(NvInitFrameworkForRayTracingTest());
 
     VkPhysicalDeviceRayTracingPropertiesNV rtnv_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(rtnv_props);


### PR DESCRIPTION
Add `FeatureRequirements` Class to help specifying the features a test requires to be enabled, or sometimes disabled
Right now only used in ray tracing tests, where this class is quite handy given the feature requirements can vary quite a lot and writing the boilerplate to run a test if and only if a test has some feature enabled is cumbersome.

Also:
- enable back running some ray tracing tests on the mock ICD, because now it supports them
- split 2 or 3 tests that had an `if (some feature enabled) { code code code }` logic, moving the `code code code` part to a dedicated test asking for the feature to be enabled 