### PR TITLE
tests: Fix support check in video test

### DIFF
--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -11704,7 +11704,7 @@ TEST_F(NegativeVideo, CreateQueryPoolEncodeFeedbackProfile) {
 
     VideoConfig decode_config = GetConfigDecode();
     VideoConfig encode_config = GetConfigEncode();
-    if (!decode_config && !encode_config) {
+    if (!decode_config || !encode_config) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 


### PR DESCRIPTION
`VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR` requires `VK_KHR_video_encode_queue`, so `encode_config` must be supported