### PR TITLE
tests: Confirm we test for valid VkDeferredOperationKHR object

### DIFF
--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -377,6 +377,11 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetNullBuildRangeInfos(bool use_null
     return *this;
 }
 
+BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDeferredOp(VkDeferredOperationKHR deferred_op) {
+    deferred_op_ = deferred_op;
+    return *this;
+}
+
 void BuildGeometryInfoKHR::BuildCmdBuffer(const vkt::Device &device, VkCommandBuffer cmd_buffer, bool use_ppGeometries /*= true*/) {
     if (blas_) {
         blas_->BuildCmdBuffer(device, cmd_buffer, use_ppGeometries);
@@ -504,7 +509,7 @@ void BuildGeometryInfoKHR::VkBuildAccelerationStructuresKHR(VkInstance instance,
     const VkAccelerationStructureBuildGeometryInfoKHR *pInfos = use_null_infos_ ? nullptr : &vk_info_;
     const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos =
         use_null_build_range_infos_ ? nullptr : pRange_infos.data();
-    vk::BuildAccelerationStructuresKHR(device.handle(), VK_NULL_HANDLE, vk_info_count_, pInfos, ppBuildRangeInfos);
+    vk::BuildAccelerationStructuresKHR(device.handle(), deferred_op_, vk_info_count_, pInfos, ppBuildRangeInfos);
 
     // pGeometries is going to be destroyed
     vk_info_.geometryCount = 0;

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -166,6 +166,7 @@ class BuildGeometryInfoKHR {
     BuildGeometryInfoKHR& SetInfoCount(uint32_t info_count);
     BuildGeometryInfoKHR& SetNullInfos(bool use_null_infos);
     BuildGeometryInfoKHR& SetNullBuildRangeInfos(bool use_null_build_range_infos);
+    BuildGeometryInfoKHR& SetDeferredOp(VkDeferredOperationKHR deferred_op);
 
     // Those functions call Build() on internal resources (geometries, src and dst acceleration structures, scratch buffer),
     // then one the build acceleration structure function.
@@ -204,6 +205,7 @@ class BuildGeometryInfoKHR {
     std::shared_ptr<BuildGeometryInfoKHR> blas_;
     std::unique_ptr<vkt::Buffer> indirect_buffer_;
     std::vector<VkAccelerationStructureBuildRangeInfoKHR> build_range_infos_;
+    VkDeferredOperationKHR deferred_op_ = VK_NULL_HANDLE;
 };
 
 // Helper functions

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -2340,6 +2340,22 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1) {
     }
 }
 
+TEST_F(NegativeRayTracing, BuildAccelerationStructuresDeferredOperation) {
+    TEST_DESCRIPTION("Call vkBuildAccelerationStructuresKHR with a valid VkDeferredOperationKHR object");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::accelerationStructureHostCommands);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBuildAccelerationStructuresKHR-deferredOperation-parameter");
+    vkt::as::BuildGeometryInfoKHR as_build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    as_build_info.SetDeferredOp(CastFromUint64<VkDeferredOperationKHR>(0xdeadbeef));
+    as_build_info.BuildHost(instance(), *m_device);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidMode) {
     TEST_DESCRIPTION("Build an acceleration structure with an invalid mode");
 


### PR DESCRIPTION
there is a missing `VUID-vkBuildAccelerationStructuresKHR-deferredOperation-03677` VUID but these tests prove that it is really just `VUID-vkBuildAccelerationStructuresKHR-deferredOperation-parameter` (plan to remove the `03677` from the spec)