### PR TITLE
layers: Add Null Layout check

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -424,6 +424,13 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorSets2KHR(VkCommandBuffer comman
         skip |= ValidatePipelineBindPoint(cb_state.get(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     }
 
+    if (pBindDescriptorSetsInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pBindDescriptorSetsInfo->pNext)) {
+        skip |= LogError("VUID-VkBindDescriptorSetsInfoKHR-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pBindDescriptorSetsInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
+    }
+
     return skip;
 }
 
@@ -2239,6 +2246,13 @@ bool CoreChecks::PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
         skip |= ValidatePipelineBindPoint(cb_state.get(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     }
 
+    if (pSetDescriptorBufferOffsetsInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pSetDescriptorBufferOffsetsInfo->pNext)) {
+        skip |= LogError("VUID-VkSetDescriptorBufferOffsetsInfoEXT-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pSetDescriptorBufferOffsetsInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
+    }
+
     return skip;
 }
 
@@ -2316,6 +2330,13 @@ bool CoreChecks::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers2EXT(
     }
     if (IsStageInPipelineBindPoint(pBindDescriptorBufferEmbeddedSamplersInfo->stageFlags, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR)) {
         skip |= ValidatePipelineBindPoint(cb_state.get(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
+    }
+
+    if (pBindDescriptorBufferEmbeddedSamplersInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pBindDescriptorBufferEmbeddedSamplersInfo->pNext)) {
+        skip |= LogError("VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pBindDescriptorBufferEmbeddedSamplersInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
     }
 
     return skip;
@@ -3716,6 +3737,13 @@ bool CoreChecks::PreCallValidateCmdPushDescriptorSetWithTemplate2KHR(
     if (!enabled_features.dynamicPipelineLayout && pPushDescriptorSetWithTemplateInfo->layout == VK_NULL_HANDLE) {
         skip |= LogError("VUID-VkPushDescriptorSetWithTemplateInfoKHR-None-09495", device,
                          error_obj.location.dot(Field::pPushDescriptorSetWithTemplateInfo).dot(Field::layout), "is not valid.");
+    }
+
+    if (pPushDescriptorSetWithTemplateInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pPushDescriptorSetWithTemplateInfo->pNext)) {
+        skip |= LogError("VUID-VkPushDescriptorSetWithTemplateInfoKHR-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pPushDescriptorSetWithTemplateInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
     }
     return skip;
 }

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -307,8 +307,16 @@ bool StatelessValidation::manual_PreCallValidateCmdPushConstants(VkCommandBuffer
 bool StatelessValidation::manual_PreCallValidateCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
                                                                      const VkPushConstantsInfoKHR *pPushConstantsInfo,
                                                                      const ErrorObject &error_obj) const {
-    return ValidateCmdPushConstants(commandBuffer, pPushConstantsInfo->offset, pPushConstantsInfo->size,
-                                    error_obj.location.dot(Field::pPushConstantsInfo));
+    bool skip = false;
+    skip |= ValidateCmdPushConstants(commandBuffer, pPushConstantsInfo->offset, pPushConstantsInfo->size,
+                                     error_obj.location.dot(Field::pPushConstantsInfo));
+    if (pPushConstantsInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pPushConstantsInfo->pNext)) {
+        skip |= LogError("VUID-VkPushConstantsInfoKHR-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pPushConstantsInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
+    }
+    return skip;
 }
 
 bool StatelessValidation::manual_PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image,
@@ -488,8 +496,16 @@ bool StatelessValidation::manual_PreCallValidateCmdPushDescriptorSetKHR(
 bool StatelessValidation::manual_PreCallValidateCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
                                                                          const VkPushDescriptorSetInfoKHR *pPushDescriptorSetInfo,
                                                                          const ErrorObject &error_obj) const {
-    return ValidateWriteDescriptorSet(error_obj.location, pPushDescriptorSetInfo->descriptorWriteCount,
-                                      pPushDescriptorSetInfo->pDescriptorWrites);
+    bool skip = false;
+    skip |= ValidateWriteDescriptorSet(error_obj.location, pPushDescriptorSetInfo->descriptorWriteCount,
+                                       pPushDescriptorSetInfo->pDescriptorWrites);
+    if (pPushDescriptorSetInfo->layout == VK_NULL_HANDLE &&
+        !vku::FindStructInPNextChain<VkPipelineLayoutCreateInfo>(pPushDescriptorSetInfo->pNext)) {
+        skip |= LogError("VUID-VkPushDescriptorSetInfoKHR-layout-09496", commandBuffer,
+                         error_obj.location.dot(Field::pPushDescriptorSetInfo).dot(Field::layout),
+                         "is VK_NULL_HANDLE and pNext is missing VkPipelineLayoutCreateInfo.");
+    }
+    return skip;
 }
 
 bool StatelessValidation::ValidateViewport(const VkViewport &viewport, VkCommandBuffer object, const Location &loc) const {

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -443,6 +443,28 @@ TEST_F(NegativeCommand, PushConstants) {
     m_commandBuffer->end();
 }
 
+TEST_F(NegativeCommand, PushConstant2PipelineLayoutCreateInfo) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_6_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::maintenance6);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    const float data[16] = {};
+    VkPushConstantsInfoKHR pc_info = vku::InitStructHelper();
+    pc_info.stageFlags = VK_SHADER_STAGE_VERTEX_BIT;
+    pc_info.offset = 32;
+    pc_info.size = 16;
+    pc_info.pValues = data;
+    pc_info.layout = VK_NULL_HANDLE;
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPushConstantsInfoKHR-layout-09496");
+    vk::CmdPushConstants2KHR(m_commandBuffer->handle(), &pc_info);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
 TEST_F(NegativeCommand, NoBeginCommandBuffer) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkEndCommandBuffer-commandBuffer-00059");
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -1296,6 +1296,7 @@ TEST_F(NegativeDescriptors, BindDescriptorSetsInfoPipelineLayout) {
 
     bind_ds_info.layout = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindDescriptorSetsInfoKHR-None-09495");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindDescriptorSetsInfoKHR-layout-09496");
     vk::CmdBindDescriptorSets2KHR(m_commandBuffer->handle(), &bind_ds_info);
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
`VK_NV_per_stage_descriptor_set` lets you do dynamic pipeline layout (`dynamicPipelineLayout`) and so check was moved from implicit to explicit

- VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-layout-09496
- VUID-VkBindDescriptorSetsInfoKHR-layout-09496
- VUID-VkSetDescriptorBufferOffsetsInfoEXT-layout-09496
- VUID-VkPushConstantsInfoKHR-layout-09496
- VUID-VkPushDescriptorSetInfoKHR-layout-09496
- VUID-VkPushDescriptorSetWithTemplateInfoKHR-layout-09496