### PR TITLE
Add more GPL pipeline layout checks

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -517,19 +517,15 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             if (layout_state) {
                 if (std::string err_msg;
                     !VerifySetLayoutCompatibility(*layout_state, *pipeline.PreRasterPipelineLayoutState(), err_msg)) {
-                    LogObjectList objs(device);
-                    objs.add(layout_state->Handle());
-                    objs.add(pipeline.PreRasterPipelineLayoutState()->Handle());
-                    skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-layout-07827", objs, create_info_loc.dot(Field::layout),
+                    LogObjectList objlist(layout_state->Handle(), pipeline.PreRasterPipelineLayoutState()->Handle());
+                    skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-layout-07827", objlist, create_info_loc.dot(Field::layout),
                                      "is incompatible with the layout specified in the pre-raster sub-state: %s", err_msg.c_str());
                 }
                 if (std::string err_msg;
                     !VerifySetLayoutCompatibility(*layout_state, *pipeline.FragmentShaderPipelineLayoutState(), err_msg)) {
-                    LogObjectList objs(device);
-                    objs.add(layout_state->Handle());
-                    objs.add(pipeline.FragmentShaderPipelineLayoutState()->Handle());
+                    LogObjectList objlist(layout_state->Handle(), pipeline.FragmentShaderPipelineLayoutState()->Handle());
                     skip |=
-                        LogError("VUID-VkGraphicsPipelineCreateInfo-layout-07827", objs, create_info_loc.dot(Field::layout),
+                        LogError("VUID-VkGraphicsPipelineCreateInfo-layout-07827", objlist, create_info_loc.dot(Field::layout),
                                  "is incompatible with the layout specified in the fragment shader sub-state: %s", err_msg.c_str());
                 }
             }
@@ -598,6 +594,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
 
     // pre-raster and fragemnt shader state is defined by some combination of this library and pLibraries
     if ((pre_raster_info.init != GPLInitType::uninitialized) && (frag_shader_info.init != GPLInitType::uninitialized)) {
+        // For VUs saying "includes only one... pLibraries includes the other flag" this would be when |only_libs == false|
+        // This is because it is not valid to have both init be from |gpl_flags|
         const bool only_libs =
             (pre_raster_info.init == GPLInitType::link_libraries) && (frag_shader_info.init == GPLInitType::link_libraries);
 
@@ -607,18 +605,33 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         if (pre_raster_indset ^ fs_indset) {
             const char *vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06615" : "VUID-VkGraphicsPipelineCreateInfo-flags-06614";
-            const char *pre_raster_str = (pre_raster_indset != 0) ? "defined with" : "not defined with";
-            const char *fs_str = (fs_indset != 0) ? "defined with" : "not defined with";
-            skip |=
-                LogError(vuid, device, create_info_loc,
-                         "is attempting to create a graphics pipeline library with pre-raster and fragment shader state. However "
-                         "the "
-                         "pre-raster layout create flags (%s) are %s VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, and the "
-                         "fragment shader layout create flags (%s) are %s VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT",
-                         string_VkPipelineLayoutCreateFlags(pre_raster_info.flags).c_str(), pre_raster_str,
-                         string_VkPipelineLayoutCreateFlags(frag_shader_info.flags).c_str(), fs_str);
+            LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+            skip |= LogError(
+                vuid, objlist, create_info_loc,
+                "is attempting to create a graphics pipeline library with pre-raster and fragment shader state. However "
+                "the pre-raster layout create flags (%s) are %s defined with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, "
+                "and the fragment shader layout create flags (%s) are %s defined with "
+                "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT",
+                string_VkPipelineLayoutCreateFlags(pre_raster_info.flags).c_str(), (pre_raster_indset != 0) ? "" : "not",
+                string_VkPipelineLayoutCreateFlags(frag_shader_info.flags).c_str(), (fs_indset != 0) ? "" : "not");
+        } else if (!pre_raster_indset && !fs_indset) {
+            // "layout used by this pipeline and the library must be identically defined"
+            // Inside VkPipelineLayoutCreateInfo, |pSetLayouts| and |pPushConstantRanges| are checked below, this leaves this VU to
+            // cover everything else. Currently no valid pNext structs are extending pipeline layout creation
+            if (pre_raster_info.layout->create_flags != frag_shader_info.layout->create_flags) {
+                const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                                             : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
+                LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                skip |= LogError(vuid, objlist, create_info_loc,
+                                 "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline library "
+                                 "have different VkPipelineLayouts, "
+                                 "pre-raster layout create flags (%s) and fragment shader layout create flags (%s).",
+                                 string_VkPipelineLayoutCreateFlags(pre_raster_info.layout->create_flags).c_str(),
+                                 string_VkPipelineLayoutCreateFlags(frag_shader_info.layout->create_flags).c_str());
+            }
         }
 
+        // Push Constants must match regardless of VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT
         if (!pre_raster_info.layout->push_constant_ranges->empty() && !frag_shader_info.layout->push_constant_ranges->empty()) {
             const uint32_t pre_raster_count = static_cast<uint32_t>(pre_raster_info.layout->push_constant_ranges->size());
             const uint32_t frag_shader_count = static_cast<uint32_t>(frag_shader_info.layout->push_constant_ranges->size());
@@ -626,7 +639,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             if (pre_raster_count != frag_shader_count) {
                 const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                              : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
-                skip |= LogError(vuid, device, create_info_loc,
+                LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                skip |= LogError(vuid, objlist, create_info_loc,
                                  "the graphics pipeline library have different push constants, pre-raster layout has "
                                  "pushConstantRangeCount of %" PRIu32
                                  ", fragment shader layout has pushConstantRangeCount of %" PRIu32 ".",
@@ -639,7 +653,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                         pre_raster_range.offset != frag_shader_range.offset || pre_raster_range.size != frag_shader_range.size) {
                         const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                                      : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
-                        skip |= LogError(vuid, device, create_info_loc,
+                        LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                        skip |= LogError(vuid, objlist, create_info_loc,
                                          "the graphics pipeline library have different push constants, pre-raster layout has "
                                          "pPushConstantRanges[%" PRIu32 "] of {%s, %" PRIu32 ", %" PRIu32
                                          "}, fragment shader layout has pPushConstantRanges[%" PRIu32 "] of {%s, %" PRIu32
@@ -657,101 +672,102 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         const auto &fs_set_layouts = frag_shader_info.layout->set_layouts;
         const auto num_set_layouts = std::max(pre_raster_set_layouts.size(), fs_set_layouts.size());
         for (size_t i = 0; i < num_set_layouts; ++i) {
-            const auto pre_raster_dsl = (i < pre_raster_set_layouts.size())
-                                            ? pre_raster_set_layouts[i]
-                                            : vvl::base_type<decltype(pre_raster_set_layouts)>::value_type{};
-            const auto fs_dsl =
-                (i < fs_set_layouts.size()) ? fs_set_layouts[i] : vvl::base_type<decltype(fs_set_layouts)>::value_type{};
-            const char *vuid_tmp = nullptr;
-            std::ostringstream msg;
+            // if using VK_NULL_HANDLE, index into set_layouts will be null
+            const auto pre_raster_dsl = i < pre_raster_set_layouts.size() ? pre_raster_set_layouts[i] : nullptr;
+            const auto fs_dsl = i < fs_set_layouts.size() ? fs_set_layouts[i] : nullptr;
+
             if (!pre_raster_dsl && fs_dsl) {
                 // Null DSL at pSetLayouts[i] in pre-raster state. Make sure that shader bindings in corresponding DSL in
                 // fragment shader state do not overlap.
                 for (const auto &fs_binding : fs_dsl->GetBindings()) {
-                    if (fs_binding.stageFlags & (PreRasterState::ValidShaderStages())) {
-                        const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
-                        const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
-                        if (pre_raster_info.init == GPLInitType::gpl_flags) {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
-                            msg << "represents a library containing pre-raster state, and descriptor set layout (from "
-                                   "layout "
-                                << pre_raster_layout_handle_str << ") at pSetLayouts[" << i << "] is NULL. "
-                                << "However, a library with fragment shader state is specified in "
-                                   "VkPipelineLibraryCreateInfoKHR::pLibraries with non-null descriptor set layout at the "
-                                   "same pSetLayouts index ("
-                                << i << ") from layout " << fs_layout_handle_str << " and bindings ("
-                                << string_VkShaderStageFlags(fs_binding.stageFlags) << ") that overlap with pre-raster state.";
-                        } else if (frag_shader_info.init == GPLInitType::gpl_flags) {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-flags-06757";
-                            msg << "represents a library containing fragment shader state, and descriptor set layout (from "
-                                   "layout "
-                                << fs_layout_handle_str << ") at pSetLayouts[" << i << "] contains bindings ("
-                                << string_VkShaderStageFlags(fs_binding.stageFlags) << ") that overlap with pre-raster state. "
-                                << "However, a library with pre-raster state is specified in "
-                                   "VkPipelineLibraryCreateInfoKHR::pLibraries with a null descriptor set layout at the "
-                                   "same pSetLayouts index ("
-                                << i << ") from layout " << pre_raster_layout_handle_str << ".";
-                        } else {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758";
-                            msg << "is linking libraries with pre-raster and fragment shader state. The descriptor set "
-                                   "layout at index "
-                                << i << " in pSetLayouts from " << pre_raster_layout_handle_str
-                                << " in the pre-raster state is NULL. "
-                                << "However, the descriptor set layout at the same index (" << i << ") in " << fs_layout_handle_str
-                                << " is non-null with bindings (" << string_VkShaderStageFlags(fs_binding.stageFlags)
-                                << ") that overlap with pre-raster state.";
-                        }
-                        break;
+                    if ((fs_binding.stageFlags & PreRasterState::ValidShaderStages()) == 0) {
+                        continue;
                     }
+                    const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
+                    const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
+                    const char *vuid = nullptr;
+                    std::ostringstream msg;
+                    if (pre_raster_info.init == GPLInitType::gpl_flags) {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
+                        msg << "represents a library containing pre-raster state, and descriptor set layout (from "
+                               "layout "
+                            << pre_raster_layout_handle_str << ") at pSetLayouts[" << i << "] is NULL. "
+                            << "However, a library with fragment shader state is specified in "
+                               "VkPipelineLibraryCreateInfoKHR::pLibraries with non-null descriptor set layout at the "
+                               "same pSetLayouts index ("
+                            << i << ") from layout " << fs_layout_handle_str << " and bindings ("
+                            << string_VkShaderStageFlags(fs_binding.stageFlags) << ") that overlap with pre-raster state.";
+                    } else if (frag_shader_info.init == GPLInitType::gpl_flags) {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06757";
+                        msg << "represents a library containing fragment shader state, and descriptor set layout (from "
+                               "layout "
+                            << fs_layout_handle_str << ") at pSetLayouts[" << i << "] contains bindings ("
+                            << string_VkShaderStageFlags(fs_binding.stageFlags) << ") that overlap with pre-raster state. "
+                            << "However, a library with pre-raster state is specified in "
+                               "VkPipelineLibraryCreateInfoKHR::pLibraries with a null descriptor set layout at the "
+                               "same pSetLayouts index ("
+                            << i << ") from layout " << pre_raster_layout_handle_str << ".";
+                    } else {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758";
+                        msg << "is linking libraries with pre-raster and fragment shader state. The descriptor set "
+                               "layout at index "
+                            << i << " in pSetLayouts from " << pre_raster_layout_handle_str << " in the pre-raster state is NULL. "
+                            << "However, the descriptor set layout at the same index (" << i << ") in " << fs_layout_handle_str
+                            << " is non-null with bindings (" << string_VkShaderStageFlags(fs_binding.stageFlags)
+                            << ") that overlap with pre-raster state.";
+                    }
+                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    skip |= LogError(vuid, objlist, create_info_loc, "%s", msg.str().c_str());
+                    break;
                 }
             } else if (pre_raster_dsl && !fs_dsl) {
                 // Null DSL at pSetLayouts[i] in FS state. Make sure that shader bindings in corresponding DSL in pre-raster
                 // state do not overlap.
                 for (const auto &pre_raster_binding : pre_raster_dsl->GetBindings()) {
-                    if (pre_raster_binding.stageFlags & (FragmentShaderState::ValidShaderStages())) {
-                        const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
-                        const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
-                        if (frag_shader_info.init == GPLInitType::gpl_flags) {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
-                            msg << "represents a library containing fragment shader state, and descriptor set layout (from "
-                                   "layout "
-                                << fs_layout_handle_str << ") at pSetLayouts[" << i << "] is null. "
-                                << "However, a library with pre-raster state is specified in "
-                                   "VkPipelineLibraryCreateInfoKHR::pLibraries with non-null descriptor set layout at the "
-                                   "same pSetLayouts index ("
-                                << i << ") from layout " << pre_raster_layout_handle_str << " and bindings ("
-                                << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
-                                << ") that overlap with fragment shader state.";
-                            break;
-                        } else if (pre_raster_info.init == GPLInitType::gpl_flags) {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-flags-06757";
-                            msg << "represents a library containing pre-raster state, and descriptor set layout (from "
-                                   "layout "
-                                << pre_raster_layout_handle_str << ") at pSetLayouts[" << i << "] contains bindings ("
-                                << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
-                                << ") that overlap with fragment shader state. "
-                                << "However, a library with fragment shader state is specified in "
-                                   "VkPipelineLibraryCreateInfoKHR::pLibraries with a null descriptor set layout at the "
-                                   "same pSetLayouts index ("
-                                << i << ") from layout " << fs_layout_handle_str << ".";
-                            break;
-                        } else {
-                            vuid_tmp = "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758";
-                            msg << "is linking libraries with pre-raster and fragment shader state. The descriptor set "
-                                   "layout at index "
-                                << i << " in pSetLayouts from " << fs_layout_handle_str << " in the fragment shader state is NULL. "
-                                << "However, the descriptor set layout at the same index (" << i << ") in "
-                                << pre_raster_layout_handle_str << " in the pre-raster state is non-null with bindings ("
-                                << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
-                                << ") that overlap with fragment shader "
-                                   "state.";
-                            break;
-                        }
+                    if ((pre_raster_binding.stageFlags & FragmentShaderState::ValidShaderStages()) == 0) {
+                        continue;
                     }
+                    const auto pre_raster_layout_handle_str = FormatHandle(pre_raster_info.layout->Handle());
+                    const auto fs_layout_handle_str = FormatHandle(frag_shader_info.layout->Handle());
+                    const char *vuid = nullptr;
+                    std::ostringstream msg;
+                    if (frag_shader_info.init == GPLInitType::gpl_flags) {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06756";
+                        msg << "represents a library containing fragment shader state, and descriptor set layout (from "
+                               "layout "
+                            << fs_layout_handle_str << ") at pSetLayouts[" << i << "] is null. "
+                            << "However, a library with pre-raster state is specified in "
+                               "VkPipelineLibraryCreateInfoKHR::pLibraries with non-null descriptor set layout at the "
+                               "same pSetLayouts index ("
+                            << i << ") from layout " << pre_raster_layout_handle_str << " and bindings ("
+                            << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
+                            << ") that overlap with fragment shader state.";
+                    } else if (pre_raster_info.init == GPLInitType::gpl_flags) {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-flags-06757";
+                        msg << "represents a library containing pre-raster state, and descriptor set layout (from "
+                               "layout "
+                            << pre_raster_layout_handle_str << ") at pSetLayouts[" << i << "] contains bindings ("
+                            << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
+                            << ") that overlap with fragment shader state. "
+                            << "However, a library with fragment shader state is specified in "
+                               "VkPipelineLibraryCreateInfoKHR::pLibraries with a null descriptor set layout at the "
+                               "same pSetLayouts index ("
+                            << i << ") from layout " << fs_layout_handle_str << ".";
+                    } else {
+                        vuid = "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758";
+                        msg << "is linking libraries with pre-raster and fragment shader state. The descriptor set "
+                               "layout at index "
+                            << i << " in pSetLayouts from " << fs_layout_handle_str << " in the fragment shader state is NULL. "
+                            << "However, the descriptor set layout at the same index (" << i << ") in "
+                            << pre_raster_layout_handle_str << " in the pre-raster state is non-null with bindings ("
+                            << string_VkShaderStageFlags(pre_raster_binding.stageFlags)
+                            << ") that overlap with fragment shader "
+                               "state.";
+                    }
+                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    skip |= LogError(vuid, objlist, create_info_loc, "%s", msg.str().c_str());
+                    break;
                 }
-            }
-            if (vuid_tmp) {
-                skip |= LogError(vuid_tmp, device, create_info_loc, "%s", msg.str().c_str());
             }
         }
     }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -675,7 +675,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         const uint32_t frag_shader_count = static_cast<uint32_t>(fs_set_layouts.size());
         if (not_independent_sets && pre_raster_count != frag_shader_count) {
             const char *vuid =
-                only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617" : "VUID-VkGraphicsPipelineCreateInfo-flags-06616";
+                only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613" : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
             LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
             skip |= LogError(vuid, objlist, create_info_loc,
                              "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline library "
@@ -818,8 +818,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 // both handles are valid, but without VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, need to check everything
                 // is identically defined
                 if (pre_raster_dsl->GetCreateFlags() != fs_dsl->GetCreateFlags()) {
-                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617"
-                                                 : "VUID-VkGraphicsPipelineCreateInfo-flags-06616";
+                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                                                 : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                     LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
                     skip |= LogError(vuid, objlist, create_info_loc,
                                      "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline "
@@ -830,8 +830,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                                      i, string_VkDescriptorSetLayoutCreateFlags(pre_raster_dsl->GetCreateFlags()).c_str(), i,
                                      string_VkDescriptorSetLayoutCreateFlags(fs_dsl->GetCreateFlags()).c_str());
                 } else if (pre_raster_dsl->GetBindingCount() != fs_dsl->GetBindingCount()) {
-                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617"
-                                                 : "VUID-VkGraphicsPipelineCreateInfo-flags-06616";
+                    const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                                                 : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                     LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
                     skip |= LogError(vuid, objlist, create_info_loc,
                                      "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline "
@@ -847,9 +847,9 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                     for (uint32_t binding_index = 0; binding_index < binding_count; binding_index++) {
                         const auto &pre_raster_binding = pre_raster_bindings[binding_index];
                         const auto &fs_binding = fs_bindings[binding_index];
-                        if (memcmp(pre_raster_binding.ptr(), fs_binding.ptr(), sizeof(VkDescriptorSetLayoutCreateInfo)) != 0) {
-                            const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617"
-                                                         : "VUID-VkGraphicsPipelineCreateInfo-flags-06616";
+                        if (memcmp(pre_raster_binding.ptr(), fs_binding.ptr(), sizeof(VkDescriptorSetLayoutBinding)) != 0) {
+                            const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
+                                                         : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
                             LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
                             skip |= LogError(
                                 vuid, objlist, create_info_loc,

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -712,19 +712,16 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
                                              });
 
     // We _vs and _fs layouts are identical, but we want them to be separate handles handles for the sake layout merging
-    vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, nullptr, &ds2.layout_}, {},
+    vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, &ds2.layout_}, {},
                                            VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
-    vkt::PipelineLayout pipeline_layout_fs(*m_device, {&ds.layout_, nullptr, &ds2.layout_}, {},
+    vkt::PipelineLayout pipeline_layout_fs(*m_device, {&ds.layout_, &ds2.layout_}, {},
                                            VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
-    vkt::PipelineLayout pipeline_layout_null(*m_device, {&ds.layout_, nullptr, &ds_immutable_sampler.layout_}, {},
+    vkt::PipelineLayout pipeline_layout_null(*m_device, {&ds.layout_, &ds_immutable_sampler.layout_}, {},
                                              VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
 
-    const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, ds2.set_};
+    const std::array<VkDescriptorSet, 2> desc_sets = {ds.set_, ds2.set_};
 
-    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
-    ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    ub_ci.size = 1024;
-    vkt::Buffer uniform_buffer(*m_device, ub_ci);
+    vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
     ds.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);
     ds.UpdateDescriptorSets();
 
@@ -1366,10 +1363,7 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
     const std::array<VkDescriptorSet, 3> desc_sets_null = {ds.set_, VK_NULL_HANDLE, ds2.set_};
     const std::array<VkDescriptorSet, 3> desc_sets_empty = {ds.set_, ds_empty.set_, ds2.set_};
 
-    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
-    ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    ub_ci.size = 1024;
-    vkt::Buffer uniform_buffer(*m_device, ub_ci);
+    vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
     ds.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);
     ds.UpdateDescriptorSets();
     ds2.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);
@@ -1425,6 +1419,7 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout.handle();
+    m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06681");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -2043,7 +2043,7 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCount) {
         frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06616");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
         frag_shader_lib.CreateGraphicsPipeline(false);
         m_errorMonitor->VerifyFound();
     }
@@ -2093,7 +2093,7 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCountLinking) {
     link_info.libraryCount = size(libraries);
     link_info.pLibraries = libraries;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613");
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
@@ -2147,7 +2147,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutCreateFlags) {
         frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06616");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
         frag_shader_lib.CreateGraphicsPipeline(false);
         m_errorMonitor->VerifyFound();
     }
@@ -2192,7 +2192,7 @@ TEST_F(NegativeGraphicsLibrary, BindingCount) {
         frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06616");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
         frag_shader_lib.CreateGraphicsPipeline(false);
         m_errorMonitor->VerifyFound();
     }
@@ -2236,7 +2236,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutBinding) {
         frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06616");
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
         frag_shader_lib.CreateGraphicsPipeline(false);
         m_errorMonitor->VerifyFound();
     }

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -1609,3 +1609,47 @@ TEST_F(PositiveGraphicsLibrary, PushConstantOneLibrary) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     vkt::Pipeline lib(*m_device, lib_ci);
 }
+
+TEST_F(PositiveGraphicsLibrary, SetLayoutCount) {
+    TEST_DESCRIPTION("Have setLayoutCount not be the same between pipeline layouts");
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+    InitRenderTarget();
+
+    OneOffDescriptorSet ds(m_device, {
+                                         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_GEOMETRY_BIT, nullptr},
+                                     });
+    OneOffDescriptorSet ds2(m_device, {
+                                          {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_GEOMETRY_BIT, nullptr},
+                                      });
+
+    // with VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT, we can have different setLayoutCount
+    vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, &ds2.layout_}, {},
+                                           VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+    vkt::PipelineLayout pipeline_layout_fs(*m_device, {&ds.layout_}, {}, VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
+
+    CreatePipelineHelper pre_raster_lib(*this);
+    {
+        const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
+        vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
+        pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
+        pre_raster_lib.InitState();
+        pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
+        pre_raster_lib.CreateGraphicsPipeline(false);
+    }
+
+    CreatePipelineHelper frag_shader_lib(*this);
+    {
+        const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
+        vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+        VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
+        link_info.libraryCount = 1;
+        link_info.pLibraries = &pre_raster_lib.pipeline_;
+
+        frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
+        frag_shader_lib.InitState();
+
+        frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
+        frag_shader_lib.CreateGraphicsPipeline(false);
+    }
+}

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -170,19 +170,16 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
                                       });
 
     // We _vs and _fs layouts are identical, but we want them to be separate handles handles for the sake layout merging
-    vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, nullptr, &ds2.layout_}, {},
+    vkt::PipelineLayout pipeline_layout_vs(*m_device, {&ds.layout_, &ds.layout_, nullptr}, {},
                                            VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
     vkt::PipelineLayout pipeline_layout_fs(*m_device, {&ds.layout_, nullptr, &ds2.layout_}, {},
                                            VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
-    vkt::PipelineLayout pipeline_layout_null(*m_device, {&ds.layout_, nullptr, &ds2.layout_}, {},
+    vkt::PipelineLayout pipeline_layout_null(*m_device, {&ds.layout_, nullptr, nullptr}, {},
                                              VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
 
-    const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, ds2.set_};
+    const std::array<VkDescriptorSet, 3> desc_sets = {ds.set_, VK_NULL_HANDLE, VK_NULL_HANDLE};
 
-    VkBufferCreateInfo ub_ci = vku::InitStructHelper();
-    ub_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    ub_ci.size = 1024;
-    vkt::Buffer uniform_buffer(*m_device, ub_ci);
+    vkt::Buffer uniform_buffer(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
     ds.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);
     ds.UpdateDescriptorSets();
     ds2.WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, 1024);


### PR DESCRIPTION
Adds

-  `VUID-VkGraphicsPipelineCreateInfo-flags-06612`
- `VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613`
- `VUID-VkGraphicsPipelineCreateInfo-flags-06616`
- `VUID-VkGraphicsPipelineCreateInfo-pLibraries-06617`
- `VUID-VkGraphicsPipelineCreateInfo-flags-06679`
- `VUID-VkGraphicsPipelineCreateInfo-pLibraries-06681`

note: `VUID-VkGraphicsPipelineCreateInfo-flags-06680` should be removed from spec as it is the same as `VUID-VkGraphicsPipelineCreateInfo-flags-06679`
