### PR TITLE
layers: Add 03804 03805

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -548,6 +548,33 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                     skip |= buffer_check(geom_i, geom_data.geometry.triangles.transformData,
                                          p_geom_geom_triangles_loc.dot(Field::transformData));
 
+                    auto buffer_states = GetBuffersByAddress(geom_data.geometry.triangles.vertexData.deviceAddress);
+                    if (buffer_states.empty()) {
+                        skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03804", cmd_buffer,
+                                         p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
+                                         "(0x%" PRIx64 ") is not a valid address.",
+                                         geom_data.geometry.triangles.vertexData.deviceAddress);
+                    } else {
+                        using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
+                        BufferAddressValidation<1> buffer_address_validator = {
+                            {{{"VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03805", LogObjectList(cmd_buffer),
+                               [this, &p_geom_geom_triangles_loc, cmd_buffer](const BUFFER_STATE_PTR &buffer_state,
+                                                                              std::string *out_error_msg) {
+                                   if (!out_error_msg) {
+                                       return !buffer_state->sparse && buffer_state->IsMemoryBound();
+                                   } else {
+                                       return ValidateMemoryIsBoundToBuffer(
+                                           cmd_buffer, *buffer_state,
+                                           p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
+                                           "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03805");
+                                   }
+                               }}}}};
+
+                        skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(
+                            *this, buffer_states, p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
+                            geom_data.geometry.triangles.vertexData.deviceAddress);
+                    }
+
                     if (geom_data.geometry.triangles.indexType != VK_INDEX_TYPE_NONE_KHR) {
                         if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
                             const uint32_t recorded_first_vertex = src_as_state->build_range_infos[geom_i].firstVertex;

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -133,6 +133,10 @@ GeometryKHR &GeometryKHR::SetTrianglesTransformatData(VkDeviceAddress address) {
     return *this;
 }
 
+GeometryKHR &GeometryKHR::SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress address) {
+    vk_obj_.geometry.triangles.vertexData.deviceAddress = address;
+    return *this;
+}
 GeometryKHR &GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer &&buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.device_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.address();

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -78,6 +78,7 @@ class GeometryKHR {
     GeometryKHR& SetTrianglesVertexFormat(VkFormat vertex_format);
     GeometryKHR& SetTrianglesMaxVertex(uint32_t max_vertex);
     GeometryKHR& SetTrianglesTransformatData(VkDeviceAddress address);
+    GeometryKHR& SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress address);
     // AABB
     GeometryKHR& SetAABBsDeviceBuffer(vkt::Buffer&& buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));
     GeometryKHR& SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[]> buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -2530,6 +2530,26 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     m_commandBuffer->end();
 }
 
+TEST_F(NegativeRayTracing, TrianglesVertexBufferBadMemory) {
+    TEST_DESCRIPTION("Use a triangles vertex buffer whose memory has been destroyed for an acceleration structure build operation");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
+    build_info.GetGeometries()[0].SetTrianglesVertexBufferDeviceAddress(0);
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03804");
+    build_info.BuildCmdBuffer(*m_commandBuffer);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometry) {
     TEST_DESCRIPTION(
         "Build a list of destination acceleration structures, then do an update build on that same list but with triangles "


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03804**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, geometry.triangles.vertexData.deviceAddress must be a valid device address obtained from [vkGetBufferDeviceAddress](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetBufferDeviceAddress.html)

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03805**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, if geometry.triangles.vertexData.deviceAddress is the address of a non-sparse buffer then it must be bound completely and contiguously to a single [VkDeviceMemory](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceMemory.html) object