### PR TITLE
layers: Add missing implicit RasterizationStateCreateInfo

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -1134,6 +1134,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
 
         if (create_info.pRasterizationState) {
             const Location rasterization_loc = create_info_loc.dot(Field::pRasterizationState);
+            skip |= ValidatePipelineRasterizationStateCreateInfo(*create_info.pRasterizationState, rasterization_loc);
+
             if (!IsExtEnabled(device_extensions.vk_nv_fill_rectangle)) {
                 if (create_info.pRasterizationState->polygonMode == VK_POLYGON_MODE_FILL_RECTANGLE_NV) {
                     skip |= LogError("VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01414", device,

--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -302,7 +302,7 @@ bool StatelessValidation::ValidateReservedFlags(const Location &loc, VkFlags val
     bool skip = false;
 
     if (value != 0) {
-        skip |= LogError(vuid, device, loc, "must be 0.");
+        skip |= LogError(vuid, device, loc, "is %" PRIu32 ", but must be 0.", value);
     }
 
     return skip;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -26908,5 +26908,45 @@ bool StatelessValidation::ValidatePipelineInputAssemblyStateCreateInfo(const VkP
     skip |= ValidateBool32(loc.dot(Field::primitiveRestartEnable), info.primitiveRestartEnable);
     return skip;
 }
+bool StatelessValidation::ValidatePipelineRasterizationStateCreateInfo(const VkPipelineRasterizationStateCreateInfo& info,
+                                                                       const Location& loc) const {
+    bool skip = false;
+    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO", &info,
+                               VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO, false, kVUIDUndefined,
+                               "VUID-VkPipelineRasterizationStateCreateInfo-sType-sType");
+
+    constexpr std::array allowed_structs_VkPipelineRasterizationStateCreateInfo = {
+        VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_CONSERVATIVE_STATE_CREATE_INFO_EXT,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_DEPTH_CLIP_STATE_CREATE_INFO_EXT,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_LINE_STATE_CREATE_INFO_EXT,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_PROVOKING_VERTEX_STATE_CREATE_INFO_EXT,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_RASTERIZATION_ORDER_AMD,
+        VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_STREAM_CREATE_INFO_EXT};
+
+    skip |= ValidateStructPnext(loc, info.pNext, allowed_structs_VkPipelineRasterizationStateCreateInfo.size(),
+                                allowed_structs_VkPipelineRasterizationStateCreateInfo.data(), GeneratedVulkanHeaderVersion,
+                                "VUID-VkPipelineRasterizationStateCreateInfo-pNext-pNext",
+                                "VUID-VkPipelineRasterizationStateCreateInfo-sType-unique", false, true);
+
+    skip |=
+        ValidateReservedFlags(loc.dot(Field::flags), info.flags, "VUID-VkPipelineRasterizationStateCreateInfo-flags-zerobitmask");
+
+    skip |= ValidateBool32(loc.dot(Field::depthClampEnable), info.depthClampEnable);
+
+    skip |= ValidateBool32(loc.dot(Field::rasterizerDiscardEnable), info.rasterizerDiscardEnable);
+
+    skip |= ValidateRangedEnum(loc.dot(Field::polygonMode), "VkPolygonMode", info.polygonMode,
+                               "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-parameter");
+
+    skip |= ValidateFlags(loc.dot(Field::cullMode), "VkCullModeFlagBits", AllVkCullModeFlagBits, info.cullMode, kOptionalFlags,
+                          "VUID-VkPipelineRasterizationStateCreateInfo-cullMode-parameter");
+
+    skip |= ValidateRangedEnum(loc.dot(Field::frontFace), "VkFrontFace", info.frontFace,
+                               "VUID-VkPipelineRasterizationStateCreateInfo-frontFace-parameter");
+
+    skip |= ValidateBool32(loc.dot(Field::depthBiasEnable), info.depthBiasEnable);
+    return skip;
+}
 
 // NOLINTEND

--- a/layers/vulkan/generated/stateless_validation_helper.h
+++ b/layers/vulkan/generated/stateless_validation_helper.h
@@ -1818,4 +1818,5 @@ bool ValidatePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleState
 bool ValidatePipelineColorBlendStateCreateInfo(const VkPipelineColorBlendStateCreateInfo& info, const Location& loc) const;
 bool ValidatePipelineDepthStencilStateCreateInfo(const VkPipelineDepthStencilStateCreateInfo& info, const Location& loc) const;
 bool ValidatePipelineInputAssemblyStateCreateInfo(const VkPipelineInputAssemblyStateCreateInfo& info, const Location& loc) const;
+bool ValidatePipelineRasterizationStateCreateInfo(const VkPipelineRasterizationStateCreateInfo& info, const Location& loc) const;
 // NOLINTEND

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -221,6 +221,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'VkPipelineColorBlendStateCreateInfo',
             'VkPipelineDepthStencilStateCreateInfo',
             'VkPipelineInputAssemblyStateCreateInfo',
+            'VkPipelineRasterizationStateCreateInfo',
         ]
 
         # Map of structs type names to generated validation code for that struct type

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -3625,6 +3625,19 @@ TEST_F(NegativePipeline, PipelineCreateFlags2) {
     pipe.InitState();
     pipe.gp_ci_.pNext = &flags2;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativePipeline, RasterizationStateFlag) {
+    TEST_DESCRIPTION("Enabled depth bounds when the features is disabled");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.InitState();
+    pipe.rs_state_ci_.flags = 1;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateCreateInfo-flags-zerobitmask");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -43,6 +43,7 @@ TEST_F(NegativePipelineTopology, PolygonMode) {
     // Set polygonMode to FILL_RECTANGLE_NV while the extension is not enabled.
     // Introduce failure by setting unsupported polygon mode
     rs_ci.polygonMode = VK_POLYGON_MODE_FILL_RECTANGLE_NV;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-parameter");
     CreatePipelineHelper::OneshotTest(*this, set_polygonMode, kErrorBit,
                                       "VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01414");
 }


### PR DESCRIPTION
somehow the `VkPipelineRasterizationStateCreateInfo` implicit VUs were not added in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6824