### PR TITLE
layers: Add debug label tracking VU 01912

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1770,7 +1770,7 @@ void CoreChecks::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer comman
                                                           const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
-    cb_state->BeginLabel();
+    cb_state->BeginLabel((pLabelInfo && pLabelInfo->pLabelName) ? pLabelInfo->pLabelName : "");
 }
 
 bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -196,6 +196,8 @@ void CommandBuffer::ResetCBState() {
 
     // Clean up the label data
     debug_label.Reset();
+    label_stack_depth_ = 0;
+    debug_label_commands_.clear();
 
     // Best practices info
     small_indexed_draw_call_count = 0;
@@ -1643,6 +1645,16 @@ void CommandBuffer::GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipel
     }
     *rtn_pipe = last_bound.pipeline_state;
     *rtn_sets = &(last_bound.per_set);
+}
+
+void CommandBuffer::BeginLabel(const char *label_name) {
+    ++label_stack_depth_;
+    debug_label_commands_.push_back(DebugLabelCommand{true, label_name});
+}
+
+void CommandBuffer::EndLabel() {
+    --label_stack_depth_;
+    debug_label_commands_.push_back(DebugLabelCommand{false, std::string()});
 }
 
 }  // namespace vvl

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -1,7 +1,7 @@
 /* Copyright (c) 2015-2024 The Khronos Group Inc.
  * Copyright (c) 2015-2024 Valve Corporation
  * Copyright (c) 2015-2024 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -103,6 +103,16 @@ class Queue: public StateObject {
     const uint32_t queueFamilyIndex;
     const VkDeviceQueueCreateFlags flags;
     const VkQueueFamilyProperties queueFamilyProperties;
+
+    // Track command buffer label stack depth accross all command buffers submitted to this queue.
+    // Negative value indicates unbalanced usage of begin/end label commands.
+    // Access to this variable relies on external queue synchronization.
+    int cmdbuf_label_stack_depth{0};
+
+    // Track the last closed label. It is used in the error messages to help locate unbalanced vkCmdEndDebugUtilsLabelEXT command.
+    // Access to these variables relies on external queue synchronization.
+    std::vector<std::string> cmdbuf_label_names;
+    std::string last_closed_cmdbuf_label;
 
   private:
     using LockGuard = std::unique_lock<std::mutex>;

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -7169,20 +7169,6 @@ TEST_F(NegativeCommand, ClearImageAspectMask) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeCommand, DebugLabelSecondaryCommandBuffer) {
-    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-
-    vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    cb.begin();
-
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913");
-    vk::CmdEndDebugUtilsLabelEXT(cb);
-    m_errorMonitor->VerifyFound();
-
-    cb.end();
-}
-
 TEST_F(NegativeCommand, RenderPassContinueNotSupportedByCommandPool) {
     TEST_DESCRIPTION("Use render pass continue bit with unsupported command pool.");
 

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -806,69 +806,6 @@ TEST_F(PositiveCommand, FillBufferCmdPoolTransferQueue) {
 
     cb.begin();
     vk::CmdFillBuffer(cb.handle(), buffer.handle(), 0, 12, 0x11111111);
-    cb.end();
-}
-
-TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffer) {
-    TEST_DESCRIPTION("Create a debug label on a primary command buffer");
-
-    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-    m_commandBuffer->begin();
-
-    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
-    label.pLabelName = "test";
-    vk::CmdBeginDebugUtilsLabelEXT(*m_commandBuffer, &label);
-    vk::CmdEndDebugUtilsLabelEXT(*m_commandBuffer);
-
-    m_commandBuffer->end();
-
-    m_default_queue->submit(*m_commandBuffer);
-    m_default_queue->wait();
-}
-
-TEST_F(PositiveCommand, DebugLabelPrimaryCommandBuffers) {
-    TEST_DESCRIPTION("Begin a debug label on 1 command buffer, then end it on another command buffer");
-
-    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-
-    vkt::CommandBuffer command_buffer_start(m_device, m_commandPool);
-    vkt::CommandBuffer command_buffer_end(m_device, m_commandPool);
-
-    // Start DebugLabel on 1 command buffer
-    {
-        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
-        label.pLabelName = "test";
-        command_buffer_start.begin();
-        vk::CmdBeginDebugUtilsLabelEXT(command_buffer_start.handle(), &label);
-        command_buffer_start.end();
-    }
-
-    // End DebugLabel on another command buffer
-    {
-        command_buffer_end.begin();
-        vk::CmdEndDebugUtilsLabelEXT(command_buffer_end.handle());
-        command_buffer_end.end();
-    }
-
-    vkt::Fence fence;
-    std::vector<const vkt::CommandBuffer *> command_buffers = {&command_buffer_start, &command_buffer_end};
-    m_default_queue->submit(command_buffers, fence);
-    m_default_queue->wait();
-}
-
-TEST_F(PositiveCommand, DebugLabelSecondaryCommandBuffer) {
-    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    RETURN_IF_SKIP(Init());
-    vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    cb.begin();
-    {
-        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
-        label.pLabelName = "test";
-        vk::CmdBeginDebugUtilsLabelEXT(cb, &label);
-        vk::CmdEndDebugUtilsLabelEXT(cb);
-    }
     cb.end();
 }
 

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -83,3 +83,76 @@ TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectDevice) {
 
     vk::DestroyDebugUtilsMessengerEXT(instance(), my_messenger, nullptr);
 }
+
+TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer) {
+    TEST_DESCRIPTION("Test primary command buffer debug labels");
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    m_commandBuffer->begin();
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+    label.pLabelName = "test";
+    vk::CmdBeginDebugUtilsLabelEXT(*m_commandBuffer, &label);
+    vk::CmdEndDebugUtilsLabelEXT(*m_commandBuffer);
+    m_commandBuffer->end();
+
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
+}
+
+TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer2) {
+    TEST_DESCRIPTION("Test primary command buffer debug labels with multiple submits");
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+    label.pLabelName = "test";
+    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    cb0.begin();
+    vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
+    cb0.end();
+    m_default_queue->submit(cb0);
+
+    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    cb1.begin();
+    vk::CmdEndDebugUtilsLabelEXT(cb1);
+    cb1.end();
+    m_default_queue->submit(cb1);
+
+    m_default_queue->wait();
+}
+
+TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
+    TEST_DESCRIPTION("Test primary command buffer debug labels with multiple submits");
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+    label.pLabelName = "test";
+    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    cb0.begin();
+    vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
+    cb0.end();
+
+    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    cb1.begin();
+    vk::CmdEndDebugUtilsLabelEXT(cb1);
+    cb1.end();
+
+    m_default_queue->submit({&cb0, &cb1}, vkt::Fence{});
+    m_default_queue->wait();
+}
+
+TEST_F(PositiveDebugExtensions, DebugLabelSecondaryCommandBuffer) {
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    cb.begin();
+    {
+        VkDebugUtilsLabelEXT label = vku::InitStructHelper();
+        label.pLabelName = "test";
+        vk::CmdBeginDebugUtilsLabelEXT(cb, &label);
+        vk::CmdEndDebugUtilsLabelEXT(cb);
+    }
+    cb.end();
+}


### PR DESCRIPTION
The validation of labels in the primary command buffer happens on the queue level because debug regions can cross command buffer boundaries. Validation should be done at submit time.

This is more complicated comparing to a similar VU for a secondary command buffer where debug regions are not allowed to cross command buffer boundaries.

Error messages:
> Validation Error: [ VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912 ] Object 0: handle = 0x20800790df0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x56146426 | vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] (VkCommandBuffer 0x20800790df0[]) contains vkCmdEndDebugUtilsLabelEXT that does not have a matching vkCmdBeginDebugUtilsLabelEXT in this or one of the previously submitted command buffers. There are no previous debug regions before invalid command.

> Validation Error: [ VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912 ] Object 0: handle = 0x2087d800680, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x56146426 | vkQueueSubmit(): pSubmits[0].pCommandBuffers[0] (VkCommandBuffer 0x2087d800680[]) contains vkCmdEndDebugUtilsLabelEXT that does not have a matching vkCmdBeginDebugUtilsLabelEXT in this or one of the previously submitted command buffers. The previous debug region before the invalid command is 'regionA'.