### PR TITLE
tests: Fix closing handles in external sync test

### DIFF
--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -491,6 +491,8 @@ TEST_F(PositiveExternalMemorySync, ExportFromImportedFence) {
     import_fence.export_handle(handle2, handle_type);
 
     ::CloseHandle(handle);
-    ::CloseHandle(handle2);
+    if (handle2 != handle) {
+        ::CloseHandle(handle2);
+    }
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR


### PR DESCRIPTION
On windows handle and handle2 would be the same, so closing it twice would throw an exception.