### PR TITLE
layers: Add 03813 03814

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1544,7 +1544,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                          size_t dataSize, void* pData, const ErrorObject& error_obj) const override;
     // Validate buffers accessed using a device address
-    bool ValidateAccelerationBuffers(uint32_t info_i, const VkAccelerationStructureBuildGeometryInfoKHR& info,
+    bool ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
+                                     const VkAccelerationStructureBuildGeometryInfoKHR& info,
                                      const VkAccelerationStructureBuildRangeInfoKHR* geometry_build_ranges,
                                      const Location& loc) const;
     bool ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer commandBuffer, uint32_t infoCount,

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -85,6 +85,7 @@ class GeometryKHR {
     // Instance
     GeometryKHR& SetInstanceDeviceAccelStructRef(const vkt::Device& device, VkAccelerationStructureKHR bottom_level_as);
     GeometryKHR& SetInstanceHostAccelStructRef(VkAccelerationStructureKHR bottom_level_as);
+    GeometryKHR& SetInstanceDeviceAddress(VkDeviceAddress address);
 
     GeometryKHR& Build();
 
@@ -92,6 +93,7 @@ class GeometryKHR {
     VkAccelerationStructureBuildRangeInfoKHR GetFullBuildRange() const;
     const auto& GetTriangles() const { return triangles_; }
     const auto& GetAABBs() const { return aabbs_; }
+    auto& GetInstance() { return instance_; }
 
   private:
     VkAccelerationStructureGeometryKHR vk_obj_;
@@ -170,10 +172,14 @@ class BuildGeometryInfoKHR {
     BuildGeometryInfoKHR& SetDeferredOp(VkDeferredOperationKHR deferred_op);
 
     // Those functions call Build() on internal resources (geometries, src and dst acceleration structures, scratch buffer),
-    // then one the build acceleration structure function.
+    // then will build/update an acceleration structure.
     void BuildCmdBuffer(VkCommandBuffer cmd_buffer, bool use_ppGeometries = true);
     void BuildCmdBufferIndirect(VkCommandBuffer cmd_buffer);
     void BuildHost();
+
+    void SetupBuild(bool is_on_device_build, bool use_ppGeometries = true);
+
+    // These will only setup the geometries lists and the pertaining build ranges
     void VkCmdBuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, bool use_ppGeometries = true);
     // TODO - indirect build not fully implemented, only cared about having a valid call at time of writing
     void VkCmdBuildAccelerationStructuresIndirectKHR(VkCommandBuffer cmd_buffer);
@@ -190,8 +196,6 @@ class BuildGeometryInfoKHR {
 
   private:
     friend void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<BuildGeometryInfoKHR>& infos);
-
-    void BuildCommon(bool is_on_device_build, bool use_ppGeometries = true);
 
     const vkt::Device* device_;
     uint32_t vk_info_count_ = 1;


### PR DESCRIPTION
part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03813**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_INSTANCES_KHR, geometry.instances.data.deviceAddress must be a valid device address obtained from [vkGetBufferDeviceAddress](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetBufferDeviceAddress.html)

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03814**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_INSTANCES_KHR, if geometry.instances.data.deviceAddress is the address of a non-sparse buffer then it must be bound completely and contiguously to a single [VkDeviceMemory](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceMemory.html) object