### PR TITLE
Fix core vkGetPhysicalDeviceToolProperties and Private Date

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -221,7 +221,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
                 object_name_infos.emplace_back(null_object_name);
             }
             if (current_callback.debug_report_callback_function_ptr(
-                    msg_flags, convertCoreObjectToDebugReportObject(object_name_infos[0].objectType),
+                    msg_flags, ConvertCoreObjectToDebugReportObject(object_name_infos[0].objectType),
                     object_name_infos[0].objectHandle, message_id_number, 0, layer_prefix, composite.c_str(),
                     current_callback.pUserData)) {
                 bail = true;

--- a/layers/layer_chassis_dispatch_manual.cpp
+++ b/layers/layer_chassis_dispatch_manual.cpp
@@ -1074,6 +1074,20 @@ VkResult DispatchGetPhysicalDeviceToolPropertiesEXT(
     return result;
 }
 
+VkResult DispatchGetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevice, uint32_t *pToolCount,
+                                                 VkPhysicalDeviceToolProperties *pToolProperties) {
+    VkResult result = VK_SUCCESS;
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (layer_data->instance_dispatch_table.GetPhysicalDeviceToolProperties == nullptr) {
+        // This layer is the terminator. Set pToolCount to zero.
+        *pToolCount = 0;
+    } else {
+        result = layer_data->instance_dispatch_table.GetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties);
+    }
+
+    return result;
+}
+
 bool NotDispatchableHandle(VkObjectType object_type) {
     bool not_dispatchable = true;
     if ((object_type == VK_OBJECT_TYPE_INSTANCE)        ||

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -114,7 +114,7 @@ class ObjectLifetimes : public ValidationObject {
     bool ValidateSamplerObjects(const VkDescriptorSetLayoutCreateInfo *pCreateInfo, const Location &loc) const;
     bool ValidateDescriptorWrite(VkWriteDescriptorSet const *desc, bool isPush, const Location &loc) const;
     bool ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, const char *invalid_handle_vuid,
-                                 const Location &loc) const;
+                                 const char *wrong_parent_vuid, const Location &loc) const;
     bool ValidateAccelerationStructures(const char *dst_handle_vuid, uint32_t count,
                                         const VkAccelerationStructureBuildGeometryInfoKHR *infos, const Location &loc) const;
 

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -1435,3 +1435,40 @@ bool ObjectLifetimes::PreCallValidateGetDescriptorEXT(VkDevice device, const VkD
 
     return skip;
 }
+
+// Need to manually check if objectType and objectHandle are valid
+bool ObjectLifetimes::PreCallValidateSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
+                                                    VkPrivateDataSlot privateDataSlot, uint64_t data,
+                                                    const ErrorObject &error_obj) const {
+    bool skip = false;
+
+    if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
+        skip |= LogError("VUID-vkSetPrivateData-objectHandle-04016", device, error_obj.location.dot(Field::objectType), "is %s.",
+                         string_VkObjectType(objectType));
+    } else {
+        skip |= ValidateAnonymousObject(objectHandle, objectType, "VUID-vkSetPrivateData-objectHandle-04017",
+                                        error_obj.location.dot(Field::objectHandle));
+    }
+
+    skip |=
+        ValidateObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, false, "VUID-vkSetPrivateData-privateDataSlot-parameter",
+                       "VUID-vkSetPrivateData-privateDataSlot-parent", error_obj.location.dot(Field::privateDataSlot));
+
+    return skip;
+}
+
+bool ObjectLifetimes::PreCallValidateGetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
+                                                    VkPrivateDataSlot privateDataSlot, uint64_t *pData,
+                                                    const ErrorObject &error_obj) const {
+    bool skip = false;
+    if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
+        skip |= LogError("VUID-vkGetPrivateData-objectType-04018", device, error_obj.location.dot(Field::objectType), "is %s.",
+                         string_VkObjectType(objectType));
+    }
+
+    skip |=
+        ValidateObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, false, "VUID-vkGetPrivateData-privateDataSlot-parameter",
+                       "VUID-vkGetPrivateData-privateDataSlot-parent", error_obj.location.dot(Field::privateDataSlot));
+
+    return skip;
+}

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -1464,6 +1464,9 @@ bool ObjectLifetimes::PreCallValidateGetPrivateData(VkDevice device, VkObjectTyp
     if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-vkGetPrivateData-objectType-04018", device, error_obj.location.dot(Field::objectType), "is %s.",
                          string_VkObjectType(objectType));
+    } else {
+        skip |= ValidateAnonymousObject(objectHandle, objectType, "UNASSIGNED-vkGetPrivateData-objectHandle",
+                                        error_obj.location.dot(Field::objectHandle));
     }
 
     skip |=

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -154,9 +154,9 @@ void ObjectLifetimes::DestroyUndestroyedObjects(VulkanObjectType object_type) {
 }
 
 bool ObjectLifetimes::ValidateAnonymousObject(uint64_t object, VkObjectType core_object_type, const char *invalid_handle_vuid,
-                                              const Location &loc) const {
+                                              const char *wrong_parent_vuid, const Location &loc) const {
     auto object_type = ConvertCoreObjectToVulkanObject(core_object_type);
-    return CheckObjectValidity(object, object_type, invalid_handle_vuid, kVUIDUndefined, loc, kVulkanObjectTypeDevice);
+    return CheckObjectValidity(object, object_type, invalid_handle_vuid, wrong_parent_vuid, loc, kVulkanObjectTypeDevice);
 }
 
 void ObjectLifetimes::AllocateCommandBuffer(const VkCommandPool command_pool, const VkCommandBuffer command_buffer,
@@ -1163,9 +1163,9 @@ bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device,
     bool skip = false;
     // Checked by chassis: device: "VUID-vkSetDebugUtilsObjectNameEXT-device-parameter"
 
-    skip |= ValidateAnonymousObject(pNameInfo->objectHandle, pNameInfo->objectType,
-                                    "VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02590",
-                                    error_obj.location.dot(Field::pNameInfo).dot(Field::objectHandle));
+    skip |= ValidateAnonymousObject(
+        pNameInfo->objectHandle, pNameInfo->objectType, "VUID-VkDebugUtilsObjectNameInfoEXT-objectType-02590",
+        "VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-07874", error_obj.location.dot(Field::pNameInfo).dot(Field::objectHandle));
 
     return skip;
 }
@@ -1175,9 +1175,9 @@ bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice device, 
     bool skip = false;
     // Checked by chassis: device: "VUID-vkSetDebugUtilsObjectTagEXT-device-parameter"
 
-    skip |= ValidateAnonymousObject(pTagInfo->objectHandle, pTagInfo->objectType,
-                                    "VUID-VkDebugUtilsObjectTagInfoEXT-objectHandle-01910",
-                                    error_obj.location.dot(Field::pTagInfo).dot(Field::objectHandle));
+    skip |= ValidateAnonymousObject(
+        pTagInfo->objectHandle, pTagInfo->objectType, "VUID-VkDebugUtilsObjectTagInfoEXT-objectHandle-01910",
+        "VUID-vkSetDebugUtilsObjectTagEXT-pNameInfo-07877", error_obj.location.dot(Field::pTagInfo).dot(Field::objectHandle));
 
     return skip;
 }
@@ -1445,9 +1445,16 @@ bool ObjectLifetimes::PreCallValidateSetPrivateData(VkDevice device, VkObjectTyp
     if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-vkSetPrivateData-objectHandle-04016", device, error_obj.location.dot(Field::objectType), "is %s.",
                          string_VkObjectType(objectType));
+    } else if (objectType == VK_OBJECT_TYPE_DEVICE) {
+        // Need to check device handle as has no parent to check as the caller is the same device object
+        if (HandleToUint64(device) != objectHandle) {
+            skip |= LogError("VUID-vkSetPrivateData-objectHandle-04016", device, error_obj.location.dot(Field::objectHandle),
+                             "is VK_OBJECT_TYPE_DEVICE but objectHandle (0x%" PRIx64 ") != device (%s).", objectHandle,
+                             FormatHandle(device).c_str());
+        }
     } else {
         skip |= ValidateAnonymousObject(objectHandle, objectType, "VUID-vkSetPrivateData-objectHandle-04017",
-                                        error_obj.location.dot(Field::objectHandle));
+                                        "VUID-vkSetPrivateData-objectHandle-04016", error_obj.location.dot(Field::objectHandle));
     }
 
     skip |=
@@ -1464,9 +1471,16 @@ bool ObjectLifetimes::PreCallValidateGetPrivateData(VkDevice device, VkObjectTyp
     if (IsInstanceVkObjectType(objectType) || objectType == VK_OBJECT_TYPE_UNKNOWN) {
         skip |= LogError("VUID-vkGetPrivateData-objectType-04018", device, error_obj.location.dot(Field::objectType), "is %s.",
                          string_VkObjectType(objectType));
+    } else if (objectType == VK_OBJECT_TYPE_DEVICE) {
+        // Need to check device handle as has no parent to check as the caller is the same device object
+        if (HandleToUint64(device) != objectHandle) {
+            skip |= LogError("VUID-vkGetPrivateData-objectType-04018", device, error_obj.location.dot(Field::objectHandle),
+                             "is VK_OBJECT_TYPE_DEVICE but objectHandle (0x%" PRIx64 ") != device (%s).", objectHandle,
+                             FormatHandle(device).c_str());
+        }
     } else {
         skip |= ValidateAnonymousObject(objectHandle, objectType, "UNASSIGNED-vkGetPrivateData-objectHandle",
-                                        error_obj.location.dot(Field::objectHandle));
+                                        "VUID-vkGetPrivateData-objectType-04018", error_obj.location.dot(Field::objectHandle));
     }
 
     skip |=

--- a/layers/vulkan/generated/layer_chassis_dispatch.cpp
+++ b/layers/vulkan/generated/layer_chassis_dispatch.cpp
@@ -2459,16 +2459,6 @@ uint64_t DispatchGetDeviceMemoryOpaqueCaptureAddress(VkDevice device, const VkDe
     return result;
 }
 
-VkResult DispatchGetPhysicalDeviceToolProperties(VkPhysicalDevice physicalDevice, uint32_t* pToolCount,
-                                                 VkPhysicalDeviceToolProperties* pToolProperties) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-
-    VkResult result =
-        layer_data->instance_dispatch_table.GetPhysicalDeviceToolProperties(physicalDevice, pToolCount, pToolProperties);
-
-    return result;
-}
-
 VkResult DispatchCreatePrivateDataSlot(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -2296,30 +2296,6 @@ void ObjectLifetimes::PreCallRecordDestroyPrivateDataSlot(VkDevice device, VkPri
     RecordDestroyObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot);
 }
 
-bool ObjectLifetimes::PreCallValidateSetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
-                                                    VkPrivateDataSlot privateDataSlot, uint64_t data,
-                                                    const ErrorObject& error_obj) const {
-    bool skip = false;
-    // Checked by chassis: device: "VUID-vkSetPrivateData-device-parameter"
-    skip |=
-        ValidateObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, false, "VUID-vkSetPrivateData-privateDataSlot-parameter",
-                       "VUID-vkSetPrivateData-privateDataSlot-parent", error_obj.location.dot(Field::privateDataSlot));
-
-    return skip;
-}
-
-bool ObjectLifetimes::PreCallValidateGetPrivateData(VkDevice device, VkObjectType objectType, uint64_t objectHandle,
-                                                    VkPrivateDataSlot privateDataSlot, uint64_t* pData,
-                                                    const ErrorObject& error_obj) const {
-    bool skip = false;
-    // Checked by chassis: device: "VUID-vkGetPrivateData-device-parameter"
-    skip |=
-        ValidateObject(privateDataSlot, kVulkanObjectTypePrivateDataSlot, false, "VUID-vkGetPrivateData-privateDataSlot-parameter",
-                       "VUID-vkGetPrivateData-privateDataSlot-parent", error_obj.location.dot(Field::privateDataSlot));
-
-    return skip;
-}
-
 bool ObjectLifetimes::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event,
                                                   const VkDependencyInfo* pDependencyInfo, const ErrorObject& error_obj) const {
     bool skip = false;
@@ -4861,9 +4837,11 @@ bool ObjectLifetimes::PreCallValidateDisplayPowerControlEXT(VkDevice device, VkD
     bool skip = false;
     // Checked by chassis: device: "VUID-vkDisplayPowerControlEXT-device-parameter"
     // Checked by chassis: device: "VUID-vkDisplayPowerControlEXT-commonparent"
-    skip |= ValidateObject(display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkDisplayPowerControlEXT-display-parameter",
-                           "VUID-vkDisplayPowerControlEXT-commonparent", error_obj.location.dot(Field::display),
-                           kVulkanObjectTypePhysicalDevice);
+    auto instance_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
+    auto instance_object_lifetimes = instance_data->GetValidationObject<ObjectLifetimes>();
+    skip |= instance_object_lifetimes->ValidateObject(
+        display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkDisplayPowerControlEXT-display-parameter",
+        "VUID-vkDisplayPowerControlEXT-commonparent", error_obj.location.dot(Field::display), kVulkanObjectTypePhysicalDevice);
 
     return skip;
 }
@@ -4885,9 +4863,11 @@ bool ObjectLifetimes::PreCallValidateRegisterDisplayEventEXT(VkDevice device, Vk
     bool skip = false;
     // Checked by chassis: device: "VUID-vkRegisterDisplayEventEXT-device-parameter"
     // Checked by chassis: device: "VUID-vkRegisterDisplayEventEXT-commonparent"
-    skip |= ValidateObject(display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkRegisterDisplayEventEXT-display-parameter",
-                           "VUID-vkRegisterDisplayEventEXT-commonparent", error_obj.location.dot(Field::display),
-                           kVulkanObjectTypePhysicalDevice);
+    auto instance_data = GetLayerDataPtr(get_dispatch_key(instance), layer_data_map);
+    auto instance_object_lifetimes = instance_data->GetValidationObject<ObjectLifetimes>();
+    skip |= instance_object_lifetimes->ValidateObject(
+        display, kVulkanObjectTypeDisplayKHR, false, "VUID-vkRegisterDisplayEventEXT-display-parameter",
+        "VUID-vkRegisterDisplayEventEXT-commonparent", error_obj.location.dot(Field::display), kVulkanObjectTypePhysicalDevice);
 
     return skip;
 }

--- a/layers/vulkan/generated/vk_object_types.h
+++ b/layers/vulkan/generated/vk_object_types.h
@@ -406,7 +406,7 @@ static inline VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulk
     }
 }
 
-static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
+static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
     switch (core_report_obj) {
         case VK_OBJECT_TYPE_UNKNOWN:
             return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
@@ -492,6 +492,22 @@ static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(Vk
             return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT;
         default:
             return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
+}
+
+// Helper function to get Instance object types
+static inline bool IsInstanceVkObjectType(VkObjectType type) {
+    switch (type) {
+        case VK_OBJECT_TYPE_INSTANCE:
+        case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
+        case VK_OBJECT_TYPE_SURFACE_KHR:
+        case VK_OBJECT_TYPE_DISPLAY_KHR:
+        case VK_OBJECT_TYPE_DISPLAY_MODE_KHR:
+        case VK_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT:
+        case VK_OBJECT_TYPE_DEBUG_UTILS_MESSENGER_EXT:
+            return true;
+        default:
+            return false;
     }
 }
 

--- a/scripts/generators/base_generator.py
+++ b/scripts/generators/base_generator.py
@@ -590,7 +590,7 @@ class BaseGenerator(OutputGenerator):
                 return
             type = typeElem.get('objtypeenum')
 
-            # will resolve later these later, the VulkanObjectType doesn't list things in dependent order
+            # will resolve these later, the VulkanObjectType doesn't list things in dependent order
             parent = typeElem.get('parent')
             instance = typeName == 'VkInstance'
             device = typeName == 'VkDevice'

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -73,6 +73,7 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             'vkEnumerateDeviceExtensionProperties',
             'vkEnumerateDeviceLayerProperties',
             'vkEnumerateInstanceVersion',
+            'vkGetPhysicalDeviceToolProperties',
             'vkGetPhysicalDeviceToolPropertiesEXT',
             'vkSetPrivateDataEXT',
             'vkGetPrivateDataEXT',

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -104,6 +104,8 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
             'vkCreateRayTracingPipelinesKHR',
             'vkExportMetalObjectsEXT',
             'vkGetDescriptorEXT',
+            'vkGetPrivateData',
+            'vkSetPrivateData',
             ]
         # These VUIDS are not implicit, but are best handled in this layer. Codegen for vkDestroy calls will generate a key
         # which is translated here into a good VU.  Saves ~40 checks.

--- a/scripts/generators/object_types_generator.py
+++ b/scripts/generators/object_types_generator.py
@@ -110,7 +110,7 @@ static inline VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulk
 }\n''')
 
         out.append('''
-static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
+static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
     switch (core_report_obj) {
         case VK_OBJECT_TYPE_UNKNOWN: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n''')
         for handle in self.vk.handles.values():
@@ -118,6 +118,16 @@ static inline VkDebugReportObjectTypeEXT convertCoreObjectToDebugReportObject(Vk
             if object != 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT':
                 out.append(f'        case {handle.type}: return {object};\n')
         out.append('''        default: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
+}\n''')
+
+        out.append('''
+// Helper function to get Instance object types
+static inline bool IsInstanceVkObjectType(VkObjectType type) {
+    switch (type) {\n''')
+        out.extend([f'        case {handle.type}:\n' for handle in self.vk.handles.values() if handle.instance])
+        out.append('''            return true;''')
+        out.append('''        default: return false;
     }
 }\n''')
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -185,6 +185,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/sync_val_positive.cpp
     unit/threading.cpp
     unit/threading_positive.cpp
+    unit/tooling.cpp
     unit/tooling_positive.cpp
     unit/transform_feedback.cpp
     unit/vertex_input.cpp

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -593,7 +593,9 @@ class NegativeTransformFeedback : public VkLayerTest {
     void InitBasicTransformFeedback();
 };
 
-class PositiveTooling : public VkLayerTest {};
+class ToolingTest : public VkLayerTest {};
+class NegativeTooling : public ToolingTest {};
+class PositiveTooling : public ToolingTest {};
 
 class VertexInputTest : public VkLayerTest {};
 class NegativeVertexInput : public VertexInputTest {};

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -103,6 +103,47 @@ TEST_F(NegativeTooling, PrivateDataGetNonDevice) {
     vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
 }
 
+TEST_F(NegativeTooling, PrivateDataGetBadHandle) {
+    TEST_DESCRIPTION("Use Private Data a non valid handle.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+
+    uint64_t data;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkGetPrivateData-objectHandle");
+    // valid handle, but not a vkSample
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)m_device->device(), data_slot, &data);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(NegativeTooling, PrivateDataGetDestroyedHandle) {
+    TEST_DESCRIPTION("Use Private Data a non valid handle.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    sampler.destroy();
+
+    uint64_t data;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkGetPrivateData-objectHandle");
+    // valid handle, but not a vkSample
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler.handle(), data_slot, &data);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
 TEST_F(NegativeTooling, ValidateNVDeviceDiagnosticCheckpoints) {
     TEST_DESCRIPTION("General testing of VK_NV_device_diagnostic_checkpoints");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2015-2023 The Khronos Group Inc.
+ * Copyright (c) 2015-2023 Valve Corporation
+ * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2023 Google, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "generated/vk_extension_helper.h"
+
+TEST_F(NegativeTooling, PrivateDataFeature) {
+    TEST_DESCRIPTION("Test privateData feature not being enabled.");
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
+    // feature not enabled
+    RETURN_IF_SKIP(Init());
+
+    bool vulkan_13 = (DeviceValidationVersion() >= VK_API_VERSION_1_3);
+
+    VkPrivateDataSlotEXT data_slot;
+    VkPrivateDataSlotCreateInfoEXT data_create_info = vku::InitStructHelper();
+    data_create_info.flags = 0;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreatePrivateDataSlot-privateData-04564");
+    vk::CreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, NULL, &data_slot);
+    m_errorMonitor->VerifyFound();
+    if (vulkan_13) {
+        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCreatePrivateDataSlot-privateData-04564");
+        vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+        m_errorMonitor->VerifyFound();
+    }
+}
+
+TEST_F(NegativeTooling, PrivateDataSetNonDevice) {
+    TEST_DESCRIPTION("Use Private Data on a non-Device object type.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+
+    static const uint64_t data_value = 0x70AD;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetPrivateData-objectHandle-04016");
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)gpu(), data_slot, data_value);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetPrivateData-objectHandle-04016");
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)gpu(), data_slot, data_value);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(NegativeTooling, PrivateDataSetBadHandle) {
+    TEST_DESCRIPTION("Use Private Data a non valid handle.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+
+    static const uint64_t data_value = 0x70AD;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetPrivateData-objectHandle-04017");
+    // valid handle, but not a vkSample
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)m_device->device(), data_slot, data_value);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(NegativeTooling, PrivateDataGetNonDevice) {
+    TEST_DESCRIPTION("Basic usage calling private data as core.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Private data not supported by MockICD";
+    }
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    data_create_info.flags = 0;
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, nullptr, &data_slot);
+
+    uint64_t data;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPrivateData-objectType-04018");
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)gpu(), data_slot, &data);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPrivateData-objectType-04018");
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)gpu(), data_slot, &data);
+    m_errorMonitor->VerifyFound();
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(NegativeTooling, ValidateNVDeviceDiagnosticCheckpoints) {
+    TEST_DESCRIPTION("General testing of VK_NV_device_diagnostic_checkpoints");
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_DEVICE_DIAGNOSTIC_CHECKPOINTS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    uint32_t data = 100;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetCheckpointNV-commandBuffer-recording");
+    vk::CmdSetCheckpointNV(m_commandBuffer->handle(), &data);
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -14,20 +14,17 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
-TEST_F(PositiveTooling, BasicUsage) {
-    TEST_DESCRIPTION("Call Tooling Extension and verify layer results");
-
+TEST_F(PositiveTooling, InfoExt) {
+    TEST_DESCRIPTION("Basic usage calling Tooling Extension and verify layer results.");
+    AddRequiredExtensions(VK_EXT_TOOLING_INFO_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     if (IsPlatformMockICD()) {
-        GTEST_SKIP() << "Test not supported by MockICD";
+        GTEST_SKIP() << "Tooling Info not supported by MockICD";
     }
 
-    const auto fpGetPhysicalDeviceToolPropertiesEXT =
-        GetInstanceProcAddr<PFN_vkGetPhysicalDeviceToolPropertiesEXT>("vkGetPhysicalDeviceToolPropertiesEXT");
-
     uint32_t tool_count = 0;
-    auto result = fpGetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, nullptr);
+    auto result = vk::GetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, nullptr);
 
     if (tool_count <= 0) {
         m_errorMonitor->SetError("Expected layer tooling data but received none");
@@ -41,7 +38,7 @@ TEST_F(PositiveTooling, BasicUsage) {
     bool found_validation_layer = false;
 
     if (result == VK_SUCCESS) {
-        result = fpGetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, tool_properties.data());
+        result = vk::GetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, tool_properties.data());
 
         for (uint32_t i = 0; i < tool_count; i++) {
             if (strcmp(tool_properties[0].name, "Khronos Validation Layer") == 0) {
@@ -53,4 +50,116 @@ TEST_F(PositiveTooling, BasicUsage) {
     if (!found_validation_layer) {
         m_errorMonitor->SetError("Expected layer tooling data but received none");
     }
+}
+
+TEST_F(PositiveTooling, InfoCore) {
+    TEST_DESCRIPTION("Basic usage calling Tooling Extension as core.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Tooling Info not supported by MockICD";
+    }
+
+    uint32_t tool_count = 0;
+    auto result = vk::GetPhysicalDeviceToolProperties(gpu(), &tool_count, nullptr);
+
+    if (tool_count <= 0) {
+        m_errorMonitor->SetError("Expected layer tooling data but received none");
+    }
+
+    std::vector<VkPhysicalDeviceToolProperties> tool_properties(tool_count);
+    for (uint32_t i = 0; i < tool_count; i++) {
+        tool_properties[i] = vku::InitStructHelper();
+    }
+
+    bool found_validation_layer = false;
+
+    if (result == VK_SUCCESS) {
+        result = vk::GetPhysicalDeviceToolProperties(gpu(), &tool_count, tool_properties.data());
+
+        for (uint32_t i = 0; i < tool_count; i++) {
+            if (strcmp(tool_properties[0].name, "Khronos Validation Layer") == 0) {
+                found_validation_layer = true;
+                break;
+            }
+        }
+    }
+    if (!found_validation_layer) {
+        m_errorMonitor->SetError("Expected layer tooling data but received none");
+    }
+}
+
+TEST_F(PositiveTooling, PrivateDataExt) {
+    TEST_DESCRIPTION("Basic usage calling private data extension.");
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Private data not supported by MockICD";
+    }
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    data_create_info.flags = 0;
+    vk::CreatePrivateDataSlotEXT(m_device->handle(), &data_create_info, nullptr, &data_slot);
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    static const uint64_t data_value = 0x70AD;
+    vk::SetPrivateDataEXT(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler.handle(), data_slot, data_value);
+
+    uint64_t data;
+    vk::GetPrivateDataEXT(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler.handle(), data_slot, &data);
+    if (data != data_value) {
+        m_errorMonitor->SetError("Got unexpected private data, %s.\n");
+    }
+    vk::DestroyPrivateDataSlotEXT(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(PositiveTooling, PrivateDataCore) {
+    TEST_DESCRIPTION("Basic usage calling private data as core.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Private data not supported by MockICD";
+    }
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    data_create_info.flags = 0;
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, nullptr, &data_slot);
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    static const uint64_t data_value = 0x70AD;
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler.handle(), data_slot, data_value);
+
+    uint64_t data;
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)sampler.handle(), data_slot, &data);
+    if (data != data_value) {
+        m_errorMonitor->SetError("Got unexpected private data, %s.\n");
+    }
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
+}
+
+TEST_F(PositiveTooling, PrivateDataDevice) {
+    TEST_DESCRIPTION("Test private data can set VkDevice.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::privateData);
+    RETURN_IF_SKIP(Init());
+
+    VkPrivateDataSlot data_slot;
+    VkPrivateDataSlotCreateInfo data_create_info = vku::InitStructHelper();
+    vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
+
+    static const uint64_t data_value = 0x70AD;
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_DEVICE, (uint64_t)m_device->device(), data_slot, data_value);
+    uint64_t data;
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_DEVICE, (uint64_t)m_device->device(), data_slot, &data);
+
+    vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6993

- the core `vkGetPhysicalDeviceToolProperties` was not implemented
- Add `VUID-vkSetPrivateData-objectHandle-04016`,  `VUID-vkSetPrivateData-objectHandle-04017`, `VUID-vkGetPrivateData-objectType-04018`
- Fix code gen problem where `VkDisplayKHR` and `VkDisplayModeKHR` were not viewed as instance based handles
- Move (and added) testing to `tooling` 