### PR TITLE
layers: Retire submissions using acquire fence

### DIFF
--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -29,6 +29,7 @@ class ValidationStateTracker;
 namespace vvl {
 
 class Queue;
+struct SubmissionLocator;
 
 class Semaphore : public REFCOUNTED_NODE {
   public:
@@ -171,6 +172,9 @@ class Semaphore : public REFCOUNTED_NODE {
 
     // look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(const std::function<bool(const SemOp &, bool is_pending)> &filter = nullptr) const;
+
+    // Returns queue submission associated with the last binary signal.
+    std::optional<SubmissionLocator> GetLastBinarySignalSubmission() const;
 
     bool CanBinaryBeSignaled() const;
     bool CanBinaryBeWaited() const;

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -384,6 +384,7 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
     Semaphore() = default;
     Semaphore(const Device &dev) { init(dev, vku::InitStruct<VkSemaphoreCreateInfo>()); }
     Semaphore(const Device &dev, const VkSemaphoreCreateInfo &info) { init(dev, info); }
+    Semaphore(Semaphore &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     ~Semaphore() noexcept;
     void destroy() noexcept;
 
@@ -961,6 +962,14 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     explicit CommandBuffer(Device *device, const CommandPool *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
                            Queue *queue = nullptr) {
         Init(device, pool, level, queue);
+    }
+    CommandBuffer(CommandBuffer &&rhs) noexcept : Handle(std::move(rhs)) {
+        dev_handle_ = rhs.dev_handle_;
+        rhs.dev_handle_ = VK_NULL_HANDLE;
+        cmd_pool_ = rhs.cmd_pool_;
+        rhs.cmd_pool_ = VK_NULL_HANDLE;
+        m_queue = rhs.m_queue;
+        rhs.m_queue = nullptr;
     }
 
     // vkAllocateCommandBuffers()


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/12

The test implements and explains a scenario where image-acquire-fence can synchronize frames and guarantees that resources are not in use. Will repeat sync chain structure here too:

1) wait on the image acquire fence -> image was acquired
2) image was acquired -> image was presented in one of the previous frames
3) image was presented ->  corresponding present waited on the submit semaphore
4) submit semaphore was waited on -> corresponding submit finished execution and can be retired/reused

