### PR TITLE
layers: Fix label for VkSparseImageMemoryBindInfo VUs

### DIFF
--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -1793,16 +1793,16 @@ bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const 
 
     if (subresource.mipLevel >= image_state.createInfo.mipLevels) {
         skip |=
-            LogError("VUID-VkSparseImageMemoryBind-subresource-01106", image_state.Handle(), subresource_loc.dot(Field::mipLevel),
-                     "(%" PRIu32 ") is not less than mipLevels (%" PRIu32 ") of %s.image.", subresource.mipLevel,
-                     image_state.createInfo.mipLevels, bind_loc.Fields().c_str());
+            LogError("VUID-VkSparseImageMemoryBindInfo-subresource-01722", image_state.Handle(),
+                     subresource_loc.dot(Field::mipLevel), "(%" PRIu32 ") is not less than mipLevels (%" PRIu32 ") of %s.image.",
+                     subresource.mipLevel, image_state.createInfo.mipLevels, bind_loc.Fields().c_str());
     }
 
     if (subresource.arrayLayer >= image_state.createInfo.arrayLayers) {
-        skip |=
-            LogError("VUID-VkSparseImageMemoryBind-subresource-01106", image_state.Handle(), subresource_loc.dot(Field::arrayLayer),
-                     "(%" PRIu32 ") is not less than arrayLayers (%" PRIu32 ") of %s.image.", subresource.arrayLayer,
-                     image_state.createInfo.arrayLayers, bind_loc.Fields().c_str());
+        skip |= LogError("VUID-VkSparseImageMemoryBindInfo-subresource-01723", image_state.Handle(),
+                         subresource_loc.dot(Field::arrayLayer),
+                         "(%" PRIu32 ") is not less than arrayLayers (%" PRIu32 ") of %s.image.", subresource.arrayLayer,
+                         image_state.createInfo.arrayLayers, bind_loc.Fields().c_str());
     }
 
     return skip;

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -1087,14 +1087,14 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
 
     // Force greater mip level
     image_bind.subresource.mipLevel = VK_REMAINING_MIP_LEVELS;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSparseImageMemoryBind-subresource-01106");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSparseImageMemoryBindInfo-subresource-01722");
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
     image_bind.subresource.mipLevel = 0;
 
     // Force greater array layer
     image_bind.subresource.arrayLayer = VK_REMAINING_ARRAY_LAYERS;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSparseImageMemoryBind-subresource-01106");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSparseImageMemoryBindInfo-subresource-01723");
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
     image_bind.subresource.arrayLayer = 0;


### PR DESCRIPTION
Adds proper VUID tags for `VUID-VkSparseImageMemoryBindInfo-subresource-01722` and `VUID-VkSparseImageMemoryBindInfo-subresource-01723`