### PR TITLE
layers: Add maxTexelBufferElements for decriptor buffers

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -868,7 +868,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region, const vvl::Image& image_state, bool is_src,
                                     const Location& region_loc) const;
     bool ValidateBufferViewRange(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo* pCreateInfo,
-                                 const VkPhysicalDeviceLimits* device_limits, const Location& loc) const;
+                                 const Location& loc) const;
     bool ValidateBufferViewBuffer(const vvl::Buffer& buffer_state, const VkBufferViewCreateInfo* pCreateInfo,
                                   const Location& loc) const;
 

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -923,7 +923,7 @@
                         "maxTessellationEvaluationOutputComponents": 128,
                         "maxTessellationGenerationLevel": 64,
                         "maxTessellationPatchSize": 32,
-                        "maxTexelBufferElements": 134217728,
+                        "maxTexelBufferElements": 4294967000,
                         "maxTexelGatherOffset": 31,
                         "maxTexelOffset": 7,
                         "maxUniformBufferRange": 65536,


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6027

adds

- `VUID-VkDescriptorGetInfoEXT-type-09427`
- `VUID-VkDescriptorGetInfoEXT-type-09428`

these are similar to VUs like `VUID-VkBufferViewCreateInfo-range-00930`

while here cleaned up the function as there were a few bugs