### PR TITLE
layers: Add VK_EXT_debug_marker

### DIFF
--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -1189,6 +1189,48 @@ void ObjectLifetimes::PostCallRecordCreateFramebuffer(VkDevice device, const VkF
     CreateObject(*pFramebuffer, kVulkanObjectTypeFramebuffer, pAllocator, record_obj.location);
 }
 
+bool ObjectLifetimes::PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT *pTagInfo,
+                                                                const ErrorObject &error_obj) const {
+    // Checked by chassis: device: "VUID-vkDebugMarkerSetObjectTagEXT-device-parameter"
+    bool skip = false;
+    if (pTagInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {
+        skip |=
+            LogError("VUID-VkDebugMarkerObjectTagInfoEXT-objectType-01493", device,
+                     error_obj.location.dot(Field::pTagInfo).dot(Field::objectType), "is VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT.");
+    } else {
+        const auto object_type = ConvertDebugReportObjectToVulkanObject(pTagInfo->objectType);
+        if (pTagInfo->object == (uint64_t)VK_NULL_HANDLE) {
+            skip |= LogError("VUID-VkDebugMarkerObjectTagInfoEXT-object-01494", device,
+                             error_obj.location.dot(Field::pTagInfo).dot(Field::object), "is VK_NULL_HANDLE.");
+        } else if (!object_map[object_type].contains(pTagInfo->object)) {
+            skip |= LogError("VUID-VkDebugMarkerObjectTagInfoEXT-object-01495", device,
+                             error_obj.location.dot(Field::pTagInfo).dot(Field::objectType), "doesn't match the object.");
+        }
+    }
+    return skip;
+}
+
+bool ObjectLifetimes::PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT *pNameInfo,
+                                                                 const ErrorObject &error_obj) const {
+    // Checked by chassis: device: "VUID-vkDebugMarkerSetObjectNameEXT-device-parameter"
+    bool skip = false;
+    if (pNameInfo->objectType == VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT) {
+        skip |= LogError("VUID-VkDebugMarkerObjectNameInfoEXT-objectType-01490", device,
+                         error_obj.location.dot(Field::pNameInfo).dot(Field::objectType),
+                         "is VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT.");
+    } else {
+        const auto object_type = ConvertDebugReportObjectToVulkanObject(pNameInfo->objectType);
+        if (pNameInfo->object == (uint64_t)VK_NULL_HANDLE) {
+            skip |= LogError("VUID-VkDebugMarkerObjectNameInfoEXT-object-01491", device,
+                             error_obj.location.dot(Field::pNameInfo).dot(Field::object), "is VK_NULL_HANDLE.");
+        } else if (!object_map[object_type].contains(pNameInfo->object)) {
+            skip |= LogError("VUID-VkDebugMarkerObjectNameInfoEXT-object-01492", device,
+                             error_obj.location.dot(Field::pNameInfo).dot(Field::objectType), "doesn't match the object.");
+        }
+    }
+    return skip;
+}
+
 bool ObjectLifetimes::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice device, const VkDebugUtilsObjectNameInfoEXT *pNameInfo,
                                                                 const ErrorObject &error_obj) const {
     bool skip = false;

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -3,11 +3,11 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google Inc.
- * Copyright (c) 2015-2023 RasterGrid Kft.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google Inc.
+ * Copyright (c) 2015-2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -4381,12 +4381,6 @@ void ObjectLifetimes::PreCallRecordDestroyDebugReportCallbackEXT(VkInstance inst
 
 // vkDebugReportMessageEXT:
 // Checked by chassis: instance: "VUID-vkDebugReportMessageEXT-instance-parameter"
-
-// vkDebugMarkerSetObjectTagEXT:
-// Checked by chassis: device: "VUID-vkDebugMarkerSetObjectTagEXT-device-parameter"
-
-// vkDebugMarkerSetObjectNameEXT:
-// Checked by chassis: device: "VUID-vkDebugMarkerSetObjectNameEXT-device-parameter"
 
 // vkCmdDebugMarkerBeginEXT:
 // Checked by chassis: commandBuffer: "VUID-vkCmdDebugMarkerBeginEXT-commandBuffer-parameter"

--- a/layers/vulkan/generated/object_tracker.h
+++ b/layers/vulkan/generated/object_tracker.h
@@ -3,11 +3,11 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google Inc.
- * Copyright (c) 2015-2023 RasterGrid Kft.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google Inc.
+ * Copyright (c) 2015-2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -830,6 +830,10 @@ bool PreCallValidateDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugRe
                                                   const ErrorObject& error_obj) const override;
 void PreCallRecordDestroyDebugReportCallbackEXT(VkInstance instance, VkDebugReportCallbackEXT callback,
                                                 const VkAllocationCallbacks* pAllocator, const RecordObject& record_obj) override;
+bool PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice device, const VkDebugMarkerObjectTagInfoEXT* pTagInfo,
+                                               const ErrorObject& error_obj) const override;
+bool PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice device, const VkDebugMarkerObjectNameInfoEXT* pNameInfo,
+                                                const ErrorObject& error_obj) const override;
 bool PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuffer commandBuffer, uint32_t firstBinding, uint32_t bindingCount,
                                                        const VkBuffer* pBuffers, const VkDeviceSize* pOffsets,
                                                        const VkDeviceSize* pSizes, const ErrorObject& error_obj) const override;

--- a/layers/vulkan/generated/vk_object_types.h
+++ b/layers/vulkan/generated/vk_object_types.h
@@ -3,10 +3,10 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -492,6 +492,95 @@ static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(Vk
             return VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT;
         default:
             return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
+}
+
+static inline VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
+    switch (debug_obj) {
+        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
+            return kVulkanObjectTypeUnknown;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT:
+            return kVulkanObjectTypeBuffer;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT:
+            return kVulkanObjectTypeImage;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT:
+            return kVulkanObjectTypeInstance;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT:
+            return kVulkanObjectTypePhysicalDevice;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT:
+            return kVulkanObjectTypeDevice;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT:
+            return kVulkanObjectTypeQueue;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT:
+            return kVulkanObjectTypeSemaphore;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT:
+            return kVulkanObjectTypeCommandBuffer;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT:
+            return kVulkanObjectTypeFence;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT:
+            return kVulkanObjectTypeDeviceMemory;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT:
+            return kVulkanObjectTypeEvent;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT:
+            return kVulkanObjectTypeQueryPool;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT:
+            return kVulkanObjectTypeBufferView;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT:
+            return kVulkanObjectTypeImageView;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT:
+            return kVulkanObjectTypeShaderModule;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT:
+            return kVulkanObjectTypePipelineCache;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT:
+            return kVulkanObjectTypePipelineLayout;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT:
+            return kVulkanObjectTypePipeline;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT:
+            return kVulkanObjectTypeRenderPass;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT:
+            return kVulkanObjectTypeDescriptorSetLayout;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT:
+            return kVulkanObjectTypeSampler;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT:
+            return kVulkanObjectTypeDescriptorSet;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT:
+            return kVulkanObjectTypeDescriptorPool;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT:
+            return kVulkanObjectTypeFramebuffer;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT:
+            return kVulkanObjectTypeCommandPool;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT:
+            return kVulkanObjectTypeSamplerYcbcrConversion;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT:
+            return kVulkanObjectTypeDescriptorUpdateTemplate;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT:
+            return kVulkanObjectTypeSurfaceKHR;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT:
+            return kVulkanObjectTypeSwapchainKHR;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT:
+            return kVulkanObjectTypeDisplayKHR;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT:
+            return kVulkanObjectTypeDisplayModeKHR;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT:
+            return kVulkanObjectTypeDebugReportCallbackEXT;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT:
+            return kVulkanObjectTypeCuModuleNVX;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT:
+            return kVulkanObjectTypeCuFunctionNVX;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT:
+            return kVulkanObjectTypeValidationCacheEXT;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT:
+            return kVulkanObjectTypeAccelerationStructureNV;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_MODULE_NV_EXT:
+            return kVulkanObjectTypeCudaModuleNV;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_FUNCTION_NV_EXT:
+            return kVulkanObjectTypeCudaFunctionNV;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT:
+            return kVulkanObjectTypeAccelerationStructureKHR;
+        case VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT:
+            return kVulkanObjectTypeBufferCollectionFUCHSIA;
+        default:
+            return kVulkanObjectTypeUnknown;
     }
 }
 

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2023 The Khronos Group Inc.
-# Copyright (c) 2015-2023 Valve Corporation
-# Copyright (c) 2015-2023 LunarG, Inc.
-# Copyright (c) 2015-2023 Google Inc.
-# Copyright (c) 2023-2023 RasterGrid Kft.
+# Copyright (c) 2015-2024 The Khronos Group Inc.
+# Copyright (c) 2015-2024 Valve Corporation
+# Copyright (c) 2015-2024 LunarG, Inc.
+# Copyright (c) 2015-2024 Google Inc.
+# Copyright (c) 2023-2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -95,6 +95,8 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
             'vkGetDisplayModePropertiesKHR',
             'vkGetDisplayModeProperties2KHR',
             'vkCreateFramebuffer',
+            'vkDebugMarkerSetObjectNameEXT',
+            'vkDebugMarkerSetObjectTagEXT',
             'vkSetDebugUtilsObjectNameEXT',
             'vkSetDebugUtilsObjectTagEXT',
             'vkCreateDescriptorUpdateTemplate',
@@ -318,11 +320,11 @@ class ObjectTrackerOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2015-2023 The Khronos Group Inc.
-            * Copyright (c) 2015-2023 Valve Corporation
-            * Copyright (c) 2015-2023 LunarG, Inc.
-            * Copyright (c) 2015-2023 Google Inc.
-            * Copyright (c) 2015-2023 RasterGrid Kft.
+            * Copyright (c) 2015-2024 The Khronos Group Inc.
+            * Copyright (c) 2015-2024 Valve Corporation
+            * Copyright (c) 2015-2024 LunarG, Inc.
+            * Copyright (c) 2015-2024 Google Inc.
+            * Copyright (c) 2015-2024 RasterGrid Kft.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.

--- a/scripts/generators/object_types_generator.py
+++ b/scripts/generators/object_types_generator.py
@@ -1,10 +1,10 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2015-2023 The Khronos Group Inc.
-# Copyright (c) 2015-2023 Valve Corporation
-# Copyright (c) 2015-2023 LunarG, Inc.
-# Copyright (c) 2015-2023 Google Inc.
-# Copyright (c) 2023-2023 RasterGrid Kft.
+# Copyright (c) 2015-2024 The Khronos Group Inc.
+# Copyright (c) 2015-2024 Valve Corporation
+# Copyright (c) 2015-2024 LunarG, Inc.
+# Copyright (c) 2015-2024 Google Inc.
+# Copyright (c) 2023-2024 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -44,10 +44,10 @@ class ObjectTypesOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2015-2023 The Khronos Group Inc.
-            * Copyright (c) 2015-2023 Valve Corporation
-            * Copyright (c) 2015-2023 LunarG, Inc.
-            * Copyright (c) 2015-2023 Google Inc.
+            * Copyright (c) 2015-2024 The Khronos Group Inc.
+            * Copyright (c) 2015-2024 Valve Corporation
+            * Copyright (c) 2015-2024 LunarG, Inc.
+            * Copyright (c) 2015-2024 Google Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.
@@ -118,6 +118,18 @@ static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(Vk
             if object != 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT':
                 out.append(f'        case {handle.type}: return {object};\n')
         out.append('''        default: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    }
+}\n''')
+
+        out.append('''
+static inline VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
+    switch (debug_obj) {
+        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT: return kVulkanObjectTypeUnknown;\n''')
+        for handle in self.vk.handles.values():
+            object = debugReportObject[handle.name]
+            if object != 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT':
+                out.append(f'        case {object}: return kVulkanObjectType{handle.name[2:]};\n')
+        out.append('''        default: return kVulkanObjectTypeUnknown;
     }
 }\n''')
 

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -16,7 +16,6 @@
 
 TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     TEST_DESCRIPTION("Ensure debug marker object names are printed in debug report output");
-
     AddRequiredExtensions(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
@@ -25,45 +24,35 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
         GTEST_SKIP() << "Skipping object naming test with MockICD.";
     }
 
-    VkBuffer buffer;
-    VkDeviceMemory memory_1, memory_2;
     std::string memory_name = "memory_name";
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.size = 1;
-
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_create_info);
 
     VkMemoryRequirements memRequirements;
-    vk::GetBufferMemoryRequirements(device(), buffer, &memRequirements);
+    vk::GetBufferMemoryRequirements(device(), buffer.handle(), &memRequirements);
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper();
     memory_allocate_info.allocationSize = memRequirements.size;
     memory_allocate_info.memoryTypeIndex = 0;
 
-    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory_1);
-    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory_2);
-
+    vkt::DeviceMemory memory_1(*m_device, memory_allocate_info);
+    vkt::DeviceMemory memory_2(*m_device, memory_allocate_info);
     VkDebugMarkerObjectNameInfoEXT name_info = vku::InitStructHelper();
-    name_info.object = (uint64_t)memory_2;
+    name_info.object = (uint64_t)memory_2.handle();
     name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT;
     name_info.pObjectName = memory_name.c_str();
     vk::DebugMarkerSetObjectNameEXT(device(), &name_info);
 
-    vk::BindBufferMemory(device(), buffer, memory_1, 0);
+    vk::BindBufferMemory(device(), buffer.handle(), memory_1.handle(), 0);
 
     // Test core_validation layer
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, memory_name);
-    vk::BindBufferMemory(device(), buffer, memory_2, 0);
+    vk::BindBufferMemory(device(), buffer.handle(), memory_2.handle(), 0);
     m_errorMonitor->VerifyFound();
-
-    vk::FreeMemory(device(), memory_1, nullptr);
-    memory_1 = VK_NULL_HANDLE;
-    vk::FreeMemory(device(), memory_2, nullptr);
-    memory_2 = VK_NULL_HANDLE;
-    vk::DestroyBuffer(device(), buffer, nullptr);
-    buffer = VK_NULL_HANDLE;
 
     VkCommandBuffer commandBuffer;
     std::string commandBuffer_name = "command_buffer_name";
@@ -102,6 +91,42 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeDebugExtensions, DebugMarkerSetObject) {
+    AddRequiredExtensions(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Skipping object naming test with MockICD.";
+    }
+
+    std::string memory_name = "memory_name";
+
+    VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper();
+    memory_allocate_info.allocationSize = 64;
+    memory_allocate_info.memoryTypeIndex = 0;
+    vkt::DeviceMemory memory(*m_device, memory_allocate_info);
+
+    VkDebugMarkerObjectNameInfoEXT name_info = vku::InitStructHelper();
+    name_info.object = (uint64_t)VK_NULL_HANDLE;
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT;
+    name_info.pObjectName = memory_name.c_str();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectNameInfoEXT-object-01491");
+    vk::DebugMarkerSetObjectNameEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
+
+    name_info.object = (uint64_t)memory.handle();
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectNameInfoEXT-objectType-01490");
+    vk::DebugMarkerSetObjectNameEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
+
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectNameInfoEXT-object-01492");
+    vk::DebugMarkerSetObjectNameEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     TEST_DESCRIPTION("Ensure debug utils object names are printed in debug messenger output");
 
@@ -128,25 +153,23 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     VkDebugUtilsMessengerEXT my_messenger = VK_NULL_HANDLE;
     vk::CreateDebugUtilsMessengerEXT(instance(), &callback_create_info, nullptr, &my_messenger);
 
-    VkBuffer buffer;
-    VkDeviceMemory memory_1, memory_2;
     std::string memory_name = "memory_name";
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.size = 1;
-
-    vk::CreateBuffer(device(), &buffer_create_info, nullptr, &buffer);
+    vkt::Buffer buffer;
+    buffer.init_no_mem(*m_device, buffer_create_info);
 
     VkMemoryRequirements memRequirements;
-    vk::GetBufferMemoryRequirements(device(), buffer, &memRequirements);
+    vk::GetBufferMemoryRequirements(device(), buffer.handle(), &memRequirements);
 
     VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper();
     memory_allocate_info.allocationSize = memRequirements.size;
     memory_allocate_info.memoryTypeIndex = 0;
 
-    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory_1);
-    vk::AllocateMemory(device(), &memory_allocate_info, nullptr, &memory_2);
+    vkt::DeviceMemory memory_1(*m_device, memory_allocate_info);
+    vkt::DeviceMemory memory_2(*m_device, memory_allocate_info);
 
     VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
     name_info.objectType = VK_OBJECT_TYPE_DEVICE_MEMORY;
@@ -166,7 +189,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
 
     // Pass in 'unknown' object type and see if parameter validation catches it
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-02587");
-    name_info.objectHandle = (uint64_t)memory_2;
+    name_info.objectHandle = (uint64_t)memory_2.handle();
     name_info.objectType = VK_OBJECT_TYPE_UNKNOWN;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
     m_errorMonitor->VerifyFound();
@@ -174,19 +197,12 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     name_info.objectType = VK_OBJECT_TYPE_DEVICE_MEMORY;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    vk::BindBufferMemory(device(), buffer, memory_1, 0);
+    vk::BindBufferMemory(device(), buffer.handle(), memory_1.handle(), 0);
 
     // Test core_validation layer
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, memory_name);
-    vk::BindBufferMemory(device(), buffer, memory_2, 0);
+    vk::BindBufferMemory(device(), buffer.handle(), memory_2.handle(), 0);
     m_errorMonitor->VerifyFound();
-
-    vk::FreeMemory(device(), memory_1, nullptr);
-    memory_1 = VK_NULL_HANDLE;
-    vk::FreeMemory(device(), memory_2, nullptr);
-    memory_2 = VK_NULL_HANDLE;
-    vk::DestroyBuffer(device(), buffer, nullptr);
-    buffer = VK_NULL_HANDLE;
 
     VkCommandBuffer commandBuffer;
     std::string commandBuffer_name = "command_buffer_name";
@@ -248,6 +264,43 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     m_errorMonitor->VerifyFound();
 
     vk::DestroyDebugUtilsMessengerEXT(instance(), my_messenger, nullptr);
+}
+
+TEST_F(NegativeDebugExtensions, DebugMarkerSetUtils) {
+    AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_DEBUG_MARKER_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    if (IsPlatformMockICD()) {
+        GTEST_SKIP() << "Skipping object naming test with MockICD.";
+    }
+
+    VkMemoryAllocateInfo memory_allocate_info = vku::InitStructHelper();
+    memory_allocate_info.allocationSize = 64;
+    memory_allocate_info.memoryTypeIndex = 0;
+    vkt::DeviceMemory memory(*m_device, memory_allocate_info);
+
+    int tags[3] = {1, 2, 3};
+    VkDebugMarkerObjectTagInfoEXT name_info = vku::InitStructHelper();
+    name_info.object = (uint64_t)VK_NULL_HANDLE;
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT;
+    name_info.tagName = 1;
+    name_info.tagSize = 4;
+    name_info.pTag = tags;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectTagInfoEXT-object-01494");
+    vk::DebugMarkerSetObjectTagEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
+
+    name_info.object = (uint64_t)memory.handle();
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectTagInfoEXT-objectType-01493");
+    vk::DebugMarkerSetObjectTagEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
+
+    name_info.objectType = VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT;
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDebugMarkerObjectTagInfoEXT-object-01495");
+    vk::DebugMarkerSetObjectTagEXT(device(), &name_info);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDebugExtensions, DebugUtilsParameterFlags) {


### PR DESCRIPTION
`VK_EXT_debug_marker` is old and deprecated, but it had 6 simple VUs better to add then keep forever un-done

- VUID-VkDebugMarkerObjectNameInfoEXT-object-01491
- VUID-VkDebugMarkerObjectNameInfoEXT-object-01492
- VUID-VkDebugMarkerObjectNameInfoEXT-objectType-01490
- VUID-VkDebugMarkerObjectTagInfoEXT-object-01494
- VUID-VkDebugMarkerObjectTagInfoEXT-object-01495
- VUID-VkDebugMarkerObjectTagInfoEXT-objectType-01493