### PR TITLE
layers: Add 03808 03809

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -180,7 +180,7 @@ bool BufferAddressValidation<N>::LogInvalidBuffers(const CoreChecks& checker,
         error_msg_beginning += "(";
         error_msg_beginning += address_string;
         error_msg_beginning +=
-            ") has no buffer associated to it. "
+            ") has no valid buffer associated to it. "
             "At least one buffer associated to this device address must be valid. ";
     }
 

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -30,12 +30,11 @@ bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory *mem_state, co
     auto type_name = object_string[typed_handle.type];
     if (!mem_state) {
         result |=
-            LogError(vuid, objlist, loc, "(%s) used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
+            LogError(vuid, objlist, loc, "(%s) is used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
                      FormatHandle(typed_handle).c_str(), type_name + 2);
     } else if (mem_state->Destroyed()) {
         result |= LogError(vuid, objlist, loc,
-                           "(%s) used with no memory bound and previously bound memory was freed. Memory must not be freed "
-                           "prior to this operation.",
+                           "(%s) is used, but bound memory was freed. Memory must not be freed prior to this operation.",
                            FormatHandle(typed_handle).c_str());
     }
     return result;

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -631,6 +631,36 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                             }
                         }
                     }
+
+                    if (geom_data.geometry.triangles.transformData.deviceAddress != 0) {
+                        auto tranform_buffer_states = GetBuffersByAddress(geom_data.geometry.triangles.transformData.deviceAddress);
+                        if (tranform_buffer_states.empty()) {
+                            skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808", cmd_buffer,
+                                             p_geom_geom_triangles_loc.dot(Field::transformData).dot(Field::deviceAddress),
+                                             "(0x%" PRIx64 ") is not an address belonging to an existing buffer.",
+                                             geom_data.geometry.triangles.transformData.deviceAddress);
+                        } else {
+                            using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
+                            BufferAddressValidation<1> buffer_address_validator = {
+                                {{{"VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03809", LogObjectList(cmd_buffer),
+                                   [this, &p_geom_geom_triangles_loc, cmd_buffer](const BUFFER_STATE_PTR &buffer_state,
+                                                                                  std::string *out_error_msg) {
+                                       if (!out_error_msg) {
+                                           return !buffer_state->sparse && buffer_state->IsMemoryBound();
+                                       } else {
+                                           return ValidateMemoryIsBoundToBuffer(
+                                               cmd_buffer, *buffer_state,
+                                               p_geom_geom_triangles_loc.dot(Field::transformData).dot(Field::deviceAddress),
+                                               "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03809");
+                                       }
+                                   }}}}};
+
+                            skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(
+                                *this, tranform_buffer_states,
+                                p_geom_geom_triangles_loc.dot(Field::transformData).dot(Field::deviceAddress),
+                                geom_data.geometry.triangles.transformData.deviceAddress);
+                        }
+                    }
                     break;
                 }
                 case VK_GEOMETRY_TYPE_INSTANCES_KHR: {


### PR DESCRIPTION
part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, if geometry.triangles.transformData.deviceAddress is not 0, it must be a valid device address obtained from [vkGetBufferDeviceAddress](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetBufferDeviceAddress.html)

**VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03809**
For any element of pInfos[i].pGeometries or pInfos[i].ppGeometries with a geometryType of VK_GEOMETRY_TYPE_TRIANGLES_KHR, if geometry.triangles.transformData.deviceAddress is the address of a non-sparse buffer then it must be bound completely and contiguously to a single [VkDeviceMemory](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkDeviceMemory.html) object