### PR TITLE
tests: Remove unused functions from VkImageObj

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -750,11 +750,6 @@ VkSubresourceLayout Image::subresource_layout(const VkImageSubresourceLayers &su
     return data;
 }
 
-bool Image::transparent() const {
-    return (create_info_.tiling == VK_IMAGE_TILING_LINEAR && create_info_.samples == VK_SAMPLE_COUNT_1_BIT &&
-            !(create_info_.usage & (VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)));
-}
-
 VkImageAspectFlags Image::aspect_mask(VkFormat format) {
     VkImageAspectFlags image_aspect;
     if (vkuFormatIsDepthAndStencil(format)) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -587,6 +587,8 @@ class Image : public internal::NonDispHandle<VkImage> {
     void init(const Device &dev, const VkImageCreateInfo &info) { init(dev, info, 0); }
     void init_no_mem(const Device &dev, const VkImageCreateInfo &info);
 
+    VkImage image() const { return handle(); }
+
     // get the internal memory
     const DeviceMemory &memory() const { return internal_mem_; }
     DeviceMemory &memory() { return internal_mem_; }
@@ -605,18 +607,15 @@ class Image : public internal::NonDispHandle<VkImage> {
     VkSubresourceLayout subresource_layout(const VkImageSubresource &subres) const;
     VkSubresourceLayout subresource_layout(const VkImageSubresourceLayers &subres) const;
 
-    bool transparent() const;
-    bool copyable() const { return (format_features_ & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT); }
-
-    VkImageAspectFlags aspect_mask() const { return aspect_mask(create_info_.format); }
-
-    VkImageSubresourceRange subresource_range() const { return subresource_range(create_info_, aspect_mask()); }
     VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect) const { return subresource_range(create_info_, aspect); }
 
     VkExtent3D extent() const { return create_info_.extent; }
+    uint32_t width() const { return create_info_.extent.width; }
+    uint32_t height() const { return create_info_.extent.height; }
     VkFormat format() const { return create_info_.format; }
+    uint32_t mip_levels() const { return create_info_.mipLevels; }
+    uint32_t array_layers() const { return create_info_.arrayLayers; }
     VkImageUsageFlags usage() const { return create_info_.usage; }
-    VkSharingMode sharing_mode() const { return create_info_.sharingMode; }
     VkImageMemoryBarrier image_memory_barrier(VkFlags output_mask, VkFlags input_mask, VkImageLayout old_layout,
                                               VkImageLayout new_layout, const VkImageSubresourceRange &range,
                                               uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -1098,7 +1098,7 @@ void VkImageObj::ImageMemoryBarrier(vkt::CommandBuffer *cmd_buf, VkImageAspectFl
                                     VkPipelineStageFlags src_stages, VkPipelineStageFlags dest_stages,
                                     uint32_t srcQueueFamilyIndex, uint32_t dstQueueFamilyIndex) {
     // clang-format on
-    const VkImageSubresourceRange subresourceRange = subresource_range(aspect, 0, m_mipLevels, 0, m_arrayLayers);
+    const VkImageSubresourceRange subresourceRange = subresource_range(aspect, 0, mip_levels(), 0, array_layers());
     VkImageMemoryBarrier barrier;
     barrier = image_memory_barrier(output_mask, input_mask, Layout(), image_layout, subresourceRange, srcQueueFamilyIndex,
                                    dstQueueFamilyIndex);
@@ -1312,10 +1312,6 @@ void VkImageObj::InitNoLayout(const VkImageCreateInfo &create_info, VkMemoryProp
     VkImageCreateInfo imageCreateInfo = create_info;
     imageCreateInfo.tiling = tiling;
 
-    m_format = imageCreateInfo.format;
-    m_mipLevels = imageCreateInfo.mipLevels;
-    m_arrayLayers = imageCreateInfo.arrayLayers;
-
     Layout(imageCreateInfo.initialLayout);
     if (memory)
         vkt::Image::init(*m_device, imageCreateInfo, reqs);
@@ -1384,9 +1380,6 @@ void VkImageObj::init(const VkImageCreateInfo *create_info) {
     Layout(create_info->initialLayout);
 
     vkt::Image::init(*m_device, *create_info, 0);
-    m_format = create_info->format;
-    m_mipLevels = create_info->mipLevels;
-    m_arrayLayers = create_info->arrayLayers;
 
     VkImageAspectFlags image_aspect = 0;
     if (vkuFormatIsDepthAndStencil(create_info->format)) {
@@ -1404,120 +1397,4 @@ void VkImageObj::init(const VkImageCreateInfo *create_info) {
 void VkImageObj::init_no_mem(const vkt::Device &dev, const VkImageCreateInfo &info) {
     vkt::Image::init_no_mem(dev, info);
     Layout(info.initialLayout);
-    m_format = info.format;
-    m_mipLevels = info.mipLevels;
-    m_arrayLayers = info.arrayLayers;
-}
-
-VkResult VkImageObj::CopyImage(VkImageObj &src_image) {
-    VkImageLayout src_image_layout, dest_image_layout;
-
-    vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);
-    vkt::CommandBuffer cmd_buf(m_device, &pool);
-
-    /* Build command buffer to copy staging texture to usable texture */
-    cmd_buf.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-
-    /* TODO: Can we determine image aspect from image object? */
-    src_image_layout = src_image.Layout();
-    src_image.SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-
-    dest_image_layout = (this->Layout() == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_IMAGE_LAYOUT_GENERAL : this->Layout();
-    this->SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-
-    VkImageCopy copy_region = {};
-    copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    copy_region.srcSubresource.baseArrayLayer = 0;
-    copy_region.srcSubresource.mipLevel = 0;
-    copy_region.srcSubresource.layerCount = 1;
-    copy_region.srcOffset.x = 0;
-    copy_region.srcOffset.y = 0;
-    copy_region.srcOffset.z = 0;
-    copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    copy_region.dstSubresource.baseArrayLayer = 0;
-    copy_region.dstSubresource.mipLevel = 0;
-    copy_region.dstSubresource.layerCount = 1;
-    copy_region.dstOffset.x = 0;
-    copy_region.dstOffset.y = 0;
-    copy_region.dstOffset.z = 0;
-    copy_region.extent = src_image.extent();
-
-    vk::CmdCopyImage(cmd_buf.handle(), src_image.handle(), src_image.Layout(), handle(), Layout(), 1, &copy_region);
-
-    src_image.SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, src_image_layout);
-
-    this->SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, dest_image_layout);
-
-    cmd_buf.end();
-
-    cmd_buf.QueueCommandBuffer();
-
-    return VK_SUCCESS;
-}
-
-// Same as CopyImage, but in the opposite direction
-VkResult VkImageObj::CopyImageOut(VkImageObj &dst_image) {
-    VkImageLayout src_image_layout, dest_image_layout;
-
-    vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);
-    vkt::CommandBuffer cmd_buf(m_device, &pool);
-
-    cmd_buf.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-
-    src_image_layout = this->Layout();
-    this->SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-
-    dest_image_layout = (dst_image.Layout() == VK_IMAGE_LAYOUT_UNDEFINED) ? VK_IMAGE_LAYOUT_GENERAL : dst_image.Layout();
-    dst_image.SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-
-    VkImageCopy copy_region = {};
-    copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    copy_region.srcSubresource.baseArrayLayer = 0;
-    copy_region.srcSubresource.mipLevel = 0;
-    copy_region.srcSubresource.layerCount = 1;
-    copy_region.srcOffset.x = 0;
-    copy_region.srcOffset.y = 0;
-    copy_region.srcOffset.z = 0;
-    copy_region.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-    copy_region.dstSubresource.baseArrayLayer = 0;
-    copy_region.dstSubresource.mipLevel = 0;
-    copy_region.dstSubresource.layerCount = 1;
-    copy_region.dstOffset.x = 0;
-    copy_region.dstOffset.y = 0;
-    copy_region.dstOffset.z = 0;
-    copy_region.extent = dst_image.extent();
-
-    vk::CmdCopyImage(cmd_buf.handle(), handle(), Layout(), dst_image.handle(), dst_image.Layout(), 1, &copy_region);
-
-    this->SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, src_image_layout);
-
-    dst_image.SetLayout(&cmd_buf, VK_IMAGE_ASPECT_COLOR_BIT, dest_image_layout);
-
-    cmd_buf.end();
-
-    cmd_buf.QueueCommandBuffer();
-
-    return VK_SUCCESS;
-}
-
-// Return 16x16 pixel block
-std::array<std::array<uint32_t, 16>, 16> VkImageObj::Read() {
-    VkImageObj stagingImage(m_device);
-    VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-
-    stagingImage.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
-                      VK_IMAGE_TILING_LINEAR, reqs);
-    stagingImage.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
-    VkSubresourceLayout layout = stagingImage.subresource_layout(subresource(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0));
-    CopyImageOut(stagingImage);
-    void *data = stagingImage.MapMemory();
-    std::array<std::array<uint32_t, 16>, 16> m = {};
-    if (data) {
-        for (uint32_t y = 0; y < stagingImage.extent().height; y++) {
-            uint32_t *row = (uint32_t *)((char *)data + layout.rowPitch * y);
-            for (uint32_t x = 0; x < stagingImage.extent().width; x++) m[y][x] = row[x];
-        }
-    }
-    stagingImage.UnmapMemory();
-    return m;
 }

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -283,29 +283,13 @@ class VkImageObj : public vkt::Image {
 
     void InitNoLayout(const VkImageCreateInfo &create_info, VkMemoryPropertyFlags reqs = 0, bool memory = true);
 
-    //    void clear( CommandBuffer*, uint32_t[4] );
-
     void Layout(VkImageLayout const layout) { m_descriptorImageInfo.imageLayout = layout; }
-
-    VkDeviceMemory Memory() const { return Image::memory().handle(); }
-
-    void *MapMemory() { return Image::memory().map(); }
-
-    void UnmapMemory() { Image::memory().unmap(); }
 
     void ImageMemoryBarrier(vkt::CommandBuffer *cmd, VkImageAspectFlags aspect, VkFlags output_mask, VkFlags input_mask,
                             VkImageLayout image_layout, VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                             VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                             uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
                             uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED);
-
-    VkResult CopyImage(VkImageObj &src_image);
-
-    VkResult CopyImageOut(VkImageObj &dst_image);
-
-    std::array<std::array<uint32_t, 16>, 16> Read();
-
-    VkImage image() const { return handle(); }
 
     VkImageViewCreateInfo BasicViewCreatInfo(VkImageAspectFlags aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT) const {
         VkImageViewCreateInfo ci = vku::InitStructHelper();
@@ -338,17 +322,12 @@ class VkImageObj : public vkt::Image {
 
     void SetLayout(vkt::CommandBuffer *cmd_buf, VkImageAspectFlags aspect, VkImageLayout image_layout);
     void SetLayout(VkImageAspectFlags aspect, VkImageLayout image_layout);
-    void SetLayout(VkImageLayout image_layout) { SetLayout(aspect_mask(), image_layout); };
+    void SetLayout(VkImageLayout image_layout) { SetLayout(aspect_mask(format()), image_layout); };
 
     VkImageLayout Layout() const { return m_descriptorImageInfo.imageLayout; }
-    uint32_t width() const { return extent().width; }
-    uint32_t height() const { return extent().height; }
     vkt::Device *device() const { return m_device; }
 
   protected:
     vkt::Device *m_device = nullptr;
-    VkFormat m_format = VK_FORMAT_UNDEFINED;
-    uint32_t m_mipLevels = 0;
-    uint32_t m_arrayLayers = 0;
     VkDescriptorImageInfo m_descriptorImageInfo = {VK_NULL_HANDLE, VK_NULL_HANDLE, VK_IMAGE_LAYOUT_GENERAL};
 };


### PR DESCRIPTION
(redo of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7106)

`VkImageObj` is the last remaining object we have both in binding.cpp and render.cpp and it is a mess currently

This is a first step of cleaning it up by removing things that are not being used anymore to make the migration process a bit nicer