### PR TITLE
tests: Use vkt::no_mem

### DIFF
--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -669,9 +669,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportMemoryAllocateBuffer) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = VK_NULL_HANDLE;
@@ -984,9 +982,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportBufferAllocationSize) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
@@ -1080,9 +1076,7 @@ TEST_F(NegativeAndroidHardwareBuffer, InvalidBindBufferMemory) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = ahb_props.allocationSize;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     // Try to get memory requirements prior to binding memory
     VkMemoryRequirements mem_reqs;
@@ -1144,11 +1138,10 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportBufferHandleType) {
     vkt::DeviceMemory memory(*m_device, memory_allocate_info);
 
     // Create buffer without VkExternalMemoryBufferCreateInfo
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = ahb_props.allocationSize;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memory-02986");
     m_errorMonitor->SetUnexpectedError("VUID-vkBindBufferMemory-memory-01035");
@@ -1301,11 +1294,10 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
     VkExternalMemoryBufferCreateInfo ext_buf_info = vku::InitStructHelper();
     ext_buf_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 512;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkAndroidHardwareBufferPropertiesANDROID ahb_props = vku::InitStructHelper();
     vk::GetAndroidHardwareBufferPropertiesANDROID(m_device->device(), ahb.handle(), &ahb_props);

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -39,11 +39,10 @@ TEST_F(PositiveAndroidHardwareBuffer, MemoryRequirements) {
         GTEST_SKIP() << "No valid memory type index could be found";
     }
 
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = memory_allocate_info.allocationSize;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     // Should be able to bind memory with no error
     vkt::DeviceMemory memory(*m_device, memory_allocate_info);
@@ -124,9 +123,7 @@ TEST_F(PositiveAndroidHardwareBuffer, BindBufferMemory) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 8192;  // greater than the 4k AHB usually are
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     // Try to get memory requirements prior to binding memory
     VkMemoryRequirements mem_reqs;
@@ -171,9 +168,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportBuffer) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper(&ext_buf_info);
     buffer_create_info.size = 4096;
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -902,8 +902,7 @@ TEST_F(NegativeBuffer, CompletelyOverlappingBufferCopy) {
     copy_info.size = 256;
     vkt::Buffer buffer(*m_device, copy_info.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
-    vkt::Buffer buffer_shared_memory;
-    buffer_shared_memory.init_no_mem(*m_device, buffer.create_info());
+    vkt::Buffer buffer_shared_memory(*m_device, buffer.create_info(), vkt::no_mem);
     buffer_shared_memory.bind_memory(buffer.memory(), 0u);
 
     m_commandBuffer->begin();
@@ -939,8 +938,7 @@ TEST_F(NegativeBuffer, CopyingInterleavedRegions) {
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
-    vkt::Buffer buffer_shared_memory;
-    buffer_shared_memory.init_no_mem(*m_device, buffer.create_info());
+    vkt::Buffer buffer_shared_memory(*m_device, buffer.create_info(), vkt::no_mem);
     buffer_shared_memory.bind_memory(buffer.memory(), 0u);
 
     m_commandBuffer->begin();

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -5039,9 +5039,7 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = sizeof(VkDrawIndirectCommand);
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
-    vkt::Buffer draw_buffer;
-    draw_buffer.init_no_mem(*m_device, buffer_create_info);
-    ASSERT_TRUE(draw_buffer.initialized());
+    vkt::Buffer draw_buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkDeviceSize count_buffer_size = 128;
     VkBufferCreateInfo count_buffer_create_info = vku::InitStructHelper();
@@ -5056,9 +5054,7 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
 
     draw_buffer.allocate_and_bind_memory(*m_device);
 
-    vkt::Buffer count_buffer_unbound;
-    count_buffer_unbound.init_no_mem(*m_device, count_buffer_create_info);
-    ASSERT_TRUE(count_buffer_unbound.initialized());
+    vkt::Buffer count_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
     vkt::Buffer count_buffer_wrong;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
@@ -5138,18 +5134,14 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
 
     vk::CmdBindIndexBuffer(m_commandBuffer->handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
 
-    vkt::Buffer draw_buffer_unbound;
-    draw_buffer_unbound.init_no_mem(*m_device, count_buffer_create_info);
-    ASSERT_TRUE(draw_buffer_unbound.initialized());
+    vkt::Buffer draw_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawIndexedIndirectCount-buffer-02708");
     vk::CmdDrawIndexedIndirectCountKHR(m_commandBuffer->handle(), draw_buffer_unbound.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_errorMonitor->VerifyFound();
 
-    vkt::Buffer count_buffer_unbound;
-    count_buffer_unbound.init_no_mem(*m_device, count_buffer_create_info);
-    ASSERT_TRUE(count_buffer_unbound.initialized());
+    vkt::Buffer count_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
     vkt::Buffer count_buffer_wrong;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDEX_BUFFER_BIT;
@@ -6198,10 +6190,10 @@ TEST_F(NegativeCommand, DISABLED_CopyImageOverlappingMemory) {
         VkImageObj::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                       VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
 
-    vkt::Buffer buffer;
     VkDeviceSize buff_size = 32 * 32 * 4;
-    buffer.init_no_mem(*DeviceObj(),
-                       vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer(*m_device,
+                       vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
+                       vkt::no_mem);
     const auto buffer_memory_requirements = buffer.memory_requirements();
 
     VkImageObj image(m_device);
@@ -6216,7 +6208,7 @@ TEST_F(NegativeCommand, DISABLED_CopyImageOverlappingMemory) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
-    mem.init(*DeviceObj(), alloc_info);
+    mem.init(*m_device, alloc_info);
 
     buffer.bind_memory(mem, 0);
     image.bind_memory(mem, 0);

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -1229,10 +1229,10 @@ TEST_F(PositiveCommand, CopyImageOverlappingMemory) {
         VkImageObj::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                       VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
 
-    vkt::Buffer buffer;
     VkDeviceSize buff_size = 32 * 32 * 4;
-    buffer.init_no_mem(*DeviceObj(),
-                       vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer(*m_device,
+                       vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
+                       vkt::no_mem);
     auto buffer_memory_requirements = buffer.memory_requirements();
 
     VkImageObj image(m_device);
@@ -1247,7 +1247,7 @@ TEST_F(PositiveCommand, CopyImageOverlappingMemory) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
-    mem.init(*DeviceObj(), alloc_info);
+    mem.init(*m_device, alloc_info);
 
     buffer.bind_memory(mem, 0);
     image.bind_memory(mem, buffer_memory_requirements.size);
@@ -1277,11 +1277,11 @@ TEST_F(PositiveCommand, CopyImageOverlappingMemory) {
         printf("VK_FORMAT_BC7_UNORM_BLOCK with linear tiling not supported - skipping compressed format test.\n");
         return;
     }
-    vkt::Buffer buffer2;
     // 1 byte per texel
     buff_size = 32 * 32 * 1;
-    buffer2.init_no_mem(*DeviceObj(),
-                        vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer2(*m_device,
+                        vkt::Buffer::create_info(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
+                        vkt::no_mem);
     buffer_memory_requirements = buffer.memory_requirements();
 
     VkImageObj image2(m_device);
@@ -1297,7 +1297,7 @@ TEST_F(PositiveCommand, CopyImageOverlappingMemory) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
     }
 
-    mem2.init(*DeviceObj(), alloc_info);
+    mem2.init(*m_device, alloc_info);
 
     buffer2.bind_memory(mem2, 0);
     image2.bind_memory(mem2, buffer_memory_requirements.size);

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -29,8 +29,7 @@ TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.size = 1;
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryRequirements memRequirements;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &memRequirements);
@@ -158,8 +157,7 @@ TEST_F(NegativeDebugExtensions, DebugUtilsName) {
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
     buffer_create_info.size = 1;
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryRequirements memRequirements;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &memRequirements);

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -758,12 +758,10 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
         buffCI.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         buffCI.size = large_buffer_size;
         buffCI.usage = VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
-        auto large_buffer = std::make_unique<vkt::Buffer>();
-        large_buffer->init_no_mem(*m_device, buffCI);
+        auto large_buffer = std::make_unique<vkt::Buffer>(*m_device, buffCI, vkt::no_mem);
 
         buffCI.size = small_buffer_size;
-        auto small_buffer = std::make_unique<vkt::Buffer>();
-        small_buffer->init_no_mem(*m_device, buffCI);
+        auto small_buffer = std::make_unique<vkt::Buffer>(*m_device, buffCI, vkt::no_mem);
 
         VkMemoryRequirements buffer_mem_reqs = {};
         vk::GetBufferMemoryRequirements(m_device->device(), large_buffer->handle(), &buffer_mem_reqs);
@@ -1159,9 +1157,7 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     VkBufferCreateInfo buffCI = vku::InitStructHelper();
     buffCI.size = 4096;
     buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-    vkt::Buffer d_buffer;
-    d_buffer.init_no_mem(*m_device, buffCI);
+    vkt::Buffer d_buffer(*m_device, buffCI, vkt::no_mem);
 
     VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
     VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -1945,8 +1945,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
         bci.usage = test_case.buffer_usage;
         bci.size = test_case.max_range + test_case.min_align;  // Make buffer bigger than range limit
         bci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-        vkt::Buffer buffer;
-        buffer.init_no_mem(*m_device, bci);
+        vkt::Buffer buffer(*m_device, bci, vkt::no_mem);
         if (buffer.handle() == VK_NULL_HANDLE) {
             std::string msg = "Failed to allocate buffer of size " + std::to_string(bci.size) + " in DSBufferLimitErrors; skipped";
             printf("%s\n", msg.c_str());

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -1132,8 +1132,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 
     auto buffer_info = vkt::Buffer::create_info(buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     buffer_info.pNext = &external_buffer_info;
-    vkt::Buffer buffer_export;
-    buffer_export.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer_export(*m_device, buffer_info, vkt::no_mem);
     const VkMemoryRequirements buffer_export_reqs = buffer_export.memory_requirements();
 
     auto importable_buffer_types =
@@ -1144,8 +1143,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
         static_cast<VkExternalMemoryHandleTypeFlagBits>(1 << MostSignificantBit(importable_buffer_types));
     external_buffer_info.handleTypes = wrong_buffer_handle_type;
 
-    vkt::Buffer buffer_import;
-    buffer_import.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer_import(*m_device, buffer_info, vkt::no_mem);
     const VkMemoryRequirements buffer_import_reqs = buffer_import.memory_requirements();
     assert(buffer_import_reqs.memoryTypeBits != 0);  // according to spec at least one bit is set
     if ((buffer_import_reqs.memoryTypeBits & buffer_export_reqs.memoryTypeBits) == 0) {
@@ -2086,8 +2084,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     buffer_info.pNext = &external_buffer_info;
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer.handle();
@@ -2106,8 +2103,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     HANDLE handle = NULL;
     vk::GetMemoryWin32HandleKHR(m_device->device(), &get_handle_info, &handle);
 
-    vkt::Buffer buffer2;
-    buffer2.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer2(*m_device, buffer_info, vkt::no_mem);
     dedicated_info.buffer = buffer2.handle();
 
     VkImportMemoryWin32HandleInfoKHR import_info = vku::InitStructHelper(&dedicated_info);
@@ -2232,8 +2228,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
@@ -2286,8 +2281,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
     dedicated_info.image = VK_NULL_HANDLE;
@@ -2307,8 +2301,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     int fd;
     vk::GetMemoryFdKHR(m_device->device(), &mgfi, &fd);
 
-    vkt::Buffer buffer2;
-    buffer2.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer2(*m_device, buffer_info, vkt::no_mem);
 
     dedicated_info.buffer = buffer2.handle();
 
@@ -2336,8 +2329,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBadFd) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper();
     import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
@@ -2364,8 +2356,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkImportMemoryFdInfoKHR import_info = vku::InitStructHelper();
     import_info.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
@@ -2390,8 +2381,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferSupport) {
         GTEST_SKIP() << "Need buffer with no import support";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
     dedicated_info.image = VK_NULL_HANDLE;

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -59,8 +59,7 @@ TEST_F(PositiveExternalMemorySync, ImportMemoryFd) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfoKHR dedicated_info = vku::InitStructHelper();
     dedicated_info.image = VK_NULL_HANDLE;
@@ -174,10 +173,8 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
                                                                       nullptr, handle_type};
     auto buffer_info = vkt::Buffer::create_info(buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     buffer_info.pNext = &external_buffer_info;
-    vkt::Buffer buffer_export;
-    buffer_export.init_no_mem(*m_device, buffer_info);
-    vkt::Buffer buffer_import;
-    buffer_import.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer_export(*m_device, buffer_info, vkt::no_mem);
+    vkt::Buffer buffer_import(*m_device, buffer_info, vkt::no_mem);
 
     // Allocation info
     auto alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer_export.memory_requirements(), mem_flags);

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -146,9 +146,9 @@ TEST_F(PositiveImage, AliasedMemoryTracking) {
 
     RETURN_IF_SKIP(Init());
 
-    auto buffer = std::unique_ptr<vkt::Buffer>(new vkt::Buffer());
     VkDeviceSize buff_size = 256;
-    buffer->init_no_mem(*DeviceObj(), vkt::Buffer::create_info(buff_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT));
+    auto buffer = std::make_unique<vkt::Buffer>(*m_device, vkt::Buffer::create_info(buff_size, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT),
+                                                vkt::no_mem);
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -162,8 +162,8 @@ TEST_F(PositiveImage, AliasedMemoryTracking) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    VkImageObj image(DeviceObj());
-    image.init_no_mem(*DeviceObj(), image_create_info);
+    VkImageObj image(m_device);
+    image.init_no_mem(*m_device, image_create_info);
 
     const auto buffer_memory_requirements = buffer->memory_requirements();
     const auto image_memory_requirements = image.memory_requirements();
@@ -177,7 +177,7 @@ TEST_F(PositiveImage, AliasedMemoryTracking) {
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a host visible memory type for both a buffer and an image";
     }
-    mem.init(*DeviceObj(), alloc_info);
+    mem.init(*m_device, alloc_info);
 
     auto pData = mem.map();
     std::memset(pData, 0xCADECADE, static_cast<size_t>(buff_size));

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -505,8 +505,7 @@ TEST_F(NegativeMemory, BindMemory) {
         VkImageObj image(m_device);
         image.init_no_mem(*m_device, image_create_info);
 
-        vkt::Buffer buffer;
-        buffer.init_no_mem(*m_device, buffer_create_info);
+        vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -540,8 +539,7 @@ TEST_F(NegativeMemory, BindMemory) {
         VkImageObj image(m_device);
         image.init_no_mem(*m_device, image_create_info);
 
-        vkt::Buffer buffer;
-        buffer.init_no_mem(*m_device, buffer_create_info);
+        vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
@@ -572,8 +570,7 @@ TEST_F(NegativeMemory, BindMemory) {
         VkImageObj image(m_device);
         image.init_no_mem(*m_device, image_create_info);
 
-        vkt::Buffer buffer;
-        buffer.init_no_mem(*m_device, buffer_create_info);
+        vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
         VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
         vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -679,8 +676,7 @@ TEST_F(NegativeMemory, BindMemory) {
         if (!m_device->phy().features().sparseResidencyBuffer) {
             // most likely means sparse formats aren't supported here; skip this test.
         } else {
-            vkt::Buffer sparse_buffer;
-            sparse_buffer.init_no_mem(*m_device, sparse_buffer_create_info);
+            vkt::Buffer sparse_buffer(*m_device, sparse_buffer_create_info, vkt::no_mem);
             VkMemoryRequirements sparse_mem_reqs = {};
             vk::GetBufferMemoryRequirements(m_device->device(), sparse_buffer.handle(), &sparse_mem_reqs);
             if (sparse_mem_reqs.memoryTypeBits != 0) {
@@ -715,8 +711,7 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     image.init_no_mem(*m_device, image_create_info);
 
     auto buffer_info = vkt::Buffer::create_info(4 * 1024 * 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs = {}, buffer_mem_reqs = {};
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -1386,8 +1381,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     VkMemoryPropertyFlags mem_flags = 0;
     const VkDeviceSize resource_size = 1024;
     auto buffer_info = vkt::Buffer::create_info(resource_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
     auto buffer_alloc_info = vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), mem_flags);
     VkMemoryDedicatedAllocateInfoKHR buffer_dedicated_info = vku::InitStructHelper();
     buffer_dedicated_info.buffer = buffer.handle();
@@ -1395,8 +1389,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     vkt::DeviceMemory dedicated_buffer_memory;
     dedicated_buffer_memory.init(*m_device, buffer_alloc_info);
 
-    vkt::Buffer wrong_buffer;
-    wrong_buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer wrong_buffer(*m_device, buffer_info, vkt::no_mem);
 
     // Bind with wrong buffer
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkBindBufferMemory-memory-01508");
@@ -2239,9 +2232,8 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
         GTEST_SKIP() << "Test requires a physical device group with more than 1 device";
     }
 
-    vkt::Buffer buffer;
     auto buffer_info = vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    buffer.init_no_mem(*m_device, buffer_info);
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &buffer_mem_reqs);
@@ -2336,8 +2328,7 @@ TEST_F(NegativeMemory, SetDeviceMemoryPriority) {
     AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer(*m_device, vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
     vkt::DeviceMemory buffer_memory;
     buffer_memory.init(*m_device, vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer.memory_requirements(), 0));

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
- * Copyright (c) 2023 Collabora, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2024 Collabora, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -72,10 +72,9 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
 
     AddRequiredExtensions(VK_KHR_GET_MEMORY_REQUIREMENTS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    // Create a test buffer
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device,
-                       vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer(*m_device,
+                       vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT),
+                       vkt::no_mem);
 
     // Use extension to get buffer memory requirements
     VkBufferMemoryRequirementsInfo2KHR buffer_info = {VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2_KHR, nullptr,
@@ -138,9 +137,7 @@ TEST_F(PositiveMemory, BindMemory2) {
     AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    // Create a test buffer
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT));
+    vkt::Buffer buffer(*m_device, vkt::Buffer::create_info(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
     // Allocate buffer memory
     vkt::DeviceMemory buffer_memory;
@@ -388,16 +385,10 @@ TEST_F(PositiveMemory, DeviceBufferMemoryRequirements) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t queue_family_index = 0;
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.size = 1024;
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    buffer_create_info.queueFamilyIndexCount = 1;
-    buffer_create_info.pQueueFamilyIndices = &queue_family_index;
-
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
-    ASSERT_TRUE(buffer.initialized());
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkDeviceBufferMemoryRequirements info = vku::InitStructHelper();
     info.pCreateInfo = &buffer_create_info;

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -1080,9 +1080,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     vk::CmdDrawMeshTasksIndirectEXT(m_commandBuffer->handle(), buffer.handle(), 0, 4, sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
-    vkt::Buffer draw_buffer;
-    draw_buffer.init_no_mem(*m_device, buffer_create_info);
-    ASSERT_TRUE(draw_buffer.initialized());
+    vkt::Buffer draw_buffer(*m_device, buffer_create_info, vkt::no_mem);
     draw_buffer.allocate_and_bind_memory(*m_device);
 
     VkBufferCreateInfo count_buffer_create_info = vku::InitStructHelper();
@@ -1090,15 +1088,10 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     count_buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
 
     vkt::Buffer count_buffer(*m_device, count_buffer_create_info);
-    ASSERT_TRUE(count_buffer.initialized());
+    vkt::Buffer count_buffer_unbound(*m_device, count_buffer_create_info, vkt::no_mem);
 
-    vkt::Buffer count_buffer_unbound;
-    count_buffer_unbound.init_no_mem(*m_device, count_buffer_create_info);
-    ASSERT_TRUE(count_buffer_unbound.initialized());
-
-    vkt::Buffer count_buffer_wrong_usage;
     count_buffer_create_info.usage = VK_BUFFER_USAGE_VERTEX_BUFFER_BIT;
-    count_buffer_wrong_usage.init(*m_device, count_buffer_create_info);
+    vkt::Buffer count_buffer_wrong_usage(*m_device, count_buffer_create_info);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02714");
     vk::CmdDrawMeshTasksIndirectCountEXT(m_commandBuffer->handle(), draw_buffer.handle(), 0, count_buffer_unbound.handle(), 0, 1,

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -91,9 +91,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buf_info.size = 256;
     buf_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buf_info);
-    ASSERT_TRUE(buffer.initialized());
+    vkt::Buffer buffer(*m_device, buf_info, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(m_device->device(), buffer.handle(), &mem_reqs);

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -74,9 +74,7 @@ TEST_F(NegativeParent, BindBuffer) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT;
-    buffer_ci.queueFamilyIndexCount = 0;
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetBufferMemoryRequirements-buffer-parent");

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -177,12 +177,10 @@ TEST_F(NegativeProtectedMemory, Memory) {
 
     // Create actual protected and unprotected buffers
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
-    vkt::Buffer buffer_protected;
-    buffer_protected.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer_protected(*m_device, buffer_create_info, vkt::no_mem);
 
     buffer_create_info.flags = 0;
-    vkt::Buffer buffer_unprotected;
-    buffer_unprotected.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer_unprotected(*m_device, buffer_create_info, vkt::no_mem);
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = VK_IMAGE_CREATE_PROTECTED_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
@@ -727,12 +725,10 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     buffer_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
-    vkt::Buffer buffer_protected;
-    buffer_protected.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer_protected(*m_device, buffer_create_info, vkt::no_mem);
 
     buffer_create_info.flags = 0;
-    vkt::Buffer buffer_unprotected;
-    buffer_unprotected.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer_unprotected(*m_device, buffer_create_info, vkt::no_mem);
 
     // Create actual protected and unprotected images
     const VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -585,11 +585,10 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     RETURN_IF_SKIP(Init());
 
     // Init a non host visible buffer
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
-    buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
     VkMemoryRequirements memory_requirements = buffer.memory_requirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
@@ -670,8 +669,7 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHR) {
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 1024;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
-    vkt::Buffer dst_buffer;
-    dst_buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer dst_buffer(*m_device, buffer_ci, vkt::no_mem);
 
     auto blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 0);
     blas->SetDeviceBuffer(std::move(dst_buffer));
@@ -702,11 +700,10 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     RETURN_IF_SKIP(Init());
 
     // Init a non host visible buffer
-    vkt::Buffer non_host_visible_buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
-    non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
     VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
@@ -764,11 +761,10 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
     RETURN_IF_SKIP(Init());
 
     // Init a non host visible buffer
-    vkt::Buffer non_host_visible_buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
-    non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
     VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
@@ -806,11 +802,10 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     RETURN_IF_SKIP(Init());
 
     // Init a non host visible buffer
-    vkt::Buffer non_host_visible_buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
-    non_host_visible_buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
     VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
@@ -1038,13 +1033,12 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
         ASSERT_EQ(VK_SUCCESS, result);
     }
 
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage =
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
     buffer_ci.size = 4096;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
@@ -1119,9 +1113,8 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
 
     // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
     {
-        vkt::Buffer buffer_missing_flag;
         buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        buffer_missing_flag.init_no_mem(*m_device, buffer_ci);
+        vkt::Buffer buffer_missing_flag(*m_device, buffer_ci, vkt::no_mem);
         vk::BindBufferMemory(device(), buffer_missing_flag.handle(), mem.handle(), 0);
         const VkDeviceAddress device_address_missing_flag = buffer_missing_flag.address();
 
@@ -1508,8 +1501,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
         auto buffer_ci =
             vkt::Buffer::create_info(4096, VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
                                                VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
-        vkt::Buffer invalid_buffer;
-        invalid_buffer.init_no_mem(*m_device, buffer_ci);
+        vkt::Buffer invalid_buffer(*m_device, buffer_ci, vkt::no_mem);
         auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         build_info.GetDstAS()->SetDeviceBuffer(std::move(invalid_buffer));
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03707");
@@ -1716,8 +1708,7 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         std::vector<std::shared_ptr<vkt::Buffer>> scratch_buffers(build_info_count);
         std::vector<vkt::as::BuildGeometryInfoKHR> build_infos;
         for (auto &scratch_buffer : scratch_buffers) {
-            scratch_buffer = std::make_shared<vkt::Buffer>();
-            scratch_buffer->init_no_mem(*m_device, scratch_buffer_ci);
+            scratch_buffer = std::make_shared<vkt::Buffer>(*m_device, scratch_buffer_ci, vkt::no_mem);
             vk::BindBufferMemory(m_device->device(), scratch_buffer->handle(), buffer_memory.handle(), 0);
 
             auto build_info = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
@@ -1983,8 +1974,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     buffer_ci.size = buffer_size;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkAccelerationStructureCreateInfoKHR as_create_info = vku::InitStructHelper();
     as_create_info.pNext = NULL;
@@ -2085,12 +2075,10 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
             buffer_ci.usage = bad_buffer_usage;
         }
 
-        vkt::Buffer vbo;
-        vbo.init_no_mem(*m_device, buffer_ci);
+        vkt::Buffer vbo(*m_device, buffer_ci, vkt::no_mem);
         vk::BindBufferMemory(device(), vbo.handle(), buffer_memory.handle(), 0);
 
-        vkt::Buffer ibo;
-        ibo.init_no_mem(*m_device, buffer_ci);
+        vkt::Buffer ibo(*m_device, buffer_ci, vkt::no_mem);
         vk::BindBufferMemory(device(), ibo.handle(), buffer_memory.handle(), 0);
 
         // Those calls to vkGetBufferDeviceAddressKHR will internally record vbo and ibo device addresses

--- a/tests/unit/ray_tracing_gpu.cpp
+++ b/tests/unit/ray_tracing_gpu.cpp
@@ -80,13 +80,12 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
     ASSERT_EQ(VK_SUCCESS, result);
 
     // Create dummy shader binding table (SBT)
-    vkt::Buffer sbt_buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage =
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
     buffer_ci.size = 4096;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    sbt_buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer sbt_buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), sbt_buffer.handle(), &mem_reqs);

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -1079,8 +1079,7 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     VkBufferCreateInfo unbound_buffer_ci = vku::InitStructHelper();
     unbound_buffer_ci.size = 1024;
     unbound_buffer_ci.usage = VK_BUFFER_USAGE_RAY_TRACING_BIT_NV;
-    vkt::Buffer unbound_buffer;
-    unbound_buffer.init_no_mem(*m_device, unbound_buffer_ci);
+    vkt::Buffer unbound_buffer(*m_device, unbound_buffer_ci, vkt::no_mem);
 
     constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
     constexpr std::array<uint32_t, 3> indicies = {0, 1, 2};

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -177,13 +177,12 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
         ASSERT_EQ(VK_SUCCESS, result);
     }
 
-    vkt::Buffer buffer;
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.usage =
         VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR;
     buffer_ci.size = 4096;
     buffer_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    buffer.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
@@ -479,8 +478,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                   VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
-        auto scratch_buffer = std::make_shared<vkt::Buffer>();
-        scratch_buffer->init_no_mem(*m_device, scratch_buffer_ci);
+        auto scratch_buffer = std::make_shared<vkt::Buffer>(*m_device, scratch_buffer_ci, vkt::no_mem);
         vk::BindBufferMemory(m_device->device(), scratch_buffer->handle(), buffer_memory.handle(), 0);
         std::vector<vkt::as::BuildGeometryInfoKHR> build_infos;
         for (size_t i = 0; i < build_info_count; ++i) {

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -29,8 +29,7 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSize) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -73,8 +72,7 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindResourceOffset) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -119,8 +117,7 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSizeResourceOffset) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -166,8 +163,7 @@ TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSizeMemoryOffset) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -223,10 +219,8 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(copy_info.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
-    vkt::Buffer buffer_sparse2;
-    buffer_sparse2.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
+    vkt::Buffer buffer_sparse2(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -319,8 +313,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -391,8 +384,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     VkBufferCreateInfo buffer_ci =
         vkt::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -504,9 +496,7 @@ TEST_F(NegativeSparseBuffer, VkSparseMemoryBindMemory) {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
-
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
     VkDeviceMemory bad_memory = CastToHandle<VkDeviceMemory, uintptr_t>(0xbaadbeef);
 
     VkSparseMemoryBind buffer_memory_bind = {};
@@ -544,8 +534,7 @@ TEST_F(NegativeSparseBuffer, VkSparseMemoryBindFlags) {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &buffer_mem_reqs);

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -35,10 +35,8 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(copy_info.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
-    vkt::Buffer buffer_sparse2;
-    buffer_sparse2.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
+    vkt::Buffer buffer_sparse2(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -131,8 +129,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
     VkBufferCreateInfo b_info =
         vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, b_info);
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -197,8 +194,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     VkBufferCreateInfo buffer_ci =
         vkt::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
@@ -276,8 +272,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     VkBufferCreateInfo buffer_ci =
         vkt::Buffer::create_info(4096 * 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
     buffer_ci.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
-    vkt::Buffer buffer_sparse;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    vkt::Buffer buffer_sparse(*m_device, buffer_ci, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -278,8 +278,7 @@ TEST_F(NegativeSparseImage, MemoryBindOffset) {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyImage2D feature";
     }
 
-    vkt::Buffer buffer;
-    buffer.init_no_mem(*m_device, buffer_create_info);
+    vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_mem_alloc =

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -264,7 +264,7 @@ TEST_F(PositiveThreading, Queue) {
 
     const auto queue_family = m_device->graphics_queues()[0]->get_family_index();
     constexpr uint32_t queue_index = 0;
-    vkt::CommandPool command_pool(*DeviceObj(), queue_family);
+    vkt::CommandPool command_pool(*m_device, queue_family);
 
     const VkDevice device_h = device();
     VkQueue queue_h;
@@ -273,7 +273,7 @@ TEST_F(PositiveThreading, Queue) {
 
     const VkCommandBufferAllocateInfo cbai = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, nullptr, command_pool.handle(),
                                               VK_COMMAND_BUFFER_LEVEL_PRIMARY, 1};
-    vkt::CommandBuffer mock_cmdbuff(*DeviceObj(), cbai);
+    vkt::CommandBuffer mock_cmdbuff(*m_device, cbai);
     const VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                         VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT, nullptr};
     mock_cmdbuff.begin(&cbbi);

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -251,13 +251,10 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
 
     // Don't bind memory.
     {
-        vkt::Buffer buffer;
-        {
-            VkBufferCreateInfo info = vku::InitStructHelper();
-            info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
-            info.size = 4;
-            buffer.init_no_mem(*m_device, info);
-        }
+        VkBufferCreateInfo info = vku::InitStructHelper();
+        info.usage = VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT;
+        info.size = 4;
+        vkt::Buffer buffer(*m_device, info, vkt::no_mem);
 
         VkDeviceSize const offsets[1]{};
 

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -23,7 +23,7 @@ TEST_F(NegativeVideo, VideoCodingScope) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -406,7 +406,7 @@ TEST_F(NegativeVideo, InUseDestroyed) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -443,7 +443,7 @@ TEST_F(NegativeVideo, CreateSessionVideoMaintenance1NotEnabled) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -466,7 +466,7 @@ TEST_F(NegativeVideo, CreateSessionProtectedMemoryNotEnabled) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -493,7 +493,7 @@ TEST_F(NegativeVideo, CreateSessionProtectedContentUnsupported) {
         GTEST_SKIP() << "Test requires a video profile with no protected content support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -540,7 +540,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidReferencePictureCounts) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -591,7 +591,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidMaxCodedExtent) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -640,7 +640,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidDecodeReferencePictureFormat) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -666,7 +666,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidEncodeReferencePictureFormat) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -689,7 +689,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidDecodePictureFormat) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -712,7 +712,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidEncodePictureFormat) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -735,7 +735,7 @@ TEST_F(NegativeVideo, CreateSessionInvalidStdHeaderVersion) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -767,7 +767,7 @@ TEST_F(NegativeVideo, CreateSessionEncodeH264InvalidMaxLevel) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -796,7 +796,7 @@ TEST_F(NegativeVideo, CreateSessionEncodeH265InvalidMaxLevel) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionKHR session;
     VkVideoSessionCreateInfoKHR create_info = *config.SessionCreateInfo();
@@ -825,7 +825,7 @@ TEST_F(NegativeVideo, BindVideoSessionMemory) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     uint32_t mem_req_count;
     ASSERT_EQ(VK_SUCCESS,
@@ -1004,8 +1004,8 @@ TEST_F(NegativeVideo, CreateSessionParamsIncompatibleTemplate) {
         GTEST_SKIP() << "Test requires a video profile with session parameters";
     }
 
-    VideoContext context1(DeviceObj(), config);
-    VideoContext context2(DeviceObj(), config);
+    VideoContext context1(m_device, config);
+    VideoContext context2(m_device, config);
 
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
     create_info.videoSessionParametersTemplate = context1.SessionParams();
@@ -1028,7 +1028,7 @@ TEST_F(NegativeVideo, CreateSessionParamsIncompatibleTemplateEncodeQualityLevel)
         GTEST_SKIP() << "Test requires an encode profile with support for parameters objects and at least two quality levels";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionParametersKHR params;
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1085,7 +1085,7 @@ TEST_F(NegativeVideo, CreateSessionParamsMissingCodecInfo) {
 
     if (GetConfigDecodeH264()) {
         VideoConfig config = GetConfigDecodeH264();
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1103,7 +1103,7 @@ TEST_F(NegativeVideo, CreateSessionParamsMissingCodecInfo) {
 
     if (GetConfigDecodeH265()) {
         VideoConfig config = GetConfigDecodeH265();
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1120,7 +1120,7 @@ TEST_F(NegativeVideo, CreateSessionParamsMissingCodecInfo) {
 
     if (GetConfigEncodeH264()) {
         VideoConfig config = GetConfigEncodeH264();
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1138,7 +1138,7 @@ TEST_F(NegativeVideo, CreateSessionParamsMissingCodecInfo) {
 
     if (GetConfigEncodeH265()) {
         VideoConfig config = GetConfigEncodeH265();
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
 
         VkVideoSessionParametersKHR params;
         VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
@@ -1164,7 +1164,7 @@ TEST_F(NegativeVideo, CreateSessionParamsInvalidEncodeQualityLevel) {
         GTEST_SKIP() << "Test requires an encode profile with session parameters";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoSessionParametersCreateInfoKHR create_info = *config.SessionParamsCreateInfo();
     auto quality_level_info = vku::InitStruct<VkVideoEncodeQualityLevelInfoKHR>();
@@ -1188,7 +1188,7 @@ TEST_F(NegativeVideo, CreateSessionParamsDecodeH264ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.264 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
@@ -1273,7 +1273,7 @@ TEST_F(NegativeVideo, CreateSessionParamsDecodeH265ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.265 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
     auto h265_ai = vku::InitStruct<VkVideoDecodeH265SessionParametersAddInfoKHR>();
@@ -1399,7 +1399,7 @@ TEST_F(NegativeVideo, CreateSessionParamsEncodeH264ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoEncodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoEncodeH264SessionParametersAddInfoKHR>();
@@ -1484,7 +1484,7 @@ TEST_F(NegativeVideo, CreateSessionParamsEncodeH265ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h265_ci = vku::InitStruct<VkVideoEncodeH265SessionParametersCreateInfoKHR>();
     auto h265_ai = vku::InitStruct<VkVideoEncodeH265SessionParametersAddInfoKHR>();
@@ -1610,7 +1610,7 @@ TEST_F(NegativeVideo, CreateUpdateSessionParamsEncodeH265InvalidTileColumnsRows)
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h265_ci = vku::InitStruct<VkVideoEncodeH265SessionParametersCreateInfoKHR>();
     auto h265_ai = vku::InitStruct<VkVideoEncodeH265SessionParametersAddInfoKHR>();
@@ -1726,7 +1726,7 @@ TEST_F(NegativeVideo, DecodeH264ParametersAddInfoUniqueness) {
         GTEST_SKIP() << "Test requires H.264 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
@@ -1796,7 +1796,7 @@ TEST_F(NegativeVideo, DecodeH265ParametersAddInfoUniqueness) {
         GTEST_SKIP() << "Test requires H.265 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
@@ -1892,7 +1892,7 @@ TEST_F(NegativeVideo, EncodeH264ParametersAddInfoUniqueness) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoEncodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoEncodeH264SessionParametersAddInfoKHR>();
@@ -1962,7 +1962,7 @@ TEST_F(NegativeVideo, EncodeH265ParametersAddInfoUniqueness) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoEncodeH265SessionParametersCreateInfoKHR>();
@@ -2058,7 +2058,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsIncorrectSequenceCount) {
         GTEST_SKIP() << "Test requires a video profile with session parameters";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto update_info = vku::InitStruct<VkVideoSessionParametersUpdateInfoKHR>();
 
@@ -2093,7 +2093,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsDecodeH264ConflictingKeys) {
         GTEST_SKIP() << "Test requires H.264 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
@@ -2160,7 +2160,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsDecodeH265ConflictingKeys) {
         GTEST_SKIP() << "Test requires H.265 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
@@ -2251,7 +2251,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsEncodeH264ConflictingKeys) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoEncodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoEncodeH264SessionParametersAddInfoKHR>();
@@ -2318,7 +2318,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsEncodeH265ConflictingKeys) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoEncodeH265SessionParametersCreateInfoKHR>();
@@ -2409,7 +2409,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsDecodeH264ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.264 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoDecodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoDecodeH264SessionParametersAddInfoKHR>();
@@ -2474,7 +2474,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsDecodeH265ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.265 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoDecodeH265SessionParametersCreateInfoKHR>();
@@ -2568,7 +2568,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsEncodeH264ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_ci = vku::InitStruct<VkVideoEncodeH264SessionParametersCreateInfoKHR>();
     auto h264_ai = vku::InitStruct<VkVideoEncodeH264SessionParametersAddInfoKHR>();
@@ -2633,7 +2633,7 @@ TEST_F(NegativeVideo, UpdateSessionParamsEncodeH265ExceededCapacity) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto h265_ci = vku::InitStruct<VkVideoEncodeH265SessionParametersCreateInfoKHR>();
@@ -2728,8 +2728,8 @@ TEST_F(NegativeVideo, GetEncodedSessionParamsRequiresEncodeProfile) {
         GTEST_SKIP() << "Test requires video encode support and a decode profile with session parameters";
     }
 
-    VideoContext decode_context(DeviceObj(), decode_config);
-    VideoContext encode_context(DeviceObj(), encode_config);
+    VideoContext decode_context(m_device, decode_config);
+    VideoContext encode_context(m_device, encode_config);
 
     auto get_info = vku::InitStruct<VkVideoEncodeSessionParametersGetInfoKHR>();
     get_info.videoSessionParameters = decode_context.SessionParams();
@@ -2749,7 +2749,7 @@ TEST_F(NegativeVideo, GetEncodedSessionParamsMissingCodecInfo) {
     }
 
     if (GetConfigEncodeH264()) {
-        VideoContext context(DeviceObj(), GetConfigEncodeH264());
+        VideoContext context(m_device, GetConfigEncodeH264());
 
         auto get_info = vku::InitStruct<VkVideoEncodeSessionParametersGetInfoKHR>();
         get_info.videoSessionParameters = context.SessionParams();
@@ -2762,7 +2762,7 @@ TEST_F(NegativeVideo, GetEncodedSessionParamsMissingCodecInfo) {
     }
 
     if (GetConfigEncodeH265()) {
-        VideoContext context(DeviceObj(), GetConfigEncodeH265());
+        VideoContext context(m_device, GetConfigEncodeH265());
 
         auto get_info = vku::InitStruct<VkVideoEncodeSessionParametersGetInfoKHR>();
         get_info.videoSessionParameters = context.SessionParams();
@@ -2785,7 +2785,7 @@ TEST_F(NegativeVideo, GetEncodedSessionParamsH264) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_info = vku::InitStruct<VkVideoEncodeH264SessionParametersGetInfoKHR>();
     auto get_info = vku::InitStruct<VkVideoEncodeSessionParametersGetInfoKHR>(&h264_info);
@@ -2844,7 +2844,7 @@ TEST_F(NegativeVideo, GetEncodedSessionParamsH265) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h265_info = vku::InitStruct<VkVideoEncodeH265SessionParametersGetInfoKHR>();
     auto get_info = vku::InitStruct<VkVideoEncodeSessionParametersGetInfoKHR>(&h265_info);
@@ -2950,11 +2950,11 @@ TEST_F(NegativeVideo, BeginCodingUnsupportedCodecOp) {
         GTEST_SKIP() << "Test requires a queue family that supports video but not the specific codec op";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
-    vkt::CommandPool pool(*DeviceObj(), queue_family_index);
-    vkt::CommandBuffer cb(DeviceObj(), &pool);
+    vkt::CommandPool pool(*m_device, queue_family_index);
+    vkt::CommandBuffer cb(m_device, &pool);
 
     cb.begin();
 
@@ -2979,7 +2979,7 @@ TEST_F(NegativeVideo, BeginCodingActiveQueriesNotAllowed) {
         GTEST_SKIP() << "Test requires video queue to support result status queries";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateStatusQueryPool();
 
@@ -3010,13 +3010,13 @@ TEST_F(NegativeVideo, BeginCodingProtectedNoFaultSession) {
 
     const bool use_protected = true;
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources();
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(use_protected /* bitstream */, use_protected /* DPB */, use_protected /* src/dst image */);
 
@@ -3054,13 +3054,13 @@ TEST_F(NegativeVideo, BeginCodingProtectedNoFaultSlots) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources(false /* bitstream */, use_protected /* DPB */, false /* src/dst image */);
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(use_protected /* bitstream */, false /* DPB */, use_protected /* src/dst image */);
 
@@ -3089,7 +3089,7 @@ TEST_F(NegativeVideo, BeginCodingSessionMemoryNotBound) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     uint32_t mem_req_count;
     context.vk.GetVideoSessionMemoryRequirementsKHR(m_device->device(), context.Session(), &mem_req_count, nullptr);
@@ -3148,8 +3148,8 @@ TEST_F(NegativeVideo, BeginCodingInvalidSessionParams) {
         GTEST_SKIP() << "Test requires a video profile with session parameters";
     }
 
-    VideoContext context1(DeviceObj(), config);
-    VideoContext context2(DeviceObj(), config);
+    VideoContext context1(m_device, config);
+    VideoContext context2(m_device, config);
     vkt::CommandBuffer& cb = context1.CmdBuffer();
 
     context1.CreateAndBindSessionMemory();
@@ -3174,7 +3174,7 @@ TEST_F(NegativeVideo, BeginCodingDecodeH264RequiresParams) {
         GTEST_SKIP() << "Test requires H.264 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -3199,7 +3199,7 @@ TEST_F(NegativeVideo, BeginCodingDecodeH265RequiresParams) {
         GTEST_SKIP() << "Test requires H.265 decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -3224,7 +3224,7 @@ TEST_F(NegativeVideo, BeginCodingEncodeH264RequiresParams) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -3249,7 +3249,7 @@ TEST_F(NegativeVideo, BeginCodingEncodeH265RequiresParams) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -3294,8 +3294,8 @@ TEST_F(NegativeVideo, BeginCodingIncompatRefPicProfile) {
         configs[i].SessionCreateInfo()->maxActiveReferencePictures = 1;
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateAndBindSessionMemory();
@@ -3323,7 +3323,7 @@ TEST_F(NegativeVideo, BeginCodingInvalidResourceLayer) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3355,7 +3355,7 @@ TEST_F(NegativeVideo, BeginCodingDecodeSlotInactive) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3413,7 +3413,7 @@ TEST_F(NegativeVideo, BeginCodingDecodeInvalidSlotResourceAssociation) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3450,7 +3450,7 @@ TEST_F(NegativeVideo, BeginCodingInvalidSlotIndex) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 3;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3478,7 +3478,7 @@ TEST_F(NegativeVideo, BeginCodingResourcesNotUnique) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3517,7 +3517,7 @@ TEST_F(NegativeVideo, BeginCodingReferenceFormatMismatch) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3549,7 +3549,7 @@ TEST_F(NegativeVideo, BeginCodingInvalidCodedOffset) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3587,7 +3587,7 @@ TEST_F(NegativeVideo, BeginCodingInvalidCodedExtent) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3651,11 +3651,11 @@ TEST_F(NegativeVideo, BeginCodingInvalidSeparateReferenceImages) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
-    VideoDPB separate_dpb(DeviceObj(), config);
+    VideoDPB separate_dpb(m_device, config);
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
 
@@ -3685,7 +3685,7 @@ TEST_F(NegativeVideo, BeginCodingMissingDecodeDpbUsage) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3733,7 +3733,7 @@ TEST_F(NegativeVideo, BeginCodingMissingEncodeDpbUsage) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3776,7 +3776,7 @@ TEST_F(NegativeVideo, BeginCodingEncodeH264MissingGopRemainingFrames) {
         GTEST_SKIP() << "Test requires an H.264 encode profile with rate control and requiresGopRemainingFrames == VK_TRUE";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3834,7 +3834,7 @@ TEST_F(NegativeVideo, BeginCodingEncodeH265MissingGopRemainingFrames) {
         GTEST_SKIP() << "Test requires an H.265 encode profile with rate control and requiresGopRemainingFrames == VK_TRUE";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3894,7 +3894,7 @@ TEST_F(NegativeVideo, EndCodingActiveQueriesNotAllowed) {
         GTEST_SKIP() << "Test requires video queue to support result status queries";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateStatusQueryPool();
 
@@ -3921,7 +3921,7 @@ TEST_F(NegativeVideo, ControlSessionUninitialized) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3954,7 +3954,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelControlInvalidQualityLevel) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -3987,7 +3987,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelControlRequiresEncodeSession) {
         GTEST_SKIP() << "Test requires video decode and encode support";
     }
 
-    VideoContext context(DeviceObj(), decode_config);
+    VideoContext context(m_device, decode_config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4017,7 +4017,7 @@ TEST_F(NegativeVideo, EncodeQualityLevelControlMissingChain) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4045,7 +4045,7 @@ TEST_F(NegativeVideo, EncodeParamsQualityLevelMismatch) {
         GTEST_SKIP() << "Test requires an encode profile with support for parameters objects and at least two quality levels";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4166,7 +4166,7 @@ TEST_F(NegativeVideo, EncodeRateControlRequiresEncodeSession) {
         GTEST_SKIP() << "Test requires video decode and encode support";
     }
 
-    VideoContext context(DeviceObj(), decode_config);
+    VideoContext context(m_device, decode_config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4202,7 +4202,7 @@ TEST_F(NegativeVideo, EncodeRateControlUnsupportedMode) {
         GTEST_SKIP() << "Test requires an encode profile that does not support all rate control modes";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4243,7 +4243,7 @@ TEST_F(NegativeVideo, EncodeRateControlTooManyLayers) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4287,7 +4287,7 @@ TEST_F(NegativeVideo, EncodeRateControlNoLayers) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4333,7 +4333,7 @@ TEST_F(NegativeVideo, EncodeRateControlMissingLayers) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4376,7 +4376,7 @@ TEST_F(NegativeVideo, EncodeRateControlLayerBitrate) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto rc_info = VideoEncodeRateControlInfo(config).SetAnyMode();
@@ -4448,7 +4448,7 @@ TEST_F(NegativeVideo, EncodeRateControlLayerBitrateCBR) {
         GTEST_SKIP() << "Test requires video encode support with CBR rate control mode";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto rc_info = VideoEncodeRateControlInfo(config);
@@ -4490,7 +4490,7 @@ TEST_F(NegativeVideo, EncodeRateControlLayerBitrateVBR) {
         GTEST_SKIP() << "Test requires video encode support with VBR rate control mode";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto rc_info = VideoEncodeRateControlInfo(config);
@@ -4526,7 +4526,7 @@ TEST_F(NegativeVideo, EncodeRateControlLayerFrameRate) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto rc_info = VideoEncodeRateControlInfo(config).SetAnyMode();
@@ -4570,7 +4570,7 @@ TEST_F(NegativeVideo, EncodeRateControlVirtualBufferSize) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     auto rc_info = VideoEncodeRateControlInfo(config).SetAnyMode();
@@ -4609,7 +4609,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264ConstantQpNonZero) {
         GTEST_SKIP() << "Test requires H.264 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4647,7 +4647,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264ConstantQpNotInCapRange) {
         GTEST_SKIP() << "Test requires H.264 encode support with DISABLED rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4696,7 +4696,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264ConstantQpPerSliceMismatch) {
                         "support for multiple slices but no support for per-slice constant QP";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4742,7 +4742,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265ConstantQpNonZero) {
         GTEST_SKIP() << "Test requires H.265 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4780,7 +4780,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265ConstantQpNotInCapRange) {
         GTEST_SKIP() << "Test requires H.265 encode support with DISABLED rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4829,7 +4829,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265ConstantQpPerSliceSegmentMismatch) {
                         "support for multiple slice segments but no support for per-slice-segment constant QP";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4878,7 +4878,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264LayerCountMismatch) {
         GTEST_SKIP() << "Test requires H.264 encode support with multi-layer rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4932,7 +4932,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265LayerCountMismatch) {
         GTEST_SKIP() << "Test requires H.265 encode support with multi-layer rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -4986,7 +4986,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264HrdCompliance) {
         GTEST_SKIP() << "Test requires H.264 encode without HRD compliance support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5023,7 +5023,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265HrdCompliance) {
         GTEST_SKIP() << "Test requires H.265 encode without HRD compliance support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5058,7 +5058,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264InvalidCodecInfo) {
         GTEST_SKIP() << "Test requires H.264 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5152,7 +5152,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265InvalidCodecInfo) {
         GTEST_SKIP() << "Test requires H.265 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5246,7 +5246,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264QpRange) {
         GTEST_SKIP() << "Test requires H.264 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5331,7 +5331,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265QpRange) {
         GTEST_SKIP() << "Test requires H.265 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5418,7 +5418,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264PerPicTypeQp) {
         GTEST_SKIP() << "Test requires H.264 encode without per picture type min/max QP support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5503,7 +5503,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265PerPicTypeQp) {
         GTEST_SKIP() << "Test requires H.265 encode without per picture type min/max QP support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5586,7 +5586,7 @@ TEST_F(NegativeVideo, EncodeRateControlH264MinQpGreaterThanMaxQp) {
         GTEST_SKIP() << "Test requires H.264 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5657,7 +5657,7 @@ TEST_F(NegativeVideo, EncodeRateControlH265MinQpGreaterThanMaxQp) {
         GTEST_SKIP() << "Test requires H.265 encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5728,7 +5728,7 @@ TEST_F(NegativeVideo, EncodeRateControlMissingChain) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5756,7 +5756,7 @@ TEST_F(NegativeVideo, EncodeRateControlStateMismatchNotDefault) {
         GTEST_SKIP() << "Test requires video encode support with rate control";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5800,7 +5800,7 @@ TEST_F(NegativeVideo, EncodeRateControlStateMismatch) {
         GTEST_SKIP() << "Test requires an encode profile that supports both CBR and VBR rate control modes";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -5894,7 +5894,7 @@ TEST_F(NegativeVideo, EncodeRateControlStateMismatchH264) {
         GTEST_SKIP() << "Test requires an H.264 encode profile that supports both CBR and VBR rate control modes";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6028,7 +6028,7 @@ TEST_F(NegativeVideo, EncodeRateControlStateMismatchH265) {
         GTEST_SKIP() << "Test requires an H.265 encode profile that supports both CBR and VBR rate control modes";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6158,11 +6158,11 @@ TEST_F(NegativeVideo, DecodeSessionNotDecode) {
         GTEST_SKIP() << "Test requires both video decode and video encode support";
     }
 
-    VideoContext decode_context(DeviceObj(), decode_config);
+    VideoContext decode_context(m_device, decode_config);
     decode_context.CreateAndBindSessionMemory();
     decode_context.CreateResources();
 
-    VideoContext encode_context(DeviceObj(), encode_config);
+    VideoContext encode_context(m_device, encode_config);
     encode_context.CreateAndBindSessionMemory();
     encode_context.CreateResources();
 
@@ -6191,11 +6191,11 @@ TEST_F(NegativeVideo, EncodeSessionNotEncode) {
         GTEST_SKIP() << "Test requires both video decode and video encode support";
     }
 
-    VideoContext decode_context(DeviceObj(), decode_config);
+    VideoContext decode_context(m_device, decode_config);
     decode_context.CreateAndBindSessionMemory();
     decode_context.CreateResources();
 
-    VideoContext encode_context(DeviceObj(), encode_config);
+    VideoContext encode_context(m_device, encode_config);
     encode_context.CreateAndBindSessionMemory();
     encode_context.CreateResources();
 
@@ -6223,7 +6223,7 @@ TEST_F(NegativeVideo, DecodeSessionUninitialized) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6251,7 +6251,7 @@ TEST_F(NegativeVideo, EncodeSessionUninitialized) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6285,13 +6285,13 @@ TEST_F(NegativeVideo, DecodeProtectedNoFaultBitstreamBuffer) {
 
     const bool use_protected = true;
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources(use_protected /* bitstream */, false /* DPB */, false /* dst image */);
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(false /* bitstream */, use_protected /* DPB */, use_protected /* dst image */);
 
@@ -6334,13 +6334,13 @@ TEST_F(NegativeVideo, EncodeProtectedNoFaultBitstreamBuffer) {
         GTEST_SKIP() << "Test requires a video encode profile with protected content support";
     }
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources(use_protected /* bitstream */, false /* DPB */, false /* src image */);
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(false /* bitstream */, use_protected /* DPB */, use_protected /* src image */);
 
@@ -6383,13 +6383,13 @@ TEST_F(NegativeVideo, DecodeProtectedNoFaultDecodeOutput) {
         GTEST_SKIP() << "Test requires a video decode profile with protected content support";
     }
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources(false /* bitstream */, false /* DPB */, use_protected /* dst image */);
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(use_protected /* bitstream */, use_protected /* DPB */, false /* dst image */);
 
@@ -6432,13 +6432,13 @@ TEST_F(NegativeVideo, EncodeProtectedNoFaultEncodeInput) {
         GTEST_SKIP() << "Test requires a video encode profile with protected content support";
     }
 
-    VideoContext unprotected_context(DeviceObj(), config);
+    VideoContext unprotected_context(m_device, config);
     unprotected_context.CreateAndBindSessionMemory();
     unprotected_context.CreateResources(false /* bitstream */, false /* DPB */, use_protected /* src image */);
 
     vkt::CommandBuffer& unprotected_cb = unprotected_context.CmdBuffer();
 
-    VideoContext protected_context(DeviceObj(), config, use_protected);
+    VideoContext protected_context(m_device, config, use_protected);
     protected_context.CreateAndBindSessionMemory();
     protected_context.CreateResources(use_protected /* bitstream */, use_protected /* DPB */, false /* src image */);
 
@@ -6478,7 +6478,7 @@ TEST_F(NegativeVideo, DecodeImageLayouts) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6543,7 +6543,7 @@ TEST_F(NegativeVideo, EncodeImageLayouts) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6595,7 +6595,7 @@ TEST_F(NegativeVideo, DecodeInvalidResourceLayer) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6656,7 +6656,7 @@ TEST_F(NegativeVideo, DecodeQueryTooManyOperations) {
         GTEST_SKIP() << "Test requires video decode queue to support result status queries";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool(2);
@@ -6691,7 +6691,7 @@ TEST_F(NegativeVideo, EncodeQueryTooManyOperations) {
         GTEST_SKIP() << "Test requires video encode queue to support result status queries";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool(2);
@@ -6736,8 +6736,8 @@ TEST_F(NegativeVideo, DecodeIncompatBufferProfile) {
         GTEST_SKIP() << "Test requires two video decode profiles";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateAndBindSessionMemory();
@@ -6766,8 +6766,8 @@ TEST_F(NegativeVideo, EncodeIncompatBufferProfile) {
         GTEST_SKIP() << "Test requires two video encode profiles";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateAndBindSessionMemory();
@@ -6796,7 +6796,7 @@ TEST_F(NegativeVideo, DecodeBufferMissingDecodeSrcUsage) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6836,7 +6836,7 @@ TEST_F(NegativeVideo, EncodeBufferMissingEncodeDstUsage) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6876,7 +6876,7 @@ TEST_F(NegativeVideo, DecodeBufferOffsetOutOfBounds) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6909,7 +6909,7 @@ TEST_F(NegativeVideo, EncodeBufferOffsetOutOfBounds) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6943,7 +6943,7 @@ TEST_F(NegativeVideo, DecodeBufferOffsetAlignment) {
         GTEST_SKIP() << "Test requires a video decode profile with minBitstreamBufferOffsetAlignment > 1";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -6975,7 +6975,7 @@ TEST_F(NegativeVideo, EncodeBufferOffsetAlignment) {
         GTEST_SKIP() << "Test requires a video encode profile with minBitstreamBufferOffsetAlignment > 1";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7006,7 +7006,7 @@ TEST_F(NegativeVideo, DecodeBufferRangeOutOfBounds) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7042,7 +7042,7 @@ TEST_F(NegativeVideo, EncodeBufferRangeOutOfBounds) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7079,7 +7079,7 @@ TEST_F(NegativeVideo, DecodeBufferRangeAlignment) {
         GTEST_SKIP() << "Test requires a video decode profile with minBitstreamBufferSizeAlignment > 1";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7110,7 +7110,7 @@ TEST_F(NegativeVideo, EncodeBufferRangeAlignment) {
         GTEST_SKIP() << "Test requires a video encode profile with minBitstreamBufferSizeAlignment > 1";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7147,7 +7147,7 @@ TEST_F(NegativeVideo, DecodeInvalidOutputAndSetupCoincide) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7182,7 +7182,7 @@ TEST_F(NegativeVideo, DecodeInvalidOutputAndSetupDistinct) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7212,7 +7212,7 @@ TEST_F(NegativeVideo, DecodeInvalidSetupSlotIndex) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7252,7 +7252,7 @@ TEST_F(NegativeVideo, EncodeInvalidSetupSlotIndex) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7292,7 +7292,7 @@ TEST_F(NegativeVideo, DecodeInvalidRefSlotIndex) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7327,7 +7327,7 @@ TEST_F(NegativeVideo, EncodeInvalidRefSlotIndex) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7362,7 +7362,7 @@ TEST_F(NegativeVideo, DecodeSetupNull) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7395,7 +7395,7 @@ TEST_F(NegativeVideo, DecodeSetupResourceNull) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7430,7 +7430,7 @@ TEST_F(NegativeVideo, EncodeSetupNull) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7463,7 +7463,7 @@ TEST_F(NegativeVideo, EncodeSetupResourceNull) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7498,7 +7498,7 @@ TEST_F(NegativeVideo, DecodeReferenceResourceNull) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7528,7 +7528,7 @@ TEST_F(NegativeVideo, EncodeReferenceResourceNull) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7570,8 +7570,8 @@ TEST_F(NegativeVideo, DecodeIncompatOutputPicProfile) {
         GTEST_SKIP() << "Test requires two video profiles with matching decode output format/size";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateAndBindSessionMemory();
@@ -7615,8 +7615,8 @@ TEST_F(NegativeVideo, EncodeIncompatInputPicProfile) {
         GTEST_SKIP() << "Test requires two video profiles with matching encode input format/size";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateAndBindSessionMemory();
@@ -7655,7 +7655,7 @@ TEST_F(NegativeVideo, DecodeOutputFormatMismatch) {
         GTEST_SKIP() << "Test requires a video decode profile with support for two output picture formats";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7696,7 +7696,7 @@ TEST_F(NegativeVideo, EncodeInputFormatMismatch) {
         GTEST_SKIP() << "Test requires a video encode profile with support for two input picture formats";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7731,7 +7731,7 @@ TEST_F(NegativeVideo, DecodeOutputMissingDecodeDstUsage) {
         GTEST_SKIP() << "Test requires output format to support at least one more usage besides DECODE_DST";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7777,7 +7777,7 @@ TEST_F(NegativeVideo, EncodeInputMissingEncodeSrcUsage) {
         GTEST_SKIP() << "Test requires input format to support at least one more usage besides ENCODE_SRC";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7819,7 +7819,7 @@ TEST_F(NegativeVideo, DecodeOutputCodedOffsetExtent) {
         GTEST_SKIP() << "Test requires video decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7868,7 +7868,7 @@ TEST_F(NegativeVideo, EncodeInputCodedOffsetExtent) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7920,7 +7920,7 @@ TEST_F(NegativeVideo, DecodeSetupAndRefCodedOffset) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -7982,7 +7982,7 @@ TEST_F(NegativeVideo, EncodeSetupAndRefCodedOffset) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8038,7 +8038,7 @@ TEST_F(NegativeVideo, DecodeSetupResourceNotBound) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8068,7 +8068,7 @@ TEST_F(NegativeVideo, EncodeSetupResourceNotBound) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8100,7 +8100,7 @@ TEST_F(NegativeVideo, DecodeRefResourceNotBoundToDPBSlot) {
     config.SessionCreateInfo()->maxDpbSlots = config.Caps()->maxDpbSlots;
     config.SessionCreateInfo()->maxActiveReferencePictures = config.Caps()->maxActiveReferencePictures;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8156,7 +8156,7 @@ TEST_F(NegativeVideo, EncodeRefResourceNotBoundToDPBSlot) {
     config.SessionCreateInfo()->maxDpbSlots = config.Caps()->maxDpbSlots;
     config.SessionCreateInfo()->maxActiveReferencePictures = config.Caps()->maxActiveReferencePictures;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8210,7 +8210,7 @@ TEST_F(NegativeVideo, DecodeTooManyReferences) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8240,7 +8240,7 @@ TEST_F(NegativeVideo, EncodeTooManyReferences) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8272,7 +8272,7 @@ TEST_F(NegativeVideo, DecodeTooManyReferencesH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8306,7 +8306,7 @@ TEST_F(NegativeVideo, DecodeDuplicateRefResource) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8346,7 +8346,7 @@ TEST_F(NegativeVideo, DecodeDuplicateRefResourceH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8376,7 +8376,7 @@ TEST_F(NegativeVideo, EncodeDuplicateRefResource) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8414,7 +8414,7 @@ TEST_F(NegativeVideo, DecodeDuplicateFrame) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8444,7 +8444,7 @@ TEST_F(NegativeVideo, EncodeDuplicateFrame) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8474,7 +8474,7 @@ TEST_F(NegativeVideo, DecodeDuplicateFrameFieldH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 4;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8527,7 +8527,7 @@ TEST_F(NegativeVideo, DecodeImplicitDeactivation) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8568,7 +8568,7 @@ TEST_F(NegativeVideo, DecodeImplicitDeactivationH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8728,7 +8728,7 @@ TEST_F(NegativeVideo, DecodeRefPictureKindMismatchH264) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8850,7 +8850,7 @@ TEST_F(NegativeVideo, DecodeInvalidationOnlyH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -8920,7 +8920,7 @@ TEST_F(NegativeVideo, DecodeInvalidCodecInfoH264) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9073,7 +9073,7 @@ TEST_F(NegativeVideo, DecodeFieldFrameMismatchH264) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9129,7 +9129,7 @@ TEST_F(NegativeVideo, DecodeInvalidCodecInfoH265) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9254,7 +9254,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryOpCount) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool(2);
@@ -9292,7 +9292,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryOutOfBounds) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool(4);
@@ -9336,7 +9336,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool();
@@ -9404,7 +9404,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryType) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9447,8 +9447,8 @@ TEST_F(NegativeVideo, DecodeInlineQueryProfileMismatch) {
 
     configs[0].SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateStatusQueryPool();
@@ -9494,7 +9494,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryIncompatibleQueueFamily) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool();
@@ -9535,7 +9535,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryOpCount) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateEncodeFeedbackQueryPool(2);
@@ -9569,7 +9569,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryOutOfBounds) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateEncodeFeedbackQueryPool(4);
@@ -9609,7 +9609,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateEncodeFeedbackQueryPool();
@@ -9673,7 +9673,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryType) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9712,8 +9712,8 @@ TEST_F(NegativeVideo, EncodeInlineQueryProfileMismatch) {
 
     configs[0].SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context1.CreateResources();
     context2.CreateEncodeFeedbackQueryPool();
@@ -9759,7 +9759,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryIncompatibleQueueFamily) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
     context.CreateStatusQueryPool();
@@ -9796,7 +9796,7 @@ TEST_F(NegativeVideo, EncodeCapsH264GenPrefixNalu) {
         GTEST_SKIP() << "Test requires H.264 encode support without prefix NALU generation support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9836,7 +9836,7 @@ TEST_F(NegativeVideo, EncodeCapsH264MaxSliceCount) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9885,7 +9885,7 @@ TEST_F(NegativeVideo, EncodeCapsH264MoreSlicesThanMBs) {
         GTEST_SKIP() << "Test requires H.264 encode with row unaligned slice supported";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9935,7 +9935,7 @@ TEST_F(NegativeVideo, EncodeCapsH264MoreSlicesThanMBRows) {
         GTEST_SKIP() << "Test requires H.264 encode without row unaligned slice supported";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -9975,7 +9975,7 @@ TEST_F(NegativeVideo, EncodeCapsH264DifferentSliceTypes) {
         GTEST_SKIP() << "Test requires H.264 encode support with multiple slice support but no different slice types";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10020,7 +10020,7 @@ TEST_F(NegativeVideo, EncodeCapsH265DifferentSliceSegmentTypes) {
             << "Test requires H.265 encode support with multiple slice segment support but no different slice segment types";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10073,7 +10073,7 @@ TEST_F(NegativeVideo, EncodeCapsH265MultipleTilesPerSliceSegment) {
     pps->num_tile_columns_minus1 = (uint8_t)config.EncodeCapsH265()->maxTiles.width - 1;
     pps->num_tile_rows_minus1 = (uint8_t)config.EncodeCapsH265()->maxTiles.height - 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10104,7 +10104,7 @@ TEST_F(NegativeVideo, EncodeCapsH265MultipleSliceSegmentsPerTile) {
             << "Test requires H.265 encode support with multiple slice segment but no multiple slice segments per tile support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10151,7 +10151,7 @@ TEST_F(NegativeVideo, EncodeCapsH265MaxSliceSegmentCount) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10202,7 +10202,7 @@ TEST_F(NegativeVideo, EncodeCapsH265MoreSliceSegmentsThanCTBs) {
         GTEST_SKIP() << "Test requires H.265 encode with row unaligned slice segment supported";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10254,7 +10254,7 @@ TEST_F(NegativeVideo, EncodeCapsH265MoreSliceSegmentsThanCTBRows) {
         GTEST_SKIP() << "Test requires H.265 encode without row unaligned slice segment supported";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -10311,7 +10311,7 @@ TEST_F(NegativeVideo, EncodeCapsH264WeightTable) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10339,7 +10339,7 @@ TEST_F(NegativeVideo, EncodeCapsH264WeightTable) {
         config.SessionCreateInfo()->maxDpbSlots = 3;
         config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10387,7 +10387,7 @@ TEST_F(NegativeVideo, EncodeCapsH265WeightTable) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10415,7 +10415,7 @@ TEST_F(NegativeVideo, EncodeCapsH265WeightTable) {
         config.SessionCreateInfo()->maxDpbSlots = 3;
         config.SessionCreateInfo()->maxActiveReferencePictures = 2;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10455,7 +10455,7 @@ TEST_F(NegativeVideo, EncodeCapsH264PicType) {
     if (config_no_p) {
         VideoConfig config = config_no_p;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10478,7 +10478,7 @@ TEST_F(NegativeVideo, EncodeCapsH264PicType) {
     if (config_no_b) {
         VideoConfig config = config_no_b;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10522,7 +10522,7 @@ TEST_F(NegativeVideo, EncodeCapsH264RefPicType) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10550,7 +10550,7 @@ TEST_F(NegativeVideo, EncodeCapsH264RefPicType) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10597,7 +10597,7 @@ TEST_F(NegativeVideo, EncodeCapsH264BPicInRefList) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10623,7 +10623,7 @@ TEST_F(NegativeVideo, EncodeCapsH264BPicInRefList) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10662,7 +10662,7 @@ TEST_F(NegativeVideo, EncodeCapsH265PicType) {
     if (config_no_p) {
         VideoConfig config = config_no_p;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10685,7 +10685,7 @@ TEST_F(NegativeVideo, EncodeCapsH265PicType) {
     if (config_no_b) {
         VideoConfig config = config_no_b;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10729,7 +10729,7 @@ TEST_F(NegativeVideo, EncodeCapsH265RefPicType) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10757,7 +10757,7 @@ TEST_F(NegativeVideo, EncodeCapsH265RefPicType) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10804,7 +10804,7 @@ TEST_F(NegativeVideo, EncodeCapsH265BPicInRefList) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10830,7 +10830,7 @@ TEST_F(NegativeVideo, EncodeCapsH265BPicInRefList) {
         config.SessionCreateInfo()->maxDpbSlots = 2;
         config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-        VideoContext context(DeviceObj(), config);
+        VideoContext context(m_device, config);
         context.CreateAndBindSessionMemory();
         context.CreateResources();
 
@@ -10864,7 +10864,7 @@ TEST_F(NegativeVideo, EncodeInvalidCodecInfoH264) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -11036,7 +11036,7 @@ TEST_F(NegativeVideo, EncodeInvalidCodecInfoH265) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -11508,7 +11508,7 @@ TEST_F(NegativeVideo, CreateImageIncompatibleProfile) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     VkVideoProfileListInfoKHR profile_list = vku::InitStructHelper();
     profile_list.profileCount = 1;
@@ -11791,7 +11791,7 @@ TEST_F(NegativeVideo, BeginQueryVideoCodingScopeQueryAlreadyActive) {
         GTEST_SKIP() << "Test requires video queue to support result status queries";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateStatusQueryPool(2);
 
@@ -11825,8 +11825,8 @@ TEST_F(NegativeVideo, BeginQueryResultStatusProfileMismatch) {
         GTEST_SKIP() << "Test requires video queue to support result status queries";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context2.CreateStatusQueryPool();
 
@@ -11853,8 +11853,8 @@ TEST_F(NegativeVideo, BeginQueryEncodeFeedbackProfileMismatch) {
         GTEST_SKIP() << "Test requires support for at least two video encode profiles";
     }
 
-    VideoContext context1(DeviceObj(), configs[0]);
-    VideoContext context2(DeviceObj(), configs[1]);
+    VideoContext context1(m_device, configs[0]);
+    VideoContext context2(m_device, configs[1]);
     context1.CreateAndBindSessionMemory();
     context2.CreateEncodeFeedbackQueryPool();
 
@@ -11881,7 +11881,7 @@ TEST_F(NegativeVideo, BeginQueryEncodeFeedbackNoBoundVideoSession) {
         GTEST_SKIP() << "Test requires video encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateEncodeFeedbackQueryPool();
 
@@ -11906,7 +11906,7 @@ TEST_F(NegativeVideo, BeginQueryVideoCodingScopeIncompatibleQueryType) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
@@ -11942,7 +11942,7 @@ TEST_F(NegativeVideo, BeginQueryInlineQueries) {
 
     config.SessionCreateInfo()->flags |= VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateStatusQueryPool();
 
@@ -11973,7 +11973,7 @@ TEST_F(NegativeVideo, GetQueryPoolResultsVideoQueryDataSize) {
     auto feedback_flag_count = GetBitSetCount(feedback_flags);
     uint32_t total_query_count = 4;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateEncodeFeedbackQueryPool(total_query_count, feedback_flags);
 
     auto query_pool = context.EncodeFeedbackQueryPool();
@@ -12103,7 +12103,7 @@ TEST_F(NegativeVideo, ImageLayoutUsageMismatch) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateResources();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -12198,7 +12198,7 @@ TEST_F(NegativeVideoSyncVal, DecodeOutputPicture) {
         GTEST_SKIP() << "Test requires decode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12232,7 +12232,7 @@ TEST_F(NegativeVideoSyncVal, DecodeReconstructedPicture) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12286,7 +12286,7 @@ TEST_F(NegativeVideoSyncVal, DecodeReferencePicture) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12333,7 +12333,7 @@ TEST_F(NegativeVideoSyncVal, EncodeBitstream) {
         GTEST_SKIP() << "Test requires Encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12366,7 +12366,7 @@ TEST_F(NegativeVideoSyncVal, EncodeReconstructedPicture) {
     config.SessionCreateInfo()->maxDpbSlots = 2;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12420,7 +12420,7 @@ TEST_F(NegativeVideoSyncVal, EncodeReferencePicture) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -12467,7 +12467,7 @@ TEST_F(NegativeVideoBestPractices, GetVideoSessionMemoryRequirements) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto mem_req = vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>();
     uint32_t mem_req_count = 1;
@@ -12488,7 +12488,7 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     // Create a buffer to get non-video-related memory requirements
     VkBufferCreateInfo buffer_create_info =

--- a/tests/unit/video_positive.cpp
+++ b/tests/unit/video_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2022-2023 The Khronos Group Inc.
- * Copyright (c) 2022-2023 RasterGrid Kft.
+ * Copyright (c) 2022-2024 The Khronos Group Inc.
+ * Copyright (c) 2022-2024 RasterGrid Kft.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@ TEST_F(PositiveVideo, VideoCodingScope) {
         GTEST_SKIP() << "Test requires video support";
     }
 
-    VideoContext context(DeviceObj(), GetConfigDecode());
+    VideoContext context(m_device, GetConfigDecode());
     context.CreateAndBindSessionMemory();
 
     vkt::CommandBuffer& cb = context.CmdBuffer();
@@ -46,7 +46,7 @@ TEST_F(PositiveVideo, MultipleCmdBufs) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -90,7 +90,7 @@ TEST_F(PositiveVideo, VideoDecodeProfileIndependentResources) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -121,7 +121,7 @@ TEST_F(PositiveVideo, VideoEncodeProfileIndependentResources) {
     config.SessionCreateInfo()->maxDpbSlots = 1;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -151,7 +151,7 @@ TEST_F(PositiveVideo, VideoDecodeH264) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -199,7 +199,7 @@ TEST_F(PositiveVideo, VideoDecodeH264Interlaced) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -247,7 +247,7 @@ TEST_F(PositiveVideo, VideoDecodeH264InterlacedPartialInvalidation) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -294,7 +294,7 @@ TEST_F(PositiveVideo, VideoDecodeH265) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -343,7 +343,7 @@ TEST_F(PositiveVideo, VideoEncodeH264) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -402,7 +402,7 @@ TEST_F(PositiveVideo, VideoEncodeH265) {
     config.SessionCreateInfo()->maxDpbSlots = dpb_slots;
     config.SessionCreateInfo()->maxActiveReferencePictures = active_refs;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -459,7 +459,7 @@ TEST_F(PositiveVideo, EncodeRateControlH264LayerCount) {
         GTEST_SKIP() << "Test requires H.264 encode support with rate control and temporal layer support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -490,7 +490,7 @@ TEST_F(PositiveVideo, EncodeRateControlH265LayerCount) {
         GTEST_SKIP() << "Test requires H.265 encode support with rate control and sub-layer support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -517,7 +517,7 @@ TEST_F(PositiveVideo, GetEncodedSessionParamsH264) {
         GTEST_SKIP() << "Test requires H.264 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h264_info = vku::InitStruct<VkVideoEncodeH264SessionParametersGetInfoKHR>();
     h264_info.writeStdSPS = VK_TRUE;
@@ -551,7 +551,7 @@ TEST_F(PositiveVideo, GetEncodedSessionParamsH265) {
         GTEST_SKIP() << "Test requires H.265 encode support";
     }
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
 
     auto h265_info = vku::InitStruct<VkVideoEncodeH265SessionParametersGetInfoKHR>();
     h265_info.writeStdVPS = VK_TRUE;
@@ -599,7 +599,7 @@ TEST_F(PositiveVideoSyncVal, ImageRangeGenYcbcrSubsampling) {
 
     config.SessionCreateInfo()->maxCodedExtent = max_coded_extent;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -638,7 +638,7 @@ TEST_F(PositiveVideoSyncVal, DecodeCoincide) {
     config.SessionCreateInfo()->maxDpbSlots = 3;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -683,7 +683,7 @@ TEST_F(PositiveVideoSyncVal, DecodeDistinct) {
     config.SessionCreateInfo()->maxDpbSlots = 4;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 
@@ -725,7 +725,7 @@ TEST_F(PositiveVideoSyncVal, Encode) {
     config.SessionCreateInfo()->maxDpbSlots = 4;
     config.SessionCreateInfo()->maxActiveReferencePictures = 1;
 
-    VideoContext context(DeviceObj(), config);
+    VideoContext context(m_device, config);
     context.CreateAndBindSessionMemory();
     context.CreateResources();
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -982,7 +982,7 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     vkt::ImageView image_view(*m_device, ivci);
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle(), 1, 1);
 
-    vkt::CommandBuffer cmdbuff(DeviceObj(), m_commandPool);
+    vkt::CommandBuffer cmdbuff(m_device, m_commandPool);
     cmdbuff.begin();
     cmdbuff.BeginRenderPass(render_pass.handle(), framebuffer.handle());
 


### PR DESCRIPTION
- Make use of the `vkt::no_mem` in `vkt::Buffer`
- Realized some places were using `DeviceObj()` instead of just the `m_device` and made it all consistent