### PR TITLE
layers: Fix wrapping of returned driver managed VkDisplayKHR handles

### DIFF
--- a/layers/layer_chassis_dispatch_manual.cpp
+++ b/layers/layer_chassis_dispatch_manual.cpp
@@ -1,8 +1,8 @@
 /***************************************************************************
 *
-* Copyright (c) 2015-2023 The Khronos Group Inc.
-* Copyright (c) 2015-2023 Valve Corporation
-* Copyright (c) 2015-2023 LunarG, Inc.
+* Copyright (c) 2015-2024 The Khronos Group Inc.
+* Copyright (c) 2015-2024 Valve Corporation
+* Copyright (c) 2015-2024 LunarG, Inc.
 *
 * Licensed under the Apache License, Version 2.0 (the "License");
 * you may not use this file except in compliance with the License.
@@ -1722,3 +1722,41 @@ VkResult DispatchReleasePerformanceConfigurationINTEL(
 
     return result;
 }
+
+#ifdef VK_USE_PLATFORM_XLIB_XRANDR_EXT
+VkResult DispatchGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
+    VkDisplayKHR* pDisplay) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (!wrap_handles) return layer_data->instance_dispatch_table.GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
+
+    VkResult result = layer_data->instance_dispatch_table.GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
+    if (VK_SUCCESS == result) {
+        *pDisplay = layer_data->MaybeWrapDisplay(*pDisplay, layer_data);
+    }
+    return result;
+}
+#endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
+
+VkResult DispatchGetDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, uint32_t connectorId, VkDisplayKHR* display) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (!wrap_handles) return layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
+
+    VkResult result = layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
+    if (VK_SUCCESS == result) {
+        *display = layer_data->MaybeWrapDisplay(*display, layer_data);
+    }
+    return result;
+}
+
+#ifdef VK_USE_PLATFORM_WIN32_KHR
+VkResult DispatchGetWinrtDisplayNV(VkPhysicalDevice physicalDevice, uint32_t deviceRelativeId, VkDisplayKHR* pDisplay) {
+    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
+    if (!wrap_handles) return layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
+
+    VkResult result = layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
+    if (VK_SUCCESS == result) {
+        *pDisplay = layer_data->MaybeWrapDisplay(*pDisplay, layer_data);
+    }
+    return result;
+}
+#endif  // VK_USE_PLATFORM_WIN32_KHR

--- a/layers/vulkan/generated/layer_chassis_dispatch.cpp
+++ b/layers/vulkan/generated/layer_chassis_dispatch.cpp
@@ -5652,18 +5652,6 @@ VkResult DispatchAcquireXlibDisplayEXT(VkPhysicalDevice physicalDevice, Display*
 
     return result;
 }
-
-VkResult DispatchGetRandROutputDisplayEXT(VkPhysicalDevice physicalDevice, Display* dpy, RROutput rrOutput,
-                                          VkDisplayKHR* pDisplay) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-    if (!wrap_handles) return layer_data->instance_dispatch_table.GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
-
-    VkResult result = layer_data->instance_dispatch_table.GetRandROutputDisplayEXT(physicalDevice, dpy, rrOutput, pDisplay);
-    if (VK_SUCCESS == result) {
-        *pDisplay = layer_data->WrapNew(*pDisplay);
-    }
-    return result;
-}
 #endif  // VK_USE_PLATFORM_XLIB_XRANDR_EXT
 
 VkResult DispatchGetPhysicalDeviceSurfaceCapabilities2EXT(VkPhysicalDevice physicalDevice, VkSurfaceKHR surface,
@@ -7144,17 +7132,6 @@ VkResult DispatchAcquireDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t d
     return result;
 }
 
-VkResult DispatchGetDrmDisplayEXT(VkPhysicalDevice physicalDevice, int32_t drmFd, uint32_t connectorId, VkDisplayKHR* display) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-    if (!wrap_handles) return layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-
-    VkResult result = layer_data->instance_dispatch_table.GetDrmDisplayEXT(physicalDevice, drmFd, connectorId, display);
-    if (VK_SUCCESS == result) {
-        *display = layer_data->WrapNew(*display);
-    }
-    return result;
-}
-
 VkResult DispatchCreatePrivateDataSlotEXT(VkDevice device, const VkPrivateDataSlotCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkPrivateDataSlot* pPrivateDataSlot) {
     auto layer_data = GetLayerDataPtr(get_dispatch_key(device), layer_data_map);
@@ -7469,15 +7446,6 @@ VkResult DispatchAcquireWinrtDisplayNV(VkPhysicalDevice physicalDevice, VkDispla
     if (!wrap_handles) return layer_data->instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
     { display = layer_data->Unwrap(display); }
     VkResult result = layer_data->instance_dispatch_table.AcquireWinrtDisplayNV(physicalDevice, display);
-
-    return result;
-}
-
-VkResult DispatchGetWinrtDisplayNV(VkPhysicalDevice physicalDevice, uint32_t deviceRelativeId, VkDisplayKHR* pDisplay) {
-    auto layer_data = GetLayerDataPtr(get_dispatch_key(physicalDevice), layer_data_map);
-    if (!wrap_handles) return layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
-    { pDisplay = layer_data->Unwrap(pDisplay); }
-    VkResult result = layer_data->instance_dispatch_table.GetWinrtDisplayNV(physicalDevice, deviceRelativeId, pDisplay);
 
     return result;
 }

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -86,6 +86,9 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             'vkGetDescriptorEXT',
             'vkReleasePerformanceConfigurationINTEL',
             'vkExportMetalObjectsEXT',
+            'vkGetWinrtDisplayNV',
+            'vkGetRandROutputDisplayEXT',
+            'vkGetDrmDisplayEXT',
             # These are for special-casing the pInheritanceInfo issue (must be ignored for primary CBs)
             'vkAllocateCommandBuffers',
             'vkFreeCommandBuffers',
@@ -219,7 +222,7 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             out.extend(guard_helper.add_guard(command.protect))
 
             # Generate NDO wrapping/unwrapping code for all parameters
-            isCreate = any(x in command.name for x in ['Create', 'Allocate', 'GetRandROutputDisplayEXT', 'GetDrmDisplayEXT', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL'])
+            isCreate = any(x in command.name for x in ['Create', 'Allocate', 'RegisterDeviceEvent', 'RegisterDisplayEvent', 'AcquirePerformanceConfigurationINTEL'])
             isDestroy = any(x in command.name for x in ['Destroy', 'Free'])
 
             # Handle ndo create/allocate operations


### PR DESCRIPTION
The following commands don't "create" a handle, but rather return a handle the driver is managing:
vkGetWinrtDisplayNV
vkGetRandROutputDisplayEXT
vkGetDrmDisplayEXT