### PR TITLE
Use CTest in Github Actions

### DIFF
--- a/scripts/common_ci.py
+++ b/scripts/common_ci.py
@@ -1,8 +1,8 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2023 The Khronos Group Inc.
-# Copyright (c) 2015-2023 Valve Corporation
-# Copyright (c) 2015-2023 LunarG, Inc.
+# Copyright (c) 2015-2024 The Khronos Group Inc.
+# Copyright (c) 2015-2024 Valve Corporation
+# Copyright (c) 2015-2024 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@ import os
 import sys
 import subprocess
 import platform
-import argparse
 
 # Use Ninja for all platforms for performance/simplicity
 os.environ['CMAKE_GENERATOR'] = "Ninja"
@@ -34,13 +33,6 @@ PROJECT_SRC_DIR = os.path.abspath(os.path.join(os.path.split(os.path.abspath(__f
 if not os.path.isfile(f'{PROJECT_SRC_DIR}/CMakeLists.txt'):
     print(f'PROJECT_SRC_DIR invalid! {PROJECT_SRC_DIR}')
     sys.exit(1)
-
-# Where all artifacts will ultimately be placed under
-CI_BUILD_DIR = RepoRelative('build-ci')
-# Where all dependencies will be installed under
-CI_EXTERNAL_DIR = f'{CI_BUILD_DIR}/external'
-# Where all repos will install to
-CI_INSTALL_DIR = f'{CI_BUILD_DIR}/install'
 
 # Returns true if we are running in GitHub actions
 # https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables
@@ -70,194 +62,3 @@ def RunShellCmd(command, start_dir = PROJECT_SRC_DIR, env=None, verbose=False):
 #
 # Check if the system is Windows
 def IsWindows(): return 'windows' == platform.system().lower()
-
-#
-# Prepare the Validation Layers for testing
-def BuildVVL(config, cmake_args, build_tests, mock_android):
-    print("Log CMake version")
-    cmake_ver_cmd = 'cmake --version'
-    RunShellCmd(cmake_ver_cmd)
-
-    SRC_DIR = PROJECT_SRC_DIR
-    BUILD_DIR = f'{CI_BUILD_DIR}/vvl'
-
-    print("Configure VVL")
-    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
-    cmake_cmd += f' -D CMAKE_BUILD_TYPE={config}'
-    cmake_cmd += f' -D BUILD_TESTS={build_tests}'
-    cmake_cmd += f' -D UPDATE_DEPS=ON -D UPDATE_DEPS_DIR={CI_EXTERNAL_DIR}'
-    cmake_cmd += ' -D BUILD_WERROR=ON'
-
-    if cmake_args:
-         cmake_cmd += f' {cmake_args}'
-
-    if mock_android:
-         cmake_cmd += ' -DVVL_MOCK_ANDROID=ON'
-
-    RunShellCmd(cmake_cmd)
-
-    print("Build VVL")
-    build_cmd = f'cmake --build {BUILD_DIR}'
-    RunShellCmd(build_cmd)
-
-    print("Install VVL")
-    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
-    RunShellCmd(install_cmd)
-
-#
-# Prepare Loader for executing Layer Validation Tests
-def BuildLoader():
-    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Loader'
-    BUILD_DIR = f'{SRC_DIR}/build'
-
-    if not os.path.exists(SRC_DIR):
-        print("Unable to find Vulkan-Loader")
-        sys.exit(1)
-
-    print("Run CMake for Loader")
-    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
-    cmake_cmd += ' -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release'
-
-    # GitHub actions runs our test as admin on Windows
-    if IsGHA() and IsWindows():
-        cmake_cmd += ' -D LOADER_USE_UNSAFE_FILE_SEARCH=ON'
-
-    RunShellCmd(cmake_cmd)
-
-    print("Build Loader")
-    build_cmd = f'cmake --build {BUILD_DIR}'
-    RunShellCmd(build_cmd)
-
-    print("Install Loader")
-    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
-    RunShellCmd(install_cmd)
-
-#
-# Prepare Mock ICD for use with Layer Validation Tests
-def BuildMockICD(mockAndroid):
-    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Tools'
-    BUILD_DIR = f'{SRC_DIR}/build'
-
-    if not os.path.exists(SRC_DIR):
-        print("Unable to find Vulkan-Tools")
-        sys.exit(1)
-
-    print("Configure Mock ICD")
-    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR} -D CMAKE_BUILD_TYPE=Release '
-    cmake_cmd += '-DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -D INSTALL_ICD=ON -D UPDATE_DEPS=ON'
-    if mockAndroid:
-        cmake_cmd += ' -DBUILD_MOCK_ANDROID_SUPPORT=ON'
-    RunShellCmd(cmake_cmd)
-
-    print("Build Mock ICD")
-    build_cmd = f'cmake --build {BUILD_DIR} --target VkICD_mock_icd'
-    RunShellCmd(build_cmd)
-
-    print("Install Mock ICD")
-    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
-    RunShellCmd(install_cmd)
-
-#
-# Prepare Profile Layer for use with Layer Validation Tests
-def BuildProfileLayer(mockAndroid):
-    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Profiles'
-    BUILD_DIR = f'{SRC_DIR}/build'
-
-    if not os.path.exists(SRC_DIR):
-        print("Unable to find Vulkan-Profiles")
-        sys.exit(1)
-
-    print("Run CMake for Profile Layer")
-    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
-    cmake_cmd += ' -D CMAKE_BUILD_TYPE=Release'
-    cmake_cmd += ' -D UPDATE_DEPS=ON'
-    if mockAndroid:
-        cmake_cmd += ' -DBUILD_MOCK_ANDROID_SUPPORT=ON'
-    RunShellCmd(cmake_cmd)
-
-    print("Build Profile Layer")
-    build_cmd = f'cmake --build {BUILD_DIR}'
-    RunShellCmd(build_cmd)
-
-    print("Install Profile Layer")
-    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
-    RunShellCmd(install_cmd)
-
-#
-# Run the Layer Validation Tests
-def RunVVLTests(args):
-    print("Run VVL Tests using Mock ICD")
-
-    lvt_env = dict(os.environ)
-
-    # Because we installed everything to CI_INSTALL_DIR all the libraries/json files are in pre-determined locations
-    # defined by GNUInstallDirs. This makes setting VK_LAYER_PATH and other environment variables trivial/robust.
-    if IsWindows():
-        lvt_env['VK_LAYER_PATH'] = os.path.join(CI_INSTALL_DIR, 'bin')
-        lvt_env['VK_DRIVER_FILES'] = os.path.join(CI_INSTALL_DIR, 'bin\\VkICD_mock_icd.json')
-    else:
-        lvt_env['LD_LIBRARY_PATH'] = os.path.join(CI_INSTALL_DIR, 'lib')
-        lvt_env['DYLD_LIBRARY_PATH'] = os.path.join(CI_INSTALL_DIR, 'lib')
-        lvt_env['VK_LAYER_PATH'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/explicit_layer.d')
-        lvt_env['VK_DRIVER_FILES'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/icd.d/VkICD_mock_icd.json')
-
-    # This enables better stack traces from tools like leak sanitizer by using the loader feature which prevents unloading of libraries at shutdown.
-    lvt_env['VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING'] = '1'
-
-    # Useful for debugging
-    # lvt_env['VK_LOADER_DEBUG'] = 'error,warn,info'
-    # lvt_env['VK_LAYER_TESTS_PRINT_DRIVER'] = '1'
-
-    lvt_env['VK_INSTANCE_LAYERS'] = 'VK_LAYER_KHRONOS_validation' + os.pathsep + 'VK_LAYER_KHRONOS_profiles'
-    lvt_env['VK_KHRONOS_PROFILES_SIMULATE_CAPABILITIES'] = 'SIMULATE_API_VERSION_BIT,SIMULATE_FEATURES_BIT,SIMULATE_PROPERTIES_BIT,SIMULATE_EXTENSIONS_BIT,SIMULATE_FORMATS_BIT,SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT'
-
-    # By default use the max_profile.json
-    if "VK_KHRONOS_PROFILES_PROFILE_FILE" not in os.environ:
-        lvt_env['VK_KHRONOS_PROFILES_PROFILE_FILE'] = RepoRelative('tests/device_profiles/max_profile.json')
-
-    # By default set portability to false
-    if "VK_KHRONOS_PROFILES_EMULATE_PORTABILITY" not in os.environ:
-        lvt_env['VK_KHRONOS_PROFILES_EMULATE_PORTABILITY'] = 'false'
-
-    lvt_env['VK_KHRONOS_PROFILES_DEBUG_REPORTS'] = 'DEBUG_REPORT_ERROR_BIT'
-
-    lvt_cmd = os.path.join(CI_INSTALL_DIR, 'bin', 'vk_layer_validation_tests')
-
-    if args.mockAndroid:
-        # TODO - only reason running this subset, is mockAndoid fails any test that does
-        # a manual vkCreateDevice call and need to investigate more why
-        RunShellCmd(lvt_cmd + " --gtest_filter=*AndroidHardwareBuffer.*:*AndroidExternalResolve.*", env=lvt_env)
-        return
-
-    RunShellCmd(lvt_cmd, env=lvt_env)
-
-    print("Re-Running syncval tests with core validation enabled (--syncval-enable-core)")
-    RunShellCmd(lvt_cmd + f' --gtest_filter=*SyncVal* --syncval-enable-core', env=lvt_env)
-
-    print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")
-    lvt_env['VK_LAYER_FINE_GRAINED_LOCKING'] = '0'
-    RunShellCmd(lvt_cmd + f' --gtest_filter=*Thread*', env=lvt_env)
-
-def GetArgParser():
-    configs = ['release', 'debug']
-    default_config = configs[0]
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        '-c', '--config', dest='configuration',
-        metavar='CONFIG', action='store',
-        choices=configs, default=default_config,
-        help='Build target configuration. Can be one of: {0}'.format(
-            ', '.join(configs)))
-    parser.add_argument(
-        '--cmake', dest='cmake',
-        metavar='CMAKE', type=str,
-        default='', help='Additional args to pass to cmake')
-    parser.add_argument(
-        '--build', dest='build',
-        action='store_true', help='Build the layers')
-    parser.add_argument(
-        '--test', dest='test',
-        action='store_true', help='Tests the layers')
-
-    return parser

--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
-# Copyright (c) 2020-2023 Valve Corporation
-# Copyright (c) 2020-2023 LunarG, Inc.
+# Copyright (c) 2020-2024 Valve Corporation
+# Copyright (c) 2020-2024 LunarG, Inc.
 
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,7 +17,127 @@
 import subprocess
 import sys
 import os
+import argparse
 import common_ci
+
+# Where all artifacts will ultimately be placed under
+CI_BUILD_DIR = common_ci.RepoRelative('build-ci')
+# Where all dependencies will be installed under
+CI_EXTERNAL_DIR = f'{CI_BUILD_DIR}/external'
+# Where all repos will install to
+CI_INSTALL_DIR = f'{CI_BUILD_DIR}/install'
+
+#
+# Prepare the Validation Layers for testing
+def BuildVVL(config, cmake_args, build_tests, mock_android):
+    print("Log CMake version")
+    cmake_ver_cmd = 'cmake --version'
+    common_ci.RunShellCmd(cmake_ver_cmd)
+
+    SRC_DIR = common_ci.PROJECT_SRC_DIR
+    BUILD_DIR = f'{CI_BUILD_DIR}/vvl'
+
+    print("Configure VVL")
+    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
+    cmake_cmd += f' -D CMAKE_BUILD_TYPE={config}'
+    cmake_cmd += f' -D BUILD_TESTS={build_tests}'
+    cmake_cmd += f' -D UPDATE_DEPS=ON -D UPDATE_DEPS_DIR={CI_EXTERNAL_DIR}'
+    cmake_cmd += ' -D BUILD_WERROR=ON'
+
+    if cmake_args:
+         cmake_cmd += f' {cmake_args}'
+
+    if mock_android:
+         cmake_cmd += ' -DVVL_MOCK_ANDROID=ON'
+
+    common_ci.RunShellCmd(cmake_cmd)
+
+    print("Build VVL")
+    build_cmd = f'cmake --build {BUILD_DIR}'
+    common_ci.RunShellCmd(build_cmd)
+
+    print("Install VVL")
+    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
+    common_ci.RunShellCmd(install_cmd)
+
+#
+# Prepare Loader for executing Layer Validation Tests
+def BuildLoader():
+    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Loader'
+    BUILD_DIR = f'{SRC_DIR}/build'
+
+    if not os.path.exists(SRC_DIR):
+        print("Unable to find Vulkan-Loader")
+        sys.exit(1)
+
+    print("Run CMake for Loader")
+    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
+    cmake_cmd += ' -D UPDATE_DEPS=ON -D CMAKE_BUILD_TYPE=Release'
+
+    # GitHub actions runs our test as admin on Windows
+    if common_ci.IsGHA() and common_ci.IsWindows():
+        cmake_cmd += ' -D LOADER_USE_UNSAFE_FILE_SEARCH=ON'
+
+    common_ci.RunShellCmd(cmake_cmd)
+
+    print("Build Loader")
+    build_cmd = f'cmake --build {BUILD_DIR}'
+    common_ci.RunShellCmd(build_cmd)
+
+    print("Install Loader")
+    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
+    common_ci.RunShellCmd(install_cmd)
+
+#
+# Prepare Mock ICD for use with Layer Validation Tests
+def BuildMockICD(mockAndroid):
+    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Tools'
+    BUILD_DIR = f'{SRC_DIR}/build'
+
+    if not os.path.exists(SRC_DIR):
+        print("Unable to find Vulkan-Tools")
+        sys.exit(1)
+
+    print("Configure Mock ICD")
+    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR} -D CMAKE_BUILD_TYPE=Release '
+    cmake_cmd += '-DBUILD_CUBE=NO -DBUILD_VULKANINFO=NO -D INSTALL_ICD=ON -D UPDATE_DEPS=ON'
+    if mockAndroid:
+        cmake_cmd += ' -DBUILD_MOCK_ANDROID_SUPPORT=ON'
+    common_ci.RunShellCmd(cmake_cmd)
+
+    print("Build Mock ICD")
+    build_cmd = f'cmake --build {BUILD_DIR} --target VkICD_mock_icd'
+    common_ci.RunShellCmd(build_cmd)
+
+    print("Install Mock ICD")
+    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
+    common_ci.RunShellCmd(install_cmd)
+
+#
+# Prepare Profile Layer for use with Layer Validation Tests
+def BuildProfileLayer(mockAndroid):
+    SRC_DIR = f'{CI_EXTERNAL_DIR}/Vulkan-Profiles'
+    BUILD_DIR = f'{SRC_DIR}/build'
+
+    if not os.path.exists(SRC_DIR):
+        print("Unable to find Vulkan-Profiles")
+        sys.exit(1)
+
+    print("Run CMake for Profile Layer")
+    cmake_cmd = f'cmake -S {SRC_DIR} -B {BUILD_DIR}'
+    cmake_cmd += ' -D CMAKE_BUILD_TYPE=Release'
+    cmake_cmd += ' -D UPDATE_DEPS=ON'
+    if mockAndroid:
+        cmake_cmd += ' -DBUILD_MOCK_ANDROID_SUPPORT=ON'
+    common_ci.RunShellCmd(cmake_cmd)
+
+    print("Build Profile Layer")
+    build_cmd = f'cmake --build {BUILD_DIR}'
+    common_ci.RunShellCmd(build_cmd)
+
+    print("Install Profile Layer")
+    install_cmd = f'cmake --install {BUILD_DIR} --prefix {CI_INSTALL_DIR}'
+    common_ci.RunShellCmd(install_cmd)
 
 #
 # Module Entrypoint
@@ -32,10 +152,10 @@ def Build(args):
             sys.exit(1)
 
     try:
-        common_ci.BuildVVL(config = config, cmake_args = args.cmake, build_tests = "ON", mock_android = args.mockAndroid)
-        common_ci.BuildLoader()
-        common_ci.BuildProfileLayer(args.mockAndroid)
-        common_ci.BuildMockICD(args.mockAndroid)
+        BuildVVL(config = config, cmake_args = args.cmake, build_tests = "ON", mock_android = args.mockAndroid)
+        BuildLoader()
+        BuildProfileLayer(args.mockAndroid)
+        BuildMockICD(args.mockAndroid)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
@@ -46,9 +166,64 @@ def Build(args):
 
     sys.exit(0)
 
+#
+# Run the Layer Validation Tests
+def RunVVLTests(args):
+    print("Run VVL Tests using Mock ICD")
+
+    lvt_env = dict(os.environ)
+
+    # Because we installed everything to CI_INSTALL_DIR all the libraries/json files are in pre-determined locations
+    # defined by GNUInstallDirs. This makes setting VK_LAYER_PATH and other environment variables trivial/robust.
+    if common_ci.IsWindows():
+        lvt_env['VK_LAYER_PATH'] = os.path.join(CI_INSTALL_DIR, 'bin')
+        lvt_env['VK_DRIVER_FILES'] = os.path.join(CI_INSTALL_DIR, 'bin\\VkICD_mock_icd.json')
+    else:
+        lvt_env['LD_LIBRARY_PATH'] = os.path.join(CI_INSTALL_DIR, 'lib')
+        lvt_env['DYLD_LIBRARY_PATH'] = os.path.join(CI_INSTALL_DIR, 'lib')
+        lvt_env['VK_LAYER_PATH'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/explicit_layer.d')
+        lvt_env['VK_DRIVER_FILES'] = os.path.join(CI_INSTALL_DIR, 'share/vulkan/icd.d/VkICD_mock_icd.json')
+
+    # This enables better stack traces from tools like leak sanitizer by using the loader feature which prevents unloading of libraries at shutdown.
+    lvt_env['VK_LOADER_DISABLE_DYNAMIC_LIBRARY_UNLOADING'] = '1'
+
+    # Useful for debugging
+    # lvt_env['VK_LOADER_DEBUG'] = 'error,warn,info'
+    # lvt_env['VK_LAYER_TESTS_PRINT_DRIVER'] = '1'
+
+    lvt_env['VK_INSTANCE_LAYERS'] = 'VK_LAYER_KHRONOS_validation' + os.pathsep + 'VK_LAYER_KHRONOS_profiles'
+    lvt_env['VK_KHRONOS_PROFILES_SIMULATE_CAPABILITIES'] = 'SIMULATE_API_VERSION_BIT,SIMULATE_FEATURES_BIT,SIMULATE_PROPERTIES_BIT,SIMULATE_EXTENSIONS_BIT,SIMULATE_FORMATS_BIT,SIMULATE_QUEUE_FAMILY_PROPERTIES_BIT'
+
+    # By default use the max_profile.json
+    if "VK_KHRONOS_PROFILES_PROFILE_FILE" not in os.environ:
+        lvt_env['VK_KHRONOS_PROFILES_PROFILE_FILE'] = common_ci.RepoRelative('tests/device_profiles/max_profile.json')
+
+    # By default set portability to false
+    if "VK_KHRONOS_PROFILES_EMULATE_PORTABILITY" not in os.environ:
+        lvt_env['VK_KHRONOS_PROFILES_EMULATE_PORTABILITY'] = 'false'
+
+    lvt_env['VK_KHRONOS_PROFILES_DEBUG_REPORTS'] = 'DEBUG_REPORT_ERROR_BIT'
+
+    lvt_cmd = os.path.join(CI_INSTALL_DIR, 'bin', 'vk_layer_validation_tests')
+
+    if args.mockAndroid:
+        # TODO - only reason running this subset, is mockAndoid fails any test that does
+        # a manual vkCreateDevice call and need to investigate more why
+        common_ci.RunShellCmd(lvt_cmd + " --gtest_filter=*AndroidHardwareBuffer.*:*AndroidExternalResolve.*", env=lvt_env)
+        return
+
+    common_ci.RunShellCmd(lvt_cmd, env=lvt_env)
+
+    print("Re-Running syncval tests with core validation enabled (--syncval-enable-core)")
+    common_ci.RunShellCmd(lvt_cmd + ' --gtest_filter=*SyncVal* --syncval-enable-core', env=lvt_env)
+
+    print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")
+    lvt_env['VK_LAYER_FINE_GRAINED_LOCKING'] = '0'
+    common_ci.RunShellCmd(lvt_cmd + ' --gtest_filter=*Thread*', env=lvt_env)
+
 def Test(args):
     try:
-        common_ci.RunVVLTests(args)
+        RunVVLTests(args)
 
     except subprocess.CalledProcessError as proc_error:
         print('Command "%s" failed with return code %s' % (' '.join(proc_error.cmd), proc_error.returncode))
@@ -60,7 +235,26 @@ def Test(args):
     sys.exit(0)
 
 if __name__ == '__main__':
-    parser = common_ci.GetArgParser()
+    configs = ['release', 'debug']
+    default_config = configs[0]
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '-c', '--config', dest='configuration',
+        metavar='CONFIG', action='store',
+        choices=configs, default=default_config,
+        help='Build target configuration. Can be one of: {0}'.format(
+            ', '.join(configs)))
+    parser.add_argument(
+        '--cmake', dest='cmake',
+        metavar='CMAKE', type=str,
+        default='', help='Additional args to pass to cmake')
+    parser.add_argument(
+        '--build', dest='build',
+        action='store_true', help='Build the layers')
+    parser.add_argument(
+        '--test', dest='test',
+        action='store_true', help='Tests the layers')
     parser.add_argument(
         '--mockAndroid', dest='mockAndroid',
         action='store_true', help='Use Mock Android')

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -1,7 +1,7 @@
 ﻿/*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -198,6 +198,15 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             printf("\nUse --help or -h for option list.\n");
             exit(0);
         }
+    }
+
+    // Allow some options to be set via env variables because some tools like ctest
+    // can't provide a way to pass arguments to this test executable in the current state
+    if (!GetEnvironment("VVL_TEST_SNYCVAL_ENABLE_CORE").empty()) {
+        m_syncval_enable_core = true;
+    }
+    if (!GetEnvironment("VVL_TEST_GPUAV_ENABLE_CORE").empty()) {
+        m_gpuav_enable_core = true;
     }
 }
 


### PR DESCRIPTION
(note first commit is to just move non-common code from `common_ci.py` to `tests.py`)

This makes use of `ctest` over the traditional `gtest` flow

The main advantage (will update time improvements when CI is done) is to have the tests run in parallel since using MockICD, there is zero risk when the needing the share the same kernel context as there is with a real GPU