### PR TITLE
syncval: Set queue submit time sync val to default on

### DIFF
--- a/docs/synchronization_usage.md
+++ b/docs/synchronization_usage.md
@@ -24,11 +24,11 @@ Synchronization Validation settings are managed by configuring the Validation La
 
 Synchronization Validation settings can also be enabled and configured using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html) included with the Vulkan SDK.
 
-The alpha release of QueueSubmit time validation can be enabled using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html), or by adding:
+Queue submit time validation can be disabled using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html), or by adding:
 
-`VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT`
+`VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT`
 
-to the "Enables" as documented in [VK_LAYER_KHRONOS_validation](https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html#user-content-layer-details). ***NOTE*:** changes to configuration of this feature between alpha, and full release should be expected.
+to the "Disables" as documented in [VK_LAYER_KHRONOS_validation](https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html#user-content-layer-details).
 
 
 ## Synchronization Validation Functionality
@@ -100,6 +100,7 @@ The pipelined and multi-threaded nature of Vulkan makes it particularly importan
 - QueueSubmit/QueueSubmit2 time hazard detection
 - Semaphore (binary only) and Fence synchronization operations/effects
 - Device and Queue WaitIdle support
+- Dynamic Rendering support
 
 ### Known Limitations
 

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -686,8 +686,8 @@
                                     "label": "QueueSubmit Synchronization Validation",
                                     "description": "Enable synchronization validation between submitted command buffers when Synchronization Validation is enabled. This option will increase the synchronization performance cost.",
                                     "type": "BOOL",
-                                    "default": false,
-                                    "status": "ALPHA",
+                                    "default": true,
+                                    "status": "STABLE",
                                     "dependence": {
                                         "mode": "ALL",
                                         "settings": [
@@ -1270,6 +1270,12 @@
                             "view": "ADVANCED"
                         },
                         {
+                            "key": "VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
+                            "label": "QueueSubmit Synchronization Validation",
+                            "description": "Check synchronization validation between submitted command buffers when Synchronization Validation is enabled.",
+                            "view": "ADVANCED"
+                        },
+                        {
                             "key": "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHE_EXT",
                             "label": "Shader Validation Caching",
                             "description": "Disable caching of shader validation results.",
@@ -1299,12 +1305,6 @@
                                 "MACOS",
                                 "ANDROID"
                             ]
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
-                            "label": "QueueSubmit Synchronization Validation",
-                            "description": "Enable synchronization validation between submitted command buffers when Synchronization Validation is enabled.",
-                            "status": "ALPHA"
                         },
                         {
                             "key": "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -33,7 +33,6 @@ const char *SETTING_VALIDATE_BEST_PRACTICES_AMD = "validate_best_practices_amd";
 const char *SETTING_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img";
 const char *SETTING_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
 const char *SETTING_VALIDATE_SYNC = "validate_sync";
-const char *SETTING_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 const char *SETTING_VALIDATE_GPU_BASED = "validate_gpu_based";
 const char *SETTING_RESERVE_BINDING_SLOT = "reserve_binding_slot";
 
@@ -49,6 +48,7 @@ const char *SETTING_UNIQUE_HANDLES = "unique_handles";
 const char *SETTING_OBJECT_LIFETIME = "object_lifetime";
 const char *SETTING_CHECK_SHADERS = "check_shaders";
 const char *SETTING_CHECK_SHADERS_CACHING = "check_shaders_caching";
+const char *SETTING_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 
 const char *SETTING_MESSAGE_ID_FILTER = "message_id_filter";
 const char *SETTING_CUSTOM_STYPE_LIST = "custom_stype_list";
@@ -77,6 +77,9 @@ void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDis
             break;
         case VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION:
             disable_data[image_layout_validation] = true;
+            break;
+        case VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT:
+            disable_data[sync_validation_queue_submit] = true;
             break;
         default:
             assert(true);
@@ -136,9 +139,6 @@ void SetValidationEnable(CHECK_ENABLED &enable_data, const ValidationCheckEnable
             enable_data[vendor_specific_amd] = true;
             enable_data[vendor_specific_img] = true;
             enable_data[vendor_specific_nvidia] = true;
-            break;
-        case VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT:
-            enable_data[sync_validation_queue_submit] = true;
             break;
         default:
             assert(true);
@@ -449,8 +449,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_nvidia,
                              SETTING_VALIDATE_BEST_PRACTICES_NVIDIA);
         SetValidationSetting(layer_setting_set, settings_data->enables, sync_validation, SETTING_VALIDATE_SYNC);
-        SetValidationSetting(layer_setting_set, settings_data->enables, sync_validation_queue_submit,
-                             SETTING_VALIDATE_SYNC_QUEUE_SUBMIT);
 
         if (vkuHasLayerSetting(layer_setting_set, SETTING_VALIDATE_GPU_BASED)) {
             std::string setting_value;
@@ -477,6 +475,8 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         SetValidationSetting(layer_setting_set, settings_data->disables, object_tracking, SETTING_OBJECT_LIFETIME);
         SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation, SETTING_CHECK_SHADERS);
         SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation_caching, SETTING_CHECK_SHADERS_CACHING);
+        SetValidationSetting(layer_setting_set, settings_data->disables, sync_validation_queue_submit,
+                             SETTING_VALIDATE_SYNC_QUEUE_SUBMIT);
     }
 
     vkuDestroyLayerSettingSet(layer_setting_set, nullptr);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -66,6 +66,8 @@ static const vvl::unordered_map<std::string, ValidationCheckDisables> Validation
     {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
     {"VALIDATION_CHECK_DISABLE_QUERY_VALIDATION", VALIDATION_CHECK_DISABLE_QUERY_VALIDATION},
     {"VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION", VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION},
+    {"VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
+     VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT},
 };
 
 static const vvl::unordered_map<std::string, ValidationCheckEnables> ValidationEnableLookup = {
@@ -74,23 +76,22 @@ static const vvl::unordered_map<std::string, ValidationCheckEnables> ValidationE
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA},
     {"VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL", VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL},
-    {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
-     VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT},
 };
 
 // This should mirror the 'DisableFlags' enumerated type
 static const std::vector<std::string> DisableFlagNameHelper = {
-    "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",               // command_buffer_state,
-    "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                      // object_in_use,
-    "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",                   // query_validation,
-    "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",            // image_layout_validation,
-    "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",          // object_tracking,
-    "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",               // core_checks,
-    "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",             // thread_safety,
-    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",            // stateless_checks,
-    "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",            // handle_wrapping,
-    "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",                   // shader_validation,
-    "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT"  // shader_validation_caching
+    "VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE",                     // command_buffer_state,
+    "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",                            // object_in_use,
+    "VALIDATION_CHECK_DISABLE_QUERY_VALIDATION",                         // query_validation,
+    "VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION",                  // image_layout_validation,
+    "VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",  // queuesubmit time sync_validation,
+    "VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT",                // object_tracking,
+    "VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT",                     // core_checks,
+    "VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT",                   // thread_safety,
+    "VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT",                  // stateless_checks,
+    "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",                  // handle_wrapping,
+    "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",                         // shader_validation,
+    "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT"        // shader_validation_caching
 };
 
 // This should mirror the 'EnableFlags' enumerated type
@@ -104,7 +105,6 @@ static const std::vector<std::string> EnableFlagNameHelper = {
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA",                      // vendor_specific_nvidia,
     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
     "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION",             // sync_validation,
-    "VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",     // queuesubmit time sync_validation,
 };
 
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2157,6 +2157,7 @@ typedef enum ValidationCheckDisables {
     VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
     VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
     VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
+    VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
 } ValidationCheckDisables;
 
 typedef enum ValidationCheckEnables {
@@ -2165,7 +2166,6 @@ typedef enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
-    VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
 } ValidationCheckEnables;
 
 typedef enum VkValidationFeatureEnable {
@@ -2187,6 +2187,7 @@ typedef enum DisableFlags {
     handle_wrapping,
     shader_validation,
     shader_validation_caching,
+    sync_validation_queue_submit,
     // Insert new disables above this line
     kMaxDisableFlags,
 } DisableFlags;
@@ -2201,7 +2202,6 @@ typedef enum EnableFlags {
     vendor_specific_nvidia,
     debug_printf_validation,
     sync_validation,
-    sync_validation_queue_submit,
     // Insert new enables above this line
     kMaxEnableFlags,
 } EnableFlags;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -374,6 +374,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
                 VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
                 VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
+                VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
             } ValidationCheckDisables;
 
             typedef enum ValidationCheckEnables {
@@ -382,7 +383,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
                 VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA,
                 VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
-                VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
             } ValidationCheckEnables;
 
             typedef enum VkValidationFeatureEnable {
@@ -404,6 +404,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 handle_wrapping,
                 shader_validation,
                 shader_validation_caching,
+                sync_validation_queue_submit,
                 // Insert new disables above this line
                 kMaxDisableFlags,
             } DisableFlags;
@@ -418,7 +419,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 vendor_specific_nvidia,
                 debug_printf_validation,
                 sync_validation,
-                sync_validation_queue_submit,
                 // Insert new enables above this line
                 kMaxEnableFlags,
             } EnableFlags;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -52,6 +52,8 @@ target_sources(vk_layer_validation_tests PRIVATE
     framework/gpu_av_helper.h
     framework/render_pass_helper.h
     framework/render_pass_helper.cpp
+    framework/queue_submit_context.h
+    framework/queue_submit_context.cpp
     unit/amd_best_practices.cpp
     unit/android_hardware_buffer.cpp
     unit/android_hardware_buffer_positive.cpp

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -290,7 +290,7 @@ class NegativeDebugPrintf : public VkLayerTest {
 
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework(bool enable_queue_submit_validation = false);
+    void InitSyncValFramework(bool disable_queue_submit_validation = false);
 
   protected:
     const VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "queue_submit_context.h"
+#include "render.h"
+
+QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Queue* force_q1)
+    : dev(device), q0(VK_NULL_HANDLE), q1(VK_NULL_HANDLE) {
+    if (force_q0) {
+        q0 = force_q0->handle();
+        q_fam = force_q0->get_family_index();
+        if (force_q1) {
+            // The object has some assumptions that the queues are from the the same family, so enforce this here
+            if (force_q1->get_family_index() == q_fam) {
+                q1 = force_q1->handle();
+            }
+        } else {
+            q1 = q0;  // Allow the two queues to be the same and valid if forced
+        }
+    } else {
+        const auto& queues = device->dma_queues();
+
+        const uint32_t q_count = static_cast<uint32_t>(queues.size());
+        for (uint32_t q0_index = 0; q0_index < q_count; ++q0_index) {
+            const auto* q0_entry = queues[q0_index];
+            q0 = q0_entry->handle();
+            q_fam = q0_entry->get_family_index();
+            for (uint32_t q1_index = (q0_index + 1); q1_index < q_count; ++q1_index) {
+                const auto* q1_entry = queues[q1_index];
+                if (q_fam == q1_entry->get_family_index()) {
+                    q1 = q1_entry->handle();
+                    break;
+                }
+            }
+            if (Valid()) {
+                break;
+            }
+        }
+    }
+
+    if (!Valid()) return;
+
+    VkMemoryPropertyFlags mem_prop = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
+    VkBufferUsageFlags transfer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
+    buffer_a.init(*device, 256, transfer_usage, mem_prop);
+    buffer_b.init(*device, 256, transfer_usage, mem_prop);
+    buffer_c.init(*device, 256, transfer_usage, mem_prop);
+
+    VkDeviceSize size = 256;
+    VkDeviceSize half_size = size / 2;
+    full_buffer = {0, 0, size};
+    first_half = {0, 0, half_size};
+    second_half = {half_size, half_size, half_size};
+    first_to_second = {0, half_size, half_size};
+    second_to_first = {half_size, 0, half_size};
+
+    pool.init(*device, vkt::CommandPool::create_info(q_fam, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+
+    h_cba = InitFromPool(cba);
+    h_cbb = InitFromPool(cbb);
+    h_cbc = InitFromPool(cbc);
+
+    VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper();
+    semaphore.init(*device, semaphore_ci);
+
+    VkEventCreateInfo eci = vku::InitStructHelper();
+    event.init(*device, eci);
+}
+
+VkCommandBuffer QSTestContext::InitFromPool(vkt::CommandBuffer& cb_obj) {
+    cb_obj.Init(dev, &pool);
+    return cb_obj.handle();
+}
+
+void QSTestContext::Begin(vkt::CommandBuffer& cb) {
+    VkCommandBufferBeginInfo info = vku::InitStructHelper();
+    info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
+    info.pInheritanceInfo = nullptr;
+
+    cb.reset();
+    cb.begin(&info);
+    current_cb = &cb;
+}
+
+void QSTestContext::End() {
+    current_cb->end();
+    current_cb = nullptr;
+}
+
+void QSTestContext::Copy(vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy& copy_region) {
+    vk::CmdCopyBuffer(current_cb->handle(), from.handle(), to.handle(), 1, &copy_region);
+}
+
+void QSTestContext::CopyGeneral(const VkImageObj& from, const VkImageObj& to, const VkImageCopy& region) {
+    vk::CmdCopyImage(current_cb->handle(), from.handle(), VK_IMAGE_LAYOUT_GENERAL, to.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
+                     &region);
+}
+
+VkBufferMemoryBarrier QSTestContext::InitBufferBarrier(const vkt::Buffer& buffer, VkAccessFlags src, VkAccessFlags dst) {
+    VkBufferMemoryBarrier buffer_barrier = vku::InitStructHelper();
+    buffer_barrier.srcAccessMask = src;
+    buffer_barrier.dstAccessMask = dst;
+    buffer_barrier.buffer = buffer.handle();
+    buffer_barrier.offset = 0;
+    buffer_barrier.size = 256;
+    return buffer_barrier;
+}
+
+VkBufferMemoryBarrier QSTestContext::InitBufferBarrierRAW(const vkt::Buffer& buffer) {
+    return InitBufferBarrier(buffer, VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_TRANSFER_READ_BIT);
+}
+
+VkBufferMemoryBarrier QSTestContext::InitBufferBarrierWAR(const vkt::Buffer& buffer) {
+    return InitBufferBarrier(buffer, VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_TRANSFER_WRITE_BIT);
+}
+
+void QSTestContext::TransferBarrier(const VkBufferMemoryBarrier& buffer_barrier) {
+    vk::CmdPipelineBarrier(current_cb->handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 1,
+                           &buffer_barrier, 0, nullptr);
+}
+
+void QSTestContext::TransferBarrierWAR(const vkt::Buffer& buffer) { TransferBarrier(InitBufferBarrierWAR(buffer)); }
+void QSTestContext::TransferBarrierRAW(const vkt::Buffer& buffer) { TransferBarrier(InitBufferBarrierRAW(buffer)); }
+
+void QSTestContext::Submit(VkQueue q, vkt::CommandBuffer& cb, VkSemaphore wait, VkPipelineStageFlags wait_mask, VkSemaphore signal,
+                           VkFence fence) {
+    VkSubmitInfo submit1 = vku::InitStructHelper();
+    submit1.commandBufferCount = 1;
+    VkCommandBuffer h_cb = cb.handle();
+    submit1.pCommandBuffers = &h_cb;
+    if (wait != VK_NULL_HANDLE) {
+        submit1.waitSemaphoreCount = 1;
+        submit1.pWaitSemaphores = &wait;
+        submit1.pWaitDstStageMask = &wait_mask;
+    }
+    if (signal != VK_NULL_HANDLE) {
+        submit1.signalSemaphoreCount = 1;
+        submit1.pSignalSemaphores = &signal;
+    }
+    vk::QueueSubmit(q, 1, &submit1, fence);
+}
+
+void QSTestContext::SubmitX(VkQueue q, vkt::CommandBuffer& cb, VkSemaphore wait, VkPipelineStageFlags wait_mask, VkSemaphore signal,
+                            VkPipelineStageFlags signal_mask, VkFence fence) {
+    VkSubmitInfo2 submit1 = vku::InitStructHelper();
+    VkCommandBufferSubmitInfo cb_info = vku::InitStructHelper();
+    VkSemaphoreSubmitInfo wait_info = vku::InitStructHelper();
+    VkSemaphoreSubmitInfo signal_info = vku::InitStructHelper();
+
+    cb_info.commandBuffer = cb.handle();
+    submit1.commandBufferInfoCount = 1;
+    submit1.pCommandBufferInfos = &cb_info;
+
+    if (wait != VK_NULL_HANDLE) {
+        wait_info.semaphore = wait;
+        wait_info.stageMask = wait_mask;
+        submit1.waitSemaphoreInfoCount = 1;
+        submit1.pWaitSemaphoreInfos = &wait_info;
+    }
+    if (signal != VK_NULL_HANDLE) {
+        signal_info.semaphore = signal;
+        signal_info.stageMask = signal_mask;
+        submit1.signalSemaphoreInfoCount = 1;
+        submit1.pSignalSemaphoreInfos = &signal_info;
+    }
+
+    vk::QueueSubmit2(q, 1, &submit1, fence);
+}
+
+void QSTestContext::WaitEventBufferTransfer(vkt::Buffer& buffer, VkPipelineStageFlags src_mask, VkPipelineStageFlags dst_mask) {
+    std::vector<VkBufferMemoryBarrier> buffer_barriers(1, InitBufferBarrierWAR(buffer));
+    event.cmd_wait(*current_cb, src_mask, dst_mask, std::vector<VkMemoryBarrier>(), buffer_barriers,
+                   std::vector<VkImageMemoryBarrier>());
+}
+
+void QSTestContext::RecordCopy(vkt::CommandBuffer& cb, vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy& copy_region) {
+    Begin(cb);
+    Copy(from, to, copy_region);
+    End();
+}

--- a/tests/framework/queue_submit_context.h
+++ b/tests/framework/queue_submit_context.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#pragma once
+#include "test_common.h"
+
+class VkImageObj;
+
+struct QSTestContext {
+    vkt::Device* dev;
+    uint32_t q_fam = ~0U;
+    VkQueue q0 = VK_NULL_HANDLE;
+    VkQueue q1 = VK_NULL_HANDLE;
+
+    vkt::Buffer buffer_a;
+    vkt::Buffer buffer_b;
+    vkt::Buffer buffer_c;
+
+    VkBufferCopy full_buffer;
+    VkBufferCopy first_half;
+    VkBufferCopy second_half;
+    VkBufferCopy first_to_second;
+    VkBufferCopy second_to_first;
+    vkt::CommandPool pool;
+
+    vkt::CommandBuffer cba;
+    vkt::CommandBuffer cbb;
+    vkt::CommandBuffer cbc;
+
+    VkCommandBuffer h_cba = VK_NULL_HANDLE;
+    VkCommandBuffer h_cbb = VK_NULL_HANDLE;
+    VkCommandBuffer h_cbc = VK_NULL_HANDLE;
+
+    vkt::Semaphore semaphore;
+    vkt::Event event;
+
+    vkt::CommandBuffer* current_cb = nullptr;
+
+    QSTestContext(vkt::Device* device, vkt::Queue* force_q0 = nullptr, vkt::Queue* force_q1 = nullptr);
+    VkCommandBuffer InitFromPool(vkt::CommandBuffer& cb_obj);
+    bool Valid() const { return q1 != VK_NULL_HANDLE; }
+
+    void Begin(vkt::CommandBuffer& cb);
+    void BeginA() { Begin(cba); }
+    void BeginB() { Begin(cbb); }
+    void BeginC() { Begin(cbc); }
+
+    void End();
+    void Copy(vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy& copy_region);
+    void Copy(vkt::Buffer& from, vkt::Buffer& to) { Copy(from, to, full_buffer); }
+    void CopyAToB() { Copy(buffer_a, buffer_b); }
+    void CopyAToC() { Copy(buffer_a, buffer_c); }
+
+    void CopyBToA() { Copy(buffer_b, buffer_a); }
+    void CopyBToC() { Copy(buffer_b, buffer_c); }
+
+    void CopyCToA() { Copy(buffer_c, buffer_a); }
+    void CopyCToB() { Copy(buffer_c, buffer_b); }
+
+    void CopyGeneral(const VkImageObj& from, const VkImageObj& to, const VkImageCopy& region);
+    ;
+
+    VkBufferMemoryBarrier InitBufferBarrier(const vkt::Buffer& buffer, VkAccessFlags src, VkAccessFlags dst);
+    VkBufferMemoryBarrier InitBufferBarrierRAW(const vkt::Buffer& buffer);
+    VkBufferMemoryBarrier InitBufferBarrierWAR(const vkt::Buffer& buffer);
+    void TransferBarrierWAR(const vkt::Buffer& buffer);
+    void TransferBarrierRAW(const vkt::Buffer& buffer);
+    void TransferBarrier(const VkBufferMemoryBarrier& buffer_barrier);
+
+    void Submit(VkQueue q, vkt::CommandBuffer& cb, VkSemaphore wait = VK_NULL_HANDLE,
+                VkPipelineStageFlags wait_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VkSemaphore signal = VK_NULL_HANDLE,
+                VkFence fence = VK_NULL_HANDLE);
+
+    // X == Submit 2 but since we already have numeric overloads for the queues X -> eXtension version
+    void SubmitX(VkQueue q, vkt::CommandBuffer& cb, VkSemaphore wait = VK_NULL_HANDLE,
+                 VkPipelineStageFlags wait_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VkSemaphore signal = VK_NULL_HANDLE,
+                 VkPipelineStageFlags signal_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VkFence fence = VK_NULL_HANDLE);
+
+    void Submit0(vkt::CommandBuffer& cb, VkSemaphore wait = VK_NULL_HANDLE,
+                 VkPipelineStageFlags wait_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VkSemaphore signal = VK_NULL_HANDLE,
+                 VkFence fence = VK_NULL_HANDLE) {
+        Submit(q0, cb, wait, wait_mask, signal, fence);
+    }
+    void Submit0Wait(vkt::CommandBuffer& cb, VkPipelineStageFlags wait_mask) { Submit0(cb, semaphore.handle(), wait_mask); }
+    void Submit0Signal(vkt::CommandBuffer& cb) { Submit0(cb, VK_NULL_HANDLE, 0U, semaphore.handle()); }
+
+    void Submit1(vkt::CommandBuffer& cb, VkSemaphore wait = VK_NULL_HANDLE,
+                 VkPipelineStageFlags wait_mask = VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VkSemaphore signal = VK_NULL_HANDLE,
+                 VkFence fence = VK_NULL_HANDLE) {
+        Submit(q1, cb, wait, wait_mask, signal, fence);
+    }
+    void Submit1Wait(vkt::CommandBuffer& cb, VkPipelineStageFlags wait_mask) { Submit1(cb, semaphore.handle(), wait_mask); }
+    void Submit1Signal(vkt::CommandBuffer& cb, VkPipelineStageFlags signal_mask) {
+        Submit1(cb, VK_NULL_HANDLE, 0U, semaphore.handle());
+    }
+    void SetEvent(VkPipelineStageFlags src_mask) { event.cmd_set(*current_cb, src_mask); }
+    void WaitEventBufferTransfer(vkt::Buffer& buffer, VkPipelineStageFlags src_mask, VkPipelineStageFlags dst_mask);
+
+    void ResetEvent(VkPipelineStageFlags src_mask) { event.cmd_reset(*current_cb, src_mask); }
+
+    void QueueWait(VkQueue q) { vk::QueueWaitIdle(q); }
+    void QueueWait0() { QueueWait(q0); }
+    void QueueWait1() { QueueWait(q1); }
+    void DeviceWait() { vk::DeviceWaitIdle(dev->handle()); }
+
+    void RecordCopy(vkt::CommandBuffer& cb, vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy& copy_region);
+    void RecordCopy(vkt::CommandBuffer& cb, vkt::Buffer& from, vkt::Buffer& to) { RecordCopy(cb, from, to, full_buffer); }
+};

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -27,18 +27,8 @@ void VkSyncValTest::InitSyncValFramework(bool enable_queue_submit_validation) {
         features_.disabledValidationFeatureCount = 0;
     }
 
-    // Optionally enable syncval submit validation
-    static const char *kEnableQueuSubmitSyncValidation[] = {"VALIDATION_CHECK_ENABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"};
-    static const VkLayerSettingEXT settings[] = {
-        {OBJECT_LAYER_NAME, "enables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, kEnableQueuSubmitSyncValidation}};
-    // The pNext of qs_settings is modified by InitFramework that's why it can't
-    // be static (should be separate instance per stack frame). Also we show
-    // explicitly that it's not const (InitFramework casts const pNext to non-const).
-    VkLayerSettingsCreateInfoEXT qs_settings{VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr,
-                                             static_cast<uint32_t>(std::size(settings)), settings};
-    if (enable_queue_submit_validation) {
-        features_.pNext = &qs_settings;
-    }
+    // QueueSubmit Validation *always* on (default behavior)
+
     InitFramework(&features_);
 }
 


### PR DESCRIPTION
Set queue submit time sync validation to be on by default.

Add disable setting for those that want to turn it off for performance.

Fixes #7127  