### PR TITLE
layers: Add 03769

### DIFF
--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -608,16 +608,29 @@ bool CoreChecks::ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_
 
                         if (const auto src_as_state = Get<vvl::AccelerationStructureKHR>(info.srcAccelerationStructure)) {
                             if (geom_i < src_as_state->build_range_infos.size()) {
-                                const uint32_t recorded_first_vertex = src_as_state->build_range_infos[geom_i].firstVertex;
-                                if (recorded_first_vertex != geometry_build_ranges[geom_i].firstVertex) {
+                                if (const uint32_t recorded_first_vertex = src_as_state->build_range_infos[geom_i].firstVertex;
+                                    recorded_first_vertex != geometry_build_ranges[geom_i].firstVertex) {
                                     const LogObjectList objlist(cmd_buffer, info.srcAccelerationStructure);
-                                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-firstVertex-03770", objlist,
+                                    skip |=
+                                        LogError("VUID-vkCmdBuildAccelerationStructuresKHR-firstVertex-03770", objlist, p_geom_loc,
+                                                 " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s[%" PRIu32
+                                                 "], but this build range has its firstVertex member set to (%" PRIu32
+                                                 ") when it was last specified as (%" PRIu32 ").",
+                                                 pp_build_range_info_loc.Fields().c_str(), geom_i,
+                                                 geometry_build_ranges[geom_i].firstVertex, recorded_first_vertex);
+                                }
+
+                                if (const uint32_t recorded_primitive_count =
+                                        src_as_state->build_range_infos[geom_i].primitiveCount;
+                                    recorded_primitive_count != geometry_build_ranges[geom_i].primitiveCount) {
+                                    const LogObjectList objlist(cmd_buffer, info.srcAccelerationStructure);
+                                    skip |= LogError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769", objlist,
                                                      p_geom_loc,
                                                      " has corresponding VkAccelerationStructureBuildRangeInfoKHR %s[%" PRIu32
-                                                     "], but this build range has its firstVertex member set to (%" PRIu32
+                                                     "], but this build range has its primitiveCount member set to (%" PRIu32
                                                      ") when it was last specified as (%" PRIu32 ").",
                                                      pp_build_range_info_loc.Fields().c_str(), geom_i,
-                                                     geometry_build_ranges[geom_i].firstVertex, recorded_first_vertex);
+                                                     geometry_build_ranges[geom_i].primitiveCount, recorded_primitive_count);
                                 }
                             }
                         }


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3792

**VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769**
For each element of pInfos, if its mode member is VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR, then for each VkAccelerationStructureGeometryKHR structure referred to by its pGeometries or ppGeometries members, the primitiveCount member of its corresponding VkAccelerationStructureBuildRangeInfoKHR structure must have the same value which was specified when srcAccelerationStructure was last built