### PR TITLE
layers: Improve buffer address validation messages

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -559,17 +559,22 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                         using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
                         BufferAddressValidation<1> buffer_address_validator = {
                             {{{"VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03805", LogObjectList(cmd_buffer),
-                               [this, &p_geom_geom_triangles_loc, cmd_buffer](const BUFFER_STATE_PTR &buffer_state,
-                                                                              std::string *out_error_msg) {
-                                   if (!out_error_msg) {
-                                       return !buffer_state->sparse && buffer_state->IsMemoryBound();
-                                   } else {
-                                       return ValidateMemoryIsBoundToBuffer(
-                                           cmd_buffer, *buffer_state,
-                                           p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
-                                           "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03805");
+                               [this](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
+                                   if (!buffer_state->sparse && !buffer_state->IsMemoryBound()) {
+                                       if (out_error_msg) {
+                                           if (const auto mem_state = buffer_state->MemState();
+                                               mem_state && mem_state->Destroyed()) {
+                                               *out_error_msg += "buffer is bound to memory (" + FormatHandle(mem_state->Handle()) +
+                                                                 ") but it has been freed";
+                                           } else {
+                                               *out_error_msg += "buffer has not been bound to memory";
+                                           }
+                                       }
+                                       return false;
                                    }
-                               }}}}};
+                                   return true;
+                               },
+                               []() { return "The following buffers are not bound to memory or it has been freed:\n"; }}}}};
 
                         skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(
                             *this, vertex_buffer_states, p_geom_geom_triangles_loc.dot(Field::vertexData).dot(Field::deviceAddress),
@@ -599,17 +604,22 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                             using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
                             BufferAddressValidation<1> buffer_address_validator = {
                                 {{{"VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03807", LogObjectList(cmd_buffer),
-                                   [this, &p_geom_geom_triangles_loc, cmd_buffer](const BUFFER_STATE_PTR &buffer_state,
-                                                                                  std::string *out_error_msg) {
-                                       if (!out_error_msg) {
-                                           return !buffer_state->sparse && buffer_state->IsMemoryBound();
-                                       } else {
-                                           return ValidateMemoryIsBoundToBuffer(
-                                               cmd_buffer, *buffer_state,
-                                               p_geom_geom_triangles_loc.dot(Field::indexData).dot(Field::deviceAddress),
-                                               "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03807");
+                                   [this](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
+                                       if (!buffer_state->sparse && !buffer_state->IsMemoryBound()) {
+                                           if (out_error_msg) {
+                                               if (const auto mem_state = buffer_state->MemState();
+                                                   mem_state && mem_state->Destroyed()) {
+                                                   *out_error_msg += "buffer is bound to memory (" +
+                                                                     FormatHandle(mem_state->Handle()) + ") but it has been freed";
+                                               } else {
+                                                   *out_error_msg += "buffer has not been bound to memory";
+                                               }
+                                           }
+                                           return false;
                                        }
-                                   }}}}};
+                                       return true;
+                                   },
+                                   []() { return "The following buffers are not bound to memory or it has been freed:\n"; }}}}};
 
                             skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(
                                 *this, index_buffer_states,
@@ -678,16 +688,22 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
                         using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
                         BufferAddressValidation<1> buffer_address_validator = {
                             {{{"VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03814", LogObjectList(cmd_buffer),
-                               [this, instances_data_loc, cmd_buffer](const BUFFER_STATE_PTR &buffer_state,
-                                                                      std::string *out_error_msg) {
-                                   if (!out_error_msg) {
-                                       return !buffer_state->sparse && buffer_state->IsMemoryBound();
-                                   } else {
-                                       return ValidateMemoryIsBoundToBuffer(
-                                           cmd_buffer, *buffer_state, instances_data_loc.dot(Field::deviceAddress),
-                                           "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03814");
+                               [this](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
+                                   if (!buffer_state->sparse && !buffer_state->IsMemoryBound()) {
+                                       if (out_error_msg) {
+                                           if (const auto mem_state = buffer_state->MemState();
+                                               mem_state && mem_state->Destroyed()) {
+                                               *out_error_msg += "buffer is bound to memory (" + FormatHandle(mem_state->Handle()) +
+                                                                 ") but it has been freed";
+                                           } else {
+                                               *out_error_msg += "buffer has not been bound to memory";
+                                           }
+                                       }
+                                       return false;
                                    }
-                               }}}}};
+                                   return true;
+                               },
+                               []() { return "The following buffers are not bound to memory or it has been freed:\n"; }}}}};
 
                         skip |= buffer_address_validator.LogErrorsIfNoValidBuffer(*this, buffer_states,
                                                                                   instances_data_loc.dot(Field::deviceAddress),
@@ -1829,21 +1845,27 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
         using BUFFER_STATE_PTR = ValidationStateTracker::BUFFER_STATE_PTR;
         BufferAddressValidation<4> buffer_address_validator = {{{
             {vuid_single_device_memory, LogObjectList(commandBuffer),
-             [this, commandBuffer, table_loc, vuid_single_device_memory](const BUFFER_STATE_PTR &buffer_state,
-                                                                         std::string *out_error_msg) {
-                 if (!out_error_msg) {
-                     return !buffer_state->sparse && buffer_state->IsMemoryBound();
-                 } else {
-                     return ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, table_loc.dot(Field::deviceAddress),
-                                                          vuid_single_device_memory);
+             [this](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
+                 if (!buffer_state->sparse && !buffer_state->IsMemoryBound()) {
+                     if (out_error_msg) {
+                         if (const auto mem_state = buffer_state->MemState(); mem_state && mem_state->Destroyed()) {
+                             *out_error_msg +=
+                                 "buffer is bound to memory (" + FormatHandle(mem_state->Handle()) + ") but it has been freed";
+                         } else {
+                             *out_error_msg += "buffer has not been bound to memory";
+                         }
+                     }
+                     return false;
                  }
-             }},
+                 return true;
+             },
+             []() { return "The following buffers are not bound to memory or it has been freed:\n"; }},
 
             {vuid_binding_table_flag, LogObjectList(commandBuffer),
              [](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
                  if (!(static_cast<uint32_t>(buffer_state->usage) & VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR)) {
                      if (out_error_msg) {
-                         *out_error_msg += "buffer has usage " + string_VkBufferUsageFlags2KHR(buffer_state->usage) + '\n';
+                         *out_error_msg += "buffer has usage " + string_VkBufferUsageFlags2KHR(buffer_state->usage);
                      }
                      return false;
                  }
@@ -1860,7 +1882,7 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
                  if (!buffer_address_range.includes(requested_range)) {
                      if (out_error_msg) {
                          const std::string buffer_address_range_string = string_range_hex(buffer_address_range);
-                         *out_error_msg += "buffer device address range is " + buffer_address_range_string + '\n';
+                         *out_error_msg += "buffer device address range is " + buffer_address_range_string;
                      }
                      return false;
                  }
@@ -1876,7 +1898,7 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
              [&binding_table](const BUFFER_STATE_PTR &buffer_state, std::string *out_error_msg) {
                  if (binding_table.stride > buffer_state->createInfo.size) {
                      if (out_error_msg) {
-                         *out_error_msg += "buffer size is " + std::to_string(buffer_state->createInfo.size) + '\n';
+                         *out_error_msg += "buffer size is " + std::to_string(buffer_state->createInfo.size);
                      }
                      return false;
                  }


### PR DESCRIPTION
A number of VU states something along the lines of "non sparse buffers accessed through a device address must be bound to memory" The current error message was not taking advantage of the error message generation in BufferAddressValidation, it now does

Then:
>Validation Error: [ VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08052 ] Object 0: handle = 0x204b7943830, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0x9fde6b0000000014, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x17e3f381 | vkCmdBindDescriptorBuffersEXT(): pBindingInfos[0].address (VkBuffer 0x9fde6b0000000014[]) used with no memory bound and previously bound memory was freed. Memory must not be freed prior to this operation.

Now:
>Validation Error: [ VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08052 ] Object 0: handle = 0x9fde6b0000000014, type = VK_OBJECT_TYPE_BUFFER; | MessageID = 0x17e3f381 | vkCmdBindDescriptorBuffersEXT(): pBindingInfos[0].address (0x13ca7000) has no valid buffer associated to it. At least one buffer associated to this device address must be valid. The following buffers are not bound to memory or it has been freed:
Object 1: buffer is bound to memory (VkDeviceMemory 0xdd3a8a0000000015[]) but it has been freed

The important part is the mention that "At least one buffer associated to this device address must be valid". reminding that when multiple VUs refer to the same device address, valid usage passes if and only if at least one buffer satisfies all of those VUs

Need to update https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7290 and https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7271 after that