### PR TITLE
layers: Add 03797 03711 03735

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2349,20 +2349,9 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBuffer comm
             BufferAddressValidation<5> buffer_address_validator = {{{
                 {"VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08052", LogObjectList(device),
                  [this](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
-                     if (!buffer_state->sparse && !buffer_state->IsMemoryBound()) {
-                         if (out_error_msg) {
-                             if (const auto mem_state = buffer_state->MemState(); mem_state && mem_state->Destroyed()) {
-                                 *out_error_msg +=
-                                     "buffer is bound to memory (" + FormatHandle(mem_state->Handle()) + ") but it has been freed";
-                             } else {
-                                 *out_error_msg += "buffer has not been bound to memory";
-                             }
-                         }
-                         return false;
-                     }
-                     return true;
+                     return BufferAddressValidation<1>::ValidateMemoryBoundToBuffer(*this, buffer_state, out_error_msg);
                  },
-                 []() { return "The following buffers are not bound to memory or it has been freed:\n"; }},
+                 []() { return BufferAddressValidation<1>::ValidateMemoryBoundToBufferErrorMsgHeader(); }},
 
                 {"VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08055", LogObjectList(device),
                  [binding_usage = bindingInfo.usage](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -4963,7 +4963,8 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
-                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR"
+                            "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR"
                         ]
                     }
                 },


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-03797**
The [format features](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#resources-buffer-view-format-features) of vertexFormat must contain VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, geometry.triangles.vertexData.deviceAddress must be aligned to the size in bytes of the smallest component of the format in vertexFormat

**VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03735**
vertexStride must be a multiple of the size in bytes of the smallest component of vertexFormat
