### PR TITLE
tests: Create RenderPass2SingleSubpass

### DIFF
--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -12,10 +12,13 @@
 
 #include "render_pass_helper.h"
 
-RenderPassSingleSubpass::RenderPassSingleSubpass(VkLayerTest& test, vkt::Device* device) : layer_test_(test) {
+InterfaceRenderPassSingleSubpass::InterfaceRenderPassSingleSubpass(VkLayerTest& test, vkt::Device* device) : layer_test_(test) {
     // default VkDevice, can be overwritten if multi-device tests
     device_ = (device) ? device : layer_test_.DeviceObj();
+}
 
+RenderPassSingleSubpass::RenderPassSingleSubpass(VkLayerTest& test, vkt::Device* device)
+    : InterfaceRenderPassSingleSubpass(test, device) {
     rp_create_info_ = vku::InitStructHelper();
 
     rp_create_info_.dependencyCount = 0;  // default to not having one
@@ -34,8 +37,6 @@ RenderPassSingleSubpass::RenderPassSingleSubpass(VkLayerTest& test, vkt::Device*
     rp_create_info_.subpassCount = 1;
     rp_create_info_.pSubpasses = &subpass_description_;
 }
-
-RenderPassSingleSubpass::~RenderPassSingleSubpass() { Destroy(); }
 
 VkRenderPassCreateInfo RenderPassSingleSubpass::GetCreateInfo() {
     rp_create_info_.attachmentCount = attachment_descriptions_.size();
@@ -73,13 +74,13 @@ void RenderPassSingleSubpass::AddColorAttachment(uint32_t index) {
 }
 
 void RenderPassSingleSubpass::AddResolveAttachment(uint32_t index) {
-    resolve_attachments_ = attachments_references_[index];
-    subpass_description_.pResolveAttachments = &resolve_attachments_;
+    resolve_attachment_ = attachments_references_[index];
+    subpass_description_.pResolveAttachments = &resolve_attachment_;
 }
 
 void RenderPassSingleSubpass::AddDepthStencilAttachment(uint32_t index) {
-    ds_attachments_ = attachments_references_[index];
-    subpass_description_.pDepthStencilAttachment = &ds_attachments_;
+    ds_attachment_ = attachments_references_[index];
+    subpass_description_.pDepthStencilAttachment = &ds_attachment_;
 }
 
 void RenderPassSingleSubpass::AddSubpassDependency(VkSubpassDependency dependency) {
@@ -103,6 +104,122 @@ void RenderPassSingleSubpass::AddSubpassDependency(VkPipelineStageFlags srcStage
 
 void RenderPassSingleSubpass::CreateRenderPass(void* pNext) {
     VkRenderPassCreateInfo rp_create_info = GetCreateInfo();
+    rp_create_info.pNext = pNext;
+    render_pass_.init(*device_, rp_create_info);
+}
+
+RenderPass2SingleSubpass::RenderPass2SingleSubpass(VkLayerTest& test, vkt::Device* device)
+    : InterfaceRenderPassSingleSubpass(test, device) {
+    rp_create_info_ = vku::InitStructHelper();
+
+    rp_create_info_.dependencyCount = 0;  // default to not having one
+    rp_create_info_.pDependencies = &subpass_dependency_;
+
+    subpass_description_ = vku::InitStructHelper();
+    subpass_description_.flags = 0;
+    subpass_description_.viewMask = 0;
+    subpass_description_.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+    subpass_description_.inputAttachmentCount = 0;
+    subpass_description_.pInputAttachments = nullptr;
+    subpass_description_.colorAttachmentCount = 0;
+    subpass_description_.pColorAttachments = nullptr;
+    subpass_description_.pResolveAttachments = nullptr;
+    subpass_description_.pDepthStencilAttachment = nullptr;
+    subpass_description_.preserveAttachmentCount = 0;
+    subpass_description_.pPreserveAttachments = nullptr;
+    rp_create_info_.subpassCount = 1;
+    rp_create_info_.pSubpasses = &subpass_description_;
+}
+
+VkRenderPassCreateInfo2 RenderPass2SingleSubpass::GetCreateInfo() {
+    rp_create_info_.attachmentCount = attachment_descriptions_.size();
+    rp_create_info_.pAttachments = attachment_descriptions_.data();
+    return rp_create_info_;
+}
+
+void RenderPass2SingleSubpass::AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout, VkImageLayout finalLayout,
+                                                        VkAttachmentLoadOp loadOp, VkAttachmentStoreOp storeOp) {
+    attachment_descriptions_.push_back(vku::InitStruct<VkAttachmentDescription2>(
+        nullptr, 0, format, VK_SAMPLE_COUNT_1_BIT, loadOp, storeOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout));
+}
+
+void RenderPass2SingleSubpass::AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples, VkImageLayout initialLayout,
+                                                        VkImageLayout finalLayout) {
+    attachment_descriptions_.push_back(vku::InitStruct<VkAttachmentDescription2>(
+        nullptr, 0, format, samples, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+        VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout));
+}
+
+void RenderPass2SingleSubpass::SetAttachmentDescriptionPNext(uint32_t index, void* pNext) {
+    attachment_descriptions_[index].pNext = pNext;
+}
+
+void RenderPass2SingleSubpass::AddAttachmentReference(uint32_t attachment, VkImageLayout layout, VkImageAspectFlags aspect_mask,
+                                                      void* pNext) {
+    attachments_references_.push_back(vku::InitStruct<VkAttachmentReference2>(pNext, attachment, layout, aspect_mask));
+}
+
+void RenderPass2SingleSubpass::AddInputAttachment(uint32_t index) {
+    input_attachments_.push_back(attachments_references_[index]);
+    subpass_description_.inputAttachmentCount = input_attachments_.size();
+    subpass_description_.pInputAttachments = input_attachments_.data();
+}
+
+void RenderPass2SingleSubpass::AddColorAttachment(uint32_t index) {
+    color_attachments_.push_back(attachments_references_[index]);
+    subpass_description_.colorAttachmentCount = color_attachments_.size();
+    subpass_description_.pColorAttachments = color_attachments_.data();
+}
+
+void RenderPass2SingleSubpass::AddResolveAttachment(uint32_t index) {
+    resolve_attachment_ = attachments_references_[index];
+    subpass_description_.pResolveAttachments = &resolve_attachment_;
+}
+
+void RenderPass2SingleSubpass::AddDepthStencilAttachment(uint32_t index) {
+    ds_attachment_ = attachments_references_[index];
+    subpass_description_.pDepthStencilAttachment = &ds_attachment_;
+}
+
+void RenderPass2SingleSubpass::AddDepthStencilResolveAttachment(uint32_t index, VkResolveModeFlagBits depth_resolve_mode,
+                                                                VkResolveModeFlagBits stencil_resolve_mode) {
+    ds_attachment_resolve_ = vku::InitStructHelper();
+    ds_attachment_resolve_.pDepthStencilResolveAttachment = &attachments_references_[index];
+    ds_attachment_resolve_.depthResolveMode = depth_resolve_mode;
+    ds_attachment_resolve_.stencilResolveMode = stencil_resolve_mode;
+    subpass_description_.pNext = &ds_attachment_resolve_;
+}
+
+void RenderPass2SingleSubpass::AddFragmentShadingRateAttachment(uint32_t index, VkExtent2D texel_size) {
+    fsr_attachment_ = vku::InitStructHelper();
+    fsr_attachment_.pFragmentShadingRateAttachment = &attachments_references_[index];
+    fsr_attachment_.shadingRateAttachmentTexelSize = texel_size;
+    subpass_description_.pNext = &fsr_attachment_;
+}
+
+void RenderPass2SingleSubpass::AddSubpassDependency(VkSubpassDependency2 dependency) {
+    subpass_dependency_ = dependency;
+    rp_create_info_.dependencyCount = 1;
+}
+
+void RenderPass2SingleSubpass::AddSubpassDependency(VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
+                                                    VkAccessFlags srcAccessMask, VkAccessFlags dstAccessMask,
+                                                    VkDependencyFlags dependencyFlags) {
+    subpass_dependency_ = vku::InitStructHelper();
+    subpass_dependency_.srcSubpass = 0;
+    subpass_dependency_.dstSubpass = 0;
+    subpass_dependency_.srcStageMask = srcStageMask;
+    subpass_dependency_.srcStageMask = srcStageMask;
+    subpass_dependency_.dstStageMask = dstStageMask;
+    subpass_dependency_.srcAccessMask = srcAccessMask;
+    subpass_dependency_.dstAccessMask = dstAccessMask;
+    subpass_dependency_.dependencyFlags = dependencyFlags;
+    rp_create_info_.dependencyCount = 1;
+}
+
+void RenderPass2SingleSubpass::CreateRenderPass(void* pNext) {
+    VkRenderPassCreateInfo2 rp_create_info = GetCreateInfo();
     rp_create_info.pNext = pNext;
     render_pass_.init(*device_, rp_create_info);
 }

--- a/tests/framework/render_pass_helper.h
+++ b/tests/framework/render_pass_helper.h
@@ -18,6 +18,9 @@
 // Helper designed to quickly make a renderPass/framebuffer that only has a single Subpass.
 // The goal is to keep the class simple as possible.
 //
+// Interface:
+//   We use a seperate class for RenderPass1 and RenderPass2, but want to not have them diverage, so we keep an interface class
+//
 // Common usage:
 //   RenderPassSingleSubpass rp(*this);
 //   rp.AddAttachmentDescription(input_format); // sets description[0]
@@ -27,13 +30,53 @@
 //   rp.AddInputAttachment(0); // index maps to reference[0]
 //   rp.AddColorAttachment(1); // index maps to reference[1]
 //   rp.CreateRenderPass();
-class RenderPassSingleSubpass {
+class InterfaceRenderPassSingleSubpass {
+  public:
+    InterfaceRenderPassSingleSubpass(VkLayerTest &test, vkt::Device *device = nullptr);
+    virtual ~InterfaceRenderPassSingleSubpass() { Destroy(); }
+
+    VkRenderPass Handle() { return render_pass_; }
+
+    // Parameters are ordered from most likely to be custom values
+    // Most tests don't need to worry about the Load/Store ops as we never read the values
+    virtual void AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                          VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                          VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                          VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE) = 0;
+    // Overload for setting samples count
+    virtual void AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples,
+                                          VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                          VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL) = 0;
+
+    // Pass in index to VkAttachmentReference
+    virtual void AddInputAttachment(uint32_t index) = 0;
+    virtual void AddColorAttachment(uint32_t index) = 0;
+    virtual void AddResolveAttachment(uint32_t index) = 0;
+    virtual void AddDepthStencilAttachment(uint32_t index) = 0;
+
+    virtual void AddSubpassDependency(VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                      VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                                      VkAccessFlags srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                      VkAccessFlags dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                                      VkDependencyFlags dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT) = 0;
+
+    virtual void CreateRenderPass(void *pNext = nullptr) = 0;
+
+    // Explicit destroy for those tests that need to test render pass lifetime
+    void Destroy() { render_pass_.destroy(); };
+
+  protected:
+    VkLayerTest &layer_test_;
+    vkt::Device *device_;
+
+    vkt::RenderPass render_pass_;
+};
+
+class RenderPassSingleSubpass : public InterfaceRenderPassSingleSubpass {
   public:
     RenderPassSingleSubpass(VkLayerTest &test, vkt::Device *device = nullptr);
-    ~RenderPassSingleSubpass();
 
     VkRenderPassCreateInfo GetCreateInfo();
-    VkRenderPass Handle() { return render_pass_; }
 
     // Ordered from most likely to be custom vs will use defauly
     void AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
@@ -62,14 +105,7 @@ class RenderPassSingleSubpass {
 
     void CreateRenderPass(void *pNext = nullptr);
 
-    // Explicit destroy for those tests that need to test render pass lifetime
-    void Destroy() { render_pass_.destroy(); };
-
   private:
-    VkLayerTest &layer_test_;
-    vkt::Device *device_;
-
-    vkt::RenderPass render_pass_;
     VkRenderPassCreateInfo rp_create_info_;
 
     std::vector<VkAttachmentDescription> attachment_descriptions_;
@@ -77,9 +113,71 @@ class RenderPassSingleSubpass {
     std::vector<VkAttachmentReference> attachments_references_;  // global pool
     std::vector<VkAttachmentReference> input_attachments_;
     std::vector<VkAttachmentReference> color_attachments_;
-    VkAttachmentReference resolve_attachments_;
-    VkAttachmentReference ds_attachments_;
+    VkAttachmentReference resolve_attachment_;
+    VkAttachmentReference ds_attachment_;
 
     VkSubpassDescription subpass_description_;
     VkSubpassDependency subpass_dependency_;
+};
+
+class RenderPass2SingleSubpass : public InterfaceRenderPassSingleSubpass {
+  public:
+    RenderPass2SingleSubpass(VkLayerTest &test, vkt::Device *device = nullptr);
+
+    VkRenderPassCreateInfo2 GetCreateInfo();
+
+    // Ordered from most likely to be custom vs will use defauly
+    void AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                  VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE);
+    // Overload for setting sampler count
+    void AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples,
+                                  VkImageLayout initialLayout = VK_IMAGE_LAYOUT_GENERAL,
+                                  VkImageLayout finalLayout = VK_IMAGE_LAYOUT_GENERAL);
+
+    // Have a seperate set function to keep AddAttachmentDescription simple (very few things extend the AttachmentDescription)
+    void SetAttachmentDescriptionPNext(uint32_t index, void *pNext);
+
+    void AddAttachmentReference(uint32_t attachment, VkImageLayout layout, VkImageAspectFlags aspect_mask = 0,
+                                void *pNext = nullptr);
+
+    // Pass in index to VkAttachmentReference
+    void AddInputAttachment(uint32_t index);
+    void AddColorAttachment(uint32_t index);
+    void AddResolveAttachment(uint32_t index);
+    void AddDepthStencilAttachment(uint32_t index);
+    // VK_KHR_depth_stencil_resolve
+    void AddDepthStencilResolveAttachment(uint32_t index, VkResolveModeFlagBits depth_resolve_mode,
+                                          VkResolveModeFlagBits stencil_resolve_mode);
+    // VK_KHR_fragment_shading_rate
+    void AddFragmentShadingRateAttachment(uint32_t index, VkExtent2D texel_size);
+
+    void SetViewMask(uint32_t view_mask) { subpass_description_.viewMask = view_mask; }
+
+    void AddSubpassDependency(VkSubpassDependency2 dependency);
+    void AddSubpassDependency(VkPipelineStageFlags srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                              VkPipelineStageFlags dstStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
+                              VkAccessFlags srcAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                              VkAccessFlags dstAccessMask = VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
+                              VkDependencyFlags dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT);
+
+    void CreateRenderPass(void *pNext = nullptr);
+
+  private:
+    VkRenderPassCreateInfo2 rp_create_info_;
+
+    std::vector<VkAttachmentDescription2> attachment_descriptions_;
+
+    std::vector<VkAttachmentReference2> attachments_references_;  // global pool
+    std::vector<VkAttachmentReference2> input_attachments_;
+    std::vector<VkAttachmentReference2> color_attachments_;
+    VkAttachmentReference2 resolve_attachment_;
+    VkAttachmentReference2 ds_attachment_;
+
+    VkSubpassDescriptionDepthStencilResolve ds_attachment_resolve_;
+    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment_;
+
+    VkSubpassDescription2 subpass_description_;
+    VkSubpassDependency2 subpass_dependency_;
 };

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -10,6 +10,7 @@
  */
 
 #include "../framework/layer_validation_tests.h"
+#include "../framework/render_pass_helper.h"
 
 TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     TEST_DESCRIPTION("Specify shading rate pipeline stage with attachmentFragmentShadingRate feature enabled");
@@ -78,54 +79,25 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper();
-    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper(&fsr_features);
-    auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
-    if (multiview_features.multiview == VK_FALSE) {
-        GTEST_SKIP() << "multiview feature not supported";
-        return;
-    }
-    if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
-        GTEST_SKIP() << "VkPhysicalDeviceFragmentShadingRateFeaturesKHR::attachmentFragmentShadingRate not supported.";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
-
-    VkAttachmentReference2 attach = vku::InitStructHelper();
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
-    attach.attachment = 0;
+    AddRequiredFeature(vkt::Feature::multiview);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
-    fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
-    fsr_attachment.pFragmentShadingRateAttachment = &attach;
-
-    VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
-    subpass.viewMask = 0x2;
-
-    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
-    attach_desc.format = VK_FORMAT_R8_UINT;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass rp(*m_device, rpci);
-    ASSERT_TRUE(rp.initialized());
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.SetViewMask(0x2);
+    rp.CreateRenderPass();
 
     VkImageObj image(m_device);
     image.InitNoLayout(1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     vkt::ImageView imageView = image.CreateView();
 
-    vkt::Framebuffer framebuffer(*m_device, rp.handle(), 1, &imageView.handle(),
+    vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle(),
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.width,
                                  fsr_properties.minFragmentShadingRateAttachmentTexelSize.height);
     ASSERT_TRUE(framebuffer.initialized());

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -707,43 +707,15 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     uint32_t attachmentHeight = 512;
     VkFormat attachmentFormat = FindSupportedDepthStencilFormat(gpu());
 
-    VkAttachmentDescription2KHR attachmentDescriptions[2] = {};
-    // Depth/stencil attachment
-    attachmentDescriptions[0] = vku::InitStructHelper();
-    attachmentDescriptions[0].format = attachmentFormat;
-    attachmentDescriptions[0].samples = VK_SAMPLE_COUNT_4_BIT;
-    attachmentDescriptions[0].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[0].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[0].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-    // Depth/stencil resolve attachment
-    attachmentDescriptions[1] = vku::InitStructHelper();
-    attachmentDescriptions[1].format = attachmentFormat;
-    attachmentDescriptions[1].samples = VK_SAMPLE_COUNT_1_BIT;
-    attachmentDescriptions[1].loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[1].stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    attachmentDescriptions[1].finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkAttachmentReference2KHR depthStencilAttachmentReference = vku::InitStructHelper();
-    depthStencilAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    depthStencilAttachmentReference.attachment = 0;
-    VkAttachmentReference2KHR depthStencilResolveAttachmentReference = vku::InitStructHelper();
-    depthStencilResolveAttachmentReference.layout = VK_IMAGE_LAYOUT_GENERAL;
-    depthStencilResolveAttachmentReference.attachment = 1;
-    VkSubpassDescriptionDepthStencilResolveKHR subpassDescriptionDepthStencilResolve =
-        vku::InitStructHelper();
-    subpassDescriptionDepthStencilResolve.pDepthStencilResolveAttachment = &depthStencilResolveAttachmentReference;
-    subpassDescriptionDepthStencilResolve.depthResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
-    subpassDescriptionDepthStencilResolve.stencilResolveMode = VK_RESOLVE_MODE_SAMPLE_ZERO_BIT_KHR;
-    VkSubpassDescription2KHR subpassDescription = vku::InitStructHelper(&subpassDescriptionDepthStencilResolve);
-    subpassDescription.pDepthStencilAttachment = &depthStencilAttachmentReference;
-    subpassDescription.viewMask = 0x3u;
-
-    VkRenderPassCreateInfo2KHR renderPassCreateInfo = vku::InitStructHelper();
-    renderPassCreateInfo.attachmentCount = 2;
-    renderPassCreateInfo.subpassCount = 1;
-    renderPassCreateInfo.pSubpasses = &subpassDescription;
-    renderPassCreateInfo.pAttachments = attachmentDescriptions;
-    vkt::RenderPass render_pass(*m_device, renderPassCreateInfo);
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(attachmentFormat, VK_SAMPLE_COUNT_4_BIT);  // Depth/stencil
+    rp.AddAttachmentDescription(attachmentFormat, VK_SAMPLE_COUNT_1_BIT);  // Depth/stencil resolve
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddAttachmentReference(1, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddDepthStencilAttachment(0);
+    rp.AddDepthStencilResolveAttachment(1, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT, VK_RESOLVE_MODE_SAMPLE_ZERO_BIT);
+    rp.SetViewMask(0x3u);
+    rp.CreateRenderPass();
 
     VkFramebufferAttachmentImageInfoKHR framebufferAttachmentImageInfos[2] = {};
     // Depth/stencil attachment
@@ -770,7 +742,7 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
     framebufferCreateInfo.width = attachmentWidth;
     framebufferCreateInfo.height = attachmentHeight;
     framebufferCreateInfo.layers = 1;
-    framebufferCreateInfo.renderPass = render_pass.handle();
+    framebufferCreateInfo.renderPass = rp.Handle();
     framebufferCreateInfo.attachmentCount = 2;
     framebufferCreateInfo.pAttachments = nullptr;
     VkFramebuffer framebuffer = VK_NULL_HANDLE;
@@ -799,49 +771,20 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
 TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
-    // Enable KHR_fragment_shading_rate and all of its required extensions
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
+    AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    VkPhysicalDeviceImagelessFramebufferFeatures if_features = vku::InitStructHelper();
-    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper(&if_features);
-    auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
-
-    if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
-        GTEST_SKIP() << "requires attachmentFragmentShadingRate feature";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
-
-    VkAttachmentReference2 attach = vku::InitStructHelper();
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
-    attach.attachment = 0;
-
-    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
-    fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
-    fsr_attachment.pFragmentShadingRateAttachment = &attach;
-
-    // Create a renderPass with a single fsr attachment
-    VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
-
-    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
-    attach_desc.format = VK_FORMAT_R8_UINT;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass rp(*m_device, rpci);
-    ASSERT_TRUE(rp.initialized());
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.CreateRenderPass();
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
     VkFramebufferAttachmentImageInfo fbai_info = vku::InitStructHelper();
@@ -858,7 +801,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    fb_info.renderPass = rp.handle();
+    fb_info.renderPass = rp.Handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = NULL;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -873,53 +816,21 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateUsage) {
 TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
     TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
-    // Enable KHR_fragment_shading_rate and all of its required extensions
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
-    AddOptionalExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    VkPhysicalDeviceMultiviewFeaturesKHR mv_features = vku::InitStructHelper();
-    VkPhysicalDeviceImagelessFramebufferFeatures if_features = vku::InitStructHelper();
-    if (IsExtensionsEnabled(VK_KHR_MULTIVIEW_EXTENSION_NAME)) {
-        if_features.pNext = &mv_features;
-    }
-    VkPhysicalDeviceFragmentShadingRateFeaturesKHR fsr_features = vku::InitStructHelper(&if_features);
-    auto features2 = GetPhysicalDeviceFeatures2(fsr_features);
-
-    if (fsr_features.attachmentFragmentShadingRate != VK_TRUE) {
-        GTEST_SKIP() << "attachmentFragmentShadingRate feature not supported";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
-
-    VkAttachmentReference2 attach = vku::InitStructHelper();
-    attach.layout = VK_IMAGE_LAYOUT_GENERAL;
-    attach.attachment = 0;
-
-    VkFragmentShadingRateAttachmentInfoKHR fsr_attachment = vku::InitStructHelper();
-    fsr_attachment.shadingRateAttachmentTexelSize = fsr_properties.minFragmentShadingRateAttachmentTexelSize;
-    fsr_attachment.pFragmentShadingRateAttachment = &attach;
-
-    // Create a renderPass with a single fsr attachment
-    VkSubpassDescription2 subpass = vku::InitStructHelper(&fsr_attachment);
-
-    VkAttachmentDescription2 attach_desc = vku::InitStructHelper();
-    attach_desc.format = VK_FORMAT_R8_UINT;
-    attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
-    attach_desc.initialLayout = VK_IMAGE_LAYOUT_GENERAL;
-    attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &attach_desc;
-
-    vkt::RenderPass rp(*m_device, rpci);
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.CreateRenderPass();
 
     VkFormat viewFormat = VK_FORMAT_R8_UINT;
     VkFramebufferAttachmentImageInfo fbai_info = vku::InitStructHelper();
@@ -936,7 +847,7 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
     fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
-    fb_info.renderPass = rp.handle();
+    fb_info.renderPass = rp.Handle();
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = NULL;
     fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
@@ -966,21 +877,58 @@ TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensions) {
         vkt::Framebuffer fb(*m_device, fb_info);
         m_errorMonitor->VerifyFound();
     }
-    fb_info.layers = 1;
-    fbai_info.layerCount = 1;
+}
 
-    if (fsr_properties.layeredShadingRateAttachments && mv_features.multiview) {
-        subpass.viewMask = 0x4;
-        vkt::RenderPass rp2(*m_device, rpci);
-        ASSERT_TRUE(rp2.initialized());
-        subpass.viewMask = 0;
+TEST_F(NegativeImagelessFramebuffer, FragmentShadingRateDimensionsMultiview) {
+    TEST_DESCRIPTION("Specify a fragment shading rate attachment without the correct usage");
 
-        fbai_info.layerCount = 2;
-        fb_info.renderPass = rp2.handle();
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-08921");
-        vkt::Framebuffer fb(*m_device, fb_info);
-        m_errorMonitor->VerifyFound();
+    AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
+    AddRequiredFeature(vkt::Feature::attachmentFragmentShadingRate);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(fsr_properties);
+
+    if (fsr_properties.layeredShadingRateAttachments) {
+        GTEST_SKIP() << "requires layeredShadingRateAttachments to be unsupported.";
     }
+
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_R8_UINT);
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
+    rp.SetViewMask(0x4);
+    rp.CreateRenderPass();
+
+    VkFormat viewFormat = VK_FORMAT_R8_UINT;
+    VkFramebufferAttachmentImageInfo fbai_info = vku::InitStructHelper();
+    fbai_info.usage = VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
+    fbai_info.width = 1;
+    fbai_info.height = 1;
+    fbai_info.layerCount = 2;
+    fbai_info.viewFormatCount = 1;
+    fbai_info.pViewFormats = &viewFormat;
+
+    VkFramebufferAttachmentsCreateInfo fba_info = vku::InitStructHelper();
+    fba_info.attachmentImageInfoCount = 1;
+    fba_info.pAttachmentImageInfos = &fbai_info;
+
+    VkFramebufferCreateInfo fb_info = vku::InitStructHelper(&fba_info);
+    fb_info.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT;
+    fb_info.renderPass = rp.Handle();
+    fb_info.attachmentCount = 1;
+    fb_info.pAttachments = NULL;
+    fb_info.width = fsr_properties.minFragmentShadingRateAttachmentTexelSize.width;
+    fb_info.height = fsr_properties.minFragmentShadingRateAttachmentTexelSize.height;
+    fb_info.layers = 1;
+    ;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-renderPass-08921");
+    vkt::Framebuffer fb(*m_device, fb_info);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1122,45 +1122,22 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
     TEST_DESCRIPTION("Create graphics pipeline using multiview features which are not enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
+    AddRequiredFeature(vkt::Feature::multiview);
+    AddRequiredFeature(vkt::Feature::tessellationShader);
+    AddRequiredFeature(vkt::Feature::geometryShader);
+    AddDisabledFeature(vkt::Feature::multiviewTessellationShader);
+    AddDisabledFeature(vkt::Feature::multiviewGeometryShader);
+    RETURN_IF_SKIP(Init());
 
-    VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(multiview_features);
+    RenderPass2SingleSubpass rp(*this);
+    rp.AddAttachmentDescription(VK_FORMAT_B8G8R8A8_UNORM);
+    rp.AddAttachmentReference(0, VK_IMAGE_LAYOUT_GENERAL);
+    rp.AddColorAttachment(0);
+    rp.SetViewMask(0x3u);
+    rp.CreateRenderPass();
 
-    if (!multiview_features.multiview) {
-        GTEST_SKIP() << "Multiview support is required";
-    }
-
-    multiview_features.multiviewTessellationShader = VK_FALSE;
-    multiview_features.multiviewGeometryShader = VK_FALSE;
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
-
-    VkAttachmentReference2 color_attachment = vku::InitStructHelper();
-    color_attachment.layout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkAttachmentDescription2 description = vku::InitStructHelper();
-    description.samples = VK_SAMPLE_COUNT_1_BIT;
-    description.format = VK_FORMAT_B8G8R8A8_UNORM;
-    description.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    description.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-    description.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
-
-    VkSubpassDescription2 subpass = vku::InitStructHelper();
-    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpass.viewMask = 0x3u;
-    subpass.colorAttachmentCount = 1;
-    subpass.pColorAttachments = &color_attachment;
-
-    VkRenderPassCreateInfo2 rpci = vku::InitStructHelper();
-    rpci.attachmentCount = 1;
-    rpci.pAttachments = &description;
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &subpass;
-
-    vkt::RenderPass render_pass(*m_device, rpci);
-    ASSERT_TRUE(render_pass.initialized());
-
-    if (features2.features.tessellationShader) {
+    // tessellationShader
+    {
         char const *tcsSource = R"glsl(
         #version 450
         layout(vertices=3) out;
@@ -1187,7 +1164,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         VkPipelineTessellationStateCreateInfo tsci{VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, nullptr, 0, 3};
 
         CreatePipelineHelper pipe(*this);
-        pipe.gp_ci_.renderPass = render_pass.handle();
+        pipe.gp_ci_.renderPass = rp.Handle();
         pipe.gp_ci_.subpass = 0;
         pipe.cb_ci_.attachmentCount = 1;
         pipe.gp_ci_.pTessellationState = &tsci;
@@ -1200,7 +1177,8 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
     }
-    if (features2.features.geometryShader) {
+    // geometryShader
+    {
         static char const *gsSource = R"glsl(
         #version 450
         layout (points) in;
@@ -1216,7 +1194,7 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         VkShaderObj gs(this, gsSource, VK_SHADER_STAGE_GEOMETRY_BIT);
 
         CreatePipelineHelper pipe(*this);
-        pipe.gp_ci_.renderPass = render_pass.handle();
+        pipe.gp_ci_.renderPass = rp.Handle();
         pipe.gp_ci_.subpass = 0;
         pipe.cb_ci_.attachmentCount = 1;
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};


### PR DESCRIPTION
While trying to add more tests for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7141 I realize we need a `RenderPass2SingleSubpass` helper to more easily create render passes that need things extended

This adds `RenderPass2SingleSubpass` and populates many spots with it.. in process cleaned up some of the tests I touched