### PR TITLE
sync: Report debug region name

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2023 The Khronos Group Inc.
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
+/* Copyright (c) 2019-2024 The Khronos Group Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -3014,6 +3014,21 @@ void SyncValidator::PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapc
                 sync_image->SetOpaqueBaseAddress(*this);
             }
         }
+    }
+}
+
+void SyncValidator::PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
+                                                            const RecordObject &record_obj) {
+    StateTracker::PreCallRecordCmdBeginDebugUtilsLabelEXT(commandBuffer, pLabelInfo, record_obj);
+    if (auto cb_state = Get<syncval_state::CommandBuffer>(commandBuffer)) {
+        cb_state->access_context.PushDebugRegion(pLabelInfo ? pLabelInfo->pLabelName : nullptr);
+    }
+}
+
+void SyncValidator::PreCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
+    StateTracker::PreCallRecordCmdEndDebugUtilsLabelEXT(commandBuffer, record_obj);
+    if (auto cb_state = Get<syncval_state::CommandBuffer>(commandBuffer)) {
+        cb_state->access_context.PopDebugRegion();
     }
 }
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -577,5 +577,8 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                      uint64_t timeout, const RecordObject &record_obj) override;
     void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
                                              VkImage *pSwapchainImages, const RecordObject &record_obj) override;
+    void PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
+                                                 const RecordObject &record_obj) override;
+    void PreCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) override;
 };
 


### PR DESCRIPTION
This reports debug regions (defined by `vkCmdBeginDebugUtilsLabelEXT` and `vkCmdEndDebugUtilsLabelEXT`) where hazardous accesses happen.

For submit time validation the debug region is reported for the prior access and also for the current access (from practical side the
most interesting is the location of the prior access).

Error message as reported by record time validation:
> Validation Error: [ SYNC-HAZARD-WRITE-AFTER-READ ] Object 0: handle = 0xfa21a40000000003, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x376bc9df | vkCmdCopyBuffer():  Hazard WRITE_AFTER_READ for dstBuffer VkBuffer 0xfa21a40000000003[], region 0. Access info (usage: SYNC_COPY_TRANSFER_WRITE, prior_usage: SYNC_COPY_TRANSFER_READ, read_barriers: VkPipelineStageFlags2(0), command: vkCmdCopyBuffer, seq_no: 1, reset_no: 1, **debug region: VulkanFrame::CopyAToB**).

Error message as reported by submit time validation:
> Validation Error: [ SYNC-HAZARD-WRITE-AFTER-READ ] Object 0: handle = 0x133d442c300, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x376bc9df | vkQueueSubmit():  Hazard WRITE_AFTER_READ for entry 1, VkCommandBuffer 0x133d17db740[], Submitted access info (submitted_usage: SYNC_COPY_TRANSFER_WRITE, command: vkCmdCopyBuffer, seq_no: 2, reset_no: 1, **debug region: VulkanFrame_CommandBuffer1::SecondPass::CopyCToA**). Access info (prior_usage: SYNC_COPY_TRANSFER_READ, read_barriers: VkPipelineStageFlags2(0), queue: VkQueue 0x133d442c300[], submit: 0, batch: 0, batch_tag: 1, command: vkCmdCopyBuffer, command_buffer: VkCommandBuffer 0x133d0ef4db0[], seq_no: 2, reset_no: 1, **debug region: VulkanFrame_CommandBuffer0::FirstPass::CopyAToB**).

Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7159

