### PR TITLE
layers: Add Android Surface creation check

### DIFF
--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -450,3 +450,18 @@ bool StatelessValidation::manual_PreCallValidateCreateXlibSurfaceKHR(VkInstance 
     return skip;
 }
 #endif  // VK_USE_PLATFORM_XLIB_KHR
+
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+bool StatelessValidation::manual_PreCallValidateCreateAndroidSurfaceKHR(VkInstance instance,
+                                                                        const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
+                                                                        const VkAllocationCallbacks *pAllocator,
+                                                                        VkSurfaceKHR *pSurface,
+                                                                        const ErrorObject &error_obj) const {
+    bool skip = false;
+    if (pCreateInfo->window == nullptr) {
+        skip |= LogError("VUID-VkAndroidSurfaceCreateInfoKHR-window-01248", instance,
+                         error_obj.location.dot(Field::pCreateInfo).dot(Field::window), "is NULL.");
+    }
+    return skip;
+}
+#endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -714,6 +714,13 @@ class StatelessValidation : public ValidationObject {
                                                     const ErrorObject &error_obj) const;
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
+#ifdef VK_USE_PLATFORM_ANDROID_KHR
+    bool manual_PreCallValidateCreateAndroidSurfaceKHR(VkInstance instance, const VkAndroidSurfaceCreateInfoKHR *pCreateInfo,
+                                                       const VkAllocationCallbacks *pAllocator, VkSurfaceKHR *pSurface,
+                                                       const ErrorObject &error_obj) const;
+
+#endif  // VK_USE_PLATFORM_ANDROID_KHR
+
     bool manual_PreCallValidateCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
                                                     const VkAllocationCallbacks *pAllocator, VkDescriptorPool *pDescriptorPool,
                                                     const ErrorObject &error_obj) const;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -16626,6 +16626,7 @@ bool StatelessValidation::PreCallValidateCreateAndroidSurfaceKHR(VkInstance inst
         }
     }
     skip |= ValidateRequiredPointer(loc.dot(Field::pSurface), pSurface, "VUID-vkCreateAndroidSurfaceKHR-pSurface-parameter");
+    if (!skip) skip |= manual_PreCallValidateCreateAndroidSurfaceKHR(instance, pCreateInfo, pAllocator, pSurface, error_obj);
     return skip;
 }
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -158,6 +158,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkCmdBeginConditionalRenderingEXT',
             'vkGetDeviceImageMemoryRequirements',
             'vkGetDeviceImageSparseMemoryRequirements',
+            'vkCreateAndroidSurfaceKHR',
             'vkCreateWin32SurfaceKHR',
             'vkCreateWaylandSurfaceKHR',
             'vkCreateXcbSurfaceKHR',


### PR DESCRIPTION
This is a very basic WSI check we have for the other WSI platforms, but seem to have bypassed the Android one