### PR TITLE
layers: Report write access for writeonly resources

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -32,10 +32,18 @@ SyncStageAccessIndex GetSyncStageAccessIndexsByDescriptorSet(VkDescriptorType de
         return stage_accesses.uniform_read;
     }
 
+    // Detect if variable is nonreadable (writeonly in glsl).
+    // NOTE: is_written_to can be used as a more general case instead of adding is_writeonly logic.
+    // At first we need to fix is_written_to support for buffers.
+    bool is_writeonly = variable.decorations.Has(spirv::DecorationBase::nonreadable_bit);
+    if (variable.type_struct_info) {
+        is_writeonly |= variable.type_struct_info->decorations.AllMemberHave(spirv::DecorationBase::nonreadable_bit);
+    }
+
     // If the desriptorSet is writable, we don't need to care SHADER_READ. SHADER_WRITE is enough.
     // Because if write hazard happens, read hazard might or might not happen.
     // But if write hazard doesn't happen, read hazard is impossible to happen.
-    if (variable.is_written_to) {
+    if (variable.is_written_to || is_writeonly) {
         return stage_accesses.storage_write;
     } else if (descriptor_type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE ||
                descriptor_type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER ||


### PR DESCRIPTION
Always detect access as WRITE when resource is marked as writeonly (the choice is between READ and WRITE).
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7093

It looks like for buffers `ResourceInterfaceVariable::is_written_to` might not detect write access. Do you know about this @spencer-lunarg ? My thinking was if we have `writeonly` then it's a reliable metric and should have higher priority comparing to acess detection that can produce produce false-positive, but it's still interesting to know if `is_written_to` can detect write as in the test WriteOnlyBufferWriteHazard.