### PR TITLE
layers: Add 03806 03807 03712

### DIFF
--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -137,6 +137,12 @@ GeometryKHR &GeometryKHR::SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress 
     vk_obj_.geometry.triangles.vertexData.deviceAddress = address;
     return *this;
 }
+
+GeometryKHR &GeometryKHR::SetTrianglesIndexBufferDeviceAddress(VkDeviceAddress address) {
+    vk_obj_.geometry.triangles.indexData.deviceAddress = address;
+    return *this;
+}
+
 GeometryKHR &GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer &&buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.device_buffer = std::move(buffer);
     vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.address();
@@ -726,6 +732,7 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device) {
 
     // Assign vertex and index buffers to out geometry
     triangle_geometry.SetTrianglesDeviceVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3 - 1));
+    triangle_geometry.SetTrianglesIndexType(VK_INDEX_TYPE_UINT32);
     triangle_geometry.SetTrianglesDeviceIndexBuffer(std::move(index_buffer));
 
     return triangle_geometry;

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -79,6 +79,7 @@ class GeometryKHR {
     GeometryKHR& SetTrianglesMaxVertex(uint32_t max_vertex);
     GeometryKHR& SetTrianglesTransformatData(VkDeviceAddress address);
     GeometryKHR& SetTrianglesVertexBufferDeviceAddress(VkDeviceAddress address);
+    GeometryKHR& SetTrianglesIndexBufferDeviceAddress(VkDeviceAddress address);
     // AABB
     GeometryKHR& SetAABBsDeviceBuffer(vkt::Buffer&& buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));
     GeometryKHR& SetAABBsHostBuffer(std::unique_ptr<VkAabbPositionsKHR[]> buffer, VkDeviceSize stride = sizeof(VkAabbPositionsKHR));


### PR DESCRIPTION
part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03806**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, if geometry.triangles.indexType is not VK_INDEX_TYPE_NONE_KHR, geometry.triangles.indexData.deviceAddress must be a valid device address obtained from [vkGetBufferDeviceAddress](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetBufferDeviceAddress.html)

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03807**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, if geometry.triangles.indexType is not VK_INDEX_TYPE_NONE_KHR, if geometry.triangles.indexData.deviceAddress is the address of a non-sparse buffer then it must be bound completely and contiguously to a single [VkDeviceMemory](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceMemory.html) object

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03712**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, and with geometry.triangles.indexType not equal to VK_INDEX_TYPE_NONE_KHR, geometry.triangles.indexData.deviceAddress must be aligned to the size in bytes of the type in indexType