### PR TITLE
layers: Add missing VkShaderModuleCreateInfo VUs

### DIFF
--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -278,6 +278,11 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pCreateInfos[i].codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
             const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
+
+            // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7211
+            // spv_const_binary_t binary{static_cast<const uint32_t*>(pCreateInfos[i].pCode), pCreateInfos[i].codeSize /
+            // sizeof(uint32_t)}; skip |= RunSpirvValidation(binary, create_info_loc);
+
             const StageCreateInfo stage_create_info(pCreateInfos[i]);
             const auto spirv =
                 std::make_shared<spirv::Module>(pCreateInfos[i].codeSize, static_cast<const uint32_t*>(pCreateInfos[i].pCode));

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -745,6 +745,7 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                        const RecordObject& record_obj, void* csm_state_data) override;
+    bool RunSpirvValidation(spv_const_binary_t& binary, const Location& loc) const;
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                            const ErrorObject& error_obj) const override;

--- a/layers/error_message/unimplementable_validation.h
+++ b/layers/error_message/unimplementable_validation.h
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 #pragma once
+// clang-format off
 
 // This file list all VUID that are not possible to validate.
 // This file should never be included, but here for searchability and statistics
@@ -35,4 +36,11 @@ const char* unimplementable_validation[] = {
     "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912",
 
     // These VUIDs cannot be validated beyond making sure the pointer is not null
-    "VUID-VkMemoryToImageCopyEXT-pHostPointer-09061", "VUID-VkImageToMemoryCopyEXT-pHostPointer-09066"};
+    "VUID-VkMemoryToImageCopyEXT-pHostPointer-09061", "VUID-VkImageToMemoryCopyEXT-pHostPointer-09066"
+
+    // these are already taken care in spirv-val for 08737
+    "VUID-VkShaderModuleCreateInfo-pCode-08736", "VUID-VkShaderCreateInfoEXT-pCode-08736",
+    "VUID-VkShaderModuleCreateInfo-pCode-08738", "VUID-VkShaderCreateInfoEXT-pCode-08738"
+};
+
+// clang-format on

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -70,9 +70,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
 
 TEST_F(NegativeShaderSpirv, Magic) {
     TEST_DESCRIPTION("Test that an error is produced for a spirv module with a bad magic number");
-
     RETURN_IF_SKIP(Init());
-    InitRenderTarget();
 
     VkShaderModule module;
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
@@ -83,7 +81,7 @@ TEST_F(NegativeShaderSpirv, Magic) {
     module_create_info.pCode = reinterpret_cast<const uint32_t *>(&spv);
     module_create_info.codeSize = sizeof(spv);
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "Invalid SPIR-V magic number");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-07912");
     vk::CreateShaderModule(m_device->device(), &module_create_info, nullptr, &module);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
Adds missing `VkShaderModuleCreateInfo` VUs and gets logic ready for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7211