### PR TITLE
scripts: Cleanup pip usage

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -111,7 +111,6 @@ jobs:
       - uses: hendrikmuhs/ccache-action@v1.2
         with:
           key: androidOnLinux-ccache
-      - run: python3 -m pip install jsonschema pyparsing
       - run: sudo apt-get -qq update && sudo apt-get install -y libwayland-dev xorg-dev
       - name: Build
         run: python scripts/tests.py --build --mockAndroid --config release
@@ -138,7 +137,6 @@ jobs:
       - uses: ilammy/msvc-dev-cmd@v1
         with:
           arch: ${{ matrix.arch }}
-      - run: python3 -m pip install jsonschema pyparsing
       - name: Cache known_good.json installations
         id: cache-deps
         uses: actions/cache@v3
@@ -273,7 +271,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
-      - run: python3 -m pip install jsonschema pyparsing
+      - run: python3 -m pip install pyparsing
       - run: scripts/update_deps.py --dir ext --no-build
       - run: scripts/generate_source.py --verify ext/Vulkan-Headers/registry/ ext/SPIRV-Headers/include/spirv/unified1/
       - run: scripts/vk_validation_stats.py ext/Vulkan-Headers/registry/validusage.json -summary -c

--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -160,8 +160,6 @@ def BuildMockICD(mockAndroid):
 #
 # Prepare Profile Layer for use with Layer Validation Tests
 def BuildProfileLayer(mockAndroid):
-    RunShellCmd('pip3 install jsonschema')
-
     SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Profiles'
     BUILD_DIR = f'{SRC_DIR}/build'
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -123,7 +123,7 @@
             "sub_dir": "Vulkan-Profiles",
             "build_dir": "Vulkan-Profiles/build",
             "install_dir": "Vulkan-Profiles/build/install",
-            "commit": "022309960fa9354835bf5150dffa8742decbe908",
+            "commit": "c9f3044a5f5c96b283ea1280f700d31e20937767",
             "build_step": "skip",
             "optional": [
                 "tests"


### PR DESCRIPTION
profiles no longer requires jsonschema as of
KhronosGroup/Vulkan-Profiles/pull/583

Furthermore with the exception of the codegen CI check we don't need to install pyparsing.