### PR TITLE
scripts: fix international Windows update_deps

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
 
 # Copyright 2017 The Glslang Authors. All rights reserved.
-# Copyright (c) 2018-2023 Valve Corporation
-# Copyright (c) 2018-2023 LunarG, Inc.
+# Copyright (c) 2018-2024 Valve Corporation
+# Copyright (c) 2018-2024 LunarG, Inc.
 # Copyright (c) 2023-2023 RasterGrid Kft.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -281,7 +281,10 @@ def command_output(cmd, directory):
     if VERBOSE:
         print('In {d}: {cmd}'.format(d=directory, cmd=cmd))
 
-    result = subprocess.run(cmd, cwd=directory, capture_output=True, text=True)
+    # errors='replace' affects only how the text output is decoded, and indicates that
+    # 8-bit characters that aren't recognized by the UTF decoder will be replaced with
+    # an "unknown character" glyph instead of crashing.
+    result = subprocess.run(cmd, cwd=directory, capture_output=True, text=True, errors='replace')
 
     if result.returncode != 0:
         print(f'{result.stderr}', file=sys.stderr)
@@ -295,10 +298,14 @@ def run_cmake_command(cmake_cmd):
     # NOTE: Because CMake is an exectuable that runs executables
     # stdout/stderr are mixed together. So this combines the outputs
     # and prints them properly in case there is a non-zero exit code.
+    # errors='replace' affects only how the text output is decoded, and indicates that
+    # 8-bit characters that aren't recognized by the UTF decoder will be replaced with
+    # an "unknown character" glyph instead of crashing.
     result = subprocess.run(cmake_cmd, 
         stdout = subprocess.PIPE,
         stderr = subprocess.STDOUT,
-        text = True
+        text = True,
+        errors='replace'
     )
 
     if VERBOSE:


### PR DESCRIPTION
After we switched from using subprocess.Popen() to subprocess.run() for command execution in commit bdc0ce89d388155124095b3b4f090574d2d843ea, we became sensitive to non-ASCII characters being emitted to the Windows console, which can happen if a developer tries to use update_deps.py() when their Windows console is set to use a non-ASCII or non-UTF code page.

See:

    Can't update dependencies on Windows due to encoding problems
    https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/34

One fix here is to specify the Windows-only "oem" encoding by passing:

    encoding='oem'

to subprocess.run(); but this won't work on non-windows platforms.  The easier and more universal fix is to pass:

    errors='replace'

to subprocess.run(), which will cause any encoding errors (that would normally cause exceptions) to instead be replaced with the "unknown character" marker.  This should be sufficient for normal usage.