### PR TITLE
layers: Check against zero codeSize

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4526,6 +4526,10 @@ void ValidationStateTracker::PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuf
 void ValidationStateTracker::PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                                              const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                                              const RecordObject &record_obj, void *csm_state_data) {
+    if (pCreateInfo->codeSize == 0 || !pCreateInfo->pCode) {
+        return;
+    }
+
     create_shader_module_api_state *csm_state = static_cast<create_shader_module_api_state *>(csm_state_data);
     csm_state->module_state = std::make_shared<spirv::Module>(pCreateInfo->codeSize, pCreateInfo->pCode);
     if (csm_state->module_state && csm_state->module_state->static_data_.has_group_decoration) {
@@ -4553,6 +4557,9 @@ void ValidationStateTracker::PreCallRecordCreateShadersEXT(VkDevice device, uint
                                                            const RecordObject &record_obj, void *csm_state_data) {
     create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
+        if (pCreateInfos[i].codeSize == 0 || !pCreateInfos[i].pCode) {
+            continue;
+        }
         // don't need to worry about GroupDecoration with VK_EXT_shader_object
         if (pCreateInfos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
             csm_state->module_states[i] =

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -39,9 +39,9 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 skip |= ValidateReservedFlags(pNext_loc.dot(Field::flags), structure->flags,
                                               "VUID-VkShaderModuleCreateInfo-flags-zerobitmask");
 
-                skip |=
-                    ValidateArray(pNext_loc.dot(Field::codeSize), pNext_loc.dot(Field::pCode), structure->codeSize / 4,
-                                  &structure->pCode, true, true, kVUIDUndefined, "VUID-VkShaderModuleCreateInfo-pCode-parameter");
+                skip |= ValidateArray(pNext_loc.dot(Field::codeSize), pNext_loc.dot(Field::pCode), structure->codeSize / 4,
+                                      &structure->pCode, true, true, "VUID-VkShaderModuleCreateInfo-codeSize-01085",
+                                      "VUID-VkShaderModuleCreateInfo-pCode-parameter");
             }
         } break;
 
@@ -9344,7 +9344,8 @@ bool StatelessValidation::PreCallValidateCreateShaderModule(VkDevice device, con
                                       "VUID-VkShaderModuleCreateInfo-flags-zerobitmask");
 
         skip |= ValidateArray(pCreateInfo_loc.dot(Field::codeSize), pCreateInfo_loc.dot(Field::pCode), pCreateInfo->codeSize / 4,
-                              &pCreateInfo->pCode, true, true, kVUIDUndefined, "VUID-VkShaderModuleCreateInfo-pCode-parameter");
+                              &pCreateInfo->pCode, true, true, "VUID-VkShaderModuleCreateInfo-codeSize-01085",
+                              "VUID-VkShaderModuleCreateInfo-pCode-parameter");
     }
     if (pAllocator != nullptr) {
         [[maybe_unused]] const Location pAllocator_loc = loc.dot(Field::pAllocator);
@@ -24963,7 +24964,8 @@ bool StatelessValidation::PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(
                                       "VUID-VkShaderModuleCreateInfo-flags-zerobitmask");
 
         skip |= ValidateArray(pCreateInfo_loc.dot(Field::codeSize), pCreateInfo_loc.dot(Field::pCode), pCreateInfo->codeSize / 4,
-                              &pCreateInfo->pCode, true, true, kVUIDUndefined, "VUID-VkShaderModuleCreateInfo-pCode-parameter");
+                              &pCreateInfo->pCode, true, true, "VUID-VkShaderModuleCreateInfo-codeSize-01085",
+                              "VUID-VkShaderModuleCreateInfo-pCode-parameter");
     }
     skip |= ValidateStructType(loc.dot(Field::pIdentifier), "VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT", pIdentifier,
                                VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, true,

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -569,6 +569,9 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                     if member.type != 'char':
                         # A valid VU can't use '->' in the middle so the generated VUID from the spec uses '::' instead
                         count_required_vuid = self.GetVuid(vuid_tag_name, f"{member.length.replace('->', '::')}-arraylength")
+                        if structTypeName == 'VkShaderModuleCreateInfo' and member.name == 'pCode':
+                            count_required_vuid = '"VUID-VkShaderModuleCreateInfo-codeSize-01085"' # exception due to unique lenValue
+
                         # TODO - some length have unhandled symbols
                         count_loc = f'{errorLoc}.dot(Field::{member.length})'
                         if '->' in member.length:

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -32,6 +32,18 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
         VkShaderModule module;
         VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
 
+        module_create_info.pCode = nullptr;
+        module_create_info.codeSize = 0;
+
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-codeSize-01085");
+        vk::CreateShaderModule(m_device->device(), &module_create_info, nullptr, &module);
+        m_errorMonitor->VerifyFound();
+    }
+
+    {
+        VkShaderModule module;
+        VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
+
         constexpr icd_spv_header spv = {};
         module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
         module_create_info.codeSize = 4;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7188

- Adds the missing `VUID-VkShaderModuleCreateInfo-codeSize-01085` VUID
- Add test
- Don't create `spirv::Module` objects with ill-formed empty shader create info objects