### PR TITLE
tests: Revert sync_val dynamicRendering feature check

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -538,9 +538,13 @@ TEST_F(NegativeSyncVal, CmdClearAttachmentsDynamicHazards) {
     // VK_EXT_load_store_op_none is needed to disable render pass load/store accesses, so clearing
     // attachment inside a render pass can create hazards with the copy operations outside render pass.
     AddRequiredExtensions(VK_EXT_LOAD_STORE_OP_NONE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
+    if (!dynamic_rendering_features.dynamicRendering) {
+        GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
+    }
+    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
 
     ClearAttachmentHazardHelper helper(*this, *m_device, *m_commandBuffer);
 
@@ -1577,9 +1581,13 @@ TEST_F(NegativeSyncVal, AttachmentStoreHazard) {
 TEST_F(NegativeSyncVal, DynamicRenderingAttachmentLoadHazard) {
     TEST_DESCRIPTION("Copying to attachment creates hazard with attachment load operation");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
+    if (!dynamic_rendering_features.dynamicRendering) {
+        GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
+    }
+    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
 
     InitRenderTarget();
     m_renderTargets[0]->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -1625,9 +1633,13 @@ TEST_F(NegativeSyncVal, DynamicRenderingAttachmentLoadHazard) {
 TEST_F(NegativeSyncVal, DynamicRenderingAttachmentStoreHazard) {
     TEST_DESCRIPTION("Copying to attachment creates hazard with attachment store operation");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
+    if (!dynamic_rendering_features.dynamicRendering) {
+        GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
+    }
+    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
 
     InitRenderTarget();
     m_renderTargets[0]->SetLayout(VK_IMAGE_LAYOUT_GENERAL);


### PR DESCRIPTION
Galaxy s23 is failing to create a `VkDevice` (but only sometimes :cry: ) for the sync val tests

this reverts the 3 cases from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7140/ that would likely be  a problem