### PR TITLE
layers: Add 03675 03676

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -492,8 +492,9 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
 bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
                                              const VkAccelerationStructureBuildGeometryInfoKHR &info,
                                              const VkAccelerationStructureBuildRangeInfoKHR *geometry_build_ranges,
-                                             const Location &loc) const {
+                                             const Location &info_loc) const {
     bool skip = false;
+
     const auto geometry_count = info.geometryCount;
     const auto *p_geometries = info.pGeometries;
     const auto *const *const pp_geometries = info.ppGeometries;
@@ -532,9 +533,9 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
     }
 
     if (geom_accessor) {
-        const Location pp_build_range_info_loc(loc.function, Field::ppBuildRangeInfos, info_i);
+        const Location pp_build_range_info_loc(info_loc.function, Field::ppBuildRangeInfos, info_i);
         for (uint32_t geom_i = 0; geom_i < geometry_count; ++geom_i) {
-            const Location p_geom_loc = loc.dot(pp_geometries ? Field::pGeometries : Field::ppGeometries, geom_i);
+            const Location p_geom_loc = info_loc.dot(pp_geometries ? Field::pGeometries : Field::ppGeometries, geom_i);
             const Location p_geom_geom_loc = p_geom_loc.dot(Field::geometry);
             const Location p_geom_geom_triangles_loc = p_geom_geom_loc.dot(Field::triangles);
             const auto &geom_data = geom_accessor(geom_i);
@@ -634,10 +635,23 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
         }
     }
 
+    if (const auto dst_as_state = Get<vvl::AccelerationStructureKHR>(info.dstAccelerationStructure)) {
+        const VkDeviceSize as_minimum_size = rt::ComputeAccelerationStructureSize(device, info, geometry_build_ranges);
+        if (dst_as_state->create_infoKHR.size < as_minimum_size) {
+            const LogObjectList objlist(cmd_buffer, info.dstAccelerationStructure);
+            skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03675", objlist,
+                             info_loc.dot(Field::dstAccelerationStructure),
+                             " was created with size (%" PRIu64
+                             "), but an acceleration structure build with corresponding ppBuildRangeInfos[%" PRIu32
+                             "] requires a minimum size of (%" PRIu64 ").",
+                             dst_as_state->create_infoKHR.size, info_i, as_minimum_size);
+        }
+    }
+
     const auto buffer_states = GetBuffersByAddress(info.scratchData.deviceAddress);
     if (buffer_states.empty()) {
         skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03802", device,
-                         loc.dot(Field::scratchData).dot(Field::deviceAddress),
+                         info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
                          "(0x%" PRIx64 ") has no buffer is associated with it.", info.scratchData.deviceAddress);
     } else {
         const bool no_valid_buffer_found = std::none_of(buffer_states.begin(), buffer_states.end(),
@@ -650,7 +664,7 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                 objlist.add(buffer_state->Handle());
             }
             skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03674", objlist,
-                             loc.dot(Field::scratchData).dot(Field::deviceAddress),
+                             info_loc.dot(Field::scratchData).dot(Field::deviceAddress),
                              "(0x%" PRIx64
                              ") has no buffer is associated with it that was created with VK_BUFFER_USAGE_STORAGE_BUFFER_BIT bit.",
                              info.scratchData.deviceAddress);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1548,7 +1548,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
                                      const VkAccelerationStructureBuildGeometryInfoKHR& info,
                                      const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
-                                     const Location& loc) const;
+                                     const Location& info_loc) const;
     bool ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                        const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, uint32_t info_i,
                                                        const ErrorObject& error_obj) const;

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Copyright (C) 2015-2023 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1240,7 +1240,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
         for (uint32_t geom_i = 0; geom_i < info->geometryCount; ++geom_i) {
             if (info->pGeometries) {
                 const VkAccelerationStructureGeometryKHR &as_geometry = info->pGeometries[geom_i];
-                const Location geometry_loc = error_obj.location.dot(Field::pGeometries, geom_i);
+                const Location geometry_loc = info_loc.dot(Field::pGeometries, geom_i);
                 if (as_geometry.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
                     if (as_geometry.geometry.instances.arrayOfPointers == VK_TRUE) {
                         if (SafeModulo(as_geometry.geometry.instances.data.deviceAddress, 8) != 0) {
@@ -1332,7 +1332,12 @@ bool StatelessValidation::manual_PreCallValidateCmdBuildAccelerationStructuresKH
                 }
             }
         }
+
+        skip |= ValidateArray(info_loc.dot(Field::geometryCount), error_obj.location.dot(Field::ppBuildRangeInfos, info_i),
+                              info->geometryCount, &ppBuildRangeInfos[info_i], false, true, kVUIDUndefined,
+                              "VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676");
     }
+
     return skip;
 }
 

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -13,6 +13,8 @@
 
 #include "utils/vk_layer_utils.h"
 
+#include <iostream>
+
 namespace vkt {
 namespace as {
 
@@ -330,6 +332,11 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetType(VkAccelerationStructureTypeK
     return *this;
 }
 
+BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetBuildType(VkAccelerationStructureBuildTypeKHR build_type) {
+    build_type_ = build_type;
+    return *this;
+}
+
 BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetMode(VkBuildAccelerationStructureModeKHR mode) {
     vk_info_.mode = mode;
     return *this;
@@ -393,6 +400,11 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetDeferredOp(VkDeferredOperationKHR
     return *this;
 }
 
+BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetUpdateDstAccelStructSizeBeforeBuild(bool update_before_build) {
+    update_dst_as_size_before_build_ = update_before_build;
+    return *this;
+}
+
 void BuildGeometryInfoKHR::BuildCmdBuffer(VkCommandBuffer cmd_buffer, bool use_ppGeometries /*= true*/) {
     if (blas_) {
         blas_->BuildCmdBuffer(cmd_buffer, use_ppGeometries);
@@ -417,10 +429,19 @@ void BuildGeometryInfoKHR::BuildHost() {
     VkBuildAccelerationStructuresKHR();
 }
 
+void BuildGeometryInfoKHR::UpdateDstAccelStructSize() {
+    const VkAccelerationStructureBuildSizesInfoKHR size_info = GetSizeInfo();
+    dst_as_->SetSize(size_info.accelerationStructureSize);
+}
+
 void BuildGeometryInfoKHR::SetupBuild(bool is_on_device_build, bool use_ppGeometries /*= true*/) {
     // Build geometries
     for (auto &geometry : geometries_) {
         geometry.Build();
+    }
+
+    if (update_dst_as_size_before_build_ && !dst_as_->IsNull() && !dst_as_->IsBuilt()) {
+        UpdateDstAccelStructSize();
     }
 
     // Build source and destination acceleration structures
@@ -600,6 +621,7 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool 
     } else {
         geometries.reserve(geometries_.size());
     }
+
     for (const auto &geometry : geometries_) {
         primitives_count += geometry.GetFullBuildRange().primitiveCount;
         if (use_ppGeometries) {
@@ -617,8 +639,7 @@ VkAccelerationStructureBuildSizesInfoKHR BuildGeometryInfoKHR::GetSizeInfo(bool 
 
     // Get VkAccelerationStructureBuildSizesInfoKHR using this->vk_info_
     VkAccelerationStructureBuildSizesInfoKHR size_info = vku::InitStructHelper();
-    vk::GetAccelerationStructureBuildSizesKHR(device_->handle(), VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR, &vk_info_,
-                                              &primitives_count, &size_info);
+    vk::GetAccelerationStructureBuildSizesKHR(device_->handle(), build_type_, &vk_info_, &primitives_count, &size_info);
 
     // pGeometries and geometries are going to be destroyed
     vk_info_.geometryCount = 0;
@@ -868,6 +889,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Devic
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
+    out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
     // Set geometry
@@ -892,6 +914,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Devic
     out_build_info.SetSrcAS(AccelStructNull(device));
     auto dstAsSize = out_build_info.GetSizeInfo().accelerationStructureSize;
     out_build_info.SetDstAS(AccelStructSimpleOnDeviceBottomLevel(device, dstAsSize));
+    out_build_info.SetUpdateDstAccelStructSizeBeforeBuild(true);
 
     out_build_info.SetInfoCount(1);
     out_build_info.SetNullInfos(false);
@@ -905,6 +928,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device 
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
+    out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
     // Set geometry
@@ -929,6 +953,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device 
     out_build_info.SetSrcAS(AccelStructNull(device));
     auto dstAsSize = out_build_info.GetSizeInfo().accelerationStructureSize;
     out_build_info.SetDstAS(AccelStructSimpleOnHostBottomLevel(device, dstAsSize));
+    out_build_info.SetUpdateDstAccelStructSizeBeforeBuild(true);
 
     out_build_info.SetInfoCount(1);
     out_build_info.SetNullInfos(false);
@@ -942,6 +967,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+    out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
     // Set bottom level acceleration structure
@@ -960,6 +986,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(
     auto dst_as = AccelStructSimpleOnDeviceBottomLevel(device, dstAsSize);
     dst_as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
     out_build_info.SetDstAS(std::move(dst_as));
+    out_build_info.SetUpdateDstAccelStructSizeBeforeBuild(true);
 
     out_build_info.SetInfoCount(1);
     out_build_info.SetNullInfos(false);
@@ -973,6 +1000,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &de
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+    out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
     // Set bottom level acceleration structure
@@ -991,6 +1019,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &de
     auto dst_as = AccelStructSimpleOnHostBottomLevel(device, dstAsSize);
     dst_as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
     out_build_info.SetDstAS(std::move(dst_as));
+    out_build_info.SetUpdateDstAccelStructSizeBeforeBuild(true);
 
     out_build_info.SetInfoCount(1);
     out_build_info.SetNullInfos(false);

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -155,6 +155,7 @@ class BuildGeometryInfoKHR {
     BuildGeometryInfoKHR& operator=(const BuildGeometryInfoKHR&) = delete;
 
     BuildGeometryInfoKHR& SetType(VkAccelerationStructureTypeKHR type);
+    BuildGeometryInfoKHR& SetBuildType(VkAccelerationStructureBuildTypeKHR build_type);
     BuildGeometryInfoKHR& SetMode(VkBuildAccelerationStructureModeKHR mode);
     BuildGeometryInfoKHR& SetFlags(VkBuildAccelerationStructureFlagsKHR flags);
     BuildGeometryInfoKHR& AddFlags(VkBuildAccelerationStructureFlagsKHR flags);
@@ -171,6 +172,7 @@ class BuildGeometryInfoKHR {
     BuildGeometryInfoKHR& SetNullInfos(bool use_null_infos);
     BuildGeometryInfoKHR& SetNullBuildRangeInfos(bool use_null_build_range_infos);
     BuildGeometryInfoKHR& SetDeferredOp(VkDeferredOperationKHR deferred_op);
+    BuildGeometryInfoKHR& SetUpdateDstAccelStructSizeBeforeBuild(bool update_before_build);
 
     // Those functions call Build() on internal resources (geometries, src and dst acceleration structures, scratch buffer),
     // then will build/update an acceleration structure.
@@ -178,6 +180,7 @@ class BuildGeometryInfoKHR {
     void BuildCmdBufferIndirect(VkCommandBuffer cmd_buffer);
     void BuildHost();
 
+    void UpdateDstAccelStructSize();
     void SetupBuild(bool is_on_device_build, bool use_ppGeometries = true);
 
     // These will only setup the geometries lists and the pertaining build ranges
@@ -202,7 +205,9 @@ class BuildGeometryInfoKHR {
     uint32_t vk_info_count_ = 1;
     bool use_null_infos_ = false;
     bool use_null_build_range_infos_ = false;
+    bool update_dst_as_size_before_build_ = false;
     VkAccelerationStructureBuildGeometryInfoKHR vk_info_;
+    VkAccelerationStructureBuildTypeKHR build_type_;
     std::vector<GeometryKHR> geometries_;
     std::shared_ptr<AccelerationStructureKHR> src_as_, dst_as_;
     VkDeviceAddress device_scratch_offset_ = 0;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1426,11 +1426,12 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
         // Command buffer build
         {
             auto build_info_null_dst = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-    build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull(*m_device));
+            build_info_null_dst.SetDstAS(vkt::as::blueprint::AccelStructNull(*m_device));
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03800");
-    build_info_null_dst.BuildCmdBuffer(m_commandBuffer->handle());
-    m_errorMonitor->VerifyFound();
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
+                                                 "VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03800");
+            build_info_null_dst.BuildCmdBuffer(m_commandBuffer->handle());
+            m_errorMonitor->VerifyFound();
         }
     }
 
@@ -1492,6 +1493,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     // Invalid flags
     {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         build_info.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_FLAG_BITS_MAX_ENUM_KHR);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
@@ -1516,6 +1518,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         build_info.GetInfo().sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR;
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType");
         build_info.BuildCmdBuffer(m_commandBuffer->handle());
@@ -1525,12 +1528,14 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03654");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-03654");
         build_info.BuildCmdBuffer(m_commandBuffer->handle());
         m_errorMonitor->VerifyFound();
 
         build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_MAX_ENUM_KHR);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-parameter");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureBuildGeometryInfoKHR-type-parameter");
         build_info.BuildCmdBuffer(m_commandBuffer->handle());
@@ -1601,6 +1606,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         build_info.GetGeometries()[0].SetStride(VkDeviceSize(vvl::kU32Max) + 1);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03819");
         build_info.BuildCmdBuffer(m_commandBuffer->handle());
@@ -1610,6 +1616,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     if (index_type_uint8) {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         build_info.GetGeometries()[0].SetTrianglesIndexType(VK_INDEX_TYPE_UINT8_EXT);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-03798");
         build_info.BuildCmdBuffer(m_commandBuffer->handle());
@@ -1618,6 +1625,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
     // ppGeometries and pGeometries both valid pointer
     {
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+        build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
         std::vector<VkAccelerationStructureGeometryKHR> geometries;
         for (const auto &geometry : build_info.GetGeometries()) {
             geometries.emplace_back(geometry.GetVkObj());
@@ -2406,7 +2414,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryFl
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTriaglesFormat) {
+TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTrianglesFormat) {
     TEST_DESCRIPTION(
         "Build a list of destination acceleration structures, then do an update build on that same list but with a different "
         "vertex format for the triangles");
@@ -2740,6 +2748,29 @@ TEST_F(NegativeRayTracing, UpdatedFirstVertex) {
     build_info.SetBuildRanges(build_range_infos);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-firstVertex-03770");
+    build_info.BuildCmdBuffer(m_commandBuffer->handle());
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->end();
+}
+
+TEST_F(NegativeRayTracing, DstAsTooSmall) {
+    TEST_DESCRIPTION("Try to perform a build on an acceleration structure that was created too small.");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    m_commandBuffer->begin();
+    auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    build_info.SetUpdateDstAccelStructSizeBeforeBuild(false);
+
+    build_info.GetDstAS()->SetSize(1);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03675");
     build_info.BuildCmdBuffer(m_commandBuffer->handle());
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03675**
For each pInfos[i], dstAccelerationStructure must have been created with a value of [VkAccelerationStructureCreateInfoKHR](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkAccelerationStructureCreateInfoKHR.html)::size greater than or equal to the memory size required by the build operation, as returned by [vkGetAccelerationStructureBuildSizesKHR](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetAccelerationStructureBuildSizesKHR.html) with pBuildInfo = pInfos[i] and with each element of the pMaxPrimitiveCounts array greater than or equal to the equivalent ppBuildRangeInfos[i][j].primitiveCount values for j in [0,pInfos[i].geometryCount)

**VUID-vkCmdBuildAccelerationStructuresKHR-ppBuildRangeInfos-03676**
Each element of ppBuildRangeInfos[i] must be a valid pointer to an array of pInfos[i].geometryCount VkAccelerationStructureBuildRangeInfoKHR structures