### PR TITLE
layers: Add external memory import support check

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1374,6 +1374,7 @@ class CoreChecks : public ValidationStateTracker {
     void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                     const RecordObject& record_obj) override;
     bool IsZeroAllocationSizeAllowed(const VkMemoryAllocateInfo* pAllocateInfo) const;
+    bool HasExternalMemoryImportSupport(VkBuffer buffer, VkImage image, VkExternalMemoryHandleTypeFlagBits handle_type) const;
     bool PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAllocateInfo* pAllocateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkDeviceMemory* pMemory,
                                        const ErrorObject& error_obj) const override;


### PR DESCRIPTION
for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5431

Adds `VUID-VkImportMemoryFdInfoKHR-handleType-00667`