### PR TITLE
Additional updates for 275 headers

### DIFF
--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -1536,7 +1536,7 @@ bool ObjectLifetimes::PreCallValidateGetPrivateData(VkDevice device, VkObjectTyp
                              FormatHandle(device).c_str());
         }
     } else {
-        skip |= ValidateAnonymousObject(objectHandle, objectType, "UNASSIGNED-vkGetPrivateData-objectHandle",
+        skip |= ValidateAnonymousObject(objectHandle, objectType, "VUID-vkGetPrivateData-objectHandle-09498",
                                         "VUID-vkGetPrivateData-objectType-04018", error_obj.location.dot(Field::objectHandle));
     }
 

--- a/scripts/generators/extension_helper_generator.py
+++ b/scripts/generators/extension_helper_generator.py
@@ -104,9 +104,6 @@ class ExtensionHelperOutputGenerator(BaseGenerator):
                 # This is a work around for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5372
                 temp = re.sub(r',VK_VERSION_1_\d+', '', extension.depends)
                 for reqs in exprValues(parseExpr(temp)):
-                    if reqs == 'VK_VERSION_1_0':
-                        # An explicit dependency on Vulkan 1.0 is meaningless
-                        continue
                     feature = self.vk.extensions[reqs] if reqs in self.vk.extensions else self.vk.versions[reqs]
                     requiredExpression[extension.name].append(feature)
         for version in self.vk.versions.keys():

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -138,7 +138,7 @@ TEST_F(NegativeTooling, PrivateDataGetBadHandle) {
     vk::CreatePrivateDataSlot(m_device->handle(), &data_create_info, NULL, &data_slot);
 
     uint64_t data;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkGetPrivateData-objectHandle");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPrivateData-objectHandle-09498");
     // valid handle, but not a vkSample
     vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, (uint64_t)m_device->device(), data_slot, &data);
     m_errorMonitor->VerifyFound();
@@ -160,7 +160,7 @@ TEST_F(NegativeTooling, PrivateDataGetDestroyedHandle) {
     sampler.destroy();
 
     uint64_t data;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkGetPrivateData-objectHandle");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetPrivateData-objectHandle-09498");
     // valid handle, but not a vkSample
     vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_SAMPLER, bad_handle, data_slot, &data);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
- Add new VUID label
- `VK_KHR_maintenance6` had an incorrect dependency that we had a temp fix for in the scripts