### PR TITLE
Make all handles use Handle() or VkHandle()

### DIFF
--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -141,7 +141,7 @@ bool BestPractices::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryP
             const LogObjectList objlist(queryPool);
             skip |= LogWarning(kVUID_BestPractices_QueryPool_Unavailable, objlist, error_obj.location,
                                "QueryPool %s and query %" PRIu32 ": vkCmdBeginQuery() was never called.",
-                               FormatHandle(query_pool_state.pool()).c_str(), i);
+                               FormatHandle(query_pool_state.Handle()).c_str(), i);
             break;
         }
     }

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -269,7 +269,7 @@ bool BestPractices::ValidateZcull(const bp_state::CommandBuffer& cmd_state, VkIm
 
     if (is_balanced) {
         skip |= LogPerformanceWarning(
-            kVUID_BestPractices_Zcull_LessGreaterRatio, cmd_state.commandBuffer(), loc,
+            kVUID_BestPractices_Zcull_LessGreaterRatio, cmd_state.Handle(), loc,
             "%s Depth attachment %s is primarily rendered with depth compare op %s, but some draws use %s. "
             "Z-cull is disabled for the least used direction, which harms depth testing performance. "
             "The Z-cull direction can be reset by clearing the depth attachment, transitioning from VK_IMAGE_LAYOUT_UNDEFINED, "

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -139,9 +139,9 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
 
     for (const auto& item : mem_info->ObjectBindings()) {
         const auto& obj = item.first;
-        const LogObjectList objlist(device, obj, mem_info->deviceMemory());
+        const LogObjectList objlist(device, obj, mem_info->Handle());
         skip |= LogWarning(layer_name.c_str(), objlist, error_obj.location, "VK Object %s still has a reference to mem obj %s.",
-                           FormatHandle(obj).c_str(), FormatHandle(mem_info->deviceMemory()).c_str());
+                           FormatHandle(obj).c_str(), FormatHandle(mem_info->Handle()).c_str());
     }
 
     return skip;

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -35,9 +35,9 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Locati
         if (pipeline_state && pipeline_state->vertex_input_state &&
             pipeline_state->vertex_input_state->binding_descriptions.size() <= 0) {
             if ((!current_vtx_bfr_binding_info.empty()) && (!cb_state->vertex_buffer_used)) {
-                skip |= LogPerformanceWarning(kVUID_BestPractices_DrawState_VtxIndexOutOfBounds, cb_state->commandBuffer(), loc,
+                skip |= LogPerformanceWarning(kVUID_BestPractices_DrawState_VtxIndexOutOfBounds, cb_state->Handle(), loc,
                                               "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
-                                              FormatHandle(cb_state->commandBuffer()).c_str(),
+                                              FormatHandle(cb_state->Handle()).c_str(),
                                               FormatHandle(pipeline_state->pipeline()).c_str());
             }
         }
@@ -54,7 +54,7 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Locati
                     const auto* raster_state = pipe->RasterizationState();
                     if ((depth_stencil_attachment == VK_ATTACHMENT_UNUSED) && raster_state &&
                         raster_state->depthBiasEnable == VK_TRUE) {
-                        skip |= LogWarning(kVUID_BestPractices_DepthBiasNoAttachment, cb_state->commandBuffer(), loc,
+                        skip |= LogWarning(kVUID_BestPractices_DepthBiasNoAttachment, cb_state->Handle(), loc,
                                            "depthBiasEnable == VK_TRUE without a depth-stencil attachment.");
                     }
                 }

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -35,10 +35,10 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Locati
         if (pipeline_state && pipeline_state->vertex_input_state &&
             pipeline_state->vertex_input_state->binding_descriptions.size() <= 0) {
             if ((!current_vtx_bfr_binding_info.empty()) && (!cb_state->vertex_buffer_used)) {
-                skip |= LogPerformanceWarning(kVUID_BestPractices_DrawState_VtxIndexOutOfBounds, cb_state->Handle(), loc,
-                                              "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
-                                              FormatHandle(cb_state->Handle()).c_str(),
-                                              FormatHandle(pipeline_state->pipeline()).c_str());
+                skip |=
+                    LogPerformanceWarning(kVUID_BestPractices_DrawState_VtxIndexOutOfBounds, cb_state->Handle(), loc,
+                                          "Vertex buffers are bound to %s but no vertex buffers are attached to %s.",
+                                          FormatHandle(cb_state->Handle()).c_str(), FormatHandle(pipeline_state->Handle()).c_str());
             }
         }
 

--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -268,7 +268,7 @@ void BestPractices::ValidateImageInQueue(const vvl::Queue& qs, const vvl::Comman
                 usage == IMAGE_SUBRESOURCE_USAGE_BP::RESOLVE_READ) {
                 Location loc(command);
                 LogWarning(
-                    kVUID_BestPractices_ConcurrentUsageOfExclusiveImage, state.image(), loc,
+                    kVUID_BestPractices_ConcurrentUsageOfExclusiveImage, state.Handle(), loc,
                     "Subresource (arrayLayer: %" PRIu32 ", mipLevel: %" PRIu32 ") of image is used on queue family index %" PRIu32
                     " after being used on "
                     "queue family index %" PRIu32

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -435,18 +435,18 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (image_state->sparse_residency) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->image(), error_obj.location,
+                    skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->Handle(), error_obj.location,
                                        "Binding sparse memory to %s without first calling "
                                        "vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
-                                       FormatHandle(image_state->image()).c_str());
+                                       FormatHandle(image_state->Handle()).c_str());
                 }
             }
             if (!image_state->memory_requirements_checked[0]) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->image(), error_obj.location,
+                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->Handle(), error_obj.location,
                                    "Binding sparse memory to %s without first calling "
                                    "vkGetImageMemoryRequirements() to retrieve requirements.",
-                                   FormatHandle(image_state->image()).c_str());
+                                   FormatHandle(image_state->Handle()).c_str());
             }
         }
         for (uint32_t i = 0; i < bind_info.imageOpaqueBindCount; ++i) {
@@ -459,18 +459,18 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (image_state->sparse_residency) {
                 if (!image_state->get_sparse_reqs_called || image_state->sparse_requirements.empty()) {
                     // For now just warning if sparse image binding occurs without calling to get reqs first
-                    skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->image(), error_obj.location,
+                    skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->Handle(), error_obj.location,
                                        "Binding opaque sparse memory to %s without first calling "
                                        "vkGetImageSparseMemoryRequirements[2KHR]() to retrieve requirements.",
-                                       FormatHandle(image_state->image()).c_str());
+                                       FormatHandle(image_state->Handle()).c_str());
                 }
             }
             if (!image_state->memory_requirements_checked[0]) {
                 // For now just warning if sparse image binding occurs without calling to get reqs first
-                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->image(), error_obj.location,
+                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, image_state->Handle(), error_obj.location,
                                    "Binding opaque sparse memory to %s without first calling "
                                    "vkGetImageMemoryRequirements() to retrieve requirements.",
-                                   FormatHandle(image_state->image()).c_str());
+                                   FormatHandle(image_state->Handle()).c_str());
             }
             for (uint32_t j = 0; j < image_opaque_bind.bindCount; ++j) {
                 if (image_opaque_bind.pBinds[j].flags & VK_SPARSE_MEMORY_BIND_METADATA_BIT) {
@@ -482,10 +482,10 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
             if (sparse_image_state->sparse_metadata_required && !sparse_image_state->sparse_metadata_bound &&
                 sparse_images_with_metadata.find(sparse_image_state) == sparse_images_with_metadata.end()) {
                 // Warn if sparse image binding metadata required for image with sparse binding, but metadata not bound
-                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, sparse_image_state->image(), error_obj.location,
+                skip |= LogWarning(kVUID_BestPractices_MemTrack_InvalidState, sparse_image_state->Handle(), error_obj.location,
                                    "Binding sparse memory to %s which requires a metadata aspect but no "
                                    "binding with VK_SPARSE_MEMORY_BIND_METADATA_BIT set was made.",
-                                   FormatHandle(sparse_image_state->image()).c_str());
+                                   FormatHandle(sparse_image_state->Handle()).c_str());
             }
         }
     }

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -180,7 +180,7 @@ bool BestPractices::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPi
                     }
                     auto slot = variable.decorations.input_attachment_index_start;
                     if (!rpci->pSubpasses[subpass].pInputAttachments || slot >= rpci->pSubpasses[subpass].inputAttachmentCount) {
-                        const LogObjectList objlist(stage.module_state->Handle(), pipeline.PipelineLayoutState()->layout());
+                        const LogObjectList objlist(stage.module_state->Handle(), pipeline.PipelineLayoutState()->Handle());
                         skip |= LogWarning(kVUID_BestPractices_Shader_MissingInputAttachment, device, create_info_loc,
                                            "Shader consumes input attachment index %" PRIu32 " but not provided in subpass", slot);
                     }

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -379,7 +379,7 @@ void BestPractices::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, 
             }
         }
         if (depth_image_view && (depth_image_view->create_info.subresourceRange.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0U) {
-            const VkImage depth_image = depth_image_view->image_state->image();
+            const VkImage depth_image = depth_image_view->image_state->VkHandle();
             const VkImageSubresourceRange& subresource_range = depth_image_view->create_info.subresourceRange;
             RecordBindZcullScope(*cb_state, depth_image, subresource_range);
         } else {
@@ -529,7 +529,7 @@ void BestPractices::RecordCmdBeginRenderingCommon(VkCommandBuffer commandBuffer)
             }
         }
         if (depth_image_view && (depth_image_view->create_info.subresourceRange.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0U) {
-            const VkImage depth_image = depth_image_view->image_state->image();
+            const VkImage depth_image = depth_image_view->image_state->VkHandle();
             const VkImageSubresourceRange& subresource_range = depth_image_view->create_info.subresourceRange;
             RecordBindZcullScope(*cb_state, depth_image, subresource_range);
         } else {

--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2023 The Khronos Group Inc.
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
- * Copyright (C) 2019-2023 Google Inc.
+/* Copyright (c) 2019-2024 The Khronos Group Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (C) 2019-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -287,7 +287,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
     if (image.createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
         const VkImageAspectFlags first_aspect = AspectBit(0);  // AspectBit returns aspects by index
         subres = {first_aspect, 0, 0};
-        DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.image(), &subres, &layout);
+        DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.VkHandle(), &subres, &layout);
         if (layout.size > 0) {
             linear_image_ = true;
         }
@@ -321,7 +321,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
             auto subres_extent = image.GetEffectiveSubresourceExtent(subres_layers);
 
             if (linear_image_) {
-                DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.image(), &subres, &layout);
+                DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.VkHandle(), &subres, &layout);
                 if (is_3_d_) {
                     if ((layout.depthPitch == 0) && (subres_extent.depth == 1)) {
                         layout.depthPitch = layout.size;  // Certain implmentations don't supply pitches when size is 1

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -153,7 +153,7 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
     const VkImage dedicated_image = mem_info->GetDedicatedImage();
     if (dedicated_image != VK_NULL_HANDLE) {
         auto image_state = Get<vvl::Image>(dedicated_image);
-        if ((nullptr == image_state) || (0 == (image_state->CountDeviceMemory(mem_info->deviceMemory())))) {
+        if ((nullptr == image_state) || (0 == (image_state->CountDeviceMemory(mem_info->VkHandle())))) {
             const LogObjectList objlist(device, pInfo->memory, dedicated_image);
             skip |= LogError("VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-pNext-01883", objlist,
                              error_obj.location.dot(Field::pInfo).dot(Field::memory),

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -56,20 +56,20 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
     if (range != VK_WHOLE_SIZE) {
         // Range must be greater than 0
         if (range <= 0) {
-            skip |= LogError("VUID-VkBufferViewCreateInfo-range-00928", buffer_state.buffer(), loc.dot(Field::range),
+            skip |= LogError("VUID-VkBufferViewCreateInfo-range-00928", buffer_state.Handle(), loc.dot(Field::range),
                              "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, range must be greater than 0.", range);
         }
         // Range must be a multiple of the element size of format
         if (SafeModulo(range, format_info.block_size) != 0) {
             skip |=
-                LogError("VUID-VkBufferViewCreateInfo-range-00929", buffer_state.buffer(), loc.dot(Field::range),
+                LogError("VUID-VkBufferViewCreateInfo-range-00929", buffer_state.Handle(), loc.dot(Field::range),
                          "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, range must be a multiple of the element size (%" PRIu32
                          ") of the format %s.",
                          range, format_info.block_size, string_VkFormat(format));
         }
         const VkDeviceSize texels = SafeDivision(range, format_info.block_size) * texel_per_block;
         if (texels > static_cast<VkDeviceSize>(phys_dev_props.limits.maxTexelBufferElements)) {
-            skip |= LogError("VUID-VkBufferViewCreateInfo-range-00930", buffer_state.buffer(), loc.dot(Field::range),
+            skip |= LogError("VUID-VkBufferViewCreateInfo-range-00930", buffer_state.Handle(), loc.dot(Field::range),
                              "(%" PRIuLEAST64 "), %s texel block size (%" PRIu32 "), and texels-per-block (%" PRIuLEAST64
                              ") is a total of (%" PRIuLEAST64
                              ") texels which is more than VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
@@ -78,7 +78,7 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
         }
         // The sum of range and offset must be less than or equal to the size of buffer
         if (range + pCreateInfo->offset > buffer_state.createInfo.size) {
-            skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00931", buffer_state.buffer(), loc.dot(Field::range),
+            skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00931", buffer_state.Handle(), loc.dot(Field::range),
                              "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, the sum of offset (%" PRIuLEAST64
                              ") and range must be less than or equal to the size of the buffer (%" PRIuLEAST64 ").",
                              range, pCreateInfo->offset, buffer_state.createInfo.size);
@@ -87,7 +87,7 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
         const VkDeviceSize offset_range = buffer_state.createInfo.size - pCreateInfo->offset;
         const VkDeviceSize texels = SafeDivision(offset_range, format_info.block_size) * texel_per_block;
         if (texels > static_cast<VkDeviceSize>(phys_dev_props.limits.maxTexelBufferElements)) {
-            skip |= LogError("VUID-VkBufferViewCreateInfo-range-04059", buffer_state.buffer(), loc.dot(Field::range),
+            skip |= LogError("VUID-VkBufferViewCreateInfo-range-04059", buffer_state.Handle(), loc.dot(Field::range),
                              "is VK_WHOLE_SIZE, but the buffer's size (%" PRIuLEAST64 "), offset (%" PRIuLEAST64
                              "), %s texel block size (%" PRIu32 "), and texels-per-block (%" PRIuLEAST64
                              ") is a total of (%" PRIuLEAST64
@@ -107,7 +107,7 @@ bool CoreChecks::ValidateBufferViewBuffer(const vvl::Buffer &buffer_state, const
     const VkBufferUsageFlags2KHR usage = buffer_state.usage;
     if ((usage & VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_2_UNIFORM_TEXEL_BUFFER_BIT_KHR)) {
-        skip |= LogError("VUID-VkBufferViewCreateInfo-format-08778", buffer_state.buffer(), loc.dot(Field::buffer),
+        skip |= LogError("VUID-VkBufferViewCreateInfo-format-08778", buffer_state.Handle(), loc.dot(Field::buffer),
                          "was created with usage (%s) containing VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT, format "
                          "(%s) must be supported for uniform texel buffers. (supported bufferFeatures: %s)",
                          string_VkBufferUsageFlags2KHR(usage).c_str(), string_VkFormat(format),
@@ -115,7 +115,7 @@ bool CoreChecks::ValidateBufferViewBuffer(const vvl::Buffer &buffer_state, const
     }
     if ((usage & VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT) &&
         !(format_properties.bufferFeatures & VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT_KHR)) {
-        skip |= LogError("VUID-VkBufferViewCreateInfo-format-08779", buffer_state.buffer(), loc.dot(Field::buffer),
+        skip |= LogError("VUID-VkBufferViewCreateInfo-format-08779", buffer_state.Handle(), loc.dot(Field::buffer),
                          "was created with usage (%s) containing VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT, format "
                          "(%s) must be supported for storage texel buffers. (supported bufferFeatures: %s)",
                          string_VkBufferUsageFlags2KHR(usage).c_str(), string_VkFormat(format),
@@ -337,7 +337,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
 
     // Buffer view offset must be less than the size of buffer
     if (pCreateInfo->offset >= buffer_state.createInfo.size) {
-        skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00925", buffer_state.buffer(), create_info_loc.dot(Field::offset),
+        skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00925", buffer_state.Handle(), create_info_loc.dot(Field::offset),
                          "(%" PRIuLEAST64 ") must be less than the size of the buffer (%" PRIuLEAST64 ").", pCreateInfo->offset,
                          buffer_state.createInfo.size);
     }

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -835,7 +835,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         if (!cb_state.activeRenderPass->UsesDynamicRendering() && cb_state.IsPrimary() &&
             (cb_state.activeSubpassContents != VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS &&
              cb_state.activeSubpassContents != VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT)) {
-            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
             skip |= LogError("VUID-vkCmdExecuteCommands-contents-06018", objlist, error_obj.location,
                              "contents must be set to VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS or "
                              "VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT "
@@ -850,7 +850,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
               (cb_state.activeRenderPass->use_dynamic_rendering_inherited &&
                (cb_state.activeRenderPass->inheritance_rendering_info.flags &
                 VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR)))) {
-            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
             skip |= LogError("VUID-vkCmdExecuteCommands-flags-06024", objlist, error_obj.location,
                              "VkRenderingInfo::flags must include "
                              "VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR when calling vkCmdExecuteCommands() within a "
@@ -886,19 +886,19 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                 const VkRenderPass inheritance_render_pass = sub_cb_state.beginInfo.pInheritanceInfo->renderPass;
                 auto secondary_rp_state = Get<vvl::RenderPass>(inheritance_render_pass);
                 if (!(sub_cb_state.beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
-                    const LogObjectList objlist(pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                    const LogObjectList objlist(pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                     skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00096", objlist, cb_loc,
                                      "(%s) is executed within a %s "
                                      "instance scope, but the Secondary Command Buffer does not have the "
                                      "VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT set in VkCommandBufferBeginInfo::flags when "
                                      "the vkBeginCommandBuffer() was called.",
                                      FormatHandle(pCommandBuffers[i]).c_str(),
-                                     FormatHandle(cb_state.activeRenderPass->renderPass()).c_str());
+                                     FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
                 } else if (sub_cb_state.beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
                     if (!cb_state.activeRenderPass->UsesDynamicRendering()) {
                         // Make sure render pass is compatible with parent command buffer pass if secondary command buffer has
                         // "render pass continue" usage flag
-                        if (cb_state.activeRenderPass->renderPass() != secondary_rp_state->renderPass()) {
+                        if (cb_state.activeRenderPass->VkHandle() != secondary_rp_state->VkHandle()) {
                             skip |= ValidateRenderPassCompatibility("primary command buffer", *cb_state.activeRenderPass.get(),
                                                                     "secondary command buffer", *secondary_rp_state.get(), cb_loc,
                                                                     "VUID-vkCmdExecuteCommands-pBeginInfo-06020");
@@ -915,7 +915,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                 }
 
                 if (!cb_state.activeRenderPass->UsesDynamicRendering() && (cb_state.GetActiveSubpass() != inheritance_subpass)) {
-                    const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                    const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                     skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-06019", objlist, cb_loc,
                                      "(%s) is executed within a %s "
                                      "instance scope begun by vkCmdBeginRenderPass(), but "
@@ -923,11 +923,11 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                      ") does not "
                                      "match the current subpass (%" PRIu32 ").",
                                      FormatHandle(pCommandBuffers[i]).c_str(),
-                                     FormatHandle(cb_state.activeRenderPass->renderPass()).c_str(), inheritance_subpass,
+                                     FormatHandle(cb_state.activeRenderPass->Handle()).c_str(), inheritance_subpass,
                                      cb_state.GetActiveSubpass());
                 } else if (cb_state.activeRenderPass->UsesDynamicRendering()) {
                     if (inheritance_render_pass != VK_NULL_HANDLE) {
-                        const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                        const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                         skip |= LogError("VUID-vkCmdExecuteCommands-pBeginInfo-06025", objlist, cb_loc,
                                          "(%s) is executed within a dynamic renderpass instance scope begun "
                                          "by vkCmdBeginRendering(), but "
@@ -943,7 +943,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                              ~(VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR | VK_RENDERING_CONTENTS_INLINE_BIT_EXT)) !=
                             (rendering_info.flags &
                              ~(VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR | VK_RENDERING_CONTENTS_INLINE_BIT_EXT))) {
-                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                             skip |=
                                 LogError("VUID-vkCmdExecuteCommands-flags-06026", objlist, cb_loc,
                                          "(%s) is executed within a dynamic renderpass instance scope begun "
@@ -957,7 +957,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         }
 
                         if (inheritance_rendering_info.colorAttachmentCount != rendering_info.colorAttachmentCount) {
-                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                             skip |= LogError("VUID-vkCmdExecuteCommands-colorAttachmentCount-06027", objlist, cb_loc,
                                              "(%s) is executed within a dynamic renderpass instance scope begun "
                                              "by vkCmdBeginRendering(), but "
@@ -974,7 +974,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             if (rendering_info.pColorAttachments[color_i].imageView == VK_NULL_HANDLE) {
                                 if (inheritance_rendering_info.pColorAttachmentFormats[color_i] != VK_FORMAT_UNDEFINED) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-imageView-07606", objlist, cb_loc,
                                                      "(%s) is executed within a dynamic render pass instance "
                                                      "scope begun "
@@ -991,7 +991,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 if (image_view_state->create_info.format !=
                                     inheritance_rendering_info.pColorAttachmentFormats[color_i]) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-imageView-06028", objlist, cb_loc,
                                                      "(%s) is executed within a dynamic render pass instance "
                                                      "scope begun "
@@ -1011,8 +1011,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             auto image_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
 
                             if (image_view_state->create_info.format != inheritance_rendering_info.depthAttachmentFormat) {
-                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                            cb_state.activeRenderPass->renderPass());
+                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pDepthAttachment-06029", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
                                                  "instance scope begun "
@@ -1028,8 +1027,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             auto image_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
 
                             if (image_view_state->create_info.format != inheritance_rendering_info.stencilAttachmentFormat) {
-                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                            cb_state.activeRenderPass->renderPass());
+                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pStencilAttachment-06030", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
                                                  "instance scope begun "
@@ -1044,8 +1042,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             rendering_info.pDepthAttachment->imageView == VK_NULL_HANDLE) {
                             VkFormat format = inheritance_rendering_info.depthAttachmentFormat;
                             if (format != VK_FORMAT_UNDEFINED) {
-                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                            cb_state.activeRenderPass->renderPass());
+                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pDepthAttachment-06774", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
                                                  "instance scope begun by vkCmdBeginRendering(), and "
@@ -1060,8 +1057,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             rendering_info.pStencilAttachment->imageView == VK_NULL_HANDLE) {
                             VkFormat format = inheritance_rendering_info.stencilAttachmentFormat;
                             if (format != VK_FORMAT_UNDEFINED) {
-                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                            cb_state.activeRenderPass->renderPass());
+                                const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pStencilAttachment-06775", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
                                                  "instance scope begun by vkCmdBeginRendering(), and "
@@ -1073,7 +1069,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         }
 
                         if (rendering_info.viewMask != inheritance_rendering_info.viewMask) {
-                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->renderPass());
+                            const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                             skip |= LogError("VUID-vkCmdExecuteCommands-viewMask-06031", objlist, cb_loc,
                                              "(%s) is executed within a dynamic renderpass instance scope begun "
                                              "by vkCmdBeginRendering(), but "
@@ -1097,7 +1093,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != amd_sample_count->pColorAttachmentSamples[index]) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
                                         "VUID-vkCmdExecuteCommands-pNext-06032", objlist, cb_loc,
                                         "(%s) is executed within a dynamic renderpass instance "
@@ -1117,7 +1113,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
                                         "VUID-vkCmdExecuteCommands-pNext-06033", objlist, cb_loc,
                                         "(%s) is executed within a dynamic renderpass instance "
@@ -1135,7 +1131,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
                                         "VUID-vkCmdExecuteCommands-pNext-06034", objlist, cb_loc,
                                         "(%s) is executed within a dynamic renderpass instance "
@@ -1155,7 +1151,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
                                         "VUID-vkCmdExecuteCommands-pNext-06035", objlist, cb_loc,
                                         "(%s) is executed within a dynamic renderpass instance "
@@ -1174,7 +1170,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-pNext-06036", objlist, cb_loc,
                                                      "(%s) is executed within a dynamic renderpass "
                                                      "instance scope begun "
@@ -1191,7 +1187,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                                 if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
-                                                                cb_state.activeRenderPass->renderPass());
+                                                                cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-pNext-06037", objlist, cb_loc,
                                                      "(%s) is executed within a dynamic renderpass "
                                                      "instance scope begun "
@@ -1483,7 +1479,7 @@ bool CoreChecks::PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer com
         if (rp_ci.pSubpasses[i].viewMask > 0) {
             skip |= LogError("VUID-vkCmdBeginTransformFeedbackEXT-None-02373", commandBuffer, error_obj.location,
                              "active render pass (%s) has multiview enabled.",
-                             FormatHandle(cb_state->activeRenderPass->renderPass()).c_str());
+                             FormatHandle(cb_state->activeRenderPass->Handle()).c_str());
             break;
         }
     }

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -464,7 +464,7 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuff
         if (!buffer_state) {
             continue;
         }
-        const LogObjectList objlist(commandBuffer, buffer_state->buffer());
+        const LogObjectList objlist(commandBuffer, buffer_state->Handle());
         skip |= ValidateBufferUsageFlags(objlist, *buffer_state, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT, true,
                                          "VUID-vkCmdBindVertexBuffers-pBuffers-00627", error_obj.location.dot(Field::pBuffers, i));
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, error_obj.location.dot(Field::pBuffers, i),
@@ -1369,7 +1369,7 @@ bool CoreChecks::ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer &cb_st
     uint64_t validation_value = stride * (drawCount - 1) + offset + struct_size;
     if (validation_value > buffer_state->createInfo.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-        objlist.add(buffer_state->buffer());
+        objlist.add(buffer_state->Handle());
         skip |=
             LogError(vuid, objlist, loc,
                      "stride (%" PRIu32 ") * [drawCount (%" PRIu32 ") - 1] + offset (%" PRIu64 ") + sizeof(%s) (%" PRIu32
@@ -1650,14 +1650,14 @@ bool CoreChecks::PreCallValidateCmdBeginConditionalRenderingEXT(
                                                   "VUID-VkConditionalRenderingBeginInfoEXT-buffer-01981");
 
             if ((buffer_state->usage & VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT) == 0) {
-                const LogObjectList objlist(commandBuffer, buffer_state->buffer());
+                const LogObjectList objlist(commandBuffer, buffer_state->Handle());
                 skip |=
                     LogError("VUID-VkConditionalRenderingBeginInfoEXT-buffer-01982", objlist, conditional_loc.dot(Field::buffer),
                              "(%s) was created with %s.", FormatHandle(pConditionalRenderingBegin->buffer).c_str(),
                              string_VkBufferUsageFlags2KHR(buffer_state->usage).c_str());
             }
             if (pConditionalRenderingBegin->offset + 4 > buffer_state->createInfo.size) {
-                const LogObjectList objlist(commandBuffer, buffer_state->buffer());
+                const LogObjectList objlist(commandBuffer, buffer_state->Handle());
                 skip |= LogError(
                     "VUID-VkConditionalRenderingBeginInfoEXT-offset-01983", objlist, conditional_loc.dot(Field::offset),
                     "(%" PRIu64 ") + 4 bytes is not less than the size of pConditionalRenderingBegin->buffer (%" PRIu64 ").",

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1476,24 +1476,24 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         cb_state.HasExternalFormatResolveAttachment()) {
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT] &&
             cb_state.dynamic_state_value.color_blend_enable_attachments.test(0)) {
-            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->renderPass());
+            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.external_format_resolve_09366, rp_objlist, loc,
                              "blend enable for attachment zero was set to VK_TRUE.");
         }
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT] &&
             cb_state.dynamic_state_value.rasterization_samples != VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->renderPass());
+            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.external_format_resolve_09367, rp_objlist, loc, "rasterization samples set to %s.",
                              string_VkSampleCountFlagBits(cb_state.dynamic_state_value.rasterization_samples));
         }
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR]) {
             if (cb_state.dynamic_state_value.fragment_size.width != 1) {
-                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->renderPass());
+                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.external_format_resolve_09370, rp_objlist, loc, "fragment size width is %" PRIu32 ".",
                                  cb_state.dynamic_state_value.fragment_size.width);
             }
             if (cb_state.dynamic_state_value.fragment_size.height != 1) {
-                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->renderPass());
+                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.external_format_resolve_09371, rp_objlist, loc, "fragment size height is %" PRIu32 ".",
                                  cb_state.dynamic_state_value.fragment_size.height);
             }

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -38,7 +38,7 @@ bool CoreChecks::ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bou
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;
     const vvl::DrawDispatchVuid& vuid = vvl::GetDrawDispatchVuid(loc.function);
-    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+    const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
 
     // Verify vkCmdSet* calls since last bound pipeline
     const CBDynamicFlags unset_status_pipeline =
@@ -446,7 +446,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     if (discard_rectangle_state && pipeline.IsDynamic(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
         for (uint32_t i = 0; i < discard_rectangle_state->discardRectangleCount; i++) {
             if (!cb_state.dynamic_state_value.discard_rectangles.test(i)) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(
                     vuid.dynamic_discard_rectangle_07751, objlist, loc,
                     "vkCmdSetDiscardRectangleEXT was not set for discard rectangle index %" PRIu32 " for this command buffer.", i);
@@ -457,7 +457,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT]) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.color_blend_equation_07628, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT dynamic state, but "
                              "vkCmdSetColorBlendEquationEXT() was not called.");
@@ -465,7 +465,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT]) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.color_write_mask_07629, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT dynamic state, but "
                              "vkCmdSetColorWriteMaskEXT() was not called.");
@@ -473,7 +473,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT]) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.color_blend_advanced_07635, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT dynamic state, but "
                              "vkCmdSetColorBlendAdvancedEXT() was not called.");
@@ -484,7 +484,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     for (const uint32_t &color_index : cb_state.active_color_attachments_index) {
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) &&
             !cb_state.dynamic_state_value.color_blend_enable_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |=
                 LogError(vuid.dynamic_color_blend_enable_07476, objlist, loc,
                          "vkCmdSetColorBlendEnableEXT was not set for color attachment index %" PRIu32 " for this command buffer.",
@@ -492,7 +492,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
             !cb_state.dynamic_state_value.color_blend_equation_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.dynamic_color_blend_equation_07477, objlist, loc,
                              "vkCmdSetColorBlendEquationEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.",
@@ -500,7 +500,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
             !cb_state.dynamic_state_value.color_write_mask_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |=
                 LogError(vuid.dynamic_color_write_mask_07478, objlist, loc,
                          "vkCmdSetColorWriteMaskEXT was not set for color attachment index %" PRIu32 " for this command buffer.",
@@ -508,7 +508,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) &&
             !cb_state.dynamic_state_value.color_blend_advanced_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.dynamic_color_blend_advanced_07479, objlist, loc,
                              "vkCmdSetColorBlendAdvancedEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.",
@@ -517,7 +517,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT]) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.color_blend_enable_07627, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT dynamic state, but "
                              "vkCmdSetColorBlendEnableEXT() was not called.");
@@ -534,7 +534,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
                 const auto attachment = (*cb_state.active_attachments)[i];
                 if (attachment && ((attachment->format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0)) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                     skip |= LogError(vuid.blend_feature_07470, objlist, loc,
                                      "Attachment %" PRIu32
                                      " format features (%s) do not include VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT.",
@@ -546,7 +546,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT)) {
             if (advanced_blend &&
                 attachment_count > phys_dev_ext_props.blend_operation_advanced_props.advancedBlendMaxColorAttachments) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |=
                     LogError(vuid.blend_advanced_07480, objlist, loc,
                              "Advanced blend is enabled, but color attachment count (%" PRIu32
@@ -560,7 +560,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
             if (cb_state.dynamic_state_value.sample_locations_info.sampleLocationsPerPixel !=
                 pipeline.MultisampleState()->rasterizationSamples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(
                     vuid.sample_locations_07482, objlist, loc,
                     "sampleLocationsPerPixel set with vkCmdSetSampleLocationsEXT() was %s, but "
@@ -572,7 +572,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT] &&
                 cb_state.dynamic_state_value.sample_locations_info.sampleLocationsPerPixel !=
                     cb_state.dynamic_state_value.rasterization_samples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(
                     vuid.sample_locations_07483, objlist, loc,
                     "sampleLocationsPerPixel set with vkCmdSetSampleLocationsEXT() was %s, but "
@@ -604,7 +604,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                         << string_VkSampleCountFlags(phys_dev_props.limits.framebufferNoAttachmentsSampleCounts) << ").";
             }
             if (!message.str().empty()) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.sample_locations_07471, objlist, loc, "%s.", message.str().c_str());
             }
         }
@@ -626,7 +626,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (SafeModulo(multisample_prop.maxSampleLocationGridSize.width,
                            sample_locations->sampleLocationsInfo.sampleLocationGridSize.width) != 0) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.sample_locations_enable_07936, objlist, loc,
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.width (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -637,7 +637,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             }
             if (SafeModulo(multisample_prop.maxSampleLocationGridSize.height,
                            sample_locations->sampleLocationsInfo.sampleLocationGridSize.height) != 0) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.sample_locations_enable_07937, objlist, loc,
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.height (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -648,7 +648,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             }
             if (sample_locations->sampleLocationsInfo.sampleLocationsPerPixel !=
                 cb_state.dynamic_state_value.rasterization_samples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.sample_locations_enable_07938, objlist, loc,
                                  "Pipeline was created with "
                                  "VkPipelineSampleLocationsStateCreateInfoEXT::sampleLocationsInfo.sampleLocationsPerPixel %s "
@@ -671,7 +671,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                        VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY})) {
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT] &&
                 cb_state.dynamic_state_value.conservative_rasterization_mode != VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(
                     vuid.convervative_rasterization_07499, objlist, loc,
                     "Primitive topology is %s and conservativePointAndLineRasterization is VK_FALSE, but "
@@ -699,7 +699,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_viewports_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_viewport_mask = ~cb_state.viewportMask & required_viewports_mask;
             if (missing_viewport_mask) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_viewport_07831, objlist, loc,
                                  "Dynamic viewport(s) (0x%x) are used by pipeline state object, but were not provided via calls "
                                  "to vkCmdSetViewport().",
@@ -711,7 +711,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_scissor_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_scissor_mask = ~cb_state.scissorMask & required_scissor_mask;
             if (missing_scissor_mask) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_scissor_07832, objlist, loc,
                                  "Dynamic scissor(s) (0x%x) are used by pipeline state object, but were not provided via calls "
                                  "to vkCmdSetScissor().",
@@ -726,7 +726,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_viewport_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_viewport_mask = ~cb_state.viewportWithCountMask & required_viewport_mask;
             if (missing_viewport_mask || !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.viewport_count_03417, objlist, loc,
                                  "Dynamic viewport with count 0x%x are used by pipeline state object, but were not provided "
                                  "via calls to vkCmdSetViewportWithCountEXT().",
@@ -738,7 +738,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_scissor_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_scissor_mask = ~cb_state.scissorWithCountMask & required_scissor_mask;
             if (missing_scissor_mask || !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.scissor_count_03418, objlist, loc,
                                  "Dynamic scissor with count 0x%x are used by pipeline state object, but were not provided via "
                                  "calls to vkCmdSetScissorWithCountEXT().",
@@ -750,7 +750,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.viewportWithCountMask != cb_state.scissorWithCountMask ||
                 !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT] ||
                 !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.viewport_scissor_count_03419, objlist, loc,
                                  "Dynamic viewport and scissor with count 0x%x are used by pipeline state object, but were not "
                                  "provided via matching calls to "
@@ -765,7 +765,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         const uint32_t viewport_count = viewport_state->viewportCount;
         const uint32_t max_inherited = uint32_t(cb_state.inheritedViewportDepths.size());
         if (viewport_count > max_inherited) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.dynamic_state_inherited_07850, objlist, loc,
                              "Pipeline requires more viewports (%" PRIu32 ".) than inherited (viewportDepthCount = %" PRIu32 ".).",
                              viewport_count, max_inherited);
@@ -779,7 +779,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             uint32_t blend_attachment_count = color_blend_state->attachmentCount;
             uint32_t dynamic_attachment_count = cb_state.dynamic_state_value.color_write_enable_attachment_count;
             if (dynamic_attachment_count < blend_attachment_count) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(
                     vuid.dynamic_color_write_enable_count_07750, objlist, loc,
                     "Currently bound pipeline was created with VkPipelineColorBlendStateCreateInfo::attachmentCount %" PRIu32
@@ -794,7 +794,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SAMPLE_MASK_EXT] &&
                 cb_state.dynamic_state_value.samples_mask_samples < pipeline.MultisampleState()->rasterizationSamples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |=
                     LogError(vuid.sample_mask_07472, objlist, loc,
                              "Currently bound pipeline was created with VkPipelineMultisampleStateCreateInfo::rasterizationSamples "
@@ -806,7 +806,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SAMPLE_MASK_EXT] &&
                 cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT]) {
                 if (cb_state.dynamic_state_value.samples_mask_samples < cb_state.dynamic_state_value.rasterization_samples) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                     skip |= LogError(vuid.sample_mask_07473, objlist, loc,
                                      "rasterizationSamples set with vkCmdSetRasterizationSamplesEXT() %s are greater than samples "
                                      "set with vkCmdSetSampleMaskEXT() were %s",
@@ -872,7 +872,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (depth_read && dyn_depth_write_enable && mode_early_fragment_test &&
                 cb_state.dynamic_state_value.depth_write_enable) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_depth_enable_08715, objlist, loc,
                                  "Fragment shader contains OpDepthAttachmentReadEXT, but depthWriteEnable parameter in the last "
                                  "call to vkCmdSetDepthWriteEnable is not false.");
@@ -880,7 +880,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (stencil_read && dyn_stencil_write_mask && mode_early_fragment_test &&
                 ((cb_state.dynamic_state_value.write_mask_front != 0) || (cb_state.dynamic_state_value.write_mask_back != 0))) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_stencil_write_mask_08716, objlist, loc,
                                  "Fragment shader contains OpStencilAttachmentReadEXT, but writeMask parameter in the last "
                                  "call to vkCmdSetStencilWriteMask is not equal to 0 for both front (=%" PRIu32
@@ -952,7 +952,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                 break;
         }
         if (!compatible_topology) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.primitive_topology_class_07500, objlist, loc,
                              "the last primitive topology %s state set by vkCmdSetPrimitiveTopology is "
                              "not compatible with the pipeline topology %s.",
@@ -965,7 +965,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.pNext);
         if (msrtss_info && msrtss_info->multisampledRenderToSingleSampledEnable &&
             msrtss_info->rasterizationSamples != pipeline.MultisampleState()->rasterizationSamples) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
             skip |= LogError(vuid.rasterization_samples_07935, objlist, loc,
                              "VkMultisampledRenderToSingleSampledInfoEXT::multisampledRenderToSingleSampledEnable is VK_TRUE, but "
                              "the rasterizationSamples (%" PRIu32 ") is not equal to rasterizationSamples (%" PRIu32
@@ -1464,7 +1464,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         const auto fragment_shader_stage = last_bound_state.GetShaderState(ShaderObjectStage::FRAGMENT);
         if (fragment_shader_stage && fragment_shader_stage->entrypoint &&
             !fragment_shader_stage->entrypoint->has_alpha_to_coverage_variable) {
-            const LogObjectList frag_objlist(cb_state.Handle(), fragment_shader_stage->shader());
+            const LogObjectList frag_objlist(cb_state.Handle(), fragment_shader_stage->Handle());
             skip |= LogError(vuid.alpha_component_word_08920, frag_objlist, loc,
                              "alphaToCoverageEnable is set, but fragment shader doesn't declare a variable that covers "
                              "Location 0, Component 0.");
@@ -1507,7 +1507,7 @@ bool CoreChecks::ValidateRayTracingDynamicStateSetStatus(const LastBound& last_b
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;
     const vvl::DrawDispatchVuid& vuid = vvl::GetDrawDispatchVuid(loc.function);
-    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
+    const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
 
     // Verify vkCmdSet* calls since last bound pipeline
     const CBDynamicFlags unset_status_pipeline =

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -38,7 +38,7 @@ bool CoreChecks::ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bou
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;
     const vvl::DrawDispatchVuid& vuid = vvl::GetDrawDispatchVuid(loc.function);
-    const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
 
     // Verify vkCmdSet* calls since last bound pipeline
     const CBDynamicFlags unset_status_pipeline =
@@ -249,7 +249,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                     const auto color_write_mask = cb_state.dynamic_state_value.color_write_masks[i];
                     VkColorComponentFlags rgb = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT;
                     if ((color_write_mask & rgb) != rgb && (color_write_mask & rgb) != 0) {
-                        skip |= LogError(vuid.color_write_mask_09116, cb_state.commandBuffer(), loc,
+                        skip |= LogError(vuid.color_write_mask_09116, cb_state.Handle(), loc,
                                          "Render pass attachment %" PRIu32
                                          " has format VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, but the corresponding element of "
                                          "pColorWriteMasks is %s.",
@@ -361,7 +361,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                                           (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
                         if ((attachment->image_state->createInfo.flags &
                              VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
+                            const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                             skip |=
                                 LogError(vuid.sample_locations_enable_07484, objlist, loc,
                                          "Sample locations are enabled, but the depth/stencil attachment (%s) in the current "
@@ -382,7 +382,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                 DispatchGetPhysicalDeviceMultisamplePropertiesEXT(physical_device, rasterizationSamples, &multisample_prop);
                 const auto& gridSize = cb_state.dynamic_state_value.sample_locations_info.sampleLocationGridSize;
                 if (SafeModulo(multisample_prop.maxSampleLocationGridSize.width, gridSize.width) != 0) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
+                    const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                     skip |= LogError(vuid.sample_locations_enable_07485, objlist, loc,
                                      "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.width (%" PRIu32
                                      ") with rasterization samples %s is not evenly divided by "
@@ -392,7 +392,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                                      string_VkSampleCountFlagBits(rasterizationSamples), gridSize.width);
                 }
                 if (SafeModulo(multisample_prop.maxSampleLocationGridSize.height, gridSize.height) != 0) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
+                    const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                     skip |= LogError(vuid.sample_locations_enable_07486, objlist, loc,
                                      "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.height (%" PRIu32
                                      ") with rasterization samples %s is not evenly divided by "
@@ -403,7 +403,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                 }
             }
             if (frag_spirv_state && frag_spirv_state->static_data_.uses_interpolate_at_sample) {
-                const LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
+                const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                 skip |= LogError(vuid.sample_locations_enable_07487, objlist, loc,
                                  "sampleLocationsEnable set with vkCmdSetSampleLocationsEnableEXT() was VK_TRUE, but fragment "
                                  "shader uses InterpolateAtSample instruction.");
@@ -417,7 +417,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
             cb_state.activeRenderPass->GetMSRTSSInfo(cb_state.GetActiveSubpass());
         if (msrtss_info && msrtss_info->multisampledRenderToSingleSampledEnable) {
             if (msrtss_info->rasterizationSamples != cb_state.dynamic_state_value.rasterization_samples) {
-                LogObjectList objlist(cb_state.commandBuffer(), frag_spirv_state->handle());
+                LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                 skip |= LogError(vuid.rasterization_samples_09211, objlist, loc,
                                  "VkMultisampledRenderToSingleSampledInfoEXT::multisampledRenderToSingleSampledEnable is VK_TRUE "
                                  "and VkMultisampledRenderToSingleSampledInfoEXT::rasterizationSamples are %s, but rasterization "
@@ -446,7 +446,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     if (discard_rectangle_state && pipeline.IsDynamic(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT)) {
         for (uint32_t i = 0; i < discard_rectangle_state->discardRectangleCount; i++) {
             if (!cb_state.dynamic_state_value.discard_rectangles.test(i)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(
                     vuid.dynamic_discard_rectangle_07751, objlist, loc,
                     "vkCmdSetDiscardRectangleEXT was not set for discard rectangle index %" PRIu32 " for this command buffer.", i);
@@ -457,7 +457,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT]) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.color_blend_equation_07628, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT dynamic state, but "
                              "vkCmdSetColorBlendEquationEXT() was not called.");
@@ -465,7 +465,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT]) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.color_write_mask_07629, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT dynamic state, but "
                              "vkCmdSetColorWriteMaskEXT() was not called.");
@@ -473,7 +473,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT]) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.color_blend_advanced_07635, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT dynamic state, but "
                              "vkCmdSetColorBlendAdvancedEXT() was not called.");
@@ -484,7 +484,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     for (const uint32_t &color_index : cb_state.active_color_attachments_index) {
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT) &&
             !cb_state.dynamic_state_value.color_blend_enable_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |=
                 LogError(vuid.dynamic_color_blend_enable_07476, objlist, loc,
                          "vkCmdSetColorBlendEnableEXT was not set for color attachment index %" PRIu32 " for this command buffer.",
@@ -492,7 +492,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT) &&
             !cb_state.dynamic_state_value.color_blend_equation_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.dynamic_color_blend_equation_07477, objlist, loc,
                              "vkCmdSetColorBlendEquationEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.",
@@ -500,7 +500,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT) &&
             !cb_state.dynamic_state_value.color_write_mask_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |=
                 LogError(vuid.dynamic_color_write_mask_07478, objlist, loc,
                          "vkCmdSetColorWriteMaskEXT was not set for color attachment index %" PRIu32 " for this command buffer.",
@@ -508,7 +508,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT) &&
             !cb_state.dynamic_state_value.color_blend_advanced_attachments.test(color_index)) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.dynamic_color_blend_advanced_07479, objlist, loc,
                              "vkCmdSetColorBlendAdvancedEXT was not set for color attachment index %" PRIu32
                              " for this command buffer.",
@@ -517,7 +517,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     }
     if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT)) {
         if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT]) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.color_blend_enable_07627, objlist, loc,
                              "Pipeline was created with VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT dynamic state, but "
                              "vkCmdSetColorBlendEnableEXT() was not called.");
@@ -534,7 +534,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
                 const auto attachment = (*cb_state.active_attachments)[i];
                 if (attachment && ((attachment->format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0)) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                     skip |= LogError(vuid.blend_feature_07470, objlist, loc,
                                      "Attachment %" PRIu32
                                      " format features (%s) do not include VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT.",
@@ -546,7 +546,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (pipeline.IsDynamic(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT)) {
             if (advanced_blend &&
                 attachment_count > phys_dev_ext_props.blend_operation_advanced_props.advancedBlendMaxColorAttachments) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |=
                     LogError(vuid.blend_advanced_07480, objlist, loc,
                              "Advanced blend is enabled, but color attachment count (%" PRIu32
@@ -560,7 +560,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
             if (cb_state.dynamic_state_value.sample_locations_info.sampleLocationsPerPixel !=
                 pipeline.MultisampleState()->rasterizationSamples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(
                     vuid.sample_locations_07482, objlist, loc,
                     "sampleLocationsPerPixel set with vkCmdSetSampleLocationsEXT() was %s, but "
@@ -572,7 +572,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT] &&
                 cb_state.dynamic_state_value.sample_locations_info.sampleLocationsPerPixel !=
                     cb_state.dynamic_state_value.rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(
                     vuid.sample_locations_07483, objlist, loc,
                     "sampleLocationsPerPixel set with vkCmdSetSampleLocationsEXT() was %s, but "
@@ -604,7 +604,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                         << string_VkSampleCountFlags(phys_dev_props.limits.framebufferNoAttachmentsSampleCounts) << ").";
             }
             if (!message.str().empty()) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.sample_locations_07471, objlist, loc, "%s.", message.str().c_str());
             }
         }
@@ -626,7 +626,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (SafeModulo(multisample_prop.maxSampleLocationGridSize.width,
                            sample_locations->sampleLocationsInfo.sampleLocationGridSize.width) != 0) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.sample_locations_enable_07936, objlist, loc,
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.width (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -637,7 +637,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             }
             if (SafeModulo(multisample_prop.maxSampleLocationGridSize.height,
                            sample_locations->sampleLocationsInfo.sampleLocationGridSize.height) != 0) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.sample_locations_enable_07937, objlist, loc,
                                  "VkMultisamplePropertiesEXT::maxSampleLocationGridSize.height (%" PRIu32
                                  ") with rasterization samples %s is not evenly divided by "
@@ -648,7 +648,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             }
             if (sample_locations->sampleLocationsInfo.sampleLocationsPerPixel !=
                 cb_state.dynamic_state_value.rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.sample_locations_enable_07938, objlist, loc,
                                  "Pipeline was created with "
                                  "VkPipelineSampleLocationsStateCreateInfoEXT::sampleLocationsInfo.sampleLocationsPerPixel %s "
@@ -671,7 +671,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                        VK_PRIMITIVE_TOPOLOGY_LINE_LIST_WITH_ADJACENCY, VK_PRIMITIVE_TOPOLOGY_LINE_STRIP_WITH_ADJACENCY})) {
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT] &&
                 cb_state.dynamic_state_value.conservative_rasterization_mode != VK_CONSERVATIVE_RASTERIZATION_MODE_DISABLED_EXT) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(
                     vuid.convervative_rasterization_07499, objlist, loc,
                     "Primitive topology is %s and conservativePointAndLineRasterization is VK_FALSE, but "
@@ -699,7 +699,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_viewports_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_viewport_mask = ~cb_state.viewportMask & required_viewports_mask;
             if (missing_viewport_mask) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.dynamic_viewport_07831, objlist, loc,
                                  "Dynamic viewport(s) (0x%x) are used by pipeline state object, but were not provided via calls "
                                  "to vkCmdSetViewport().",
@@ -711,7 +711,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_scissor_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_scissor_mask = ~cb_state.scissorMask & required_scissor_mask;
             if (missing_scissor_mask) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.dynamic_scissor_07832, objlist, loc,
                                  "Dynamic scissor(s) (0x%x) are used by pipeline state object, but were not provided via calls "
                                  "to vkCmdSetScissor().",
@@ -726,7 +726,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_viewport_mask = (1 << viewport_state->scissorCount) - 1;
             const auto missing_viewport_mask = ~cb_state.viewportWithCountMask & required_viewport_mask;
             if (missing_viewport_mask || !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.viewport_count_03417, objlist, loc,
                                  "Dynamic viewport with count 0x%x are used by pipeline state object, but were not provided "
                                  "via calls to vkCmdSetViewportWithCountEXT().",
@@ -738,7 +738,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             const auto required_scissor_mask = (1 << viewport_state->viewportCount) - 1;
             const auto missing_scissor_mask = ~cb_state.scissorWithCountMask & required_scissor_mask;
             if (missing_scissor_mask || !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.scissor_count_03418, objlist, loc,
                                  "Dynamic scissor with count 0x%x are used by pipeline state object, but were not provided via "
                                  "calls to vkCmdSetScissorWithCountEXT().",
@@ -750,7 +750,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.viewportWithCountMask != cb_state.scissorWithCountMask ||
                 !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT] ||
                 !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT]) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.viewport_scissor_count_03419, objlist, loc,
                                  "Dynamic viewport and scissor with count 0x%x are used by pipeline state object, but were not "
                                  "provided via matching calls to "
@@ -765,7 +765,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         const uint32_t viewport_count = viewport_state->viewportCount;
         const uint32_t max_inherited = uint32_t(cb_state.inheritedViewportDepths.size());
         if (viewport_count > max_inherited) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.dynamic_state_inherited_07850, objlist, loc,
                              "Pipeline requires more viewports (%" PRIu32 ".) than inherited (viewportDepthCount = %" PRIu32 ".).",
                              viewport_count, max_inherited);
@@ -779,7 +779,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             uint32_t blend_attachment_count = color_blend_state->attachmentCount;
             uint32_t dynamic_attachment_count = cb_state.dynamic_state_value.color_write_enable_attachment_count;
             if (dynamic_attachment_count < blend_attachment_count) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(
                     vuid.dynamic_color_write_enable_count_07750, objlist, loc,
                     "Currently bound pipeline was created with VkPipelineColorBlendStateCreateInfo::attachmentCount %" PRIu32
@@ -794,7 +794,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (!pipeline.IsDynamic(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SAMPLE_MASK_EXT] &&
                 cb_state.dynamic_state_value.samples_mask_samples < pipeline.MultisampleState()->rasterizationSamples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |=
                     LogError(vuid.sample_mask_07472, objlist, loc,
                              "Currently bound pipeline was created with VkPipelineMultisampleStateCreateInfo::rasterizationSamples "
@@ -806,7 +806,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SAMPLE_MASK_EXT] &&
                 cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT]) {
                 if (cb_state.dynamic_state_value.samples_mask_samples < cb_state.dynamic_state_value.rasterization_samples) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                     skip |= LogError(vuid.sample_mask_07473, objlist, loc,
                                      "rasterizationSamples set with vkCmdSetRasterizationSamplesEXT() %s are greater than samples "
                                      "set with vkCmdSetSampleMaskEXT() were %s",
@@ -825,7 +825,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                 for (uint32_t i = 0; i < cb_state.active_attachments->size(); ++i) {
                     const auto attachment = (*cb_state.active_attachments)[i];
                     if (attachment && cb_state.dynamic_state_value.rasterization_samples != attachment->samples) {
-                        skip |= LogError(vuid.rasterization_sampled_07474, cb_state.commandBuffer(), loc,
+                        skip |= LogError(vuid.rasterization_sampled_07474, cb_state.Handle(), loc,
                                          "Render pass attachment %" PRIu32
                                          " samples %s does not match samples %s set with vkCmdSetRasterizationSamplesEXT().",
                                          i, string_VkSampleCountFlagBits(attachment->samples),
@@ -850,7 +850,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         }
         if (pgq_active) {
             skip |= LogError(
-                vuid.primitives_generated_query_07481, cb_state.commandBuffer(), loc,
+                vuid.primitives_generated_query_07481, cb_state.Handle(), loc,
                 "Query with type VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT is active and primitivesGeneratedQueryWithNonZeroStreams "
                 "feature is not enabled, but rasterizationStreams set with vkCmdSetRasterizationStreamEXT() was %" PRIu32,
                 cb_state.dynamic_state_value.rasterization_stream);
@@ -872,7 +872,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (depth_read && dyn_depth_write_enable && mode_early_fragment_test &&
                 cb_state.dynamic_state_value.depth_write_enable) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.dynamic_depth_enable_08715, objlist, loc,
                                  "Fragment shader contains OpDepthAttachmentReadEXT, but depthWriteEnable parameter in the last "
                                  "call to vkCmdSetDepthWriteEnable is not false.");
@@ -880,7 +880,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
 
             if (stencil_read && dyn_stencil_write_mask && mode_early_fragment_test &&
                 ((cb_state.dynamic_state_value.write_mask_front != 0) || (cb_state.dynamic_state_value.write_mask_back != 0))) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
                 skip |= LogError(vuid.dynamic_stencil_write_mask_08716, objlist, loc,
                                  "Fragment shader contains OpStencilAttachmentReadEXT, but writeMask parameter in the last "
                                  "call to vkCmdSetStencilWriteMask is not equal to 0 for both front (=%" PRIu32
@@ -952,7 +952,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
                 break;
         }
         if (!compatible_topology) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.primitive_topology_class_07500, objlist, loc,
                              "the last primitive topology %s state set by vkCmdSetPrimitiveTopology is "
                              "not compatible with the pipeline topology %s.",
@@ -965,7 +965,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
             cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.pNext);
         if (msrtss_info && msrtss_info->multisampledRenderToSingleSampledEnable &&
             msrtss_info->rasterizationSamples != pipeline.MultisampleState()->rasterizationSamples) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
             skip |= LogError(vuid.rasterization_samples_07935, objlist, loc,
                              "VkMultisampledRenderToSingleSampledInfoEXT::multisampledRenderToSingleSampledEnable is VK_TRUE, but "
                              "the rasterizationSamples (%" PRIu32 ") is not equal to rasterizationSamples (%" PRIu32
@@ -981,7 +981,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::DrawDispatchVuid& vuid = vvl::GetDrawDispatchVuid(loc.function);
-    const LogObjectList objlist(cb_state.commandBuffer());
+    const LogObjectList objlist(cb_state.Handle());
 
     bool graphics_shader_bound = false;
     graphics_shader_bound |= last_bound_state.IsValidShaderBound(ShaderObjectStage::VERTEX);
@@ -1014,11 +1014,11 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
 
     if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT] ||
         !cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_SCISSOR_WITH_COUNT]) {
-        skip |= LogError(vuid.viewport_and_scissor_with_count_08635, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid.viewport_and_scissor_with_count_08635, cb_state.Handle(), loc,
                          "Graphics shader objects are bound, but vkCmdSetViewportWithCount() and "
                          "vkCmdSetScissorWithCount() were not both called.");
     } else if (cb_state.dynamic_state_value.viewport_count != cb_state.dynamic_state_value.scissor_count) {
-        skip |= LogError(vuid.viewport_and_scissor_with_count_08635, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid.viewport_and_scissor_with_count_08635, cb_state.Handle(), loc,
                          "Graphics shader objects are bound, but viewportCount set with vkCmdSetViewportWithCount() was %" PRIu32
                          " and scissorCount set with vkCmdSetScissorWithCount() was %" PRIu32 ".",
                          cb_state.dynamic_state_value.viewport_count, cb_state.dynamic_state_value.scissor_count);
@@ -1028,7 +1028,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         cb_state.dynamic_state_value.viewport_w_scaling_enable &&
         cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV] &&
         cb_state.dynamic_state_value.viewport_w_scaling_count < cb_state.dynamic_state_value.viewport_count) {
-        skip |= LogError(vuid.viewport_w_scaling_08636, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid.viewport_w_scaling_08636, cb_state.Handle(), loc,
                          "Graphics shader objects are bound, but viewportCount set with vkCmdSetViewportWithCount() was %" PRIu32
                          " and viewportCount set with vkCmdSetViewportWScalingNV() was %" PRIu32 ".",
                          cb_state.dynamic_state_value.viewport_count, cb_state.dynamic_state_value.viewport_w_scaling_count);
@@ -1048,7 +1048,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
             }
             if (exclusiveScissorEnabled) {
                 skip |=
-                    LogError(vuid.exclusive_scissor_08638, cb_state.commandBuffer(), loc,
+                    LogError(vuid.exclusive_scissor_08638, cb_state.Handle(), loc,
                              "Graphics shader objects are bound, an element of pExclusiveScissorEnables set with "
                              "vkCmdSetExclusiveScissorEnableNV() was VK_TRUE, but vkCmdSetExclusiveScissorNV() was not called.");
             }
@@ -1064,7 +1064,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
                 if (attachment && vkuFormatIsColor(attachment->create_info.format) &&
                     (attachment->format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) == 0 &&
                     cb_state.dynamic_state_value.color_blend_enabled[i] == VK_TRUE) {
-                    skip |= LogError(vuid.set_color_blend_enable_08643, cb_state.commandBuffer(), loc,
+                    skip |= LogError(vuid.set_color_blend_enable_08643, cb_state.Handle(), loc,
                                      "Render pass attachment %" PRIu32
                                      " has format %s, which does not have VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT, but "
                                      "pColorBlendEnables[%" PRIu32 "] set with vkCmdSetColorBlendEnableEXT() was VK_TRUE.",
@@ -1080,7 +1080,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
                 for (uint32_t i = 0; i < cb_state.active_attachments->size(); ++i) {
                     const auto attachment = (*cb_state.active_attachments)[i];
                     if (attachment && cb_state.dynamic_state_value.rasterization_samples != attachment->samples) {
-                        skip |= LogError(vuid.set_rasterization_samples_08644, cb_state.commandBuffer(), loc,
+                        skip |= LogError(vuid.set_rasterization_samples_08644, cb_state.Handle(), loc,
                                          "Render pass attachment %" PRIu32
                                          " samples %s does not match samples %s set with vkCmdSetRasterizationSamplesEXT().",
                                          i, string_VkSampleCountFlagBits(attachment->samples),
@@ -1208,7 +1208,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
                 if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_SHADING_RATE_PALETTE_NV] &&
                     cb_state.dynamic_state_value.shading_rate_palette_count < cb_state.dynamic_state_value.viewport_count) {
                     skip |= LogError(
-                        vuid.shading_rate_palette_08637, cb_state.commandBuffer(), loc,
+                        vuid.shading_rate_palette_08637, cb_state.Handle(), loc,
                         "Graphics shader objects are bound, but viewportCount set with vkCmdSetViewportWithCount() was %" PRIu32
                         " and viewportCount set with vkCmdSetViewportShadingRatePaletteNV() was %" PRIu32 ".",
                         cb_state.dynamic_state_value.viewport_count, cb_state.dynamic_state_value.shading_rate_palette_count);
@@ -1390,7 +1390,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
                         }
                         if (!IsValueIn(format, {VK_FORMAT_R8_UINT, VK_FORMAT_R8_SINT, VK_FORMAT_R16_UINT, VK_FORMAT_R16_SINT,
                                                 VK_FORMAT_R32_UINT, VK_FORMAT_R32_SINT})) {
-                            skip |= LogError(vuid.set_coverage_to_color_location_09420, cb_state.commandBuffer(), loc,
+                            skip |= LogError(vuid.set_coverage_to_color_location_09420, cb_state.Handle(), loc,
                                              "Color attachment format selected by coverageToColorLocation (%" PRIu32 ") is %s.",
                                              cb_state.dynamic_state_value.coverage_to_color_location, string_VkFormat(format));
                         }
@@ -1400,14 +1400,14 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
             if (enabled_features.colorWriteEnable) {
                 if (!cb_state.dynamic_state_value.rasterizer_discard_enable) {
                     if (!cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT]) {
-                        skip |= LogError(vuid.set_color_write_enable_08646, cb_state.commandBuffer(), loc,
+                        skip |= LogError(vuid.set_color_write_enable_08646, cb_state.Handle(), loc,
                                          "Fragment shader object is bound and rasterization is enabled, but "
                                          "vkCmdSetColorWriteEnableEXT() was not called.");
                     }
                 }
                 if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT] &&
                     cb_state.dynamic_state_value.color_write_enable_attachment_count < cb_state.GetDynamicColorAttachmentCount()) {
-                    skip |= LogError(vuid.set_color_write_enable_08647, cb_state.commandBuffer(), loc,
+                    skip |= LogError(vuid.set_color_write_enable_08647, cb_state.Handle(), loc,
                                      "vkCmdSetColorWriteEnableEXT() was called with attachmentCount %" PRIu32
                                      ", but current render pass attachmnet count is %" PRIu32 ".",
                                      cb_state.dynamic_state_value.color_write_enable_attachment_count,
@@ -1423,7 +1423,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_VIEWPORT_SWIZZLE_NV]) {
             if (cb_state.dynamic_state_value.viewport_swizzle_count < cb_state.dynamic_state_value.viewport_count) {
                 skip |=
-                    LogError(vuid.set_viewport_swizzle_09421, cb_state.commandBuffer(), loc,
+                    LogError(vuid.set_viewport_swizzle_09421, cb_state.Handle(), loc,
                              "viewportCount (%" PRIu32 ") set with vkCmdSetViewportSwizzleNV() is less than viewportCount (%" PRIu32
                              ") set with vkCmdSetViewportWithCount()",
                              cb_state.dynamic_state_value.viewport_swizzle_count, cb_state.dynamic_state_value.viewport_count);
@@ -1449,7 +1449,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
                                                   loc, vuid.set_viewport_with_count_08642);
                 if (cb_state.dynamic_state_value.viewport_count != 1) {
                     skip |= LogError(
-                        vuid.set_viewport_with_count_08642, cb_state.commandBuffer(), loc,
+                        vuid.set_viewport_with_count_08642, cb_state.Handle(), loc,
                         "primitiveFragmentShadingRateWithMultipleViewports is not supported and shader stage %s uses "
                         "PrimitiveShadingRateKHR, but viewportCount set with vkCmdSetViewportWithCount was %" PRIu32 ".",
                         string_VkShaderStageFlagBits(shader_stage->create_info.stage), cb_state.dynamic_state_value.viewport_count);
@@ -1464,7 +1464,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         const auto fragment_shader_stage = last_bound_state.GetShaderState(ShaderObjectStage::FRAGMENT);
         if (fragment_shader_stage && fragment_shader_stage->entrypoint &&
             !fragment_shader_stage->entrypoint->has_alpha_to_coverage_variable) {
-            const LogObjectList frag_objlist(cb_state.commandBuffer(), fragment_shader_stage->shader());
+            const LogObjectList frag_objlist(cb_state.Handle(), fragment_shader_stage->shader());
             skip |= LogError(vuid.alpha_component_word_08920, frag_objlist, loc,
                              "alphaToCoverageEnable is set, but fragment shader doesn't declare a variable that covers "
                              "Location 0, Component 0.");
@@ -1476,24 +1476,24 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
         cb_state.HasExternalFormatResolveAttachment()) {
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT] &&
             cb_state.dynamic_state_value.color_blend_enable_attachments.test(0)) {
-            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
+            const LogObjectList rp_objlist(cb_state.Handle(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.external_format_resolve_09366, rp_objlist, loc,
                              "blend enable for attachment zero was set to VK_TRUE.");
         }
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT] &&
             cb_state.dynamic_state_value.rasterization_samples != VK_SAMPLE_COUNT_1_BIT) {
-            const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
+            const LogObjectList rp_objlist(cb_state.Handle(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.external_format_resolve_09367, rp_objlist, loc, "rasterization samples set to %s.",
                              string_VkSampleCountFlagBits(cb_state.dynamic_state_value.rasterization_samples));
         }
         if (cb_state.dynamic_state_status.cb[CB_DYNAMIC_STATE_FRAGMENT_SHADING_RATE_KHR]) {
             if (cb_state.dynamic_state_value.fragment_size.width != 1) {
-                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
+                const LogObjectList rp_objlist(cb_state.Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.external_format_resolve_09370, rp_objlist, loc, "fragment size width is %" PRIu32 ".",
                                  cb_state.dynamic_state_value.fragment_size.width);
             }
             if (cb_state.dynamic_state_value.fragment_size.height != 1) {
-                const LogObjectList rp_objlist(cb_state.commandBuffer(), cb_state.activeRenderPass->Handle());
+                const LogObjectList rp_objlist(cb_state.Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.external_format_resolve_09371, rp_objlist, loc, "fragment size height is %" PRIu32 ".",
                                  cb_state.dynamic_state_value.fragment_size.height);
             }
@@ -1507,7 +1507,7 @@ bool CoreChecks::ValidateRayTracingDynamicStateSetStatus(const LastBound& last_b
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;
     const vvl::DrawDispatchVuid& vuid = vvl::GetDrawDispatchVuid(loc.function);
-    const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline());
+    const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline());
 
     // Verify vkCmdSet* calls since last bound pipeline
     const CBDynamicFlags unset_status_pipeline =
@@ -1530,7 +1530,7 @@ bool CoreChecks::ValidateRayTracingDynamicStateSetStatus(const LastBound& last_b
 bool CoreChecks::ForbidInheritedViewportScissor(const vvl::CommandBuffer& cb_state, const char* vuid, const Location& loc) const {
     bool skip = false;
     if (cb_state.inheritedViewportDepths.size() != 0) {
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid, cb_state.Handle(), loc,
                          "commandBuffer must not have VkCommandBufferInheritanceViewportScissorInfoNV::viewportScissor2D enabled.");
     }
     return skip;

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2312,7 +2312,7 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
                     if (const auto [memory, overlap_range] =
                             src_buffer_state->GetResourceMemoryOverlap(src, dst_buffer_state.get(), dst);
                         memory != VK_NULL_HANDLE) {
-                        const LogObjectList objlist(commandBuffer, src_buffer_state->buffer(), dst_buffer_state->buffer(), memory);
+                        const LogObjectList objlist(commandBuffer, src_buffer_state->Handle(), dst_buffer_state->Handle(), memory);
                         skip |= this->LogError(vuid, objlist, loc,
                                                "Memory (%s) has copy overlap on range %s. Source "
                                                "buffer range is pRegions[%" PRIu32

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -615,7 +615,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         const VkImageAspectFlags region_aspect_mask = region.imageSubresource.aspectMask;
         if (image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((region.imageOffset.y != 0) || (region.imageExtent.height != 1)) {
-                const LogObjectList objlist(handle, image_state.image());
+                const LogObjectList objlist(handle, image_state.Handle());
                 skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07979", from_image, is_2, is_memory), objlist, region_loc,
                                  "imageOffset.y is %" PRId32 " and imageExtent.height is %" PRIu32
                                  ". For 1D images these must be 0 "
@@ -626,7 +626,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         if ((image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) || (image_state.createInfo.imageType == VK_IMAGE_TYPE_2D)) {
             if ((region.imageOffset.z != 0) || (region.imageExtent.depth != 1)) {
-                const LogObjectList objlist(handle, image_state.image());
+                const LogObjectList objlist(handle, image_state.Handle());
                 skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07980", from_image, is_2, is_memory), objlist, region_loc,
                                  "imageOffset.z is %" PRId32 " and imageExtent.depth is %" PRIu32
                                  ". For 1D and 2D images these "
@@ -637,7 +637,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         if (image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
             if ((0 != region.imageSubresource.baseArrayLayer) || (1 != region.imageSubresource.layerCount)) {
-                const LogObjectList objlist(handle, image_state.image());
+                const LogObjectList objlist(handle, image_state.Handle());
                 skip |=
                     LogError(GetBufferMemoryImageCopyCommandVUID("07983", from_image, is_2, is_memory), objlist, subresource_loc,
                              "baseArrayLayer is %" PRIu32 " and layerCount is %" PRIu32
@@ -649,17 +649,17 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         // Make sure not a empty region
         if (region.imageExtent.width == 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("06659", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::width), "is zero (empty copies are not allowed).");
         }
         if (region.imageExtent.height == 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("06660", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::height), "is zero (empty copies are not allowed).");
         }
         if (region.imageExtent.depth == 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("06661", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::depth), "is zero (empty copies are not allowed).");
         }
@@ -667,7 +667,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         //  BufferRowLength must be 0, or greater than or equal to the width member of imageExtent
         uint32_t row_length = GetRowLength(region);
         if ((row_length != 0) && (row_length < region.imageExtent.width)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             Field field = is_memory ? Field::memoryRowLength : Field::bufferRowLength;
             skip |=
                 LogError(GetBufferMemoryImageCopyCommandVUID("09101", from_image, is_2, is_memory), objlist, region_loc.dot(field),
@@ -678,7 +678,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         //  BufferImageHeight must be 0, or greater than or equal to the height member of imageExtent
         uint32_t image_height = GetImageHeight(region);
         if ((image_height != 0) && (image_height < region.imageExtent.height)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             Field field = is_memory ? Field::memoryImageHeight : Field::bufferImageHeight;
             skip |=
                 LogError(GetBufferMemoryImageCopyCommandVUID("00196", from_image, is_2, is_memory), objlist, region_loc.dot(field),
@@ -688,7 +688,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         // subresource aspectMask must have exactly 1 bit set
         if (GetBitSetCount(region_aspect_mask) != 1) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("09103", from_image, is_2, is_memory), objlist,
                              subresource_loc.dot(Field::aspectMask), "is %s (only one bit allowed).",
                              string_VkImageAspectFlags(region_aspect_mask).c_str());
@@ -700,7 +700,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         if ((region.imageOffset.x < 0) || (region.imageOffset.x > static_cast<int32_t>(adjusted_image_extent.width)) ||
             ((region.imageOffset.x + static_cast<int32_t>(region.imageExtent.width)) >
              static_cast<int32_t>(adjusted_image_extent.width))) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("00197", from_image, is_2, is_memory), objlist, region_loc,
                              "imageOffset.x (%" PRId32 ") and (imageExtent.width + imageOffset.x) (%" PRIu32
                              ") must be >= "
@@ -712,7 +712,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         if ((region.imageOffset.y < 0) || (region.imageOffset.y > static_cast<int32_t>(adjusted_image_extent.height)) ||
             ((region.imageOffset.y + static_cast<int32_t>(region.imageExtent.height)) >
              static_cast<int32_t>(adjusted_image_extent.height))) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |=
                 LogError(GetBufferMemoryImageCopyCommandVUID("00198", from_image, is_2, is_memory), objlist, region_loc,
                          "imageOffset.y (%" PRId32 ") and (imageExtent.height + imageOffset.y) (%" PRIu32
@@ -725,7 +725,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         if ((region.imageOffset.z < 0) || (region.imageOffset.z > static_cast<int32_t>(adjusted_image_extent.depth)) ||
             ((region.imageOffset.z + static_cast<int32_t>(region.imageExtent.depth)) >
              static_cast<int32_t>(adjusted_image_extent.depth))) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("09104", from_image, is_2, is_memory), objlist, region_loc,
                              "imageOffset.z (%" PRId32 ") and (imageExtent.depth + imageOffset.z) (%" PRIu32
                              ") must be >= "
@@ -736,7 +736,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         const VkFormat image_format = image_state.createInfo.format;
         // image subresource aspect bit must match format
         if (!VerifyAspectsPresent(region_aspect_mask, image_format)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("09105", from_image, is_2, is_memory), objlist,
                              subresource_loc.dot(Field::aspectMask), "%s invalid for image format %s.",
                              string_VkImageAspectFlags(region_aspect_mask).c_str(), string_VkFormat(image_format));
@@ -745,7 +745,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         auto block_size = vkuFormatTexelBlockExtent(image_format);
         //  BufferRowLength must be a multiple of block width
         if (SafeModulo(row_length, block_size.width) != 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             Field field = is_memory ? Field::memoryRowLength : Field::bufferRowLength;
             skip |= LogError(
                 GetBufferMemoryImageCopyCommandVUID("09106", from_image, is_2, is_memory), objlist, region_loc.dot(field),
@@ -754,7 +754,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         //  BufferRowHeight must be a multiple of block height
         if (SafeModulo(image_height, block_size.height) != 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             Field field = is_memory ? Field::memoryImageHeight : Field::bufferImageHeight;
             skip |=
                 LogError(GetBufferMemoryImageCopyCommandVUID("09107", from_image, is_2, is_memory), objlist, region_loc.dot(field),
@@ -764,7 +764,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         //  image offsets x must be multiple of block width
         if (SafeModulo(region.imageOffset.x, block_size.width) != 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07274", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageOffset).dot(Field::x),
                              "(%" PRId32
@@ -775,7 +775,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         //  image offsets y must be multiple of block height
         if (SafeModulo(region.imageOffset.y, block_size.height) != 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07275", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageOffset).dot(Field::y),
                              "(%" PRId32
@@ -786,7 +786,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         //  image offsets z must be multiple of block depth
         if (SafeModulo(region.imageOffset.z, block_size.depth) != 0) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07276", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageOffset).dot(Field::z),
                              "(%" PRId32
@@ -799,7 +799,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         VkExtent3D mip_extent = image_state.GetEffectiveSubresourceExtent(region.imageSubresource);
         if ((SafeModulo(region.imageExtent.width, block_size.width) != 0) &&
             (region.imageExtent.width + region.imageOffset.x != mip_extent.width)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("00207", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::width),
                              "(%" PRIu32
@@ -812,7 +812,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         // imageExtent height must be a multiple of block height, or extent+offset height must equal subresource height
         if ((SafeModulo(region.imageExtent.height, block_size.height) != 0) &&
             (region.imageExtent.height + region.imageOffset.y != mip_extent.height)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("00208", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::height),
                              "(%" PRIu32
@@ -825,7 +825,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         // imageExtent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
         if ((SafeModulo(region.imageExtent.depth, block_size.depth) != 0) &&
             (region.imageExtent.depth + region.imageOffset.z != mip_extent.depth)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("00209", from_image, is_2, is_memory), objlist,
                              region_loc.dot(Field::imageExtent).dot(Field::depth),
                              "(%" PRIu32
@@ -845,7 +845,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         test_value = test_value * element_size;
         const auto two_to_31_minus_1 = static_cast<double>((1u << 31) - 1);
         if (test_value > two_to_31_minus_1) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             Field field = is_memory ? Field::memoryRowLength : Field::bufferRowLength;
             skip |=
                 LogError(GetBufferMemoryImageCopyCommandVUID("09108", from_image, is_2, is_memory), objlist, region_loc.dot(field),
@@ -857,7 +857,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
 
         // Checks that apply only to multi-planar format images
         if (vkuFormatIsMultiplane(image_format) && !IsOnlyOneValidPlaneAspect(image_format, region_aspect_mask)) {
-            const LogObjectList objlist(handle, image_state.image());
+            const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07981", from_image, is_2, is_memory), objlist,
                              subresource_loc.dot(Field::aspectMask), "(%s) is invalid for multi-planar format %s.",
                              string_VkImageAspectFlags(region_aspect_mask).c_str(), string_VkFormat(image_format));
@@ -894,7 +894,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
 
         if (vkuFormatIsDepthOrStencil(image_format)) {
             if (SafeModulo(bufferOffset, 4) != 0) {
-                const LogObjectList objlist(cb_state.commandBuffer(), image_state.image());
+                const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
                 skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07978", image_to_buffer, is_2), objlist,
                                  region_loc.dot(Field::bufferOffset),
                                  "(%" PRIu64 ") must be a multiple 4 if using a depth/stencil format (%s).", bufferOffset,
@@ -903,7 +903,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
         } else {
             // If not depth/stencil and not multi-plane
             if (!vkuFormatIsMultiplane(image_format) && (SafeModulo(bufferOffset, element_size) != 0)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), image_state.image());
+                const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
                 skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07975", image_to_buffer, is_2), objlist,
                                  region_loc.dot(Field::bufferOffset),
                                  "(%" PRIu64 ") must be a multiple of %s texel size (%" PRIu32 ").", bufferOffset,
@@ -921,7 +921,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
                     vkuFindMultiplaneCompatibleFormat(image_format, static_cast<VkImageAspectFlagBits>(region_aspect_mask));
                 const uint32_t compatible_size = vkuFormatElementSize(compatible_format);
                 if (SafeModulo(bufferOffset, compatible_size) != 0) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), image_state.image());
+                    const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
                     skip |= LogError(GetBufferMemoryImageCopyCommandVUID("07976", image_to_buffer, is_2), objlist,
                                      region_loc.dot(Field::bufferOffset),
                                      "(%" PRIu64 ") is not a multiple of %s texel size (%" PRIu32 ") for plane %" PRIu32 " (%s).",
@@ -1383,7 +1383,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         // Do all checks on source image
         if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.srcOffset.y) || (1 != src_copy_extent.height)) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("00146", is_2, is_host), objlist, region_loc,
                                  "srcOffset.y is %" PRId32 " and extent.height is %" PRIu32
                                  ". For 1D images these must "
@@ -1395,7 +1395,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         if (((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) ||
              ((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
             ((0 != region.srcOffset.z) || (1 != src_copy_extent.depth))) {
-            const LogObjectList objlist(handle, src_image_state.image());
+            const LogObjectList objlist(handle, src_image_state.Handle());
             const char *image_type = is_host ? "1D or 2D" : "1D";
             skip |= LogError(GetImageCopyVUID("01785", is_2, is_host), objlist, region_loc,
                              "srcOffset.z is %" PRId32 " and extent.depth is %" PRIu32
@@ -1405,7 +1405,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         }
 
         if ((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.srcOffset.z) && (!is_host)) {
-            const LogObjectList objlist(handle, src_image_state.image());
+            const LogObjectList objlist(handle, src_image_state.Handle());
             vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-01787" : "VUID-vkCmdCopyImage-srcImage-01787";
             skip |= LogError(vuid, objlist, region_loc, "srcOffset.z is %" PRId32 ". For 2D images the z-offset must be 0.",
                              region.srcOffset.z);
@@ -1414,7 +1414,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         {  // Used to be compressed checks, now apply to all
             const VkExtent3D block_size = vkuFormatTexelBlockExtent(src_image_state.createInfo.format);
             if (SafeModulo(region.srcOffset.x, block_size.width) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07278", is_2, is_host), objlist, region_loc,
                                  "srcOffset.x (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1424,7 +1424,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
 
             //  image offsets y must be multiple of block height
             if (SafeModulo(region.srcOffset.y, block_size.height) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07279", is_2, is_host), objlist, region_loc,
                                  "srcOffset.y (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1434,7 +1434,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
 
             //  image offsets z must be multiple of block depth
             if (SafeModulo(region.srcOffset.z, block_size.depth) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07280", is_2, is_host), objlist, region_loc,
                                  "srcOffset.z (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1445,7 +1445,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             const VkExtent3D mip_extent = src_image_state.GetEffectiveSubresourceExtent(region.srcSubresource);
             if ((SafeModulo(src_copy_extent.width, block_size.width) != 0) &&
                 (src_copy_extent.width + region.srcOffset.x != mip_extent.width)) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01728", is_2, is_host), objlist, region_loc,
                                  "extent width (%" PRIu32
                                  ") must be a multiple of the blocked texture block "
@@ -1457,7 +1457,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             // Extent height must be a multiple of block height, or extent+offset height must equal subresource height
             if ((SafeModulo(src_copy_extent.height, block_size.height) != 0) &&
                 (src_copy_extent.height + region.srcOffset.y != mip_extent.height)) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01729", is_2, is_host), objlist, region_loc,
                                  "extent height (%" PRIu32
                                  ") must be a multiple of the compressed texture block "
@@ -1469,7 +1469,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             // Extent depth must be a multiple of block depth, or extent+offset depth must equal subresource depth
             uint32_t copy_depth = (slice_override ? depth_slices : src_copy_extent.depth);
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.srcOffset.z != mip_extent.depth)) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01730", is_2, is_host), objlist, region_loc,
                                  "extent width (%" PRIu32
                                  ") must be a multiple of the compressed texture block "
@@ -1482,7 +1482,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         // Do all checks on dest image
         if (dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.dstOffset.y) || (1 != dst_copy_extent.height)) {
-                const LogObjectList objlist(handle, dst_image_state.image());
+                const LogObjectList objlist(handle, dst_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("00152", is_2, is_host), objlist, region_loc,
                                  "dstOffset.y is %" PRId32 " and dst_copy_extent.height is %" PRIu32
                                  ". For 1D images "
@@ -1494,7 +1494,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         if (((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) ||
              ((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
             ((0 != region.dstOffset.z) || (1 != dst_copy_extent.depth))) {
-            const LogObjectList objlist(handle, dst_image_state.image());
+            const LogObjectList objlist(handle, dst_image_state.Handle());
             const char *image_type = is_host ? "1D or 2D" : "1D";
             skip |= LogError(GetImageCopyVUID("01786", is_2, is_host), objlist, region_loc,
                              "dstOffset.z is %" PRId32 " and extent.depth is %" PRIu32
@@ -1504,7 +1504,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         }
 
         if ((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.dstOffset.z) && !(is_host)) {
-            const LogObjectList objlist(handle, dst_image_state.image());
+            const LogObjectList objlist(handle, dst_image_state.Handle());
             vuid = is_2 ? "VUID-VkCopyImageInfo2-dstImage-01788" : "VUID-vkCmdCopyImage-dstImage-01788";
             skip |= LogError(vuid, objlist, region_loc, "dstOffset.z is %" PRId32 ". For 2D images the z-offset must be 0.",
                              region.dstOffset.z);
@@ -1513,7 +1513,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         // Handle difference between Maintenance 1
         if (IsExtEnabled(device_extensions.vk_khr_maintenance1) || is_host) {
             if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     skip |= LogError(GetImageCopyVUID("04443", is_2, is_host), objlist, region_loc,
                                      "srcSubresource.baseArrayLayer is %" PRIu32
@@ -1523,7 +1523,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                 }
             }
             if (dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
-                const LogObjectList objlist(handle, dst_image_state.image());
+                const LogObjectList objlist(handle, dst_image_state.Handle());
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
                     skip |= LogError(GetImageCopyVUID("04444", is_2, is_host), objlist, region_loc,
                                      "dstSubresource.baseArrayLayer is %" PRIu32
@@ -1536,7 +1536,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D ||
                 dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
-                    const LogObjectList objlist(handle, src_image_state.image());
+                    const LogObjectList objlist(handle, src_image_state.Handle());
                     vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
                     skip |= LogError(vuid, objlist, region_loc,
                                      "srcSubresource.baseArrayLayer is %" PRIu32
@@ -1547,7 +1547,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                                      region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
                 }
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
-                    const LogObjectList objlist(handle, dst_image_state.image());
+                    const LogObjectList objlist(handle, dst_image_state.Handle());
                     vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
                     skip |= LogError(vuid, objlist, region_loc,
                                      "dstSubresource.baseArrayLayer is %" PRIu32
@@ -1564,7 +1564,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             const VkExtent3D block_size = vkuFormatTexelBlockExtent(dst_image_state.createInfo.format);
             //  image offsets x must be multiple of block width
             if (SafeModulo(region.dstOffset.x, block_size.width) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07281", is_2, is_host), objlist, region_loc,
                                  "srcOffset.x (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1574,7 +1574,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
 
             //  image offsets y must be multiple of block height
             if (SafeModulo(region.dstOffset.y, block_size.height) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07282", is_2, is_host), objlist, region_loc,
                                  "srcOffset.y (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1584,7 +1584,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
 
             //  image offsets z must be multiple of block depth
             if (SafeModulo(region.dstOffset.z, block_size.depth) != 0) {
-                const LogObjectList objlist(handle, src_image_state.image());
+                const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("07283", is_2, is_host), objlist, region_loc,
                                  "srcOffset.z (%" PRId32
                                  ") must be a multiple of the blocked image's texel "
@@ -1595,7 +1595,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             const VkExtent3D mip_extent = dst_image_state.GetEffectiveSubresourceExtent(region.dstSubresource);
             if ((SafeModulo(dst_copy_extent.width, block_size.width) != 0) &&
                 (dst_copy_extent.width + region.dstOffset.x != mip_extent.width)) {
-                const LogObjectList objlist(handle, dst_image_state.image());
+                const LogObjectList objlist(handle, dst_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01732", is_2, is_host), objlist, region_loc,
                                  "dst_copy_extent width (%" PRIu32
                                  ") must be a multiple of the blocked texture "
@@ -1607,7 +1607,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             // Extent height must be a multiple of block height, or dst_copy_extent+offset height must equal subresource height
             if ((SafeModulo(dst_copy_extent.height, block_size.height) != 0) &&
                 (dst_copy_extent.height + region.dstOffset.y != mip_extent.height)) {
-                const LogObjectList objlist(handle, dst_image_state.image());
+                const LogObjectList objlist(handle, dst_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01733", is_2, is_host), objlist, region_loc,
                                  "dst_copy_extent height (%" PRIu32
                                  ") must be a multiple of the compressed "
@@ -1620,7 +1620,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             // Extent depth must be a multiple of block depth, or dst_copy_extent+offset depth must equal subresource depth
             uint32_t copy_depth = (slice_override ? depth_slices : dst_copy_extent.depth);
             if ((SafeModulo(copy_depth, block_size.depth) != 0) && (copy_depth + region.dstOffset.z != mip_extent.depth)) {
-                const LogObjectList objlist(handle, dst_image_state.image());
+                const LogObjectList objlist(handle, dst_image_state.Handle());
                 skip |= LogError(GetImageCopyVUID("01734", is_2, is_host), objlist, region_loc,
                                  "dst_copy_extent width (%" PRIu32
                                  ") must be a multiple of the compressed texture "
@@ -1663,8 +1663,8 @@ bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image &src_i
 
     const VkFormat src_format = src_image_state.createInfo.format;
     const VkFormat dst_format = dst_image_state.createInfo.format;
-    auto src_image = src_image_state.image();
-    auto dst_image = dst_image_state.image();
+    const VkImage src_image = src_image_state.VkHandle();
+    const VkImage dst_image = dst_image_state.VkHandle();
     const bool src_is_3d = (VK_IMAGE_TYPE_3D == src_image_state.createInfo.imageType);
     const bool dst_is_3d = (VK_IMAGE_TYPE_3D == dst_image_state.createInfo.imageType);
 
@@ -2028,7 +2028,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         // Validation is only performed when source image is the same as destination image.
         // In the general case, the mapping between an image and its underlying memory is undefined,
         // so checking for memory overlaps is not possible.
-        if (src_image_state->image() == dst_image_state->image()) {
+        if (src_image_state->VkHandle() == dst_image_state->VkHandle()) {
             for (uint32_t j = 0; j < regionCount; j++) {
                 if (auto intersection =
                         GetRegionIntersection(region, pRegions[j], src_image_type, vkuFormatIsMultiplane(src_format));
@@ -2483,7 +2483,7 @@ bool CoreChecks::ValidateImageBufferCopyMemoryOverlap(const vvl::CommandBuffer &
             isr.aspectMask = region.imageSubresource.aspectMask;
             isr.mipLevel = region.imageSubresource.mipLevel;
             VkSubresourceLayout srl = {};
-            DispatchGetImageSubresourceLayout(device, image_state.image(), &isr, &srl);
+            DispatchGetImageSubresourceLayout(device, image_state.VkHandle(), &isr, &srl);
             if (image_state.createInfo.arrayLayers == 1) srl.arrayPitch = 0;
             if (image_state.createInfo.imageType != VK_IMAGE_TYPE_3D) srl.depthPitch = 0;
             image_offset = (region.imageSubresource.baseArrayLayer * srl.arrayPitch) +
@@ -2504,7 +2504,7 @@ bool CoreChecks::ValidateImageBufferCopyMemoryOverlap(const vvl::CommandBuffer &
         auto buffer_region = sparse_container::range<VkDeviceSize>{region.bufferOffset, region.bufferOffset + copy_size};
         if (image_state.DoesResourceMemoryOverlap(image_region, &buffer_state, buffer_region)) {
             const Location region_loc = loc.dot(Field::pRegions, i);
-            const LogObjectList objlist(cb_state.commandBuffer(), image_state.image());
+            const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
             skip |= LogError(GetBufferMemoryImageCopyCommandVUID("00173", image_to_buffer, is_2), objlist, region_loc,
                              "Detected overlap between source and dest regions in memory.");
         }
@@ -2845,7 +2845,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
         const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.createInfo.pNext);
         if (image_stencil_struct != nullptr) {
             if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
-                LogObjectList objlist(device, image_state.image());
+                LogObjectList objlist(device, image_state.Handle());
                 skip |= LogError(
                     vuid_09112, objlist, loc,
                     "An element of pRegions has an aspectMask that includes "
@@ -2855,7 +2855,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
             }
         } else {
             if ((image_state.createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
-                LogObjectList objlist(device, image_state.image());
+                LogObjectList objlist(device, image_state.Handle());
                 skip |= LogError(
                     vuid_09111, objlist, loc,
                     "An element of pRegions has an aspectMask that includes "
@@ -2867,7 +2867,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
     }
     if (has_non_stencil) {
         if ((image_state.createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
-            LogObjectList objlist(device, image_state.image());
+            LogObjectList objlist(device, image_state.Handle());
             skip |= LogError(
                 vuid_09113, objlist, loc,
                 "An element of pRegions has an aspectMask that includes "
@@ -2930,7 +2930,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
     if (image_state->sparse && (!image_state->HasFullRangeBound())) {
         const char *vuid =
             from_image ? "VUID-VkCopyImageToMemoryInfoEXT-srcImage-09109" : "VUID-VkCopyMemoryToImageInfoEXT-dstImage-09109";
-        LogObjectList objlist(device, image_state->image());
+        LogObjectList objlist(device, image_state->Handle());
         skip |= LogError(vuid, objlist, image_loc, "is a sparse image with no memory bound");
     }
 
@@ -2985,7 +2985,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
             if (!IsExtentEqual(region.imageExtent, subresource_extent)) {
                 const char *vuid = from_image ? "VUID-VkCopyImageToMemoryInfoEXT-srcImage-09115"
                                               : "VUID-VkCopyMemoryToImageInfoEXT-dstImage-09115";
-                LogObjectList objlist(device, image_state->image());
+                LogObjectList objlist(device, image_state->Handle());
                 skip |= LogError(vuid, objlist, loc,
                                  "pRegion[%" PRIu32 "].imageExtent (w=%" PRIu32 ", h=%" PRIu32 ", d=%" PRIu32
                                  ") must match the image's subresource "
@@ -2997,7 +2997,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
             if ((region.memoryRowLength != 0) || (region.memoryImageHeight != 0)) {
                 const char *vuid =
                     from_image ? "VUID-VkCopyImageToMemoryInfoEXT-flags-09394" : "VUID-VkCopyMemoryToImageInfoEXT-flags-09393";
-                LogObjectList objlist(device, image_state->image());
+                LogObjectList objlist(device, image_state->Handle());
                 skip |= LogError(vuid, objlist, loc,
                                  "pRegion[%" PRIu32 "].memoryRowLength (%" PRIu32 "), and pRegion[%" PRIu32
                                  "].memoryImageHeight (%" PRIu32
@@ -3043,7 +3043,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
                     (region.pHostPointer <= state->p_driver_data && copy_end > mapped_end)) {
                     const char *vuid =
                         from_image ? "VUID-VkImageToMemoryCopyEXT-pRegions-09067" : "VUID-VkMemoryToImageCopyEXT-pRegions-09062";
-                    LogObjectList objlist(device, image_state->image());
+                    LogObjectList objlist(device, image_state->Handle());
                     skip |= LogError(vuid, objlist, loc.dot(Field::pRegions, i).dot(Field::pHostPointer),
                                      "points to memory spanning %p through %p, which overlaps with image memory"
                                      "mapped %p through %p",
@@ -3113,7 +3113,7 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(VkDevice device, const vvl::Im
     if (mismatch_stream.str().length() > 0) {
         std::stringstream ss;
         ss << "The creation parameters for srcImage and dstImage differ:\n" << mismatch_stream.str();
-        LogObjectList objlist(device, src_image_state.image(), dst_image_state.image());
+        LogObjectList objlist(device, src_image_state.Handle(), dst_image_state.Handle());
         skip |= LogError("VUID-VkCopyImageToImageInfoEXT-srcImage-09069", objlist, loc, "%s.", ss.str().c_str());
     }
     return skip;
@@ -3183,7 +3183,7 @@ bool CoreChecks::ValidateMemcpyExtents(VkDevice device, const VkImageCopy2 regio
     if (!IsExtentEqual(region.extent, image_state.createInfo.extent)) {
         const char *vuid =
             is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-09115" : "VUID-VkCopyImageToImageInfoEXT-dstImage-09115";
-        const LogObjectList objlist(device, image_state.image());
+        const LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(Field::imageExtent),
                          "(w = %" PRIu32 ", h = %" PRIu32 ", d = %" PRIu32
                          ") must match the image's subresource "
@@ -3204,7 +3204,7 @@ bool CoreChecks::ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region
         const char *vuid =
             is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-07981" : "VUID-VkCopyImageToImageInfoEXT-dstImage-07981";
         Field field = is_src ? Field::srcSubresource : Field::dstSubresource;
-        LogObjectList objlist(device, image_state.image());
+        LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(field), "is %s but %s has 2-plane format (%s).",
                          string_VkImageAspectFlags(aspect_mask).c_str(), is_src ? "srcImage" : "dstImage",
                          string_VkFormat(image_state.createInfo.format));
@@ -3215,7 +3215,7 @@ bool CoreChecks::ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region
         const char *vuid =
             is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-07981" : "VUID-VkCopyImageToImageInfoEXT-dstImage-07981";
         Field field = is_src ? Field::srcSubresource : Field::dstSubresource;
-        LogObjectList objlist(device, image_state.image());
+        LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(field), "is %s but %s has 3-plane format (%s).",
                          string_VkImageAspectFlags(aspect_mask).c_str(), is_src ? "srcImage" : "dstImage",
                          string_VkFormat(image_state.createInfo.format));
@@ -3259,12 +3259,12 @@ bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCop
                                         "VUID-VkCopyImageToImageInfoEXT-dstImageLayout-09073");
 
     if (src_image_state->sparse && (!src_image_state->HasFullRangeBound())) {
-        LogObjectList objlist(device, src_image_state->image());
+        LogObjectList objlist(device, src_image_state->Handle());
         skip |= LogError("VUID-VkCopyImageToImageInfoEXT-srcImage-09109", objlist, loc.dot(Field::srcImage),
                          "is a sparse image with no memory bound");
     }
     if (dst_image_state->sparse && (!dst_image_state->HasFullRangeBound())) {
-        LogObjectList objlist(device, dst_image_state->image());
+        LogObjectList objlist(device, dst_image_state->Handle());
         skip |= LogError("VUID-VkCopyImageToImageInfoEXT-dstImage-09109", objlist, loc.dot(Field::dstImage),
                          "is a sparse image with no memory bound");
     }
@@ -3897,7 +3897,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00271" : "VUID-vkCmdResolveImage-srcImage-00271";
                 skip |= LogError(vuid, src_objlist, region_loc,
                                  "srcOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but srcImage (%s) is 1D.",
-                                 region.srcOffset.y, region.extent.height, FormatHandle(src_image_state->image()).c_str());
+                                 region.srcOffset.y, region.extent.height, FormatHandle(src_image_state->Handle()).c_str());
             }
         }
         if ((VK_IMAGE_TYPE_1D == src_image_type) || (VK_IMAGE_TYPE_2D == src_image_type)) {
@@ -3905,7 +3905,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00273" : "VUID-vkCmdResolveImage-srcImage-00273";
                 skip |= LogError(vuid, src_objlist, region_loc,
                                  "srcOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but srcImage (%s) is 2D.",
-                                 region.srcOffset.z, region.extent.depth, FormatHandle(src_image_state->image()).c_str());
+                                 region.srcOffset.z, region.extent.depth, FormatHandle(src_image_state->Handle()).c_str());
             }
         }
 
@@ -3914,7 +3914,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00276" : "VUID-vkCmdResolveImage-dstImage-00276";
                 skip |= LogError(vuid, dst_objlist, region_loc,
                                  "dstOffset.y is %" PRId32 ", extent.height is %" PRIu32 ", but dstImage (%s) is 1D.",
-                                 region.dstOffset.y, region.extent.height, FormatHandle(dst_image_state->image()).c_str());
+                                 region.dstOffset.y, region.extent.height, FormatHandle(dst_image_state->Handle()).c_str());
             }
         }
         if ((VK_IMAGE_TYPE_1D == dst_image_type) || (VK_IMAGE_TYPE_2D == dst_image_type)) {
@@ -3922,7 +3922,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00278" : "VUID-vkCmdResolveImage-dstImage-00278";
                 skip |= LogError(vuid, dst_objlist, region_loc,
                                  "dstOffset.z is %" PRId32 ", extent.depth is %" PRIu32 ", but dstImage (%s) is 2D.",
-                                 region.dstOffset.z, region.extent.depth, FormatHandle(dst_image_state->image()).c_str());
+                                 region.dstOffset.z, region.extent.depth, FormatHandle(dst_image_state->Handle()).c_str());
             }
         }
 

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1907,14 +1907,14 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                         auto sampler_state = Get<vvl::Sampler>(desc.GetSampler());
                         if (iv_state && sampler_state) {
                             if (iv_state->samplerConversion != sampler_state->samplerConversion) {
-                                const LogObjectList objlist(update.dstSet, desc.GetSampler(), iv_state->image_view());
+                                const LogObjectList objlist(update.dstSet, desc.GetSampler(), iv_state->Handle());
                                 skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-01948", objlist, write_loc,
                                                  "Attempted write update to combined image sampler and image view and sampler "
                                                  "YCbCr conversions are not identical.");
                             }
                         }
                     } else if (iv_state && (iv_state->samplerConversion != VK_NULL_HANDLE)) {
-                        const LogObjectList objlist(update.dstSet, iv_state->image_view());
+                        const LogObjectList objlist(update.dstSet, iv_state->Handle());
                         skip |= LogError("VUID-VkWriteDescriptorSet-descriptorType-02738", objlist, write_loc.dot(Field::dstSet),
                                          "is bound to image view that includes a YCbCr conversion, it must have been allocated "
                                          "with a layout that includes an immutable sampler.");
@@ -1925,7 +1925,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                     // multiplane formats must be created with mutable format bit
                     const VkFormat image_format = image_state->createInfo.format;
                     if (0 == (image_state->createInfo.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
-                        const LogObjectList objlist(update.dstSet, image_state->image());
+                        const LogObjectList objlist(update.dstSet, image_state->Handle());
                         skip |= LogError("VUID-VkDescriptorImageInfo-sampler-01564", objlist, write_loc,
                                          "combined image sampler is a multi-planar format %s and was created with %s.",
                                          string_VkFormat(image_format),
@@ -1933,7 +1933,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                     }
                     const VkImageAspectFlags image_aspect = iv_state->create_info.subresourceRange.aspectMask;
                     if (!IsValidPlaneAspect(image_format, image_aspect)) {
-                        const LogObjectList objlist(update.dstSet, image_state->image(), iv_state->image_view());
+                        const LogObjectList objlist(update.dstSet, image_state->Handle(), iv_state->Handle());
                         skip |= LogError("VUID-VkDescriptorImageInfo-sampler-01564", objlist, write_loc,
                                          "combined image sampler is a multi-planar format %s and imageView aspectMask is %s.",
                                          string_VkFormat(image_format), string_VkImageAspectFlags(image_aspect).c_str());

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2090,7 +2090,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 
         const auto set_layout = pipeline_layout->set_layouts[firstSet + i];
         if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) == 0) {
-            const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->layout());
+            const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->Handle());
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-09006"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-09006";
             skip |= LogError(vuid, objlist, loc,

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -198,7 +198,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
             std::string error_string = "";
             if (!VerifySetLayoutCompatibility(*descriptor_set, pipeline_layout->set_layouts,
                                               pipeline_layout->Handle(), set_idx + firstSet, error_string)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx]);
+                const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx]);
                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-00358"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-00358";
                 skip |= LogError(vuid, objlist, set_loc,
@@ -212,7 +212,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
 
             const auto &dsl = descriptor_set->GetLayout();
             if (dsl->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx], dsl->VkHandle());
+                const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx], dsl->VkHandle());
                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-08010"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-08010";
                 skip |= LogError(vuid, objlist, set_loc, "was allocated from VkDescriptorSetLayout with %s flags.",
@@ -224,7 +224,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                 // First make sure we won't overstep bounds of pDynamicOffsets array
                 if ((total_dynamic_descriptors + set_dynamic_descriptor_count) > dynamicOffsetCount) {
                     // Test/report this here, such that we don't run past the end of pDynamicOffsets in the else clause
-                    const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx]);
+                    const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx]);
                     const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-dynamicOffsetCount-00359"
                                             : "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359";
                     skip |=
@@ -272,7 +272,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                 (SafeModulo(offset, limits.minUniformBufferOffsetAlignment) != 0)) {
                                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDynamicOffsets-01971"
                                                         : "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01971";
-                                skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
+                                skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
                                                  ", but must be a multiple of "
                                                  "device limit minUniformBufferOffsetAlignment %" PRIu64 ".",
@@ -282,7 +282,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                 (SafeModulo(offset, limits.minStorageBufferOffsetAlignment) != 0)) {
                                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDynamicOffsets-01972"
                                                         : "VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972";
-                                skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
+                                skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pDynamicOffsets, cur_dyn_offset),
                                                  "is %" PRIu32
                                                  ", but must be a multiple of "
                                                  "device limit minStorageBufferOffsetAlignment %" PRIu64 ".",
@@ -301,7 +301,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
 
                                 // Validate offset didn't go over buffer
                                 if ((bound_range == VK_WHOLE_SIZE) && (offset > 0)) {
-                                    const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx],
+                                    const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx],
                                                                 buffer_descriptor->GetBuffer());
                                     const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-06715"
                                                             : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-06715";
@@ -316,7 +316,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
 
                                 } else if (buffer_state && (bound_range != VK_WHOLE_SIZE) &&
                                            ((offset + bound_range + bound_offset) > buffer_state->createInfo.size)) {
-                                    const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx],
+                                    const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx],
                                                                 buffer_descriptor->GetBuffer());
                                     const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-01979"
                                                             : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-01979";
@@ -338,15 +338,14 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                 }
             }
             if (descriptor_set->GetPoolState()->createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx],
-                                            descriptor_set->GetPoolState()->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx], descriptor_set->GetPoolState()->Handle());
                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-04616"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-04616";
                 skip |= LogError(vuid, objlist, set_loc,
                                  "was allocated from a pool that was created with VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT.");
             }
         } else if (!enabled_features.graphicsPipelineLibrary) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pDescriptorSets[set_idx]);
+            const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx]);
             const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-06563"
                                     : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-06563";
             skip |= LogError(vuid, objlist, set_loc,
@@ -359,7 +358,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
     if (total_dynamic_descriptors != dynamicOffsetCount) {
         const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-dynamicOffsetCount-00359"
                                 : "VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid, cb_state.Handle(), loc,
                          "Attempting to bind %" PRIu32 " descriptorSets with %" PRIu32
                          " dynamic descriptors, but "
                          "dynamicOffsetCount is %" PRIu32
@@ -370,7 +369,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
     // firstSet and descriptorSetCount sum must be less than setLayoutCount
     if ((firstSet + setCount) > static_cast<uint32_t>(pipeline_layout->set_layouts.size())) {
         const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-firstSet-00360" : "VUID-vkCmdBindDescriptorSets-firstSet-00360";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid, cb_state.Handle(), loc,
                          "Sum of firstSet (%" PRIu32 ") and descriptorSetCount (%" PRIu32
                          ") is greater than "
                          "VkPipelineLayoutCreateInfo::setLayoutCount "
@@ -2068,13 +2067,13 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
     if (!enabled_features.descriptorBuffer) {
         const char *vuid = is_2 ? "VUID-vkCmdSetDescriptorBufferOffsets2EXT-descriptorBuffer-09470"
                                 : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-None-08060";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc, "descriptorBuffer feature was not enabled.");
+        skip |= LogError(vuid, cb_state.Handle(), loc, "descriptorBuffer feature was not enabled.");
     }
 
     if ((firstSet + setCount) > pipeline_layout->set_layouts.size()) {
         const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-08066"
                                 : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-08066";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid, cb_state.Handle(), loc,
                          "The sum of firstSet (%" PRIu32 ") and setCount (%" PRIu32
                          ") is greater than VkPipelineLayoutCreateInfo::setLayoutCount (%" PRIuLEAST64 ") when layout was created.",
                          firstSet, setCount, (uint64_t)pipeline_layout->set_layouts.size());
@@ -2091,7 +2090,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 
         const auto set_layout = pipeline_layout->set_layouts[firstSet + i];
         if ((set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT) == 0) {
-            const LogObjectList objlist(cb_state.commandBuffer(), set_layout->Handle(), pipeline_layout->layout());
+            const LogObjectList objlist(cb_state.Handle(), set_layout->Handle(), pipeline_layout->layout());
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-firstSet-09006"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-09006";
             skip |= LogError(vuid, objlist, loc,
@@ -2161,7 +2160,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
             if (!valid_binding) {
                 const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08063"
                                         : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063";
-                skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pOffsets, i),
+                skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pOffsets, i),
                                  "%" PRIuLEAST64
                                  " must be small enough such that any descriptor binding"
                                  " referenced by layout without the VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT"
@@ -2173,7 +2172,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         if (!valid_buffer) {
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08065"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08065";
-            skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pBufferIndices, i),
+            skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pBufferIndices, i),
                              "(%" PRIu32
                              ") Each element of pBufferIndices must reference a valid descriptor buffer binding "
                              "set by a previous call to vkCmdBindDescriptorBuffersEXT in commandBuffer",
@@ -2183,7 +2182,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         if (pBufferIndices[i] >= phys_dev_ext_props.descriptor_buffer_props.maxDescriptorBufferBindings) {
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pBufferIndices-08064"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pBufferIndices-08064";
-            skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pBufferIndices, i),
+            skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pBufferIndices, i),
                              "(%" PRIu32
                              ") "
                              "is greater than maxDescriptorBufferBindings (%" PRIu32 ") ",
@@ -2193,7 +2192,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
         if (SafeModulo(pOffsets[i], phys_dev_ext_props.descriptor_buffer_props.descriptorBufferOffsetAlignment) != 0) {
             const char *vuid = is_2 ? "VUID-VkSetDescriptorBufferOffsetsInfoEXT-pOffsets-08061"
                                     : "VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08061";
-            skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::pOffsets, i),
+            skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::pOffsets, i),
                              "(%" PRIuLEAST64
                              ") is not aligned to descriptorBufferOffsetAlignment"
                              " (%" PRIuLEAST64 ")",
@@ -2264,7 +2263,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
     if (!enabled_features.descriptorBuffer) {
         const char *vuid = is_2 ? "VUID-vkCmdBindDescriptorBufferEmbeddedSamplers2EXT-descriptorBuffer-09472"
                                 : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-None-08068";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc, "descriptorBuffer feature was not enabled.");
+        skip |= LogError(vuid, cb_state.Handle(), loc, "descriptorBuffer feature was not enabled.");
     }
 
     auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
@@ -2275,7 +2274,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
     if (set >= pipeline_layout->set_layouts.size()) {
         const char *vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08071"
                                 : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-set-08071";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc.dot(Field::set),
+        skip |= LogError(vuid, cb_state.Handle(), loc.dot(Field::set),
                          "(%" PRIu32
                          ") is greater than "
                          "VkPipelineLayoutCreateInfo::setLayoutCount (%" PRIuLEAST64 ") when layout was created.",
@@ -2285,7 +2284,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
         if (!(set_layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT)) {
             const char *vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08070"
                                     : "VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-set-08070";
-            skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+            skip |= LogError(vuid, cb_state.Handle(), loc,
                              "layout must have been created with the "
                              "VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT flag set.");
         }
@@ -3461,7 +3460,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
     }
 
     // Validate the set index points to a push descriptor set and is in range
-    const LogObjectList objlist(cb_state.commandBuffer(), layout);
+    const LogObjectList objlist(cb_state.Handle(), layout);
     const auto &set_layouts = layout_data->set_layouts;
     if (set < set_layouts.size()) {
         const auto &dsl = set_layouts[set];

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -764,7 +764,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, const Bi
                                    const std::vector<uint32_t> &dynamic_offsets, const vvl::CommandBuffer &cb_state,
                                    const Location &loc, const vvl::DrawDispatchVuid &vuids) const {
     bool result = false;
-    VkFramebuffer framebuffer = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->framebuffer() : VK_NULL_HANDLE;
+    VkFramebuffer framebuffer = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->VkHandle() : VK_NULL_HANDLE;
     // NOTE: GPU-AV needs non-const state objects to do lazy updates of descriptor state of only the dynamically used
     // descriptors, via the non-const version of ValidateBinding(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -150,9 +150,9 @@ bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer &cb_sta
                                                 const char *vuid) const {
     bool skip = false;
     if ((deviceMask & cb_state.active_render_pass_device_mask) != deviceMask) {
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").",
-                         deviceMask, FormatHandle(cb_state.activeRenderPass->Handle()).c_str(),
-                         cb_state.active_render_pass_device_mask);
+        skip |=
+            LogError(vuid, cb_state.Handle(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").", deviceMask,
+                     FormatHandle(cb_state.activeRenderPass->Handle()).c_str(), cb_state.active_render_pass_device_mask);
     }
     return skip;
 }

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -151,7 +151,7 @@ bool CoreChecks::ValidateDeviceMaskToRenderPass(const vvl::CommandBuffer &cb_sta
     bool skip = false;
     if ((deviceMask & cb_state.active_render_pass_device_mask) != deviceMask) {
         skip |= LogError(vuid, cb_state.commandBuffer(), loc, "(0x%" PRIx32 ") is not a subset of %s device mask (0x%" PRIx32 ").",
-                         deviceMask, FormatHandle(cb_state.activeRenderPass->renderPass()).c_str(),
+                         deviceMask, FormatHandle(cb_state.activeRenderPass->Handle()).c_str(),
                          cb_state.active_render_pass_device_mask);
     }
     return skip;

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -155,10 +155,10 @@ bool CoreChecks::ValidateSetMemBinding(VkDeviceMemory memory, const vvl::Bindabl
             } else {
                 assert(false);  // Unsupported object type
             }
-            const LogObjectList objlist(memory, typed_handle, prev_binding->deviceMemory());
+            const LogObjectList objlist(memory, typed_handle, prev_binding->Handle());
             skip |= LogError(vuid, objlist, loc, "attempting to bind %s to %s which has already been bound to %s.",
                              FormatHandle(memory).c_str(), FormatHandle(typed_handle).c_str(),
-                             FormatHandle(prev_binding->deviceMemory()).c_str());
+                             FormatHandle(prev_binding->Handle()).c_str());
         }
     }
     return skip;
@@ -602,11 +602,11 @@ bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle
             assert(false);  // Unsupported object type
         }
 
-        LogObjectList objlist(mem_info->deviceMemory(), typed_handle);
+        LogObjectList objlist(mem_info->Handle(), typed_handle);
         skip |= LogError(vuid, objlist, loc,
                          "attempting to bind %s to %s, memoryOffset (%" PRIu64
                          ") must be less than the memory allocation size (%" PRIu64 ").",
-                         FormatHandle(mem_info->deviceMemory()).c_str(), FormatHandle(typed_handle).c_str(), memoryOffset,
+                         FormatHandle(mem_info->Handle()).c_str(), FormatHandle(typed_handle).c_str(), memoryOffset,
                          mem_info->alloc_info.allocationSize);
     }
 
@@ -627,9 +627,9 @@ bool CoreChecks::ValidateMemoryTypes(const vvl::DeviceMemory *mem_info, const ui
                                      const Location &resource_loc, const char *vuid) const {
     bool skip = false;
     if (((1 << mem_info->alloc_info.memoryTypeIndex) & memory_type_bits) == 0) {
-        skip |= LogError(vuid, mem_info->deviceMemory(), resource_loc,
+        skip |= LogError(vuid, mem_info->Handle(), resource_loc,
                          "require memoryTypeBits (0x%x) but %s was allocated with memoryTypeIndex (%" PRIu32 ").", memory_type_bits,
-                         FormatHandle(mem_info->deviceMemory()).c_str(), mem_info->alloc_info.memoryTypeIndex);
+                         FormatHandle(mem_info->Handle()).c_str(), mem_info->alloc_info.memoryTypeIndex);
     }
     return skip;
 }
@@ -1000,7 +1000,7 @@ bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory &mem_info, VkDeviceSi
     bool skip = false;
     const bool map2 = offset_loc.function != Func::vkMapMemory;
     const Location loc(offset_loc.function);
-    const VkDeviceMemory memory = mem_info.deviceMemory();
+    const VkDeviceMemory memory = mem_info.VkHandle();
 
     const uint32_t memoryTypeIndex = mem_info.alloc_info.memoryTypeIndex;
     const VkMemoryPropertyFlags propertyFlags = phys_dev_mem_props.memoryTypes[memoryTypeIndex].propertyFlags;

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -137,11 +137,11 @@ bool CoreChecks::ValidateMeshShaderStage(const vvl::CommandBuffer &cb_state, con
     for (const auto &query : cb_state.activeQueries) {
         const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
         if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
-            skip |= LogError(vuid.xfb_queries_07074, cb_state.commandBuffer(), loc, "Query with type %s is active.",
+            skip |= LogError(vuid.xfb_queries_07074, cb_state.Handle(), loc, "Query with type %s is active.",
                              string_VkQueryType(query_pool_state->createInfo.queryType));
         }
         if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
-            skip |= LogError(vuid.pg_queries_07075, cb_state.commandBuffer(), loc, "Query with type %s is active.",
+            skip |= LogError(vuid.pg_queries_07075, cb_state.Handle(), loc, "Query with type %s is active.",
                              string_VkQueryType(query_pool_state->createInfo.queryType));
         }
     }
@@ -828,28 +828,26 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
             if (pHitShaderBindingTable->deviceAddress == 0) {
                 const char *vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03697" : "VUID-vkCmdTraceRaysKHR-flags-03697";
-                skip |= LogError(vuid, cb_state.commandBuffer(), table_loc.dot(Field::deviceAddress), "is zero.");
+                skip |= LogError(vuid, cb_state.Handle(), table_loc.dot(Field::deviceAddress), "is zero.");
             }
             if ((pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0)) {
                 const char *vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03514" : "VUID-vkCmdTraceRaysKHR-flags-03514";
-                skip |= LogError(vuid, cb_state.commandBuffer(), table_loc,
-                                 "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
-                                 pHitShaderBindingTable->stride);
+                skip |= LogError(vuid, cb_state.Handle(), table_loc, "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.",
+                                 pHitShaderBindingTable->size, pHitShaderBindingTable->stride);
             }
         }
         if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_CLOSEST_HIT_SHADERS_BIT_KHR) {
             if (pHitShaderBindingTable->deviceAddress == 0) {
                 const char *vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03696" : "VUID-vkCmdTraceRaysKHR-flags-03696";
-                skip |= LogError(vuid, cb_state.commandBuffer(), table_loc.dot(Field::deviceAddress), "is zero.");
+                skip |= LogError(vuid, cb_state.Handle(), table_loc.dot(Field::deviceAddress), "is zero.");
             }
             if ((pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0)) {
                 const char *vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03513" : "VUID-vkCmdTraceRaysKHR-flags-03513";
-                skip |= LogError(vuid, cb_state.commandBuffer(), table_loc,
-                                 "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
-                                 pHitShaderBindingTable->stride);
+                skip |= LogError(vuid, cb_state.Handle(), table_loc, "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.",
+                                 pHitShaderBindingTable->size, pHitShaderBindingTable->stride);
             }
         }
         if (pipeline_state->create_flags & VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_ANY_HIT_SHADERS_BIT_KHR) {
@@ -858,9 +856,8 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
             if (pHitShaderBindingTable->size == 0 || pHitShaderBindingTable->stride == 0) {
                 const char *vuid =
                     is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-flags-03512" : "VUID-vkCmdTraceRaysKHR-flags-03512";
-                skip |= LogError(vuid, cb_state.commandBuffer(), table_loc,
-                                 "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.", pHitShaderBindingTable->size,
-                                 pHitShaderBindingTable->stride);
+                skip |= LogError(vuid, cb_state.Handle(), table_loc, "either size (%" PRIu64 ") and stride (%" PRIu64 ") is zero.",
+                                 pHitShaderBindingTable->size, pHitShaderBindingTable->stride);
             }
         }
 
@@ -868,7 +865,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
                                                             : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03687";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pHitShaderBindingTable-03688"
                                                           : "VUID-vkCmdTraceRaysKHR-pHitShaderBindingTable-03688";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state.commandBuffer(), table_loc, vuid_single_device_memory,
+        skip |= ValidateRaytracingShaderBindingTable(cb_state.VkHandle(), table_loc, vuid_single_device_memory,
                                                      vuid_binding_table_flag, *pHitShaderBindingTable);
     }
 
@@ -878,7 +875,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
                                                             : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03680";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pRayGenShaderBindingTable-03681"
                                                           : "VUID-vkCmdTraceRaysKHR-pRayGenShaderBindingTable-03681";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state.commandBuffer(), table_loc, vuid_single_device_memory,
+        skip |= ValidateRaytracingShaderBindingTable(cb_state.VkHandle(), table_loc, vuid_single_device_memory,
                                                      vuid_binding_table_flag, *pRaygenShaderBindingTable);
     }
 
@@ -888,7 +885,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
                                                             : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03683";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pMissShaderBindingTable-03684"
                                                           : "VUID-vkCmdTraceRaysKHR-pMissShaderBindingTable-03684";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state.commandBuffer(), table_loc, vuid_single_device_memory,
+        skip |= ValidateRaytracingShaderBindingTable(cb_state.VkHandle(), table_loc, vuid_single_device_memory,
                                                      vuid_binding_table_flag, *pMissShaderBindingTable);
     }
 
@@ -898,7 +895,7 @@ bool CoreChecks::ValidateCmdTraceRaysKHR(const Location &loc, const vvl::Command
                                                             : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03691";
         const char *vuid_binding_table_flag = is_indirect ? "VUID-vkCmdTraceRaysIndirectKHR-pCallableShaderBindingTable-03692"
                                                           : "VUID-vkCmdTraceRaysKHR-pCallableShaderBindingTable-03692";
-        skip |= ValidateRaytracingShaderBindingTable(cb_state.commandBuffer(), table_loc, vuid_single_device_memory,
+        skip |= ValidateRaytracingShaderBindingTable(cb_state.VkHandle(), table_loc, vuid_single_device_memory,
                                                      vuid_binding_table_flag, *pCallableShaderBindingTable);
     }
     return skip;
@@ -1650,7 +1647,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
 
             if (shader_state && !shader_state->active_slots.empty() &&
                 !are_bound_sets_compat(shader_state->max_active_slot, last_bound_state, *shader_state)) {
-                LogObjectList objlist(cb_state.commandBuffer(), shader_state->shader());
+                LogObjectList objlist(cb_state.Handle(), shader_state->shader());
                 skip |= LogError(vuid.compatible_pipeline_08600, objlist, loc,
                                  "The %s statically uses descriptor set (index #%" PRIu32
                                  ") which is not compatible with the currently bound descriptor set's layout",
@@ -1661,7 +1658,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                     uint32_t set_index = set_binding_pair.first;
                     const auto set_info = last_bound_state.per_set[set_index];
                     if (!set_info.bound_descriptor_set) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), shader_state->shader());
+                        const LogObjectList objlist(cb_state.Handle(), shader_state->shader());
                         skip |= LogError(vuid.compatible_pipeline_08600, objlist, loc,
                                          "%s uses set #%" PRIu32 " but that set is not bound.",
                                          FormatHandle(shader_state->shader()).c_str(), set_index);
@@ -1669,7 +1666,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                                                              shader_state->Handle(), set_index, error_string)) {
                         // Set is bound but not compatible w/ overlapping pipeline_layout from PSO
                         VkDescriptorSet set_handle = set_info.bound_descriptor_set->VkHandle();
-                        const LogObjectList objlist(cb_state.commandBuffer(), set_handle, shader_state->shader());
+                        const LogObjectList objlist(cb_state.Handle(), set_handle, shader_state->shader());
                         skip |= LogError(vuid.compatible_pipeline_08600, objlist, loc,
                                          "%s bound as set #%" PRIu32 " is not compatible with overlapping %s due to: %s",
                                          FormatHandle(set_handle).c_str(), set_index, FormatHandle(shader_state->shader()).c_str(),
@@ -1715,7 +1712,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
 
                 // Edge case where if the shader is using push constants statically and there never was a vkCmdPushConstants
                 if (!cb_state.push_constant_data_ranges && !enabled_features.maintenance4) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline_layout->layout(), pipeline->pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline_layout->layout(), pipeline->pipeline());
                     skip |= LogError(vuid.push_constants_set_08602, objlist, loc,
                                      "Shader in %s uses push-constant statically but vkCmdPushConstants was not called yet for "
                                      "pipeline layout %s.",
@@ -1732,7 +1729,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                 }
                 // Edge case where if the shader is using push constants statically and there never was a vkCmdPushConstants
                 if (!cb_state.push_constant_data_ranges && !enabled_features.maintenance4) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), stage->shader());
+                    const LogObjectList objlist(cb_state.Handle(), stage->shader());
                     skip |= LogError(vuid.push_constants_set_08602, objlist, loc,
                                      "Shader in %s uses push-constant statically but vkCmdPushConstants was not called yet.",
                                      string_VkShaderStageFlags(stage->create_info.stage).c_str());
@@ -1747,7 +1744,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
             for (const auto &query : cb_state.activeQueries) {
                 const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
                 if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), query.pool);
+                    const LogObjectList objlist(cb_state.Handle(), query.pool);
                     skip |= LogError(vuid.mesh_shader_queries_07073, objlist, loc,
                                      "Query (slot %" PRIu32 ") with type VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT is active.",
                                      query.slot);
@@ -1803,7 +1800,7 @@ bool CoreChecks::ValidateIndirectCmd(const vvl::CommandBuffer &cb_state, const v
     LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
     objlist.add(buffer_state.Handle());
 
-    skip |= ValidateMemoryIsBoundToBuffer(cb_state.commandBuffer(), buffer_state, loc.dot(Field::buffer),
+    skip |= ValidateMemoryIsBoundToBuffer(cb_state.VkHandle(), buffer_state, loc.dot(Field::buffer),
                                           vuid.indirect_contiguous_memory_02708);
     skip |= ValidateBufferUsageFlags(objlist, buffer_state, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, true,
                                      vuid.indirect_buffer_bit_02290, loc.dot(Field::buffer));
@@ -1821,7 +1818,7 @@ bool CoreChecks::ValidateIndirectCountCmd(const vvl::CommandBuffer &cb_state, co
     LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
     objlist.add(count_buffer_state.Handle());
 
-    skip |= ValidateMemoryIsBoundToBuffer(cb_state.commandBuffer(), count_buffer_state, loc.dot(Field::countBuffer),
+    skip |= ValidateMemoryIsBoundToBuffer(cb_state.VkHandle(), count_buffer_state, loc.dot(Field::countBuffer),
                                           vuid.indirect_count_contiguous_memory_02714);
     skip |= ValidateBufferUsageFlags(objlist, count_buffer_state, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, true,
                                      vuid.indirect_count_buffer_bit_02715, loc.dot(Field::countBuffer));

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -206,7 +206,7 @@ bool CoreChecks::ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer &cb_s
         VkDeviceSize end_offset = static_cast<VkDeviceSize>(index_size * (firstIndex + indexCount));
         if (end_offset > index_buffer_binding.size) {
             LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
-            objlist.add(index_buffer_binding.buffer_state->buffer());
+            objlist.add(index_buffer_binding.buffer_state->Handle());
             skip |= LogError(first_index_vuid, objlist, loc,
                              "index size (%" PRIu32 ") * (firstIndex (%" PRIu32 ") + indexCount (%" PRIu32
                              ")) "

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1148,7 +1148,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
 
                     const VkFormat image_view_format = depth_view_state->safe_create_info.format;
                     if ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) && !vkuFormatHasDepth(image_view_format)) {
-                        const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass(),
+                        const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle(),
                                                     depth_view_state->image_view());
                         skip |= LogError("VUID-vkCmdClearAttachments-aspectMask-07884", objlist, attachment_loc,
                                          "in pSubpasses[%" PRIu32
@@ -1157,7 +1157,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                     }
 
                     if ((aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) && !vkuFormatHasStencil(image_view_format)) {
-                        const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass(),
+                        const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle(),
                                                     stencil_view_state->image_view());
                         skip |= LogError("VUID-vkCmdClearAttachments-aspectMask-07885", objlist, attachment_loc,
                                          "in pSubpasses[%" PRIu32
@@ -1171,28 +1171,28 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         }
 
         if (aspect_mask & VK_IMAGE_ASPECT_METADATA_BIT) {
-            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
             skip |= LogError("VUID-VkClearAttachment-aspectMask-00020", objlist, attachment_loc.dot(Field::aspectMask), "is %s.",
                              string_VkImageAspectFlags(aspect_mask).c_str());
         } else if (aspect_mask & (VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT |
                                   VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT | VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
-            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
             skip |= LogError("VUID-VkClearAttachment-aspectMask-02246", objlist, attachment_loc.dot(Field::aspectMask), "is %s.",
                              string_VkImageAspectFlags(aspect_mask).c_str());
         } else if (aspect_mask & VK_IMAGE_ASPECT_COLOR_BIT) {
             if (clear_desc->colorAttachment == VK_ATTACHMENT_UNUSED) {
-                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
                 skip |= LogError("VUID-vkCmdClearAttachments-aspectMask-07271", objlist, attachment_loc.dot(Field::colorAttachment),
                                  "is VK_ATTACHMENT_UNUSED, but aspectMask is VK_IMAGE_ASPECT_COLOR_BIT.");
             } else if (clear_desc->colorAttachment > color_attachment_count) {
-                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
                 skip |= LogError("VUID-vkCmdClearAttachments-aspectMask-07271", objlist, attachment_loc.dot(Field::colorAttachment),
                                  "(%" PRIu32 ") is larger than colorAttachmentCount (%" PRIu32 ").", clear_desc->colorAttachment,
                                  color_attachment_count);
             }
 
             if ((aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) || (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT)) {
-                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
                 skip |= LogError("VUID-VkClearAttachment-aspectMask-00019", objlist, attachment_loc.dot(Field::aspectMask),
                                  "is %s.", string_VkImageAspectFlags(aspect_mask).c_str());
             }
@@ -1201,7 +1201,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
             skip |= ValidateClearDepthStencilValue(commandBuffer, clear_desc->clearValue.depthStencil,
                                                    attachment_loc.dot(Field::clearValue).dot(Field::depthStencil));
         } else if (external_format_resolve && IsAnyPlaneAspect(aspect_mask)) {
-            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
             skip |= LogError("VUID-vkCmdClearAttachments-aspectMask-09298", objlist, attachment_loc.dot(Field::aspectMask),
                              "is %s.", string_VkImageAspectFlags(aspect_mask).c_str());
         }
@@ -1233,7 +1233,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         if (view_mask > 0) {
             for (uint32_t i = 0; i < rectCount; ++i) {
                 if (pRects[i].baseArrayLayer != 0 || pRects[i].layerCount != 1) {
-                    const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->renderPass());
+                    const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->Handle());
                     skip |= LogError("VUID-vkCmdClearAttachments-baseArrayLayer-00018", objlist,
                                      error_obj.location.dot(Field::pRects, i).dot(Field::baseArrayLayer),
                                      "is %" PRIu32 " and layerCount is %" PRIu32 ", but the render pass instance uses multiview.",

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -808,7 +808,7 @@ bool CoreChecks::ValidateClearImageSubresourceRange(const vvl::CommandBuffer &cb
     bool skip = false;
 
     if (range.aspectMask != VK_IMAGE_ASPECT_COLOR_BIT) {
-        LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
+        LogObjectList objlist(cb_state.Handle(), image_state.Handle());
         skip |= LogError("VUID-vkCmdClearColorImage-aspectMask-02498", objlist, loc.dot(Field::aspectMask),
                          "is %s (must only include COLOR_BIT).", string_VkImageAspectFlags(range.aspectMask).c_str());
     }
@@ -939,21 +939,21 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
         // Image aspect must be depth or stencil or both
         VkImageAspectFlags valid_aspects = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
         if (((pRanges[i].aspectMask & valid_aspects) == 0) || ((pRanges[i].aspectMask & ~valid_aspects) != 0)) {
-            LogObjectList objlist(cb_state.commandBuffer(), image);
+            LogObjectList objlist(cb_state.Handle(), image);
             skip |=
                 LogError("VUID-vkCmdClearDepthStencilImage-aspectMask-02824", objlist, range_loc.dot(Field::aspectMask),
                          "is %s (can only be DEPTH_BIT or STENCIL_BIT).", string_VkImageAspectFlags(pRanges[i].aspectMask).c_str());
         }
         if ((pRanges[i].aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0) {
             if (vkuFormatHasDepth(image_format) == false) {
-                LogObjectList objlist(cb_state.commandBuffer(), image);
+                LogObjectList objlist(cb_state.Handle(), image);
                 skip |= LogError("VUID-vkCmdClearDepthStencilImage-image-02826", objlist, range_loc.dot(Field::aspectMask),
                                  "has a VK_IMAGE_ASPECT_DEPTH_BIT but %s "
                                  "doesn't have a depth component.",
                                  string_VkFormat(image_format));
             }
             if ((image_state.createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
-                LogObjectList objlist(cb_state.commandBuffer(), image);
+                LogObjectList objlist(cb_state.Handle(), image);
                 skip |= LogError(
                     "VUID-vkCmdClearDepthStencilImage-pRanges-02660", objlist, range_loc.dot(Field::aspectMask),
                     "includes VK_IMAGE_ASPECT_DEPTH_BIT, but the image was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT.");
@@ -961,7 +961,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
         }
         if ((pRanges[i].aspectMask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0) {
             if (vkuFormatHasStencil(image_format) == false) {
-                LogObjectList objlist(cb_state.commandBuffer(), image);
+                LogObjectList objlist(cb_state.Handle(), image);
                 skip |= LogError("VUID-vkCmdClearDepthStencilImage-image-02825", objlist, range_loc.dot(Field::aspectMask),
                                  "has a VK_IMAGE_ASPECT_STENCIL_BIT but "
                                  "%s doesn't have a stencil component.",
@@ -970,14 +970,14 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
 
             if (image_stencil_struct != nullptr) {
                 if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
-                    LogObjectList objlist(cb_state.commandBuffer(), image);
+                    LogObjectList objlist(cb_state.Handle(), image);
                     skip |= LogError("VUID-vkCmdClearDepthStencilImage-pRanges-02658", objlist, range_loc.dot(Field::aspectMask),
                                      "includes VK_IMAGE_ASPECT_STENCIL_BIT and "
                                      "image was created with VkImageStencilUsageCreateInfo::stencilUsage = %s.",
                                      string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
             } else if ((image_state.createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
-                LogObjectList objlist(cb_state.commandBuffer(), image);
+                LogObjectList objlist(cb_state.Handle(), image);
                 skip |= LogError("VUID-vkCmdClearDepthStencilImage-pRanges-02659", objlist, range_loc.dot(Field::aspectMask),
                                  "includes VK_IMAGE_ASPECT_STENCIL_BIT and "
                                  "image was not created with VkImageStencilUsageCreateInfo, but was created with "
@@ -987,13 +987,13 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     }
 
     if (!vkuFormatIsDepthOrStencil(image_format)) {
-        LogObjectList objlist(cb_state.commandBuffer(), image);
+        LogObjectList objlist(cb_state.Handle(), image);
         skip |=
             LogError("VUID-vkCmdClearDepthStencilImage-image-00014", objlist, image_loc,
                      "(%s) doesn't have a depth/stencil format (%s).", FormatHandle(image).c_str(), string_VkFormat(image_format));
     }
     if (VK_IMAGE_USAGE_TRANSFER_DST_BIT != (VK_IMAGE_USAGE_TRANSFER_DST_BIT & image_state.createInfo.usage)) {
-        LogObjectList objlist(cb_state.commandBuffer(), image);
+        LogObjectList objlist(cb_state.Handle(), image);
         skip |= LogError("VUID-vkCmdClearDepthStencilImage-pRanges-02659", objlist, image_loc,
                          "(%s) was not created with the "
                          "VK_IMAGE_USAGE_TRANSFER_DST_BIT set.",

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -475,14 +475,14 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
     bool skip = false;
     auto render_pass_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     const auto *render_pass_info = render_pass_state->createInfo.ptr();
-    auto render_pass = render_pass_state->renderPass();
+    const VkRenderPass render_pass = render_pass_state->VkHandle();
     auto const &framebuffer_info = framebuffer_state.createInfo;
     const VkImageView *attachments = framebuffer_info.pAttachments;
 
-    auto framebuffer = framebuffer_state.framebuffer();
+    const VkFramebuffer framebuffer = framebuffer_state.VkHandle();
 
     if (render_pass_info->attachmentCount != framebuffer_info.attachmentCount) {
-        const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.framebuffer());
+        const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.Handle());
         // VU bieng worked on at https://gitlab.khronos.org/vulkan/vulkan/-/issues/2267
         skip |= LogError("UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass", objlist, rp_begin_loc,
                          "You cannot start a render pass using a framebuffer with a different number of attachments (%" PRIu32
@@ -510,7 +510,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
         auto view_state = Get<vvl::ImageView>(image_view);
 
         if (!view_state) {
-            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.framebuffer(), image_view);
+            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.Handle(), image_view);
             skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-parameter", objlist, attachment_loc, "%s is invalid.",
                              FormatHandle(image_view).c_str());
             continue;
@@ -520,13 +520,13 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
         const auto *image_state = view_state->image_state.get();
 
         if (!image_state) {
-            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.framebuffer(), image_view, image);
+            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.Handle(), image_view, image);
             skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-parameter", objlist, attachment_loc,
                              "%s references invalid image (%s).", FormatHandle(image_view).c_str(), FormatHandle(image).c_str());
             continue;
         }
         if (image_state->IsSwapchainImage() && image_state->owned_by_swapchain && !image_state->bind_swapchain) {
-            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.framebuffer(), image_view, image);
+            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state.Handle(), image_view, image);
             skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-parameter", objlist, attachment_loc,
                              "%s references a swapchain image (%s) from a swapchain that has been destroyed.",
                              FormatHandle(image_view).c_str(), FormatHandle(image).c_str());
@@ -580,7 +580,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
 
             skip |= subresource_map->AnyInRange(
                 normalized_range, [this, &layout_check, i, cb = cb_state.commandBuffer(),
-                                   render_pass = pRenderPassBegin->renderPass, framebuffer = framebuffer_state.framebuffer(),
+                                   render_pass = pRenderPassBegin->renderPass, framebuffer = framebuffer_state.Handle(),
                                    image = view_state->image_state->image(), image_view = view_state->image_view(), attachment_loc,
                                    rp_begin_loc](const LayoutRange &range, const LayoutEntry &state) {
                     bool subres_skip = false;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -81,7 +81,7 @@ bool CoreChecks::VerifyImageLayoutRange(const vvl::CommandBuffer &cb_state, cons
             if (!layout_check.Check(state)) {
                 *error = true;
                 auto subres = subresource_map->Decode(range.begin);
-                const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
+                const LogObjectList objlist(cb_state.Handle(), image_state.Handle());
                 subres_skip |= LogError(mismatch_layout_vuid, objlist, loc,
                                         "Cannot use %s (layer=%" PRIu32 " mip=%" PRIu32
                                         ") with specific layout %s that doesn't match the "
@@ -241,7 +241,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
                     // We can report all the errors for the intersected range directly
                     for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {
                         const auto subresource = image_state->subresource_encoder.Decode(index);
-                        const LogObjectList objlist(cb_state.commandBuffer(), image_state->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), image_state->Handle());
                         skip |= LogError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout", objlist, loc,
                                          "command buffer %s expects %s (subresource: aspectMask 0x%x array layer %" PRIu32
                                          ", mip level %" PRIu32 ") to be in layout %s--instead, current layout is %s.",
@@ -579,9 +579,9 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
             LayoutUseCheckAndMessage layout_check(check_layout, test_aspect);
 
             skip |= subresource_map->AnyInRange(
-                normalized_range, [this, &layout_check, i, cb = cb_state.commandBuffer(),
-                                   render_pass = pRenderPassBegin->renderPass, framebuffer = framebuffer_state.Handle(),
-                                   image = view_state->image_state->Handle(), image_view = view_state->Handle(), attachment_loc,
+                normalized_range, [this, &layout_check, i, cb = cb_state.Handle(), render_pass = pRenderPassBegin->renderPass,
+                                   framebuffer = framebuffer_state.Handle(), image = view_state->image_state->Handle(),
+                                   image_view = view_state->Handle(), attachment_loc,
                                    rp_begin_loc](const LayoutRange &range, const LayoutEntry &state) {
                     bool subres_skip = false;
                     if (!layout_check.Check(state)) {
@@ -778,7 +778,7 @@ bool CoreChecks::VerifyClearImageLayout(const vvl::CommandBuffer &cb_state, cons
     bool skip = false;
     if (loc.function == Func::vkCmdClearDepthStencilImage) {
         if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL)) {
-            LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
+            LogObjectList objlist(cb_state.Handle(), image_state.Handle());
             skip |= LogError("VUID-vkCmdClearDepthStencilImage-imageLayout-00012", objlist, loc,
                              "Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL or GENERAL.",
                              string_VkImageLayout(dest_image_layout));
@@ -787,7 +787,7 @@ bool CoreChecks::VerifyClearImageLayout(const vvl::CommandBuffer &cb_state, cons
     } else if (loc.function == Func::vkCmdClearColorImage) {
         if ((dest_image_layout != VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL) && (dest_image_layout != VK_IMAGE_LAYOUT_GENERAL) &&
             (dest_image_layout != VK_IMAGE_LAYOUT_SHARED_PRESENT_KHR)) {
-            LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
+            LogObjectList objlist(cb_state.Handle(), image_state.Handle());
             skip |= LogError("VUID-vkCmdClearColorImage-imageLayout-01394", objlist, loc,
                              "Layout for cleared image is %s but can only be TRANSFER_DST_OPTIMAL, SHARED_PRESENT_KHR, or GENERAL.",
                              string_VkImageLayout(dest_image_layout));
@@ -808,7 +808,7 @@ bool CoreChecks::VerifyClearImageLayout(const vvl::CommandBuffer &cb_state, cons
                 const char *vuid = (loc.function == Func::vkCmdClearDepthStencilImage)
                                        ? "VUID-vkCmdClearDepthStencilImage-imageLayout-00011"
                                        : "VUID-vkCmdClearColorImage-imageLayout-00004";
-                LogObjectList objlist(cb_state.commandBuffer(), image);
+                LogObjectList objlist(cb_state.Handle(), image);
                 subres_skip |=
                     LogError(vuid, objlist, loc, "Cannot clear an image whose layout is %s and doesn't match the %s layout %s.",
                              string_VkImageLayout(layout_check.expected_layout), layout_check.message,
@@ -854,7 +854,7 @@ bool CoreChecks::UpdateCommandBufferImageLayoutMap(const vvl::CommandBuffer *cb_
                 if (!layout_check.Check(state)) {
                     const auto &vuid = GetImageBarrierVUID(image_loc, sync_vuid_maps::ImageError::kConflictingLayout);
                     auto subres = read_subresource_map->Decode(range.begin);
-                    const LogObjectList objlist(cb_state->commandBuffer(), img_barrier.image);
+                    const LogObjectList objlist(cb_state->Handle(), img_barrier.image);
                     subres_skip =
                         LogError(vuid, objlist, image_loc,
                                  "(%s) cannot transition the layout of aspect=%" PRIu32 ", level=%" PRIu32 ", layer=%" PRIu32

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -280,7 +280,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                         skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, error_obj.location,
                                          "Previous %s's provokingVertexMode is %s, but %s doesn't chain "
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
-                                         FormatHandle(last_bound.pipeline_state->pipeline()).c_str(),
+                                         FormatHandle(last_bound.pipeline_state->Handle()).c_str(),
                                          string_VkProvokingVertexModeEXT(last_bound_provoking_vertex_state_ci->provokingVertexMode),
                                          FormatHandle(pipeline).c_str());
                     } else if (!last_bound_provoking_vertex_state_ci && current_provoking_vertex_state_ci) {
@@ -290,7 +290,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
                                          FormatHandle(pipeline).c_str(),
                                          string_VkProvokingVertexModeEXT(current_provoking_vertex_state_ci->provokingVertexMode),
-                                         FormatHandle(last_bound.pipeline_state->pipeline()).c_str());
+                                         FormatHandle(last_bound.pipeline_state->Handle()).c_str());
                     } else if (last_bound_provoking_vertex_state_ci && current_provoking_vertex_state_ci &&
                                last_bound_provoking_vertex_state_ci->provokingVertexMode !=
                                    current_provoking_vertex_state_ci->provokingVertexMode) {
@@ -300,7 +300,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                      "%s's provokingVertexMode is %s, but previous %s's provokingVertexMode is %s.",
                                      FormatHandle(pipeline).c_str(),
                                      string_VkProvokingVertexModeEXT(current_provoking_vertex_state_ci->provokingVertexMode),
-                                     FormatHandle(last_bound.pipeline_state->pipeline()).c_str(),
+                                     FormatHandle(last_bound.pipeline_state->Handle()).c_str(),
                                      string_VkProvokingVertexModeEXT(last_bound_provoking_vertex_state_ci->provokingVertexMode));
                     }
                 }
@@ -371,7 +371,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             }
 
             if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS && cb_state->GetCurrentPipeline(pipelineBindPoint) &&
-                pipeline == cb_state->GetCurrentPipeline(pipelineBindPoint)->pipeline() && cb_state->dirtyStaticState &&
+                pipeline == cb_state->GetCurrentPipeline(pipelineBindPoint)->VkHandle() && cb_state->dirtyStaticState &&
                 IsBeforeCtsVersion(1, 3, 8)) {
                 const LogObjectList objlist(commandBuffer, pipeline);
                 // This catches a bug in some drivers with conformance version lower than 1.3.8

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -243,17 +243,17 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
 
     if (pipelineBindPoint != pipeline_state.pipeline_type) {
         if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS) {
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+            const LogObjectList objlist(cb_state->Handle(), pipeline);
             skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-00779", objlist, error_obj.location,
                              "Cannot bind a pipeline of type %s to the graphics pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
         } else if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_COMPUTE) {
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+            const LogObjectList objlist(cb_state->Handle(), pipeline);
             skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-00780", objlist, error_obj.location,
                              "Cannot bind a pipeline of type %s to the compute pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
         } else if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+            const LogObjectList objlist(cb_state->Handle(), pipeline);
             skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-02392", objlist, error_obj.location,
                              "Cannot bind a pipeline of type %s to the ray-tracing pipeline bind point",
                              string_VkPipelineBindPoint(pipeline_state.pipeline_type));
@@ -276,7 +276,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                             pipeline_state.RasterizationState()->pNext);
 
                     if (last_bound_provoking_vertex_state_ci && !current_provoking_vertex_state_ci) {
-                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                        const LogObjectList objlist(cb_state->Handle(), pipeline);
                         skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, error_obj.location,
                                          "Previous %s's provokingVertexMode is %s, but %s doesn't chain "
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
@@ -284,7 +284,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                          string_VkProvokingVertexModeEXT(last_bound_provoking_vertex_state_ci->provokingVertexMode),
                                          FormatHandle(pipeline).c_str());
                     } else if (!last_bound_provoking_vertex_state_ci && current_provoking_vertex_state_ci) {
-                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                        const LogObjectList objlist(cb_state->Handle(), pipeline);
                         skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, error_obj.location,
                                          "%s's provokingVertexMode is %s, but previous %s doesn't chain "
                                          "VkPipelineRasterizationProvokingVertexStateCreateInfoEXT.",
@@ -294,7 +294,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                     } else if (last_bound_provoking_vertex_state_ci && current_provoking_vertex_state_ci &&
                                last_bound_provoking_vertex_state_ci->provokingVertexMode !=
                                    current_provoking_vertex_state_ci->provokingVertexMode) {
-                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                        const LogObjectList objlist(cb_state->Handle(), pipeline);
                         skip |=
                             LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-04881", objlist, error_obj.location,
                                      "%s's provokingVertexMode is %s, but previous %s's provokingVertexMode is %s.",
@@ -327,7 +327,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                         }
                     }
                     if (!found) {
-                        const LogObjectList objlist(cb_state->commandBuffer(), pipeline, cb_state->activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state->Handle(), pipeline, cb_state->activeRenderPass->Handle());
                         skip |= LogError("VUID-vkCmdBindPipeline-variableSampleLocations-01525", objlist, error_obj.location,
                                          "the current render pass was not begun with any element of "
                                          "pPostSubpassSampleLocations subpassIndex "
@@ -386,30 +386,30 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
             }
         } else if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
             if (!cb_state->unprotected) {
-                const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                const LogObjectList objlist(cb_state->Handle(), pipeline);
                 skip |= LogError("VUID-vkCmdBindPipeline-pipelineBindPoint-06721", objlist, error_obj.location,
                                  "Binding pipeline to VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR in a protected command buffer.");
             }
         }
         if (pipeline_state.create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) {
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+            const LogObjectList objlist(cb_state->Handle(), pipeline);
             skip |= LogError("VUID-vkCmdBindPipeline-pipeline-03382", objlist, error_obj.location,
                              "Cannot bind a pipeline that was created with the VK_PIPELINE_CREATE_LIBRARY_BIT_KHR flag.");
         }
         if (cb_state->transform_feedback_active) {
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+            const LogObjectList objlist(cb_state->Handle(), pipeline);
             skip |= LogError("VUID-vkCmdBindPipeline-None-02323", objlist, error_obj.location, "transform feedback is active.");
         }
         if (enabled_features.pipelineProtectedAccess) {
             if (cb_state->unprotected) {
-                const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                const LogObjectList objlist(cb_state->Handle(), pipeline);
                 if (pipeline_state.create_flags & VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT) {
                     skip |= LogError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07409", objlist, error_obj.location,
                                      "Binding pipeline created with "
                                      "VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT in an unprotected command buffer.");
                 }
             } else {
-                const LogObjectList objlist(cb_state->commandBuffer(), pipeline);
+                const LogObjectList objlist(cb_state->Handle(), pipeline);
                 if (pipeline_state.create_flags & VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT) {
                     skip |= LogError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07408", objlist, error_obj.location,
                                      "Binding pipeline created with "
@@ -438,7 +438,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer *cb_state, V
 
         const auto &qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
         if (0 == (qfp.queueFlags & required_mask)) {
-            const LogObjectList objlist(cb_state->commandBuffer(), cb_state->createInfo.commandPool);
+            const LogObjectList objlist(cb_state->Handle(), cb_state->createInfo.commandPool);
             const char *vuid = kVUIDUndefined;
             switch (loc.function) {
                 case Func::vkCmdBindDescriptorSets:
@@ -484,8 +484,8 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer *cb_state, V
                     break;
             }
             skip |= LogError(vuid, objlist, loc, "%s was allocated from %s that does not support bindpoint %s.",
-                             FormatHandle(cb_state->commandBuffer()).c_str(),
-                             FormatHandle(cb_state->createInfo.commandPool).c_str(), string_VkPipelineBindPoint(bind_point));
+                             FormatHandle(cb_state->Handle()).c_str(), FormatHandle(cb_state->createInfo.commandPool).c_str(),
+                             string_VkPipelineBindPoint(bind_point));
         }
     }
     return skip;

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2634,7 +2634,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer *cb_
     bool dyn_viewport = pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) || pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT);
     bool dyn_scissor = pipeline.IsDynamic(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT) || pipeline.IsDynamic(VK_DYNAMIC_STATE_SCISSOR);
     if (!dyn_viewport || !dyn_scissor) {
-        const LogObjectList objlist(cb_state->commandBuffer(), pipeline.pipeline());
+        const LogObjectList objlist(cb_state->Handle(), pipeline.pipeline());
         skip |= LogError("VUID-vkCmdBindPipeline-commandBuffer-04808", objlist, loc,
                          "Graphics pipeline incompatible with viewport/scissor inheritance.");
     }
@@ -2650,7 +2650,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer *cb_
             } else {
                 msg << "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT";
             }
-            const LogObjectList objlist(cb_state->commandBuffer(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state->Handle(), pipeline.pipeline());
             skip |= LogError(
                 "VUID-vkCmdBindPipeline-commandBuffer-04809", objlist, loc.dot(Field::commandBuffer),
                 "is a secondary command buffer with VkCommandBufferInheritanceViewportScissorInfoNV::viewportScissor2D "
@@ -2703,7 +2703,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
         if (pipeline) {
             skip |= ValidatePipelineRenderpassDraw(last_bound_state, loc);
         } else if (last_bound_state.HasShaderObjects()) {
-            skip |= LogError(vuid.render_pass_began_08876, cb_state.commandBuffer(), loc,
+            skip |= LogError(vuid.render_pass_began_08876, cb_state.Handle(), loc,
                              "Shader objects must be used with dynamic rendering, but VkRenderPass %s is active.",
                              FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
         }
@@ -2729,7 +2729,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                 rasterizer_discard_enabled = cb_state.dynamic_state_value.rasterizer_discard_enable;
             }
             if (!primitives_generated_query_with_rasterizer_discard && rasterizer_discard_enabled) {
-                LogObjectList objlist(cb_state.commandBuffer());
+                LogObjectList objlist(cb_state.Handle());
                 if (pipeline) {
                     objlist.add(pipeline->pipeline());
                 }
@@ -2742,7 +2742,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                 const auto rasterization_state_stream_ci =
                     vku::FindStructInPNextChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(pipeline->RasterizationState()->pNext);
                 if (rasterization_state_stream_ci && rasterization_state_stream_ci->rasterizationStream != 0) {
-                    LogObjectList objlist(cb_state.commandBuffer());
+                    LogObjectList objlist(cb_state.Handle());
                     if (pipeline) {
                         objlist.add(pipeline->pipeline());
                     }
@@ -2778,13 +2778,13 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
         for (size_t i = 0; i < pipeline->vertex_input_state->binding_descriptions.size(); i++) {
             const auto vertex_binding = pipeline->vertex_input_state->binding_descriptions[i].binding;
             if (current_vtx_bfr_binding_info.size() < (vertex_binding + 1)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                 skip |= LogError(vuid.vertex_binding_04007, objlist, loc,
                                  "%s expects that this Command Buffer's vertex binding Index %u should be set via "
                                  "vkCmdBindVertexBuffers. This is because pVertexBindingDescriptions[%zu].binding value is %u.",
                                  FormatHandle(*pipeline).c_str(), vertex_binding, i, vertex_binding);
             } else if ((current_vtx_bfr_binding_info[vertex_binding].buffer_state == nullptr) && !enabled_features.nullDescriptor) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                 skip |= LogError(vuid.vertex_binding_null_04008, objlist, loc,
                                  "Vertex binding %d must not be VK_NULL_HANDLE %s expects that this Command Buffer's vertex "
                                  "binding Index %u should be set via "
@@ -2810,7 +2810,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                     const uint32_t attribute_binding_extent =
                         attribute_description.offset + vkuFormatElementSize(attribute_description.format);
                     if (vertex_buffer_stride != 0 && vertex_buffer_stride < attribute_binding_extent) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                         skip |= LogError("VUID-vkCmdBindVertexBuffers2-pStrides-06209", objlist, loc,
                                          "The pStrides[%" PRIu32 "] (%" PRIu32
                                          ") parameter in the last call to %s is not 0 "
@@ -2839,7 +2839,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         attribute_description.location, vertex_buffer_offset, vertex_buffer_stride, attribute_offset);
                 }
             } else {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                 skip |= LogError(vuid.vertex_binding_attribute_02721, objlist, loc,
                                  "pVertexAttributeDescriptions[%" PRIu32 "].binding (%" PRIu32 ") is an invalid value.",
                                  vertex_binding, i);
@@ -2872,7 +2872,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (imageview_state && color_blend_state && (attachment < color_blend_state->attachmentCount)) {
                             if ((imageview_state->format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR) == 0 &&
                                 color_blend_state->pAttachments[i].blendEnable != VK_FALSE) {
-                                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
+                                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
                                                             cb_state.activeRenderPass->Handle());
                                 skip |=
                                     LogError(vuid.blend_enable_04727, objlist, loc,
@@ -2896,8 +2896,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                       IsExtEnabled(device_extensions.vk_nv_framebuffer_mixed_samples) ||
                       enabled_features.multisampledRenderToSingleSampled) &&
                     ((subpass_num_samples & static_cast<unsigned>(rasterization_samples)) != subpass_num_samples)) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.msrtss_rasterization_samples_07284, objlist, loc,
                                      "In %s the sample count is %s while the current %s has %s and they need to be the same.",
                                      FormatHandle(*pipeline).c_str(), string_VkSampleCountFlagBits(rasterization_samples),
@@ -2921,7 +2920,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                     if (stippled_line_enable) {
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT &&
                             (!enabled_features.stippledRectangularLines)) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
                                                         cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_rectangular_lines_07495, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT (set %s) with "
@@ -2931,7 +2930,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT &&
                             (!enabled_features.stippledBresenhamLines)) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
                                                         cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_bresenham_lines_07496, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT (set %s) with "
@@ -2941,7 +2940,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT &&
                             (!enabled_features.stippledSmoothLines)) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
                                                         cb_state.activeRenderPass->Handle());
                             skip |=
                                 LogError(vuid.stippled_smooth_lines_07497, objlist, loc,
@@ -2952,7 +2951,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT &&
                             (!enabled_features.stippledRectangularLines || !phys_dev_props.limits.strictLines)) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
                                                         cb_state.activeRenderPass->Handle());
                             skip |= LogError(
                                 vuid.stippled_default_strict_07498, objlist, loc,
@@ -2980,7 +2979,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
             // Currently lack support to test each index.
             if (!pipeline->fragment_shader_state->fragment_entry_point->has_alpha_to_coverage_variable &&
                 !pipeline->DualSourceBlending()) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                 skip |= LogError(vuid.dynamic_alpha_to_coverage_component_08919, objlist, loc,
                                  "vkCmdSetAlphaToCoverageEnableEXT set alphaToCoverageEnable to true but the bound pipeline "
                                  "fragment shader doesn't declare a variable that covers Location 0, Component 3.");
@@ -2994,7 +2993,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
 bool CoreChecks::ValidateShaderObjectDrawtimeState(const LastBound &last_bound_state, const Location &loc) const {
     bool skip = false;
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const LogObjectList objlist(cb_state.commandBuffer());
+    const LogObjectList objlist(cb_state.Handle());
     const vvl::DrawDispatchVuid &vuid = vvl::GetDrawDispatchVuid(loc.function);
 
     if (!last_bound_state.IsValidShaderOrNullBound(ShaderObjectStage::VERTEX)) {
@@ -3206,7 +3205,7 @@ bool CoreChecks::ValidateShaderObjectGraphicsDrawtimeState(const LastBound &last
     bool skip = false;
 
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
-    const LogObjectList objlist(cb_state.commandBuffer());
+    const LogObjectList objlist(cb_state.Handle());
     const vvl::DrawDispatchVuid &vuid = vvl::GetDrawDispatchVuid(loc.function);
 
     bool validTaskShader = last_bound_state.GetShader(ShaderObjectStage::TASK);
@@ -3242,7 +3241,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
     }
     const auto subpass = pipeline.Subpass();
     if (subpass != cb_state.GetActiveSubpass()) {
-        const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(), cb_state.activeRenderPass->Handle());
+        const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline(), cb_state.activeRenderPass->Handle());
         skip |= LogError(vuid.subpass_index_02685, objlist, loc,
                          "Pipeline was built for subpass %" PRIu32 " but used in subpass %" PRIu32 ".", subpass,
                          cb_state.GetActiveSubpass());
@@ -3259,7 +3258,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                     const auto *image_state = imageview_state->image_state.get();
                     if (image_state != nullptr) {
                         if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
-                            const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(),
+                            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline(),
                                                         cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.sample_location_02689, objlist, loc,
                                              "sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
@@ -3274,7 +3273,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
         const auto ds_state = pipeline.DepthStencilState();
         if (ds_state) {
             if (IsImageLayoutDepthReadOnly(ds_attachment->layout) && last_bound_state.IsDepthWriteEnable()) {
-                const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.commandBuffer());
+                const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
                 skip |= LogError(vuid.depth_read_only_06886, objlist, loc,
                                  "depthWriteEnable is VK_TRUE, while the layout (%s) of "
                                  "the depth aspect of the depth/stencil attachment in the render pass is read only.",
@@ -3301,7 +3300,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                 }();
 
                 if (is_stencil_layout_read_only) {
-                    const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.commandBuffer());
+                    const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
                     skip |= LogError(vuid.stencil_read_only_06887, objlist, loc,
                                      "The layout (%s) of the stencil aspect of the depth/stencil attachment in the render pass "
                                      "is read only but not all stencil ops are VK_STENCIL_OP_KEEP.\n"
@@ -3329,7 +3328,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
     if (rp_state) {
         const auto rendering_view_mask = cb_state.activeRenderPass->GetDynamicRenderingViewMask();
         if (rp_state->VkHandle() != VK_NULL_HANDLE) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), rp_state->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), rp_state->Handle());
             skip |= LogError(vuid.dynamic_rendering_06198, objlist, loc,
                              "Currently bound pipeline %s must have been created with a "
                              "VkGraphicsPipelineCreateInfo::renderPass equal to VK_NULL_HANDLE",
@@ -3339,7 +3338,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         const auto pipeline_rendering_ci = rp_state->dynamic_rendering_pipeline_create_info;
 
         if (pipeline_rendering_ci.viewMask != rendering_view_mask) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.dynamic_rendering_view_mask_06178, objlist, loc,
                              "Currently bound pipeline %s viewMask ([%" PRIu32
                              ") must be equal to VkRenderingInfo::viewMask ([%" PRIu32 ")",
@@ -3350,7 +3349,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto color_attachment_count = pipeline_rendering_ci.colorAttachmentCount;
             const auto rendering_color_attachment_count = cb_state.activeRenderPass->GetDynamicRenderingColorAttachmentCount();
             if (color_attachment_count && (color_attachment_count != rendering_color_attachment_count)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_count_06179, objlist, loc,
                                  "Currently bound pipeline %s VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
                                  ") must be equal to VkRenderingInfo::colorAttachmentCount (%" PRIu32 ")",
@@ -3367,8 +3366,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                         (view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i])) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08911, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3383,8 +3381,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 if (rendering_info.pColorAttachments[i].imageView == VK_NULL_HANDLE) {
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED)) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_color_formats_08912, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3395,8 +3392,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i]) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_color_formats_08910, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3415,8 +3411,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat)) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08915, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s) "
@@ -3428,8 +3423,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             } else {
                 if (rendering_info.pDepthAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |=
                             LogError(vuid.dynamic_rendering_undefined_depth_format_08913, objlist, loc,
                                      "VkRenderingInfo::pDepthAttachment.imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3439,8 +3433,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 } else {
                     auto view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3452,7 +3445,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.depthAttachmentFormat !=
                 pipeline_rendering_ci.depthAttachmentFormat) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::depthAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3468,8 +3461,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat)) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08918, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s) "
@@ -3481,8 +3473,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             } else {
                 if (rendering_info.pStencilAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_stencil_format_08916, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment.imageView is VK_NULL_HANDLE, but "
                                          "corresponding format in "
@@ -3492,8 +3483,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 } else {
                     auto view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3505,7 +3495,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.stencilAttachmentFormat !=
                 pipeline_rendering_ci.stencilAttachmentFormat) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::stencilAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3520,7 +3510,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (rendering_fragment_shading_rate_attachment_info &&
                 (rendering_fragment_shading_rate_attachment_info->imageView != VK_NULL_HANDLE)) {
                 if (!(pipeline->create_flags & VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                     skip |= LogError(vuid.dynamic_rendering_fsr_06183, objlist, loc,
                                      "Currently bound graphics pipeline %s must have been created with "
                                      "VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
@@ -3533,7 +3523,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (rendering_fragment_shading_rate_density_map &&
                 (rendering_fragment_shading_rate_density_map->imageView != VK_NULL_HANDLE)) {
                 if (!(pipeline->create_flags & VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT)) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
                     skip |= LogError(vuid.dynamic_rendering_fdm_06184, objlist, loc,
                                      "Currently bound graphics pipeline %s must have been created with "
                                      "VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT",
@@ -3552,8 +3542,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     rendering_info.pColorAttachments[i].imageView != VK_NULL_HANDLE) {
                     if (i >= pipeline_rendering_ci.colorAttachmentCount ||
                         pipeline_rendering_ci.pColorAttachmentFormats[i] == VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->Handle(),
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle(),
                                                     rendering_info.pColorAttachments[i].imageView);
                         skip |= LogError(vuid.color_attachment_08963, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
@@ -3569,7 +3558,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsDepthTestEnable() && last_bound_state.IsDepthWriteEnable() && rp_state->use_dynamic_rendering &&
             rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.depthAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.depth_attachment_08964, objlist, loc,
                                  "VkRenderingInfo::pDepthAttachment is %s, but currently bound graphics pipeline %s was created "
                                  "with VkPipelineRenderingCreateInfo::depthAttachmentFormat equal to VK_FORMAT_UNDEFINED",
@@ -3579,7 +3568,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsStencilTestEnable() && rp_state->use_dynamic_rendering && rendering_info.pStencilAttachment &&
             rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.stencilAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |=
                     LogError(vuid.stencil_attachment_08965, objlist, loc,
                              "VkRenderingInfo::pStencilAttachment is %s, but currently bound graphics pipeline %s was created with "
@@ -3590,7 +3579,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         const uint64_t pipeline_external_format = GetExternalFormat(pipeline->GetCreateInfo<VkGraphicsPipelineCreateInfo>().pNext);
         if (pipeline_external_format != 0) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
             if (rendering_info.colorAttachmentCount == 1 &&
                 rendering_info.pColorAttachments[0].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID) {
                 auto resolve_image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[0].resolveImageView);
@@ -3670,7 +3659,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info &&
                 (color_image_samples != p_attachment_sample_count_info->pColorAttachmentSamples[i])) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_sample_06185, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkAttachmentSampleCountInfoAMD "
@@ -3686,8 +3675,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info) {
                 if (depth_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_depth_sample_06186, objlist, loc,
                                      "Depth attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD sample "
@@ -3704,8 +3692,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info) {
                 if (stencil_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_stencil_sample_06187, objlist, loc,
                                      "Stencil attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD "
@@ -3726,7 +3713,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             auto samples = Get<vvl::Image>(view_state->create_info.image)->createInfo.samples;
 
             if (samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07285, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkPipelineMultisampleStateCreateInfo "
@@ -3739,7 +3726,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->createInfo.samples;
             if (depth_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07286, objlist, loc,
                                  "Depth attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",
@@ -3752,7 +3739,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->createInfo.samples;
             if (stencil_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07287, objlist, loc,
                                  "Stencil attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -2826,7 +2826,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                 const VkDeviceSize vtx_attrib_req_alignment = pipeline->vertex_input_state->vertex_attribute_alignments[i];
 
                 if (SafeModulo(attrib_address, vtx_attrib_req_alignment) != 0) {
-                    const LogObjectList objlist(current_vtx_bfr_binding_info[vertex_binding].buffer_state->buffer(),
+                    const LogObjectList objlist(current_vtx_bfr_binding_info[vertex_binding].buffer_state->Handle(),
                                                 pipeline->pipeline());
                     skip |= LogError(
                         vuid.vertex_binding_attribute_02721, objlist, loc,

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -61,7 +61,7 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const L
         subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
         if (subpass >= rp_state->createInfo.subpassCount) {
             skip |=
-                LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06046", rp_state->renderPass(),
+                LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06046", rp_state->Handle(),
                          create_info_loc.dot(Field::subpass), "(%" PRIu32 ") is out of range for this renderpass (0..%" PRIu32 ").",
                          subpass, rp_state->createInfo.subpassCount - 1);
             subpass_desc = nullptr;
@@ -1266,7 +1266,7 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pi
     }
     const auto &rp_state = pipeline.RenderPassState();
     if (((color_blend_state->flags & VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM) != 0) &&
-        (!rp_state || rp_state->renderPass() == VK_NULL_HANDLE)) {
+        (!rp_state || rp_state->VkHandle() == VK_NULL_HANDLE)) {
         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-flags-06482", device, color_loc.dot(Field::flags),
                          "includes "
                          "VK_PIPELINE_COLOR_BLEND_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_ACCESS_BIT_ARM, but "
@@ -1288,7 +1288,7 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline &pi
     if (subpass_desc && color_blend_state->attachmentCount != subpass_desc->colorAttachmentCount) {
         skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-07609", device, color_loc.dot(Field::attachmentCount),
                          "(%" PRIu32 ") is different than %s pSubpasses[%" PRIu32 "].colorAttachmentCount (%" PRIu32 ").",
-                         color_blend_state->attachmentCount, FormatHandle(rp_state->renderPass()).c_str(), pipeline.Subpass(),
+                         color_blend_state->attachmentCount, FormatHandle(rp_state->Handle()).c_str(), pipeline.Subpass(),
                          subpass_desc->colorAttachmentCount);
     }
     const auto &pipe_attachments = pipeline.Attachments();
@@ -1808,7 +1808,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
             const auto msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(subpass_desc->pNext);
             if (msrtss_info && msrtss_info->multisampledRenderToSingleSampledEnable &&
                 (msrtss_info->rasterizationSamples != multisample_state->rasterizationSamples)) {
-                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06854", rp_state->renderPass(),
+                skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06854", rp_state->Handle(),
                                  create_info_loc.dot(Field::pSubpasses, pipeline.Subpass())
                                      .pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples),
                                  "(%" PRIu32 ") is not equal to %s (%" PRIu32
@@ -1964,7 +1964,7 @@ bool CoreChecks::ValidateGraphicsPipelineDepthStencilState(const vvl::Pipeline &
     const Location ds_loc = create_info_loc.dot(Field::pDepthStencilState);
     const auto ds_state = pipeline.DepthStencilState();
     const auto &rp_state = pipeline.RenderPassState();
-    const bool null_rp = (!rp_state || rp_state->renderPass() == VK_NULL_HANDLE);
+    const bool null_rp = (!rp_state || rp_state->VkHandle() == VK_NULL_HANDLE);
     if (null_rp) {
         if (ds_state) {
             if ((ds_state->flags &
@@ -2705,7 +2705,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
         } else if (last_bound_state.HasShaderObjects()) {
             skip |= LogError(vuid.render_pass_began_08876, cb_state.commandBuffer(), loc,
                              "Shader objects must be used with dynamic rendering, but VkRenderPass %s is active.",
-                             FormatHandle(cb_state.activeRenderPass->renderPass()).c_str());
+                             FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
         }
     }
 
@@ -2873,7 +2873,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                             if ((imageview_state->format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR) == 0 &&
                                 color_blend_state->pAttachments[i].blendEnable != VK_FALSE) {
                                 const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                            cb_state.activeRenderPass->renderPass());
+                                                            cb_state.activeRenderPass->Handle());
                                 skip |=
                                     LogError(vuid.blend_enable_04727, objlist, loc,
                                              "Image view's format features of the color attachment (%" PRIu32
@@ -2897,7 +2897,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                       enabled_features.multisampledRenderToSingleSampled) &&
                     ((subpass_num_samples & static_cast<unsigned>(rasterization_samples)) != subpass_num_samples)) {
                     const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->renderPass());
+                                                cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.msrtss_rasterization_samples_07284, objlist, loc,
                                      "In %s the sample count is %s while the current %s has %s and they need to be the same.",
                                      FormatHandle(*pipeline).c_str(), string_VkSampleCountFlagBits(rasterization_samples),
@@ -2922,7 +2922,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT &&
                             (!enabled_features.stippledRectangularLines)) {
                             const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->renderPass());
+                                                        cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_rectangular_lines_07495, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT (set %s) with "
                                              "stippledLineEnable (set %s) but the stippledRectangularLines feature is not enabled.",
@@ -2932,7 +2932,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT &&
                             (!enabled_features.stippledBresenhamLines)) {
                             const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->renderPass());
+                                                        cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_bresenham_lines_07496, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT (set %s) with "
                                              "stippledLineEnable (set %s) but the stippledBresenhamLines feature is not enabled.",
@@ -2942,7 +2942,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT &&
                             (!enabled_features.stippledSmoothLines)) {
                             const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->renderPass());
+                                                        cb_state.activeRenderPass->Handle());
                             skip |=
                                 LogError(vuid.stippled_smooth_lines_07497, objlist, loc,
                                          "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT (set %s) with "
@@ -2953,7 +2953,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT &&
                             (!enabled_features.stippledRectangularLines || !phys_dev_props.limits.strictLines)) {
                             const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->renderPass());
+                                                        cb_state.activeRenderPass->Handle());
                             skip |= LogError(
                                 vuid.stippled_default_strict_07498, objlist, loc,
                                 "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT (set %s) with "
@@ -3235,14 +3235,14 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
 
     const auto &rp_state = pipeline.RenderPassState();
     // TODO: AMD extension codes are included here, but actual function entrypoints are not yet intercepted
-    if (cb_state.activeRenderPass->renderPass() != rp_state->renderPass()) {
+    if (cb_state.activeRenderPass->VkHandle() != rp_state->VkHandle()) {
         // renderPass that PSO was created with must be compatible with active renderPass that PSO is being used with
         skip |= ValidateRenderPassCompatibility("active render pass", *cb_state.activeRenderPass.get(), "pipeline state object",
                                                 *rp_state.get(), loc, vuid.render_pass_compatible_02684);
     }
     const auto subpass = pipeline.Subpass();
     if (subpass != cb_state.GetActiveSubpass()) {
-        const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(), cb_state.activeRenderPass->renderPass());
+        const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(), cb_state.activeRenderPass->Handle());
         skip |= LogError(vuid.subpass_index_02685, objlist, loc,
                          "Pipeline was built for subpass %" PRIu32 " but used in subpass %" PRIu32 ".", subpass,
                          cb_state.GetActiveSubpass());
@@ -3260,7 +3260,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                     if (image_state != nullptr) {
                         if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
                             const LogObjectList objlist(cb_state.commandBuffer(), pipeline.pipeline(),
-                                                        cb_state.activeRenderPass->renderPass());
+                                                        cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.sample_location_02689, objlist, loc,
                                              "sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
                                              "stencil attachment's VkImage was not created with "
@@ -3274,7 +3274,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
         const auto ds_state = pipeline.DepthStencilState();
         if (ds_state) {
             if (IsImageLayoutDepthReadOnly(ds_attachment->layout) && last_bound_state.IsDepthWriteEnable()) {
-                const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->renderPass(), cb_state.commandBuffer());
+                const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.commandBuffer());
                 skip |= LogError(vuid.depth_read_only_06886, objlist, loc,
                                  "depthWriteEnable is VK_TRUE, while the layout (%s) of "
                                  "the depth aspect of the depth/stencil attachment in the render pass is read only.",
@@ -3301,8 +3301,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                 }();
 
                 if (is_stencil_layout_read_only) {
-                    const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->renderPass(),
-                                                cb_state.commandBuffer());
+                    const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.commandBuffer());
                     skip |= LogError(vuid.stencil_read_only_06887, objlist, loc,
                                      "The layout (%s) of the stencil aspect of the depth/stencil attachment in the render pass "
                                      "is read only but not all stencil ops are VK_STENCIL_OP_KEEP.\n"
@@ -3329,8 +3328,8 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
     const auto &rp_state = pipeline->RenderPassState();
     if (rp_state) {
         const auto rendering_view_mask = cb_state.activeRenderPass->GetDynamicRenderingViewMask();
-        if (rp_state->renderPass() != VK_NULL_HANDLE) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), rp_state->renderPass());
+        if (rp_state->VkHandle() != VK_NULL_HANDLE) {
+            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), rp_state->Handle());
             skip |= LogError(vuid.dynamic_rendering_06198, objlist, loc,
                              "Currently bound pipeline %s must have been created with a "
                              "VkGraphicsPipelineCreateInfo::renderPass equal to VK_NULL_HANDLE",
@@ -3340,7 +3339,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         const auto pipeline_rendering_ci = rp_state->dynamic_rendering_pipeline_create_info;
 
         if (pipeline_rendering_ci.viewMask != rendering_view_mask) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.dynamic_rendering_view_mask_06178, objlist, loc,
                              "Currently bound pipeline %s viewMask ([%" PRIu32
                              ") must be equal to VkRenderingInfo::viewMask ([%" PRIu32 ")",
@@ -3351,8 +3350,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto color_attachment_count = pipeline_rendering_ci.colorAttachmentCount;
             const auto rendering_color_attachment_count = cb_state.activeRenderPass->GetDynamicRenderingColorAttachmentCount();
             if (color_attachment_count && (color_attachment_count != rendering_color_attachment_count)) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_count_06179, objlist, loc,
                                  "Currently bound pipeline %s VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
                                  ") must be equal to VkRenderingInfo::colorAttachmentCount (%" PRIu32 ")",
@@ -3370,7 +3368,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i])) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08911, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3386,7 +3384,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED)) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_color_formats_08912, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3398,7 +3396,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i]) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_color_formats_08910, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3418,7 +3416,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                         (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat)) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08915, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s) "
@@ -3431,7 +3429,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 if (rendering_info.pDepthAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |=
                             LogError(vuid.dynamic_rendering_undefined_depth_format_08913, objlist, loc,
                                      "VkRenderingInfo::pDepthAttachment.imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3442,7 +3440,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     auto view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3454,8 +3452,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.depthAttachmentFormat !=
                 pipeline_rendering_ci.depthAttachmentFormat) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::depthAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3472,7 +3469,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                         (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat)) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08918, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s) "
@@ -3485,7 +3482,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 if (rendering_info.pStencilAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_stencil_format_08916, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment.imageView is VK_NULL_HANDLE, but "
                                          "corresponding format in "
@@ -3496,7 +3493,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     auto view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass());
+                                                    cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3508,8 +3505,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.stencilAttachmentFormat !=
                 pipeline_rendering_ci.stencilAttachmentFormat) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::stencilAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3557,7 +3553,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if (i >= pipeline_rendering_ci.colorAttachmentCount ||
                         pipeline_rendering_ci.pColorAttachmentFormats[i] == VK_FORMAT_UNDEFINED) {
                         const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                    cb_state.activeRenderPass->renderPass(),
+                                                    cb_state.activeRenderPass->Handle(),
                                                     rendering_info.pColorAttachments[i].imageView);
                         skip |= LogError(vuid.color_attachment_08963, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
@@ -3573,8 +3569,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsDepthTestEnable() && last_bound_state.IsDepthWriteEnable() && rp_state->use_dynamic_rendering &&
             rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.depthAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.depth_attachment_08964, objlist, loc,
                                  "VkRenderingInfo::pDepthAttachment is %s, but currently bound graphics pipeline %s was created "
                                  "with VkPipelineRenderingCreateInfo::depthAttachmentFormat equal to VK_FORMAT_UNDEFINED",
@@ -3584,8 +3579,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsStencilTestEnable() && rp_state->use_dynamic_rendering && rendering_info.pStencilAttachment &&
             rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.stencilAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |=
                     LogError(vuid.stencil_attachment_08965, objlist, loc,
                              "VkRenderingInfo::pStencilAttachment is %s, but currently bound graphics pipeline %s was created with "
@@ -3596,7 +3590,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         const uint64_t pipeline_external_format = GetExternalFormat(pipeline->GetCreateInfo<VkGraphicsPipelineCreateInfo>().pNext);
         if (pipeline_external_format != 0) {
-            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->renderPass());
+            const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
             if (rendering_info.colorAttachmentCount == 1 &&
                 rendering_info.pColorAttachments[0].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID) {
                 auto resolve_image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[0].resolveImageView);
@@ -3676,8 +3670,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info &&
                 (color_image_samples != p_attachment_sample_count_info->pColorAttachmentSamples[i])) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_sample_06185, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkAttachmentSampleCountInfoAMD "
@@ -3694,7 +3687,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (p_attachment_sample_count_info) {
                 if (depth_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
                     const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->renderPass());
+                                                cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_depth_sample_06186, objlist, loc,
                                      "Depth attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD sample "
@@ -3712,7 +3705,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (p_attachment_sample_count_info) {
                 if (stencil_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
                     const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                                cb_state.activeRenderPass->renderPass());
+                                                cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_stencil_sample_06187, objlist, loc,
                                      "Stencil attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD "
@@ -3733,8 +3726,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             auto samples = Get<vvl::Image>(view_state->create_info.image)->createInfo.samples;
 
             if (samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07285, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkPipelineMultisampleStateCreateInfo "
@@ -3747,8 +3739,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->createInfo.samples;
             if (depth_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07286, objlist, loc,
                                  "Depth attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",
@@ -3761,8 +3752,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->createInfo.samples;
             if (stencil_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(),
-                                            cb_state.activeRenderPass->renderPass());
+                const LogObjectList objlist(cb_state.commandBuffer(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07287, objlist, loc,
                                  "Stencil attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -631,7 +631,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         if (pre_raster_independant_set ^ fs_independant_set) {
             const char *vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06615" : "VUID-VkGraphicsPipelineCreateInfo-flags-06614";
-            LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+            LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
             skip |= LogError(
                 vuid, objlist, create_info_loc,
                 "is attempting to create a graphics pipeline library with pre-raster and fragment shader state. However "
@@ -647,7 +647,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             if (pre_raster_info.layout->create_flags != frag_shader_info.layout->create_flags) {
                 const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                              : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
-                LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                 skip |= LogError(vuid, objlist, create_info_loc,
                                  "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline library "
                                  "have different VkPipelineLayouts, "
@@ -665,7 +665,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
             if (pre_raster_count != frag_shader_count) {
                 const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                              : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
-                LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                 skip |= LogError(vuid, objlist, create_info_loc,
                                  "the graphics pipeline library have different push constants, pre-raster layout has "
                                  "pushConstantRangeCount of %" PRIu32
@@ -679,7 +679,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                         pre_raster_range.offset != frag_shader_range.offset || pre_raster_range.size != frag_shader_range.size) {
                         const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
                                                      : "VUID-VkGraphicsPipelineCreateInfo-flags-06620";
-                        LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                        LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                         skip |= LogError(vuid, objlist, create_info_loc,
                                          "the graphics pipeline library have different push constants, pre-raster layout has "
                                          "pPushConstantRanges[%" PRIu32 "] of {%s, %" PRIu32 ", %" PRIu32
@@ -701,7 +701,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         if (not_independent_sets && pre_raster_count != frag_shader_count) {
             const char *vuid =
                 only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613" : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
-            LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+            LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
             skip |= LogError(vuid, objlist, create_info_loc,
                              "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline library "
                              "have different pipeline layouts, pre-raster layout has "
@@ -755,7 +755,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                             << " is non-null with bindings (" << string_VkShaderStageFlags(fs_binding.stageFlags)
                             << ") that overlap with pre-raster state.";
                     }
-                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                     skip |= LogError(vuid, objlist, create_info_loc, "%s", msg.str().c_str());
                     break;
                 }
@@ -803,7 +803,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                             << ") that overlap with fragment shader "
                                "state.";
                     }
-                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                     skip |= LogError(vuid, objlist, create_info_loc, "%s", msg.str().c_str());
                     break;
                 }
@@ -836,7 +836,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                         << "However, the descriptor set layout at the same index (" << i << ") in " << pre_raster_layout_handle_str
                         << " in the pre-raster state is NULL too.";
                 }
-                LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                 skip |= LogError(vuid, objlist, create_info_loc, "%s", msg.str().c_str());
                 break;
             } else if (not_independent_sets) {
@@ -845,7 +845,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 if (pre_raster_dsl->GetCreateFlags() != fs_dsl->GetCreateFlags()) {
                     const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
-                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                     skip |= LogError(vuid, objlist, create_info_loc,
                                      "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline "
                                      "library have different pipeline layouts, pre-raster layout has "
@@ -857,7 +857,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 } else if (pre_raster_dsl->GetBindingCount() != fs_dsl->GetBindingCount()) {
                     const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                  : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
-                    LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                    LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                     skip |= LogError(vuid, objlist, create_info_loc,
                                      "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline "
                                      "library have different pipeline layouts, pre-raster layout has "
@@ -875,7 +875,7 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                         if (memcmp(pre_raster_binding.ptr(), fs_binding.ptr(), sizeof(VkDescriptorSetLayoutBinding)) != 0) {
                             const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06613"
                                                          : "VUID-VkGraphicsPipelineCreateInfo-flags-06612";
-                            LogObjectList objlist(pre_raster_info.layout->layout(), frag_shader_info.layout->layout());
+                            LogObjectList objlist(pre_raster_info.layout->Handle(), frag_shader_info.layout->Handle());
                             skip |= LogError(
                                 vuid, objlist, create_info_loc,
                                 "VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT was not set and the graphics pipeline "
@@ -2634,7 +2634,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer *cb_
     bool dyn_viewport = pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT) || pipeline.IsDynamic(VK_DYNAMIC_STATE_VIEWPORT);
     bool dyn_scissor = pipeline.IsDynamic(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT) || pipeline.IsDynamic(VK_DYNAMIC_STATE_SCISSOR);
     if (!dyn_viewport || !dyn_scissor) {
-        const LogObjectList objlist(cb_state->Handle(), pipeline.pipeline());
+        const LogObjectList objlist(cb_state->Handle(), pipeline.Handle());
         skip |= LogError("VUID-vkCmdBindPipeline-commandBuffer-04808", objlist, loc,
                          "Graphics pipeline incompatible with viewport/scissor inheritance.");
     }
@@ -2650,7 +2650,7 @@ bool CoreChecks::ValidateGraphicsPipelineBindPoint(const vvl::CommandBuffer *cb_
             } else {
                 msg << "VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT";
             }
-            const LogObjectList objlist(cb_state->Handle(), pipeline.pipeline());
+            const LogObjectList objlist(cb_state->Handle(), pipeline.Handle());
             skip |= LogError(
                 "VUID-vkCmdBindPipeline-commandBuffer-04809", objlist, loc.dot(Field::commandBuffer),
                 "is a secondary command buffer with VkCommandBufferInheritanceViewportScissorInfoNV::viewportScissor2D "
@@ -2731,7 +2731,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
             if (!primitives_generated_query_with_rasterizer_discard && rasterizer_discard_enabled) {
                 LogObjectList objlist(cb_state.Handle());
                 if (pipeline) {
-                    objlist.add(pipeline->pipeline());
+                    objlist.add(pipeline->Handle());
                 }
                 skip |= LogError(vuid.primitives_generated_06708, objlist, loc,
                                  "a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
@@ -2744,7 +2744,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                 if (rasterization_state_stream_ci && rasterization_state_stream_ci->rasterizationStream != 0) {
                     LogObjectList objlist(cb_state.Handle());
                     if (pipeline) {
-                        objlist.add(pipeline->pipeline());
+                        objlist.add(pipeline->Handle());
                     }
                     skip |= LogError(vuid.primitives_generated_streams_06709, objlist, loc,
                                      "a VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT query is active and pipeline was created with "
@@ -2778,13 +2778,13 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
         for (size_t i = 0; i < pipeline->vertex_input_state->binding_descriptions.size(); i++) {
             const auto vertex_binding = pipeline->vertex_input_state->binding_descriptions[i].binding;
             if (current_vtx_bfr_binding_info.size() < (vertex_binding + 1)) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                 skip |= LogError(vuid.vertex_binding_04007, objlist, loc,
                                  "%s expects that this Command Buffer's vertex binding Index %u should be set via "
                                  "vkCmdBindVertexBuffers. This is because pVertexBindingDescriptions[%zu].binding value is %u.",
                                  FormatHandle(*pipeline).c_str(), vertex_binding, i, vertex_binding);
             } else if ((current_vtx_bfr_binding_info[vertex_binding].buffer_state == nullptr) && !enabled_features.nullDescriptor) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                 skip |= LogError(vuid.vertex_binding_null_04008, objlist, loc,
                                  "Vertex binding %d must not be VK_NULL_HANDLE %s expects that this Command Buffer's vertex "
                                  "binding Index %u should be set via "
@@ -2810,7 +2810,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                     const uint32_t attribute_binding_extent =
                         attribute_description.offset + vkuFormatElementSize(attribute_description.format);
                     if (vertex_buffer_stride != 0 && vertex_buffer_stride < attribute_binding_extent) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                         skip |= LogError("VUID-vkCmdBindVertexBuffers2-pStrides-06209", objlist, loc,
                                          "The pStrides[%" PRIu32 "] (%" PRIu32
                                          ") parameter in the last call to %s is not 0 "
@@ -2827,7 +2827,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
 
                 if (SafeModulo(attrib_address, vtx_attrib_req_alignment) != 0) {
                     const LogObjectList objlist(current_vtx_bfr_binding_info[vertex_binding].buffer_state->Handle(),
-                                                pipeline->pipeline());
+                                                pipeline->Handle());
                     skip |= LogError(
                         vuid.vertex_binding_attribute_02721, objlist, loc,
                         "Format %s has an alignment of %" PRIu64 " but the alignment of attribAddress (%" PRIu64
@@ -2839,7 +2839,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         attribute_description.location, vertex_buffer_offset, vertex_buffer_stride, attribute_offset);
                 }
             } else {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                 skip |= LogError(vuid.vertex_binding_attribute_02721, objlist, loc,
                                  "pVertexAttributeDescriptions[%" PRIu32 "].binding (%" PRIu32 ") is an invalid value.",
                                  vertex_binding, i);
@@ -2872,7 +2872,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         if (imageview_state && color_blend_state && (attachment < color_blend_state->attachmentCount)) {
                             if ((imageview_state->format_features & VK_FORMAT_FEATURE_2_COLOR_ATTACHMENT_BLEND_BIT_KHR) == 0 &&
                                 color_blend_state->pAttachments[i].blendEnable != VK_FALSE) {
-                                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
+                                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(),
                                                             cb_state.activeRenderPass->Handle());
                                 skip |=
                                     LogError(vuid.blend_enable_04727, objlist, loc,
@@ -2896,7 +2896,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                       IsExtEnabled(device_extensions.vk_nv_framebuffer_mixed_samples) ||
                       enabled_features.multisampledRenderToSingleSampled) &&
                     ((subpass_num_samples & static_cast<unsigned>(rasterization_samples)) != subpass_num_samples)) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.msrtss_rasterization_samples_07284, objlist, loc,
                                      "In %s the sample count is %s while the current %s has %s and they need to be the same.",
                                      FormatHandle(*pipeline).c_str(), string_VkSampleCountFlagBits(rasterization_samples),
@@ -2920,8 +2920,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                     if (stippled_line_enable) {
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT &&
                             (!enabled_features.stippledRectangularLines)) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->Handle());
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_rectangular_lines_07495, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_EXT (set %s) with "
                                              "stippledLineEnable (set %s) but the stippledRectangularLines feature is not enabled.",
@@ -2930,8 +2929,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT &&
                             (!enabled_features.stippledBresenhamLines)) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->Handle());
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.stippled_bresenham_lines_07496, objlist, loc,
                                              "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_EXT (set %s) with "
                                              "stippledLineEnable (set %s) but the stippledBresenhamLines feature is not enabled.",
@@ -2940,8 +2938,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT &&
                             (!enabled_features.stippledSmoothLines)) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->Handle());
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                             skip |=
                                 LogError(vuid.stippled_smooth_lines_07497, objlist, loc,
                                          "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_EXT (set %s) with "
@@ -2951,8 +2948,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                         }
                         if (line_rasterization_mode == VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT &&
                             (!enabled_features.stippledRectangularLines || !phys_dev_props.limits.strictLines)) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(),
-                                                        cb_state.activeRenderPass->Handle());
+                            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                             skip |= LogError(
                                 vuid.stippled_default_strict_07498, objlist, loc,
                                 "lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_DEFAULT_EXT (set %s) with "
@@ -2979,7 +2975,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
             // Currently lack support to test each index.
             if (!pipeline->fragment_shader_state->fragment_entry_point->has_alpha_to_coverage_variable &&
                 !pipeline->DualSourceBlending()) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                 skip |= LogError(vuid.dynamic_alpha_to_coverage_component_08919, objlist, loc,
                                  "vkCmdSetAlphaToCoverageEnableEXT set alphaToCoverageEnable to true but the bound pipeline "
                                  "fragment shader doesn't declare a variable that covers Location 0, Component 3.");
@@ -3241,7 +3237,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
     }
     const auto subpass = pipeline.Subpass();
     if (subpass != cb_state.GetActiveSubpass()) {
-        const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline(), cb_state.activeRenderPass->Handle());
+        const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), cb_state.activeRenderPass->Handle());
         skip |= LogError(vuid.subpass_index_02685, objlist, loc,
                          "Pipeline was built for subpass %" PRIu32 " but used in subpass %" PRIu32 ".", subpass,
                          cb_state.GetActiveSubpass());
@@ -3258,8 +3254,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                     const auto *image_state = imageview_state->image_state.get();
                     if (image_state != nullptr) {
                         if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
-                            const LogObjectList objlist(cb_state.Handle(), pipeline.pipeline(),
-                                                        cb_state.activeRenderPass->Handle());
+                            const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.sample_location_02689, objlist, loc,
                                              "sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
                                              "stencil attachment's VkImage was not created with "
@@ -3273,7 +3268,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
         const auto ds_state = pipeline.DepthStencilState();
         if (ds_state) {
             if (IsImageLayoutDepthReadOnly(ds_attachment->layout) && last_bound_state.IsDepthWriteEnable()) {
-                const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
+                const LogObjectList objlist(pipeline.Handle(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
                 skip |= LogError(vuid.depth_read_only_06886, objlist, loc,
                                  "depthWriteEnable is VK_TRUE, while the layout (%s) of "
                                  "the depth aspect of the depth/stencil attachment in the render pass is read only.",
@@ -3300,7 +3295,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                 }();
 
                 if (is_stencil_layout_read_only) {
-                    const LogObjectList objlist(pipeline.pipeline(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
+                    const LogObjectList objlist(pipeline.Handle(), cb_state.activeRenderPass->Handle(), cb_state.Handle());
                     skip |= LogError(vuid.stencil_read_only_06887, objlist, loc,
                                      "The layout (%s) of the stencil aspect of the depth/stencil attachment in the render pass "
                                      "is read only but not all stencil ops are VK_STENCIL_OP_KEEP.\n"
@@ -3328,7 +3323,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
     if (rp_state) {
         const auto rendering_view_mask = cb_state.activeRenderPass->GetDynamicRenderingViewMask();
         if (rp_state->VkHandle() != VK_NULL_HANDLE) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), rp_state->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), rp_state->Handle());
             skip |= LogError(vuid.dynamic_rendering_06198, objlist, loc,
                              "Currently bound pipeline %s must have been created with a "
                              "VkGraphicsPipelineCreateInfo::renderPass equal to VK_NULL_HANDLE",
@@ -3338,7 +3333,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         const auto pipeline_rendering_ci = rp_state->dynamic_rendering_pipeline_create_info;
 
         if (pipeline_rendering_ci.viewMask != rendering_view_mask) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
             skip |= LogError(vuid.dynamic_rendering_view_mask_06178, objlist, loc,
                              "Currently bound pipeline %s viewMask ([%" PRIu32
                              ") must be equal to VkRenderingInfo::viewMask ([%" PRIu32 ")",
@@ -3349,7 +3344,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto color_attachment_count = pipeline_rendering_ci.colorAttachmentCount;
             const auto rendering_color_attachment_count = cb_state.activeRenderPass->GetDynamicRenderingColorAttachmentCount();
             if (color_attachment_count && (color_attachment_count != rendering_color_attachment_count)) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_count_06179, objlist, loc,
                                  "Currently bound pipeline %s VkPipelineRenderingCreateInfo::colorAttachmentCount (%" PRIu32
                                  ") must be equal to VkRenderingInfo::colorAttachmentCount (%" PRIu32 ")",
@@ -3366,7 +3361,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                         (view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i])) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08911, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3381,7 +3376,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 if (rendering_info.pColorAttachments[i].imageView == VK_NULL_HANDLE) {
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED)) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_color_formats_08912, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3392,7 +3387,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
                     if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                         view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i]) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_color_formats_08910, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
                                          "].imageView format (%s) must match corresponding format in "
@@ -3411,7 +3406,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat)) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08915, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s) "
@@ -3423,7 +3418,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             } else {
                 if (rendering_info.pDepthAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.depthAttachmentFormat != VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |=
                             LogError(vuid.dynamic_rendering_undefined_depth_format_08913, objlist, loc,
                                      "VkRenderingInfo::pDepthAttachment.imageView is VK_NULL_HANDLE, but corresponding format in "
@@ -3433,7 +3428,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 } else {
                     auto view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.depthAttachmentFormat) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                          "VkRenderingInfo::pDepthAttachment->imageView format (%s) must match corresponding format "
                                          "in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3445,7 +3440,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.depthAttachmentFormat !=
                 pipeline_rendering_ci.depthAttachmentFormat) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_depth_format_08914, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::depthAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::depthAttachmentFormat (%s)",
@@ -3461,7 +3456,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     if ((view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                         (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) &&
                         (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat)) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_unused_attachments_08918, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s) "
@@ -3473,7 +3468,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             } else {
                 if (rendering_info.pStencilAttachment->imageView == VK_NULL_HANDLE) {
                     if (pipeline_rendering_ci.stencilAttachmentFormat != VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_undefined_stencil_format_08916, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment.imageView is VK_NULL_HANDLE, but "
                                          "corresponding format in "
@@ -3483,7 +3478,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 } else {
                     auto view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
                     if (view_state->create_info.format != pipeline_rendering_ci.stencilAttachmentFormat) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                         skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                          "VkRenderingInfo::pStencilAttachment->imageView format (%s) must match corresponding "
                                          "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3495,7 +3490,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         } else if (cb_state.activeRenderPass->use_dynamic_rendering_inherited) {
             if (cb_state.activeRenderPass->inheritance_rendering_info.stencilAttachmentFormat !=
                 pipeline_rendering_ci.stencilAttachmentFormat) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_stencil_format_08917, objlist, loc,
                                  "VkCommandBufferInheritanceRenderingInfo::stencilAttachmentFormat (%s) must match corresponding "
                                  "format in VkPipelineRenderingCreateInfo::stencilAttachmentFormat (%s)",
@@ -3510,7 +3505,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (rendering_fragment_shading_rate_attachment_info &&
                 (rendering_fragment_shading_rate_attachment_info->imageView != VK_NULL_HANDLE)) {
                 if (!(pipeline->create_flags & VK_PIPELINE_CREATE_2_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                     skip |= LogError(vuid.dynamic_rendering_fsr_06183, objlist, loc,
                                      "Currently bound graphics pipeline %s must have been created with "
                                      "VK_PIPELINE_CREATE_RENDERING_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
@@ -3523,7 +3518,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             if (rendering_fragment_shading_rate_density_map &&
                 (rendering_fragment_shading_rate_density_map->imageView != VK_NULL_HANDLE)) {
                 if (!(pipeline->create_flags & VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT)) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                     skip |= LogError(vuid.dynamic_rendering_fdm_06184, objlist, loc,
                                      "Currently bound graphics pipeline %s must have been created with "
                                      "VK_PIPELINE_RASTERIZATION_STATE_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT",
@@ -3542,7 +3537,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                     rendering_info.pColorAttachments[i].imageView != VK_NULL_HANDLE) {
                     if (i >= pipeline_rendering_ci.colorAttachmentCount ||
                         pipeline_rendering_ci.pColorAttachmentFormats[i] == VK_FORMAT_UNDEFINED) {
-                        const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle(),
+                        const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle(),
                                                     rendering_info.pColorAttachments[i].imageView);
                         skip |= LogError(vuid.color_attachment_08963, objlist, loc,
                                          "VkRenderingInfo::pColorAttachments[%" PRIu32
@@ -3558,7 +3553,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsDepthTestEnable() && last_bound_state.IsDepthWriteEnable() && rp_state->use_dynamic_rendering &&
             rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.depthAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.depth_attachment_08964, objlist, loc,
                                  "VkRenderingInfo::pDepthAttachment is %s, but currently bound graphics pipeline %s was created "
                                  "with VkPipelineRenderingCreateInfo::depthAttachmentFormat equal to VK_FORMAT_UNDEFINED",
@@ -3568,7 +3563,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
         if (last_bound_state.IsStencilTestEnable() && rp_state->use_dynamic_rendering && rendering_info.pStencilAttachment &&
             rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
             if (pipeline_rendering_ci.stencilAttachmentFormat == VK_FORMAT_UNDEFINED) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |=
                     LogError(vuid.stencil_attachment_08965, objlist, loc,
                              "VkRenderingInfo::pStencilAttachment is %s, but currently bound graphics pipeline %s was created with "
@@ -3579,7 +3574,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         const uint64_t pipeline_external_format = GetExternalFormat(pipeline->GetCreateInfo<VkGraphicsPipelineCreateInfo>().pNext);
         if (pipeline_external_format != 0) {
-            const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+            const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
             if (rendering_info.colorAttachmentCount == 1 &&
                 rendering_info.pColorAttachments[0].resolveMode == VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID) {
                 auto resolve_image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[0].resolveImageView);
@@ -3659,7 +3654,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info &&
                 (color_image_samples != p_attachment_sample_count_info->pColorAttachmentSamples[i])) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_color_sample_06185, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkAttachmentSampleCountInfoAMD "
@@ -3675,7 +3670,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info) {
                 if (depth_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_depth_sample_06186, objlist, loc,
                                      "Depth attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD sample "
@@ -3692,7 +3687,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
             if (p_attachment_sample_count_info) {
                 if (stencil_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
-                    const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuid.dynamic_rendering_stencil_sample_06187, objlist, loc,
                                      "Stencil attachment sample count (%s) must match corresponding "
                                      "VkAttachmentSampleCountInfoAMD "
@@ -3713,7 +3708,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             auto samples = Get<vvl::Image>(view_state->create_info.image)->createInfo.samples;
 
             if (samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07285, objlist, loc,
                                  "Color attachment (%" PRIu32
                                  ") sample count (%s) must match corresponding VkPipelineMultisampleStateCreateInfo "
@@ -3726,7 +3721,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
             const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->createInfo.samples;
             if (depth_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07286, objlist, loc,
                                  "Depth attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",
@@ -3739,7 +3734,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
             const auto &stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
             const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->createInfo.samples;
             if (stencil_image_samples != rasterization_samples) {
-                const LogObjectList objlist(cb_state.Handle(), pipeline->pipeline(), cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07287, objlist, loc,
                                  "Stencil attachment sample count (%s) must match corresponding "
                                  "VkPipelineMultisampleStateCreateInfo::rasterizationSamples count (%s)",
@@ -3878,7 +3873,7 @@ bool CoreChecks::ValidateGraphicsPipelineDerivatives(std::vector<std::shared_ptr
         }
 
         if (base_pipeline && !(base_pipeline->create_flags & VK_PIPELINE_CREATE_2_ALLOW_DERIVATIVES_BIT_KHR)) {
-            skip |= LogError("VUID-vkCreateGraphicsPipelines-flags-00721", base_pipeline->pipeline(), loc,
+            skip |= LogError("VUID-vkCreateGraphicsPipelines-flags-00721", base_pipeline->Handle(), loc,
                              "base pipeline does not allow derivatives.");
         }
     }

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -639,7 +639,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             skip |= LogError(vuid, objlist, loc,
                              "cannot start a query with this command as the bound video session "
                              "%s was created with VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR.",
-                             FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
+                             FormatHandle(cb_state.bound_video_session->Handle()).c_str());
         }
 
         if (!cb_state.activeQueries.empty()) {
@@ -647,7 +647,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             skip |= LogError(vuids->vuid_no_active_in_vc_scope, objlist, loc,
                              "cannot start another query while there is already an active query in a "
                              "video coding scope (%s is bound).",
-                             FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
+                             FormatHandle(cb_state.bound_video_session->Handle()).c_str());
         }
 
         switch (query_pool_ci.queryType) {
@@ -661,7 +661,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                     skip |= LogError(vuid, objlist, loc,
                                      "the video profile %s was created with does not match the video profile of %s.",
                                      FormatHandle(query_pool_state->Handle()).c_str(),
-                                     FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
+                                     FormatHandle(cb_state.bound_video_session->Handle()).c_str());
                 }
                 break;
             }
@@ -676,7 +676,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                     skip |= LogError(vuid, objlist, loc,
                                      "the video profile %s was created with does not match the video profile of %s.",
                                      FormatHandle(query_pool_state->Handle()).c_str(),
-                                     FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
+                                     FormatHandle(cb_state.bound_video_session->Handle()).c_str());
                 }
                 break;
             }
@@ -687,7 +687,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                                        : "VUID-vkCmdBeginQuery-queryType-07131";
                 const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
                 skip |= LogError(vuid, objlist, loc, "invalid query type used in a video coding scope (%s is bound).",
-                                 FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
+                                 FormatHandle(cb_state.bound_video_session->Handle()).c_str());
                 break;
             }
         }

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -1115,13 +1115,13 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
     if (dstOffset >= dst_buff_state->requirements.size) {
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-dstOffset-00819", buffer_objlist, error_obj.location.dot(Field::dstOffset),
                          "(%" PRIu64 ") is not less than the size (%" PRIu64 ") of buffer (%s).", dstOffset,
-                         dst_buff_state->requirements.size, FormatHandle(dst_buff_state->buffer()).c_str());
+                         dst_buff_state->requirements.size, FormatHandle(dst_buff_state->Handle()).c_str());
     } else if (dstOffset + (queryCount * stride) > dst_buff_state->requirements.size) {
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-dstBuffer-00824", buffer_objlist, error_obj.location,
                          "storage required (%" PRIu64
                          ") equal to dstOffset + (queryCount * stride) is greater than the size (%" PRIu64 ") of buffer (%s).",
                          dstOffset + (queryCount * stride), dst_buff_state->requirements.size,
-                         FormatHandle(dst_buff_state->buffer()).c_str());
+                         FormatHandle(dst_buff_state->Handle()).c_str());
     }
 
     if ((flags & VK_QUERY_RESULT_WITH_STATUS_BIT_KHR) && (flags & VK_QUERY_RESULT_WITH_AVAILABILITY_BIT)) {

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -396,12 +396,12 @@ bool CoreChecks::ValidateCmdQueueFlags(const vvl::CommandBuffer &cb_state, const
                     required_flags_string += string_VkQueueFlagBits(flag);
                 }
             }
-            const LogObjectList objlist(cb_state.commandBuffer(), pool->commandPool());
+            const LogObjectList objlist(cb_state.Handle(), pool->Handle());
             return LogError(vuid, objlist, loc,
                             "%scalled in command buffer %s which was allocated from the command pool %s which was created with "
                             "queueFamilyIndex %u which contains the capability flags %s (but requires %s).",
-                            extra_message, FormatHandle(cb_state).c_str(), FormatHandle(pool->commandPool()).c_str(),
-                            queue_family_index, string_VkQueueFlags(queue_flags).c_str(), required_flags_string.c_str());
+                            extra_message, FormatHandle(cb_state).c_str(), FormatHandle(pool->Handle()).c_str(), queue_family_index,
+                            string_VkQueueFlags(queue_flags).c_str(), required_flags_string.c_str());
         }
     }
     return false;
@@ -415,7 +415,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 
     switch (query_pool_ci.queryType) {
         case VK_QUERY_TYPE_TIMESTAMP: {
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02804"
                                                                                : "VUID-vkCmdBeginQuery-queryType-02804";
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with VK_QUERY_TYPE_TIMESTAMP.",
@@ -429,7 +429,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                 const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT
                                        ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-02341"
                                        : "VUID-vkCmdBeginQuery-queryType-02328";
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuid, objlist, loc.dot(Field::queryPool),
                                  "(%s) was created with queryType VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT, but "
                                  "VkPhysicalDeviceTransformFeedbackPropertiesEXT::transformFeedbackQueries is not supported.",
@@ -442,14 +442,14 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             break;
         case VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR: {
             if (!cb_state.performance_lock_acquired) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuids->vuid_profile_lock, objlist, loc,
                                  "profiling lock must be held before vkBeginCommandBuffer is called on "
                                  "a command buffer where performance queries are recorded.");
             }
 
             if (query_pool_state->has_perf_scope_command_buffer && cb_state.command_count > 0) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuids->vuid_scope_not_first, objlist, loc.dot(Field::queryPool),
                                  "(%s) was created with a counter of scope "
                                  "VK_QUERY_SCOPE_COMMAND_BUFFER_KHR but %s is not the first recorded "
@@ -458,7 +458,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (query_pool_state->has_perf_scope_render_pass && cb_state.activeRenderPass) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuids->vuid_scope_in_rp, objlist, loc.dot(Field::queryPool),
                                  "(%s) was created with a counter of scope "
                                  "VK_QUERY_SCOPE_RENDER_PASS_KHR but %s is inside a render pass.",
@@ -466,7 +466,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
 
             if (cb_state.command_pool->queueFamilyIndex != query_pool_state->perf_counter_queue_family_index) {
-                const LogObjectList objlist(cb_state.commandBuffer(), cb_state.command_pool->commandPool(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle(), query_obj.pool);
                 skip |= LogError(vuids->vuid_performance_queue_index_07289, objlist, loc.dot(Field::queryPool),
                                  "was created with VkQueryPoolPerformanceCreateInfoKHR::queueFamilyIndex (%" PRIu32
                                  ") but the command buffer is from a comment pool created with "
@@ -479,7 +479,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_SIZE_KHR: {
             const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-04728"
                                                                                : "VUID-vkCmdBeginQuery-queryType-04728";
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
                              FormatHandle(query_obj.pool).c_str(), string_VkQueryType(query_pool_ci.queryType));
             break;
@@ -487,7 +487,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV: {
             const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-04729"
                                                                                : "VUID-vkCmdBeginQuery-queryType-04729";
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
                              FormatHandle(query_obj.pool).c_str(), string_VkQueryType(query_pool_ci.queryType));
             break;
@@ -496,7 +496,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         case VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SERIALIZATION_BOTTOM_LEVEL_POINTERS_KHR: {
             const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-06741"
                                                                                : "VUID-vkCmdBeginQuery-queryType-06741";
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuid, objlist, loc.dot(Field::queryPool), "(%s) was created with queryType %s.",
                              FormatHandle(query_obj.pool).c_str(), string_VkQueryType(query_pool_ci.queryType));
             break;
@@ -513,7 +513,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                      VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT |
                      VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_CONTROL_SHADER_PATCHES_BIT |
                      VK_QUERY_PIPELINE_STATISTIC_TESSELLATION_EVALUATION_SHADER_INVOCATIONS_BIT)) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                    const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                     skip |= LogError(
                         vuids->vuid_graphics_support, objlist, loc.dot(Field::queryPool),
                         "(%s) was created with queryType VK_QUERY_TYPE_PIPELINE_STATISTICS (%s) and indicates graphics operations, "
@@ -526,7 +526,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             }
             if ((cb_state.command_pool->queue_flags & VK_QUEUE_COMPUTE_BIT) == 0) {
                 if (query_pool_ci.pipelineStatistics & VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                    const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                     skip |= LogError(
                         vuids->vuid_compute_support, objlist, loc.dot(Field::queryPool),
                         "(%s) was created with queryType VK_QUERY_TYPE_PIPELINE_STATISTICS (%s) and indicates compute operations, "
@@ -541,7 +541,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT: {
             if ((cb_state.command_pool->queue_flags & VK_QUEUE_GRAPHICS_BIT) == 0) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |=
                     LogError(vuids->vuid_primitives_generated, objlist, loc.dot(Field::queryPool),
                              "(%s) was created with queryType VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, but "
@@ -554,7 +554,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         case VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR: {
             const auto &qf_ext_props = queue_family_ext_props[cb_state.command_pool->queueFamilyIndex];
             if (!qf_ext_props.query_result_status_props.queryResultStatusSupport) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError(vuids->vuid_result_status_support, objlist, loc,
                                  "the command pool's queue family (index %u) the command buffer %s was allocated "
                                  "from does not support result status queries.",
@@ -564,7 +564,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
         case VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT: {
             if (loc.function == Func::vkCmdBeginQueryIndexedEXT) {
-                const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                 skip |= LogError("VUID-vkCmdBeginQueryIndexedEXT-queryType-07071", objlist, loc.dot(Field::queryPool),
                                  "(%s) was created with queryType %s.", FormatHandle(query_obj.pool).c_str(),
                                  string_VkQueryType(query_pool_ci.queryType));
@@ -581,7 +581,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     for (const auto &active_query_obj : cb_state.activeQueries) {
         auto active_query_pool_state = Get<vvl::QueryPool>(active_query_obj.pool);
         if (active_query_pool_state->createInfo.queryType == query_pool_ci.queryType && active_query_obj.index == index) {
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool, active_query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool, active_query_obj.pool);
             skip |= LogError(vuids->vuid_dup_query_type, objlist, loc,
                              "query %d from pool %s has same queryType (%s) as active query "
                              "%d from pool %s inside this command buffer (%s).",
@@ -592,27 +592,26 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
 
     if (flags & VK_QUERY_CONTROL_PRECISE_BIT) {
         if (!enabled_features.occlusionQueryPrecise) {
-            skip |= LogError(vuids->vuid_precise, cb_state.commandBuffer(), loc.dot(Field::flags),
+            skip |= LogError(vuids->vuid_precise, cb_state.Handle(), loc.dot(Field::flags),
                              "includes VK_QUERY_CONTROL_PRECISE_BIT, but occlusionQueryPrecise feature was not enabled.");
         }
 
         if (query_pool_ci.queryType != VK_QUERY_TYPE_OCCLUSION) {
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= LogError(vuids->vuid_precise, objlist, loc.dot(Field::flags),
                              "includes VK_QUERY_CONTROL_PRECISE_BIT provided, but pool query type is not VK_QUERY_TYPE_OCCLUSION.");
         }
     }
 
     if (query_obj.slot >= query_pool_ci.queryCount) {
-        const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+        const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= LogError(vuids->vuid_query_count, objlist, loc,
                          "Query index %" PRIu32 " must be less than query count %" PRIu32 " of %s.", query_obj.slot,
                          query_pool_ci.queryCount, FormatHandle(query_obj.pool).c_str());
     }
 
     if (cb_state.unprotected == false) {
-        skip |= LogError(vuids->vuid_protected_cb, cb_state.commandBuffer(), loc,
-                         "command can't be used in protected command buffers.");
+        skip |= LogError(vuids->vuid_protected_cb, cb_state.Handle(), loc, "command can't be used in protected command buffers.");
     }
 
     if (cb_state.activeRenderPass) {
@@ -622,7 +621,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
             if (subpass_desc) {
                 uint32_t bits = GetBitSetCount(subpass_desc->viewMask);
                 if (query_obj.slot + bits > query_pool_state->createInfo.queryCount) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+                    const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
                     skip |= LogError(vuids->vuid_multiview_query, objlist, loc,
                                      "query (%" PRIu32 ") + bits set in current subpass view mask (%" PRIx32
                                      ") is greater than the number of queries in queryPool (%" PRIu32 ").",
@@ -636,7 +635,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         if (cb_state.bound_video_session->create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR) {
             const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-None-08370"
                                                                                : "VUID-vkCmdBeginQuery-None-08370";
-            const LogObjectList objlist(cb_state.commandBuffer(), cb_state.bound_video_session->Handle());
+            const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
             skip |= LogError(vuid, objlist, loc,
                              "cannot start a query with this command as the bound video session "
                              "%s was created with VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR.",
@@ -644,7 +643,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
         }
 
         if (!cb_state.activeQueries.empty()) {
-            const LogObjectList objlist(cb_state.commandBuffer(), cb_state.bound_video_session->Handle());
+            const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
             skip |= LogError(vuids->vuid_no_active_in_vc_scope, objlist, loc,
                              "cannot start another query while there is already an active query in a "
                              "video coding scope (%s is bound).",
@@ -657,7 +656,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                     const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT
                                            ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07128"
                                            : "VUID-vkCmdBeginQuery-queryType-07128";
-                    const LogObjectList objlist(cb_state.commandBuffer(), query_pool_state->pool(),
+                    const LogObjectList objlist(cb_state.Handle(), query_pool_state->pool(),
                                                 cb_state.bound_video_session->Handle());
                     skip |= LogError(vuid, objlist, loc,
                                      "the video profile %s was created with does not match the video profile of %s.",
@@ -672,7 +671,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                     const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT
                                            ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07130"
                                            : "VUID-vkCmdBeginQuery-queryType-07130";
-                    const LogObjectList objlist(cb_state.commandBuffer(), query_pool_state->pool(),
+                    const LogObjectList objlist(cb_state.Handle(), query_pool_state->pool(),
                                                 cb_state.bound_video_session->Handle());
                     skip |= LogError(vuid, objlist, loc,
                                      "the video profile %s was created with does not match the video profile of %s.",
@@ -686,7 +685,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
                 const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT
                                        ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07131"
                                        : "VUID-vkCmdBeginQuery-queryType-07131";
-                const LogObjectList objlist(cb_state.commandBuffer(), cb_state.bound_video_session->Handle());
+                const LogObjectList objlist(cb_state.Handle(), cb_state.bound_video_session->Handle());
                 skip |= LogError(vuid, objlist, loc, "invalid query type used in a video coding scope (%s is bound).",
                                  FormatHandle(cb_state.bound_video_session->videoSession()).c_str());
                 break;
@@ -695,7 +694,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     } else if (query_pool_ci.queryType == VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR) {
         const char *vuid = loc.function == Func::vkCmdBeginQueryIndexedEXT ? "VUID-vkCmdBeginQueryIndexedEXT-queryType-07129"
                                                                            : "VUID-vkCmdBeginQuery-queryType-07129";
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc,
+        skip |= LogError(vuid, cb_state.Handle(), loc,
                          "there is no bound video session but query type is VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR.");
     }
 
@@ -766,7 +765,7 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
     }
 
     if (state != QUERYSTATE_RESET) {
-        const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+        const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         const Location loc(command);
 
         // Most of these VUIDs and the call sites of this function are not tested so we set here
@@ -806,14 +805,14 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
     bool skip = false;
 
     if (perfPass >= query_pool_state->n_performance_passes) {
-        const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+        const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= state_data->LogError("VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221", objlist, loc,
                                      "Invalid counterPassIndex (%u, maximum allowed %u) value for query pool %s.", perfPass,
                                      query_pool_state->n_performance_passes, state_data->FormatHandle(query_obj.pool).c_str());
     }
 
     if (!cb_state.performance_lock_acquired || cb_state.performance_lock_released) {
-        const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+        const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= state_data->LogError("VUID-vkQueueSubmit-pCommandBuffers-03220", objlist, loc,
                                      "Commandbuffer %s was submitted and contains a performance query but the"
                                      "profiling lock was not held continuously throughout the recording of commands.",
@@ -822,7 +821,7 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
 
     QueryState command_buffer_state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
     if (command_buffer_state == QUERYSTATE_RESET) {
-        const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+        const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
         skip |= state_data->LogError(
             query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-02863" : "VUID-vkCmdBeginQuery-None-02863", objlist, loc,
             "VkQuery begin command recorded in a command buffer that, either directly or "
@@ -832,7 +831,7 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
 
     if (firstPerfQueryPool != VK_NULL_HANDLE) {
         if (firstPerfQueryPool != query_obj.pool && !state_data->enabled_features.performanceCounterMultipleQueryPools) {
-            const LogObjectList objlist(cb_state.commandBuffer(), query_obj.pool);
+            const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
             skip |= state_data->LogError(
                 query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03226" : "VUID-vkCmdBeginQuery-queryPool-03226",
                 objlist, loc,
@@ -879,7 +878,7 @@ void CoreChecks::EnqueueVerifyEndQuery(vvl::CommandBuffer &cb_state, const Query
         // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
         auto query_pool_state = cb_state_arg.dev_data->Get<vvl::QueryPool>(query_obj.pool);
         if (query_pool_state->has_perf_scope_command_buffer && (cb_state_arg.command_count - 1) != query_obj.end_command_index) {
-            const LogObjectList objlist(cb_state_arg.commandBuffer(), query_pool_state->pool());
+            const LogObjectList objlist(cb_state_arg.Handle(), query_pool_state->pool());
             const Location loc(command);
             skip |= LogError("VUID-vkCmdEndQuery-queryPool-03227", objlist, loc,
                              "Query pool %s was created with a counter of scope "
@@ -896,7 +895,7 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
     bool skip = false;
     auto query_payload = cb_state.activeQueries.find({queryPool, slot});
     if (query_payload == cb_state.activeQueries.end()) {
-        const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+        const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuids->vuid_active_queries, objlist, loc, "Ending a query before it was started: %s, index %d.",
                          FormatHandle(queryPool).c_str(), slot);
     }
@@ -904,7 +903,7 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
     const auto &query_pool_ci = query_pool_state->createInfo;
     if (query_pool_ci.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         if (query_pool_state->has_perf_scope_render_pass && cb_state.activeRenderPass) {
-            const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+            const LogObjectList objlist(cb_state.Handle(), queryPool);
             skip |= LogError("VUID-vkCmdEndQuery-queryPool-03228", objlist, loc,
                              "Query pool %s was created with a counter of scope "
                              "VK_QUERY_SCOPE_RENDER_PASS_KHR but %s is inside a render pass.",
@@ -913,12 +912,11 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
     }
 
     if (cb_state.unprotected == false) {
-        skip |= LogError(vuids->vuid_protected_cb, cb_state.commandBuffer(), loc,
-                         "command can't be used in protected command buffers.");
+        skip |= LogError(vuids->vuid_protected_cb, cb_state.Handle(), loc, "command can't be used in protected command buffers.");
     }
     if (cb_state.activeRenderPass) {
         if (!query_payload->inside_render_pass) {
-            const LogObjectList objlist(cb_state.commandBuffer(), queryPool, cb_state.activeRenderPass->Handle());
+            const LogObjectList objlist(cb_state.Handle(), queryPool, cb_state.activeRenderPass->Handle());
             skip |= LogError(vuids->vuid_inside_renderpass_07007, objlist, loc,
                              "query (%" PRIu32 ") was started outside a renderpass", slot);
         }
@@ -927,7 +925,7 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
         if (!cb_state.activeRenderPass->UsesDynamicRendering()) {
             const uint32_t subpass = cb_state.GetActiveSubpass();
             if (query_payload->subpass != subpass) {
-                const LogObjectList objlist(cb_state.commandBuffer(), queryPool, cb_state.activeRenderPass->Handle());
+                const LogObjectList objlist(cb_state.Handle(), queryPool, cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuids->vuid_inside_renderpass_07007, objlist, loc,
                                  "query (%" PRIu32 ") was started in subpass %" PRIu32 ", but ending in subpass %" PRIu32 ".", slot,
                                  query_payload->subpass, subpass);
@@ -937,7 +935,7 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
             if (subpass_desc) {
                 const uint32_t bits = GetBitSetCount(subpass_desc->viewMask);
                 if (slot + bits > query_pool_state->createInfo.queryCount) {
-                    const LogObjectList objlist(cb_state.commandBuffer(), queryPool, cb_state.activeRenderPass->Handle());
+                    const LogObjectList objlist(cb_state.Handle(), queryPool, cb_state.activeRenderPass->Handle());
                     skip |= LogError(vuids->vuid_multiview_query, objlist, loc,
                                      "query (%" PRIu32 ") + bits set in current subpass (%" PRIu32 ") view mask (%" PRIx32
                                      ") is greater than the number of queries in queryPool (%" PRIu32 ").",
@@ -1013,7 +1011,7 @@ bool CoreChecks::ValidateQueriesNotActive(const vvl::CommandBuffer &cb_state, Vk
         const uint32_t slot = firstQuery + i;
         QueryObject query_obj = {queryPool, slot};
         if (cb_state.activeQueries.count(query_obj)) {
-            const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+            const LogObjectList objlist(cb_state.Handle(), queryPool);
             skip |= LogError(vuid, objlist, loc,
                              "Query index %" PRIu32 " is still active (firstQuery = %" PRIu32 ", queryCount = %" PRIu32 ").", slot,
                              firstQuery, queryCount);
@@ -1054,7 +1052,7 @@ void CoreChecks::PreCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, V
             for (uint32_t i = 0; i < queryCount; i++) {
                 QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
                 if (state == QUERYSTATE_ENDED) {
-                    const LogObjectList objlist(cb_state_arg.commandBuffer(), queryPool);
+                    const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
                     skip |= state_data->LogError("VUID-vkCmdResetQueryPool-firstQuery-02862", objlist, record_obj.location,
                                                  "Query index %" PRIu32 " was begun and reset in the same command buffer.",
                                                  firstQuery + i);
@@ -1190,7 +1188,7 @@ void CoreChecks::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuf
             QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
             QueryResultType result_type = GetQueryResultType(state, flags);
             if (result_type != QUERYRESULT_SOME_DATA && result_type != QUERYRESULT_UNKNOWN) {
-                const LogObjectList objlist(cb_state_arg.commandBuffer(), queryPool);
+                const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
                 skip |= state_data->LogError("VUID-vkCmdCopyQueryPoolResults-None-08752", objlist, record_obj.location,
                                              "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
                                              state_data->FormatHandle(queryPool).c_str(), firstQuery + i,
@@ -1218,7 +1216,7 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     if (timestamp_valid_bits == 0) {
         const char *vuid =
             is_2 ? "VUID-vkCmdWriteTimestamp2-timestampValidBits-03863" : "VUID-vkCmdWriteTimestamp-timestampValidBits-00829";
-        const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+        const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc, "Query Pool %s has a timestampValidBits value of zero for queueFamilyIndex %u.",
                          FormatHandle(queryPool).c_str(), cb_state.command_pool->queueFamilyIndex);
     }
@@ -1226,14 +1224,14 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
     if (query_pool_state.createInfo.queryType != VK_QUERY_TYPE_TIMESTAMP) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-queryPool-03861" : "VUID-vkCmdWriteTimestamp-queryPool-01416";
-        const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+        const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc, "Query Pool %s was not created with VK_QUERY_TYPE_TIMESTAMP.",
                          FormatHandle(queryPool).c_str());
     }
 
     if (slot >= query_pool_state.createInfo.queryCount) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-04903" : "VUID-vkCmdWriteTimestamp-query-04904";
-        const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+        const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc,
                          "query (%" PRIu32 ") is not lower than the number of queries (%" PRIu32 ") in Query pool %s.", slot,
                          query_pool_state.createInfo.queryCount, FormatHandle(queryPool).c_str());
@@ -1241,7 +1239,7 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
     if (cb_state.activeRenderPass &&
         slot + cb_state.activeRenderPass->GetViewMaskBits(cb_state.GetActiveSubpass()) > query_pool_state.createInfo.queryCount) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-03865" : "VUID-vkCmdWriteTimestamp-query-00831";
-        const LogObjectList objlist(cb_state.commandBuffer(), queryPool);
+        const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc,
                          "query (%" PRIu32 ") + number of bits in current subpass (%" PRIu32
                          ") is not lower than the number of queries (%" PRIu32 ") in Query pool %s.",

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -260,8 +260,8 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
                                      other_scratch_var_name_ss << "pInfos[" << other_info_j << "].scratchData";
 
                                      *out_error_msg += no_as_buffer_memory_overlap_msg(
-                                         dst_as_var_name_ss.str().c_str(), dst_as_buffer.buffer(),
-                                         other_scratch_var_name_ss.str().c_str(), other_scratch->buffer(), memory, overlap_range);
+                                         dst_as_var_name_ss.str().c_str(), dst_as_buffer.VkHandle(),
+                                         other_scratch_var_name_ss.str().c_str(), other_scratch->VkHandle(), memory, overlap_range);
                                  }
                                  return false;
                              }
@@ -319,8 +319,8 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
                                      other_scratch_var_name_ss << "pInfos[" << other_info_j << "].scratchData";
 
                                      *out_error_msg += no_as_buffer_memory_overlap_msg(
-                                         src_as_var_name_ss.str().c_str(), src_as_buffer.buffer(),
-                                         other_scratch_var_name_ss.str().c_str(), other_scratch->buffer(), memory, overlap_range);
+                                         src_as_var_name_ss.str().c_str(), src_as_buffer.VkHandle(),
+                                         other_scratch_var_name_ss.str().c_str(), other_scratch->VkHandle(), memory, overlap_range);
                                  }
                                  return false;
                              }
@@ -394,7 +394,7 @@ bool CoreChecks::ValidateAccelerationStructuresMemoryAlisasing(VkCommandBuffer c
                                                 memory != VK_NULL_HANDLE) {
                                                 if (parent_out_error_msg) {
                                                     std::stringstream scratch_error_msg_ss;
-                                                    scratch_error_msg_ss << " {" << FormatHandle(scratch->buffer())
+                                                    scratch_error_msg_ss << " {" << FormatHandle(scratch->Handle())
                                                                          << ", backed by " << FormatHandle(memory)
                                                                          << " - overlap on VkDeviceMemory space range "
                                                                          << string_range_hex(overlap_range) << "}";

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -1223,7 +1223,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
             skip |= LogWarning("WARNING-vkCmdBuildAccelerationStructureNV-update-requirements", dst, error_obj.location,
                                "Updating %s but vkGetAccelerationStructureMemoryRequirementsNV() "
                                "has not been called for update scratch memory.",
-                               FormatHandle(dst_as_state->acceleration_structure()).c_str());
+                               FormatHandle(dst_as_state->Handle()).c_str());
             // Use requirements fetched at create time
         }
         if (scratch_buffer_state != nullptr && dst_as_state != nullptr &&
@@ -1242,7 +1242,7 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
             skip |= LogWarning("WARNING-vkCmdBuildAccelerationStructureNV-scratch-requirements", dst, error_obj.location,
                                "Assigning scratch buffer to %s but "
                                "vkGetAccelerationStructureMemoryRequirementsNV() has not been called for scratch memory.",
-                               FormatHandle(dst_as_state->acceleration_structure()).c_str());
+                               FormatHandle(dst_as_state->Handle()).c_str());
             // Use requirements fetched at create time
         }
         if (scratch_buffer_state != nullptr && dst_as_state != nullptr &&

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -4090,7 +4090,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer &cb_state, const Location &loc, const char *vuid) const {
     bool inside = false;
     if (cb_state.activeRenderPass) {
-        inside = LogError(vuid, cb_state.commandBuffer(), loc, "It is invalid to issue this call inside an active %s.",
+        inside = LogError(vuid, cb_state.Handle(), loc, "It is invalid to issue this call inside an active %s.",
                           FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
     }
     return inside;
@@ -4103,7 +4103,7 @@ bool CoreChecks::OutsideRenderPass(const vvl::CommandBuffer &cb_state, const Loc
     if (((cb_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) && (!cb_state.activeRenderPass)) ||
         ((cb_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) && (!cb_state.activeRenderPass) &&
          !(cb_state.beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT))) {
-        outside = LogError(vuid, cb_state.commandBuffer(), loc, "This call must be issued inside an active render pass.");
+        outside = LogError(vuid, cb_state.Handle(), loc, "This call must be issued inside an active render pass.");
     }
     return outside;
 }
@@ -4197,7 +4197,7 @@ bool CoreChecks::ValidateCmdSubpassState(const vvl::CommandBuffer &cb_state, con
          loc.function != Func::vkCmdEndRenderPass && loc.function != Func::vkCmdNextSubpass2 &&
          loc.function != Func::vkCmdNextSubpass2KHR && loc.function != Func::vkCmdEndRenderPass2 &&
          loc.function != Func::vkCmdEndRenderPass2KHR)) {
-        skip |= LogError(vuid, cb_state.commandBuffer(), loc, "cannot be called in a subpass using secondary command buffers.");
+        skip |= LogError(vuid, cb_state.Handle(), loc, "cannot be called in a subpass using secondary command buffers.");
     }
     return skip;
 }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -638,7 +638,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 const auto &ici = view_state.image_state->createInfo;
 
                 if ((fdm_non_zero_offsets == true) && ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                     skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-06502", objlist, error_obj.location,
                                      "pAttachments[%" PRIu32
                                      "] is not created with flag value"
@@ -653,7 +653,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
                     if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                         if ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityMapAttachment-06504",
                                              objlist, error_obj.location,
                                              "Fragment density map attachment %" PRIu32
@@ -665,7 +665,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
 
                         if ((subpass.viewMask != 0) &&
                             (view_state.create_info.subresourceRange.layerCount != fdm_offset_info->fragmentDensityOffsetCount)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                             skip |= LogError(
                                 "VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06510", objlist,
                                 error_obj.location,
@@ -675,7 +675,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         }
 
                         if ((subpass.viewMask == 0) && (fdm_offset_info->fragmentDensityOffsetCount != 1)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06511",
                                              objlist, error_obj.location,
                                              "fragmentDensityOffsetCount %" PRIu32 " should be 1 when multiview is not enabled.",
@@ -688,7 +688,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (subpass.pDepthStencilAttachment && (subpass.pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) &&
                     (subpass.pDepthStencilAttachment->attachment == i) &&
                     ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                     skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pDepthStencilAttachment-06505", objlist,
                                      error_obj.location,
                                      "pDepthStencilAttachment[%" PRIu32
@@ -703,7 +703,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pInputAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pInputAttachments-06506", objlist,
                                          error_obj.location,
                                          "pInputAttachments[%" PRIu32
@@ -719,7 +719,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pColorAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pColorAttachments-06507", objlist,
                                          error_obj.location,
                                          "pColorAttachments[%" PRIu32
@@ -736,7 +736,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         const auto attachment = subpass.pResolveAttachments[k].attachment;
                         if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                             ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pResolveAttachments-06508", objlist,
                                              error_obj.location,
                                              "pResolveAttachments[%" PRIu32
@@ -753,7 +753,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pPreserveAttachments[k];
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pPreserveAttachments-06509", objlist,
                                          error_obj.location,
                                          "pPreserveAttachments[%" PRIu32
@@ -946,8 +946,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
         const VkFramebufferAttachmentImageInfo *framebuffer_attachment_image_info =
             &framebuffer_attachments_create_info->pAttachmentImageInfos[i];
         const auto *image_create_info = &image_view_state->image_state->createInfo;
-        const LogObjectList objlist(pRenderPassBeginInfo->renderPass, pRenderPassBeginInfo->framebuffer,
-                                    image_view_state->image_view(), image_view_state->image_state->image());
+        const LogObjectList objlist(pRenderPassBeginInfo->renderPass, pRenderPassBeginInfo->framebuffer, image_view_state->Handle(),
+                                    image_view_state->image_state->Handle());
 
         if (framebuffer_attachment_image_info->flags != image_create_info->flags) {
             skip |= LogError("VUID-VkRenderPassBeginInfo-framebuffer-03209", objlist, attachment_loc.dot(Field::flags),
@@ -3212,7 +3212,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         }
         if ((fragment_density_map_view_state->image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) > 0) {
             const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView,
-                                        fragment_density_map_view_state->image_state->image());
+                                        fragment_density_map_view_state->image_state->Handle());
             skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159", objlist, view_loc,
                              "internal image was created with flags %s.",
                              string_VkImageCreateFlags(fragment_density_map_view_state->image_state->createInfo.flags).c_str());
@@ -3239,7 +3239,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
 
         const VkComponentMapping components = fragment_density_map_view_state->create_info.components;
         if (!IsIdentitySwizzle(components)) {
-            const LogObjectList objlist(commandBuffer, fragment_density_map_view_state->image_view());
+            const LogObjectList objlist(commandBuffer, fragment_density_map_view_state->Handle());
             skip |= LogError("VUID-VkRenderingInfo-imageView-09486", objlist, view_loc,
                              "has a non-identiy swizzle component, here are the actual swizzle values:\n"
                              "r swizzle = %s\n"
@@ -3267,7 +3267,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                 vvl::GetQuotientCeil(
                     x_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width))) {
-                const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView, image_state->image());
+                const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView, image_state->Handle());
                 skip |= LogError(
                     "VUID-VkRenderingInfo-pNext-06112", objlist,
                     rendering_info.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
@@ -3282,7 +3282,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                 vvl::GetQuotientCeil(
                     y_adjusted_extent,
                     static_cast<int64_t>(phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height))) {
-                const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView, image_state->image());
+                const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView, image_state->Handle());
                 skip |= LogError(
                     "VUID-VkRenderingInfo-pNext-06114", objlist,
                     rendering_info.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
@@ -3309,7 +3309,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
     }
 
     auto view_state = Get<vvl::ImageView>(rendering_fragment_shading_rate_attachment_info->imageView);
-    const LogObjectList objlist(commandBuffer, view_state->image_view());
+    const LogObjectList objlist(commandBuffer, view_state->Handle());
     if (pRenderingInfo->viewMask == 0) {
         if (view_state->create_info.subresourceRange.layerCount != 1 &&
             view_state->create_info.subresourceRange.layerCount < pRenderingInfo->layerCount) {
@@ -3482,7 +3482,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             auto image_view_state = Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[j].imageView);
             vvl::Image *image_state = image_view_state->image_state.get();
             if (image_state->createInfo.extent.width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, image_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
                                  rendering_info.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "width (%" PRIu32
@@ -3491,7 +3491,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->createInfo.extent.width, offset_x, width);
             }
             if (image_state->createInfo.extent.height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, image_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
                                  rendering_info.dot(Field::pColorAttachments, j).dot(Field::imageView),
                                  "height (%" PRIu32
@@ -3505,7 +3505,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             auto depth_view_state = Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView);
             vvl::Image *image_state = depth_view_state->image_state.get();
             if (image_state->createInfo.extent.width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
                                  rendering_info.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
@@ -3514,7 +3514,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->createInfo.extent.width, offset_x, width);
             }
             if (image_state->createInfo.extent.height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
                                  rendering_info.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
@@ -3528,7 +3528,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             auto stencil_view_state = Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView);
             vvl::Image *image_state = stencil_view_state->image_state.get();
             if (image_state->createInfo.extent.width < offset_x + width) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06083", objlist,
                                  rendering_info.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "width (%" PRIu32
@@ -3537,7 +3537,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                                  image_state->createInfo.extent.width, offset_x, width);
             }
             if (image_state->createInfo.extent.height < offset_y + height) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pNext-06084", objlist,
                                  rendering_info.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "height (%" PRIu32
@@ -3555,7 +3555,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->createInfo.extent.width <
                 vvl::GetQuotientCeil(offset_x + width,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width)) {
-                const LogObjectList objlist(commandBuffer, view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
                     "VUID-VkRenderingInfo-pNext-06113", objlist,
                     rendering_info.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
@@ -3569,7 +3569,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             if (image_state->createInfo.extent.height <
                 vvl::GetQuotientCeil(offset_y + height,
                                      phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height)) {
-                const LogObjectList objlist(commandBuffer, view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, view_state->Handle(), image_state->Handle());
                 skip |= LogError(
                     "VUID-VkRenderingInfo-pNext-06115", objlist,
                     rendering_info.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView),
@@ -3810,14 +3810,14 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             auto image_view_state = Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[j].imageView);
             vvl::Image *image_state = image_view_state->image_state.get();
             if (!(image_state->createInfo.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
-                const LogObjectList objlist(commandBuffer, image_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-06087", objlist, color_loc.dot(Field::imageView),
                                  "must have been created with VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT.");
             }
 
             const VkComponentMapping components = image_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, image_view_state->image_view());
+                const LogObjectList objlist(commandBuffer, image_view_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-colorAttachmentCount-09479", objlist, color_loc.dot(Field::imageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n"
                                  "r swizzle = %s\n"
@@ -3910,7 +3910,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             if (resolve_view_state) {
                 const VkComponentMapping components = resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
-                    const LogObjectList objlist(commandBuffer, resolve_view_state->image_view());
+                    const LogObjectList objlist(commandBuffer, resolve_view_state->Handle());
                     skip |=
                         LogError("VUID-VkRenderingInfo-colorAttachmentCount-09480", objlist, color_loc.dot(Field::resolveImageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n"
@@ -3924,8 +3924,8 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
                 const VkImageUsageFlags image_usage = resolve_view_state->image_state->createInfo.usage;
                 if ((image_usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
-                    const LogObjectList objlist(commandBuffer, resolve_view_state->image_view(),
-                                                resolve_view_state->image_state->image());
+                    const LogObjectList objlist(commandBuffer, resolve_view_state->Handle(),
+                                                resolve_view_state->image_state->Handle());
                     skip |=
                         LogError("VUID-VkRenderingInfo-colorAttachmentCount-09476", objlist, color_loc.dot(Field::resolveImageView),
                                  "image was created with %s.", string_VkImageUsageFlags(image_usage).c_str());
@@ -3943,14 +3943,14 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             auto depth_view_state = Get<vvl::ImageView>(depth_attachment_info.imageView);
             vvl::Image *image_state = depth_view_state->image_state.get();
             if (!(image_state->createInfo.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06088", objlist,
                                  rendering_info.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "internal image must have been created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.");
             }
 
             if (!vkuFormatHasDepth(depth_view_state->create_info.format)) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->image_view());
+                const LogObjectList objlist(commandBuffer, depth_view_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-06547", objlist,
                                  rendering_info.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "was created with a format (%s) that does not have a depth aspect.",
@@ -3959,7 +3959,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
             const VkComponentMapping components = depth_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, depth_view_state->image_view());
+                const LogObjectList objlist(commandBuffer, depth_view_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09481", objlist,
                                  rendering_info.dot(Field::pDepthAttachment).dot(Field::imageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n"
@@ -3982,7 +3982,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             if (depth_resolve_view_state) {
                 const VkComponentMapping components = depth_resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
-                    const LogObjectList objlist(commandBuffer, depth_resolve_view_state->image_view());
+                    const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle());
                     skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09482", objlist,
                                      rendering_info.dot(Field::pDepthAttachment).dot(Field::resolveImageView),
                                      "has a non-identiy swizzle component, here are the actual swizzle values:\n"
@@ -3995,8 +3995,8 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                 }
                 const VkImageUsageFlags image_usage = depth_resolve_view_state->image_state->createInfo.usage;
                 if ((image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                    const LogObjectList objlist(commandBuffer, depth_resolve_view_state->image_view(),
-                                                depth_resolve_view_state->image_state->image());
+                    const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle(),
+                                                depth_resolve_view_state->image_state->Handle());
                     skip |= LogError("VUID-VkRenderingInfo-pDepthAttachment-09477", objlist,
                                      rendering_info.dot(Field::pDepthAttachment).dot(Field::resolveImageView),
                                      "image was created with %s.", string_VkImageUsageFlags(image_usage).c_str());
@@ -4014,14 +4014,14 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             auto stencil_view_state = Get<vvl::ImageView>(stencil_attachment_info.imageView);
             vvl::Image *image_state = stencil_view_state->image_state.get();
             if (!(image_state->createInfo.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->image_view(), image_state->image());
+                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06089", objlist,
                                  rendering_info.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "internal image must have been created with VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT.");
             }
 
             if (!vkuFormatHasStencil(stencil_view_state->create_info.format)) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->image_view());
+                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-06548", objlist,
                                  rendering_info.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "was created with a format (%s) that does not have a stencil aspect.",
@@ -4030,7 +4030,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
             const VkComponentMapping components = stencil_view_state->create_info.components;
             if (!IsIdentitySwizzle(components)) {
-                const LogObjectList objlist(commandBuffer, stencil_view_state->image_view());
+                const LogObjectList objlist(commandBuffer, stencil_view_state->Handle());
                 skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09483", objlist,
                                  rendering_info.dot(Field::pStencilAttachment).dot(Field::imageView),
                                  "has a non-identiy swizzle component, here are the actual swizzle values:\n"
@@ -4053,7 +4053,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
             if (stencil_resolve_view_state) {
                 const VkComponentMapping components = stencil_resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
-                    const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->image_view());
+                    const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle());
                     skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09484", objlist,
                                      rendering_info.dot(Field::pStencilAttachment).dot(Field::resolveImageView),
                                      "has a non-identiy swizzle component, here are the actual swizzle values:\n"
@@ -4066,8 +4066,8 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                 }
                 const VkImageUsageFlags image_usage = stencil_resolve_view_state->image_state->createInfo.usage;
                 if ((image_usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
-                    const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->image_view(),
-                                                stencil_resolve_view_state->image_state->image());
+                    const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle(),
+                                                stencil_resolve_view_state->image_state->Handle());
                     skip |= LogError("VUID-VkRenderingInfo-pStencilAttachment-09478", objlist,
                                      rendering_info.dot(Field::pStencilAttachment).dot(Field::resolveImageView),
                                      "image was created with %s.", string_VkImageUsageFlags(image_usage).c_str());
@@ -4160,7 +4160,7 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
                          "was created with VK_SAMPLE_COUNT_1_BIT but "
                          "VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT was not set in "
                          "pImageCreateInfo.flags when the image used to create the imageView (%s) was created",
-                         FormatHandle(image_state->image()).c_str());
+                         FormatHandle(image_state->Handle()).c_str());
     }
     if (!image_state->image_format_properties.sampleCounts) {
         if (GetPhysicalDeviceImageFormatProperties(*image_state, "VUID-VkMultisampledRenderToSingleSampledInfoEXT-pNext-06880",

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -31,7 +31,7 @@
 bool CoreChecks::LogInvalidAttachmentMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
                                              const vvl::RenderPass &rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
                                              const char *msg, const Location &loc, const char *error_code) const {
-    const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+    const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
     return LogError(error_code, objlist, loc,
                     "RenderPasses incompatible between %s w/ %s and %s w/ %s Attachment %" PRIu32
                     " is not "
@@ -273,7 +273,7 @@ bool CoreChecks::ValidateDependencyCompatibility(const char *type1_string, const
 bool CoreChecks::LogInvalidPnextMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
                                         const vvl::RenderPass &rp2_state, const char *msg, const Location &loc,
                                         const char *error_code) const {
-    const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+    const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
     return LogError(error_code, objlist, loc, "RenderPasses incompatible between %s w/ %s and %s w/ %s: %s", type1_string,
                     FormatHandle(rp1_state).c_str(), type2_string, FormatHandle(rp2_state).c_str(), msg);
 }
@@ -281,7 +281,7 @@ bool CoreChecks::LogInvalidPnextMessage(const char *type1_string, const vvl::Ren
 bool CoreChecks::LogInvalidDependencyMessage(const char *type1_string, const vvl::RenderPass &rp1_state, const char *type2_string,
                                              const vvl::RenderPass &rp2_state, const char *msg, const Location &loc,
                                              const char *error_code) const {
-    const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+    const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
     return LogError(error_code, objlist, loc, "RenderPasses incompatible between %s w/ %s and %s w/ %s: %s", type1_string,
                     FormatHandle(rp1_state).c_str(), type2_string, FormatHandle(rp2_state).c_str(), msg);
 }
@@ -296,7 +296,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
 
     // createInfo flags must be identical for the renderpasses to be compatible.
     if (rp1_state.createInfo.flags != rp2_state.createInfo.flags) {
-        const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+        const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
         skip |= LogError(vuid, objlist, loc,
                          "RenderPasses incompatible between %s w/ %s with flags of %" PRIu32
                          " and %s w/ "
@@ -306,7 +306,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
     }
 
     if (rp1_state.createInfo.subpassCount != rp2_state.createInfo.subpassCount) {
-        const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+        const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
         skip |= LogError(vuid, objlist, loc,
                          "RenderPasses incompatible between %s w/ %s with a subpassCount of %" PRIu32
                          " and %s w/ "
@@ -320,7 +320,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
     }
 
     if (rp1_state.createInfo.dependencyCount != rp2_state.createInfo.dependencyCount) {
-        const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+        const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
         skip |= LogError(vuid, objlist, loc,
                          "RenderPasses incompatible between %s w/ %s with a dependencyCount of %" PRIu32
                          " and %s w/ %s with a dependencyCount of %" PRIu32 ".",
@@ -332,7 +332,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
         }
     }
     if (rp1_state.createInfo.correlatedViewMaskCount != rp2_state.createInfo.correlatedViewMaskCount) {
-        const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+        const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
         skip |= LogError(vuid, objlist, loc,
                          "RenderPasses incompatible between %s w/ %s with a correlatedViewMaskCount of %" PRIu32
                          " and %s w/ %s with a correlatedViewMaskCount of %" PRIu32 ".",
@@ -341,7 +341,7 @@ bool CoreChecks::ValidateRenderPassCompatibility(const char *type1_string, const
     } else {
         for (uint32_t i = 0; i < rp1_state.createInfo.correlatedViewMaskCount; ++i) {
             if (rp1_state.createInfo.pCorrelatedViewMasks[i] != rp2_state.createInfo.pCorrelatedViewMasks[i]) {
-                const LogObjectList objlist(rp1_state.renderPass(), rp2_state.renderPass());
+                const LogObjectList objlist(rp1_state.Handle(), rp2_state.Handle());
                 skip |= LogError(vuid, objlist, loc,
                                  "RenderPasses incompatible between %s w/ %s with a pCorrelatedViewMasks[%" PRIu32 "] of %" PRIu32
                                  " and %s w/ %s with a pCorrelatedViewMasks[%" PRIu32 "] of %" PRIu32 ".",
@@ -464,14 +464,14 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
                          "attachment number so even if some pClearValues entries between 0 and %" PRIu32
                          " correspond to attachments "
                          "that aren't cleared they will be ignored.",
-                         pRenderPassBegin->clearValueCount, clear_op_size, FormatHandle(rp_state.renderPass()).c_str(),
-                         clear_op_size, clear_op_size - 1);
+                         pRenderPassBegin->clearValueCount, clear_op_size, FormatHandle(rp_state.Handle()).c_str(), clear_op_size,
+                         clear_op_size - 1);
     }
     skip |= VerifyFramebufferAndRenderPassImageViews(pRenderPassBegin, rp_begin_loc);
     skip |= VerifyRenderAreaBounds(pRenderPassBegin, rp_begin_loc);
 
     skip |= VerifyFramebufferAndRenderPassLayouts(cb_state, pRenderPassBegin, fb_state, rp_begin_loc);
-    if (fb_state.rp_state->renderPass() != rp_state.renderPass()) {
+    if (fb_state.rp_state->VkHandle() != rp_state.VkHandle()) {
         skip |= ValidateRenderPassCompatibility("render pass", rp_state, "framebuffer", *fb_state.rp_state, rp_begin_loc,
                                                 "VUID-VkRenderPassBeginInfo-renderPass-00904");
     }
@@ -582,12 +582,12 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
     const VkRenderPassCreateInfo2 *rpci = rp_state.createInfo.ptr();
     if (!rp_state.UsesDynamicRendering() && (cb_state.GetActiveSubpass() != rp_state.createInfo.subpassCount - 1)) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-03103" : "VUID-vkCmdEndRenderPass-None-00910";
-        const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+        const LogObjectList objlist(commandBuffer, rp_state.Handle());
         skip |= LogError(vuid, objlist, error_obj.location, "Called before reaching final subpass.");
     }
 
     if (rp_state.UsesDynamicRendering()) {
-        const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+        const LogObjectList objlist(commandBuffer, rp_state.Handle());
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-06171" : "VUID-vkCmdEndRenderPass-None-06170";
         skip |= LogError(vuid, objlist, error_obj.location,
                          "Called when the render pass instance was begun with vkCmdBeginRendering().");
@@ -597,7 +597,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
         const auto *fdm_offset_info = vku::FindStructInPNextChain<VkSubpassFragmentDensityMapOffsetEndInfoQCOM>(pSubpassEndInfo->pNext);
         if (fdm_offset_info && fdm_offset_info->fragmentDensityOffsetCount != 0) {
             if ((!enabled_features.fragmentDensityMapOffset) || (!enabled_features.fragmentDensityMap)) {
-                const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+                const LogObjectList objlist(commandBuffer, rp_state.Handle());
                 skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityMapOffsets-06503", objlist,
                                  error_obj.location.pNext(Struct::VkSubpassFragmentDensityMapOffsetEndInfoQCOM,
                                                           Field::fragmentDensityOffsetCount),
@@ -615,7 +615,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     uint32_t height = phys_dev_ext_props.fragment_density_map_offset_props.fragmentDensityOffsetGranularity.height;
 
                     if (SafeModulo(fdm_offset_info->pFragmentDensityOffsets[k].x, width) != 0) {
-                        const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle());
                         skip |= LogError(
                             "VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-x-06512", objlist, offset_loc.dot(Field::x),
                             "(%" PRIu32 ") is not an integer multiple of fragmentDensityOffsetGranularity.width (%" PRIu32 ").",
@@ -623,7 +623,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     }
 
                     if (SafeModulo(fdm_offset_info->pFragmentDensityOffsets[k].y, height) != 0) {
-                        const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle());
                         skip |= LogError(
                             "VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-y-06513", objlist, offset_loc.dot(Field::y),
                             "(%" PRIu32 ") is not an integer multiple of fragmentDensityOffsetGranularity.height (%" PRIu32 ").",
@@ -638,7 +638,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 const auto &ici = view_state.image_state->createInfo;
 
                 if ((fdm_non_zero_offsets == true) && ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                     skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-06502", objlist, error_obj.location,
                                      "pAttachments[%" PRIu32
                                      "] is not created with flag value"
@@ -653,7 +653,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
                     if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                         if ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0) {
-                            const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityMapAttachment-06504",
                                              objlist, error_obj.location,
                                              "Fragment density map attachment %" PRIu32
@@ -665,7 +665,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
 
                         if ((subpass.viewMask != 0) &&
                             (view_state.create_info.subresourceRange.layerCount != fdm_offset_info->fragmentDensityOffsetCount)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                             skip |= LogError(
                                 "VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06510", objlist,
                                 error_obj.location,
@@ -675,7 +675,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         }
 
                         if ((subpass.viewMask == 0) && (fdm_offset_info->fragmentDensityOffsetCount != 1)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06511",
                                              objlist, error_obj.location,
                                              "fragmentDensityOffsetCount %" PRIu32 " should be 1 when multiview is not enabled.",
@@ -688,7 +688,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (subpass.pDepthStencilAttachment && (subpass.pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) &&
                     (subpass.pDepthStencilAttachment->attachment == i) &&
                     ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                     skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pDepthStencilAttachment-06505", objlist,
                                      error_obj.location,
                                      "pDepthStencilAttachment[%" PRIu32
@@ -703,7 +703,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pInputAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pInputAttachments-06506", objlist,
                                          error_obj.location,
                                          "pInputAttachments[%" PRIu32
@@ -719,7 +719,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pColorAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pColorAttachments-06507", objlist,
                                          error_obj.location,
                                          "pColorAttachments[%" PRIu32
@@ -736,7 +736,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         const auto attachment = subpass.pResolveAttachments[k].attachment;
                         if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                             ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pResolveAttachments-06508", objlist,
                                              error_obj.location,
                                              "pResolveAttachments[%" PRIu32
@@ -753,7 +753,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pPreserveAttachments[k];
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.renderPass(), view_state.image_view());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.image_view());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pPreserveAttachments-06509", objlist,
                                          error_obj.location,
                                          "pPreserveAttachments[%" PRIu32
@@ -769,13 +769,13 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
 
     if (cb_state.transform_feedback_active) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-02352" : "VUID-vkCmdEndRenderPass-None-02351";
-        const LogObjectList objlist(commandBuffer, rp_state.renderPass());
+        const LogObjectList objlist(commandBuffer, rp_state.Handle());
         skip |= LogError(vuid, objlist, error_obj.location, "transform feedback is active.");
     }
 
     for (const auto &query : cb_state.renderPassQueries) {
         vuid = use_rp2 ? "VUID-vkCmdEndRenderPass2-None-07005" : "VUID-vkCmdEndRenderPass-None-07004";
-        const LogObjectList objlist(commandBuffer, rp_state.renderPass(), query.pool);
+        const LogObjectList objlist(commandBuffer, rp_state.Handle(), query.pool);
         skip |= LogError(vuid, objlist, error_obj.location,
                          "query %" PRIu32 " from %s was began in subpass %" PRIu32 " but never ended.", query.slot,
                          FormatHandle(query.pool).c_str(), query.subpass);
@@ -849,14 +849,14 @@ bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo *pRenderPass
                                  deviceRenderArea.offset.y);
             }
             if ((deviceRenderArea.offset.x + deviceRenderArea.extent.width) > framebuffer_info->width) {
-                const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->framebuffer());
+                const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->Handle());
                 skip |=
                     LogError("VUID-VkRenderPassBeginInfo-pNext-02856", objlist, render_area_loc,
                              "offset.x (%" PRId32 ") + extent.width (%" PRId32 ") is greater than framebuffer width (%" PRId32 ").",
                              deviceRenderArea.offset.x, deviceRenderArea.extent.width, framebuffer_info->width);
             }
             if ((deviceRenderArea.offset.y + deviceRenderArea.extent.height) > framebuffer_info->height) {
-                const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->framebuffer());
+                const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->Handle());
                 skip |= LogError("VUID-VkRenderPassBeginInfo-pNext-02857", objlist, render_area_loc,
                                  "offset.y (%" PRId32 ") + extent.height (%" PRId32 ") is greater than framebuffer height (%" PRId32
                                  ").",
@@ -879,7 +879,7 @@ bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo *pRenderPass
         const auto x_adjusted_extent = static_cast<int64_t>(pRenderPassBegin->renderArea.offset.x) +
                                        static_cast<int64_t>(pRenderPassBegin->renderArea.extent.width);
         if (x_adjusted_extent > static_cast<int64_t>(framebuffer_info->width)) {
-            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->framebuffer());
+            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->Handle());
             skip |=
                 LogError("VUID-VkRenderPassBeginInfo-pNext-02852", objlist, render_area_loc,
                          "offset.x (%" PRId32 ") + extent.width (%" PRId32 ") is greater than framebuffer width (%" PRId32 ").",
@@ -889,7 +889,7 @@ bool CoreChecks::VerifyRenderAreaBounds(const VkRenderPassBeginInfo *pRenderPass
         const auto y_adjusted_extent = static_cast<int64_t>(pRenderPassBegin->renderArea.offset.y) +
                                        static_cast<int64_t>(pRenderPassBegin->renderArea.extent.height);
         if (y_adjusted_extent > static_cast<int64_t>(framebuffer_info->height)) {
-            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->framebuffer());
+            const LogObjectList objlist(pRenderPassBegin->renderPass, framebuffer_state->Handle());
             skip |= LogError(
                 "VUID-VkRenderPassBeginInfo-pNext-02853", objlist, render_area_loc,
                 "offset.y (%" PRId32 ") + extent.height (%" PRId32 ") is greater than framebuffer height (%" PRId32 ").",
@@ -2202,7 +2202,7 @@ bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state,
 
             if (attachment_indices.count(attachment)) {
                 skip |= LogError(
-                    "UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass", render_pass_state.renderPass(), error_obj.location,
+                    "UNASSIGNED-CoreValidation-DrawState-InvalidRenderpass", render_pass_state.Handle(), error_obj.location,
                     "Cannot use same attachment (%" PRIu32 ") as both color and depth output in same subpass (%" PRIu32 ").",
                     attachment, i);
             }
@@ -2217,7 +2217,7 @@ bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state,
             uint32_t attachment = subpass.pInputAttachments[j].attachment;
             if (attachment == VK_ATTACHMENT_UNUSED) continue;
             const Location attachment_loc = subpass_loc.dot(Field::pInputAttachments, j);
-            CheckDependencyExists(render_pass_state.renderPass(), i, subpass.pInputAttachments[j].layout,
+            CheckDependencyExists(render_pass_state.VkHandle(), i, subpass.pInputAttachments[j].layout,
                                   attachments[attachment].outputs, subpass_to_node, attachment_loc, skip);
         }
         // If the attachment is an output then all subpasses that use the attachment must have a dependency relationship
@@ -2225,17 +2225,17 @@ bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state,
             uint32_t attachment = subpass.pColorAttachments[j].attachment;
             if (attachment == VK_ATTACHMENT_UNUSED) continue;
             const Location attachment_loc = subpass_loc.dot(Field::pColorAttachments, j);
-            CheckDependencyExists(render_pass_state.renderPass(), i, subpass.pColorAttachments[j].layout,
+            CheckDependencyExists(render_pass_state.VkHandle(), i, subpass.pColorAttachments[j].layout,
                                   attachments[attachment].outputs, subpass_to_node, attachment_loc, skip);
-            CheckDependencyExists(render_pass_state.renderPass(), i, subpass.pColorAttachments[j].layout,
+            CheckDependencyExists(render_pass_state.VkHandle(), i, subpass.pColorAttachments[j].layout,
                                   attachments[attachment].inputs, subpass_to_node, attachment_loc, skip);
         }
         if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
             const uint32_t &attachment = subpass.pDepthStencilAttachment->attachment;
             const Location attachment_loc = subpass_loc.dot(Field::pDepthStencilAttachment);
-            CheckDependencyExists(render_pass_state.renderPass(), i, subpass.pDepthStencilAttachment->layout,
+            CheckDependencyExists(render_pass_state.VkHandle(), i, subpass.pDepthStencilAttachment->layout,
                                   attachments[attachment].outputs, subpass_to_node, attachment_loc, skip);
-            CheckDependencyExists(render_pass_state.renderPass(), i, subpass.pDepthStencilAttachment->layout,
+            CheckDependencyExists(render_pass_state.VkHandle(), i, subpass.pDepthStencilAttachment->layout,
                                   attachments[attachment].inputs, subpass_to_node, attachment_loc, skip);
         }
     }
@@ -2246,7 +2246,7 @@ bool CoreChecks::ValidateDependencies(const vvl::Framebuffer &framebuffer_state,
         const VkSubpassDescription2 &subpass = create_info->pSubpasses[i];
         for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
             const Location attachment_loc = subpass_loc.dot(Field::pInputAttachments, j);
-            CheckPreserved(render_pass_state.renderPass(), create_info, i, subpass.pInputAttachments[j].attachment, subpass_to_node,
+            CheckPreserved(render_pass_state.VkHandle(), create_info, i, subpass.pInputAttachments[j].attachment, subpass_to_node,
                            0, attachment_loc, skip);
         }
     }
@@ -4091,7 +4091,7 @@ bool CoreChecks::InsideRenderPass(const vvl::CommandBuffer &cb_state, const Loca
     bool inside = false;
     if (cb_state.activeRenderPass) {
         inside = LogError(vuid, cb_state.commandBuffer(), loc, "It is invalid to issue this call inside an active %s.",
-                          FormatHandle(cb_state.activeRenderPass->renderPass()).c_str());
+                          FormatHandle(cb_state.activeRenderPass->Handle()).c_str());
     }
     return inside;
 }
@@ -5078,7 +5078,7 @@ bool CoreChecks::ValidateInheritanceInfoFramebuffer(VkCommandBuffer primaryBuffe
     if (!sub_cb_state.beginInfo.pInheritanceInfo) {
         return skip;
     }
-    VkFramebuffer primary_fb = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->framebuffer() : VK_NULL_HANDLE;
+    VkFramebuffer primary_fb = cb_state.activeFramebuffer ? cb_state.activeFramebuffer->VkHandle() : VK_NULL_HANDLE;
     VkFramebuffer secondary_fb = sub_cb_state.beginInfo.pInheritanceInfo->framebuffer;
     if (secondary_fb != VK_NULL_HANDLE) {
         if (primary_fb != secondary_fb) {

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -55,19 +55,19 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module &module_state
 
         // Same error, but provide more useful message 'how' VK_ATTACHMENT_UNUSED is derived
         if (!input_attachments) {
-            const LogObjectList objlist(module_state.handle(), rp_state->renderPass());
+            const LogObjectList objlist(module_state.handle(), rp_state->Handle());
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06038", objlist, loc,
                              "SPIR-V consumes input attachment index %" PRIu32 " but pSubpasses[%" PRIu32
                              "].pInputAttachments is NULL.",
                              input_attachment_index, subpass);
         } else if (input_attachment_index >= subpass_description.inputAttachmentCount) {
-            const LogObjectList objlist(module_state.handle(), rp_state->renderPass());
+            const LogObjectList objlist(module_state.handle(), rp_state->Handle());
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06038", objlist, loc,
                              "SPIR-V consumes input attachment index %" PRIu32 " but that is greater than the pSubpasses[%" PRIu32
                              "].inputAttachmentCount (%" PRIu32 ").",
                              input_attachment_index, subpass, subpass_description.inputAttachmentCount);
         } else if (input_attachments[input_attachment_index].attachment == VK_ATTACHMENT_UNUSED) {
-            const LogObjectList objlist(module_state.handle(), rp_state->renderPass());
+            const LogObjectList objlist(module_state.handle(), rp_state->Handle());
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06038", objlist, loc,
                              "SPIR-V consumes input attachment index %" PRIu32 " but pSubpasses[%" PRIu32
                              "].pInputAttachments[%" PRIu32 "].attachment is VK_ATTACHMENT_UNUSED.",
@@ -830,7 +830,7 @@ bool CoreChecks::ValidateShaderResolveQCOM(const spirv::Module &module_state, Vk
         const auto &rp_state = pipeline.RenderPassState();
         auto subpass_flags = (!rp_state) ? 0 : rp_state->createInfo.pSubpasses[pipeline.Subpass()].flags;
         if ((subpass_flags & VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM) != 0) {
-            const LogObjectList objlist(module_state.handle(), rp_state->renderPass());
+            const LogObjectList objlist(module_state.handle(), rp_state->Handle());
             skip |= LogError("VUID-RuntimeSpirv-SampleRateShading-06378", objlist, loc,
                              "SPIR-V (Fragment stage) enables SampleRateShading capability "
                              "and the subpass flags includes VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM.");

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -95,7 +95,7 @@ bool CoreChecks::ValidateConservativeRasterization(const spirv::Module &module_s
     if (module_state.static_data_.has_builtin_fully_covered) {
         LogObjectList objlist(module_state.handle());
         if (stage_create_info.pipeline) {
-            objlist.add(stage_create_info.pipeline->PipelineLayoutState()->layout());
+            objlist.add(stage_create_info.pipeline->PipelineLayoutState()->Handle());
         }
         skip |= LogError("VUID-FullyCoveredEXT-conservativeRasterizationPostDepthCoverage-04235", objlist, loc,
                          "SPIR-V (Fragment stage) has a\nOpExecutionMode EarlyFragmentTests\nOpDecorate BuiltIn "
@@ -154,7 +154,7 @@ bool CoreChecks::ValidatePushConstantUsage(const StageCreateInfo &create_info, c
             // spec: "If a push constant block is declared in a shader"
             // Is checked regardless if element in Block is not statically used
             if ((push_constant_variable->offset < range.offset) | (push_constant_end > range_end)) {
-                const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+                const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
                 skip |= LogError(vuid, objlist, loc,
                                  "SPIR-V (%s) has a push constant buffer Block with range [%" PRIu32 ", %" PRIu32
                                  "] which outside the pipeline layout range of [%" PRIu32 ", %" PRIu32 "].",
@@ -166,9 +166,9 @@ bool CoreChecks::ValidatePushConstantUsage(const StageCreateInfo &create_info, c
     }
 
     if (!found_stage) {
-        const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+        const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
         skip |= LogError(vuid, objlist, loc, "SPIR-V (%s) Push constant are used, but %s doesn't set %s.",
-                         string_VkShaderStageFlags(stage).c_str(), FormatHandle(pipeline.PipelineLayoutState()->layout()).c_str(),
+                         string_VkShaderStageFlags(stage).c_str(), FormatHandle(pipeline.PipelineLayoutState()->Handle()).c_str(),
                          string_VkShaderStageFlags(stage).c_str());
     }
     return skip;
@@ -1663,14 +1663,14 @@ bool CoreChecks::ValidateShaderDescriptorVariable(const spirv::Module &module_st
         TypeToDescriptorTypeSet(module_state, variable.type_id, required_descriptor_count, descriptor_type_set, is_khr);
 
         if (!binding) {
-            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07988, objlist, loc,
                              "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32
                              "] (type `%s`) but was not declared in the pipeline layout.",
                              string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
                              string_DescriptorTypeSet(descriptor_type_set).c_str());
         } else if (~binding->stageFlags & variable.stage) {
-            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07988, objlist, loc,
                              "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32
                              "] (type `%s`) but the VkDescriptorSetLayoutBinding::stageFlags was %s.",
@@ -1679,14 +1679,14 @@ bool CoreChecks::ValidateShaderDescriptorVariable(const spirv::Module &module_st
                              string_VkShaderStageFlags(binding->stageFlags).c_str());
         } else if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_MUTABLE_EXT) &&
                    (descriptor_type_set.find(binding->descriptorType) == descriptor_type_set.end())) {
-            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |=
                 LogError(vuid_07990, objlist, loc,
                          "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32 "] of type %s but expected %s.",
                          string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
                          string_VkDescriptorType(binding->descriptorType), string_DescriptorTypeSet(descriptor_type_set).c_str());
         } else if (binding->descriptorCount < required_descriptor_count) {
-            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->layout());
+            const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07991, objlist, loc,
                              "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32 "] with %" PRIu32
                              " descriptors, but requires at least %" PRIu32 ".",

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2265,8 +2265,8 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
         skip |= ValidateBarrierQueueFamilies(objects, barrier_loc, image_loc, mem_barrier, image_data->Handle(),
                                              image_data->createInfo.sharingMode);
 
-        skip |= ValidateImageAspectMask(image_data->image(), image_data->createInfo.format, mem_barrier.subresourceRange.aspectMask,
-                                        image_data->disjoint, image_loc);
+        skip |= ValidateImageAspectMask(image_data->VkHandle(), image_data->createInfo.format,
+                                        mem_barrier.subresourceRange.aspectMask, image_data->disjoint, image_loc);
 
         skip |= ValidateImageBarrierSubresourceRange(barrier_loc.dot(Field::subresourceRange), *image_data,
                                                      mem_barrier.subresourceRange);

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -3167,8 +3167,8 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
                     if (!IsImageCompatibleWithVideoProfile(*reference_resource.image_state, vs_state->profile)) {
                         const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession,
-                                                    reference_resource.image_view_state->image_view(),
-                                                    reference_resource.image_state->image());
+                                                    reference_resource.image_view_state->Handle(),
+                                                    reference_resource.image_state->Handle());
                         skip |= LogError(
                             "VUID-VkVideoBeginCodingInfoKHR-pPictureResource-07240", objlist,
                             begin_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource).dot(Field::imageViewBinding),
@@ -3181,8 +3181,8 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
                     if (reference_resource.image_view_state->create_info.format != vs_state->create_info.referencePictureFormat) {
                         const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession,
-                                                    reference_resource.image_view_state->image_view(),
-                                                    reference_resource.image_state->image());
+                                                    reference_resource.image_view_state->Handle(),
+                                                    reference_resource.image_state->Handle());
                         skip |= LogError(
                             "VUID-VkVideoBeginCodingInfoKHR-pPictureResource-07241", objlist,
                             begin_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource).dot(Field::imageViewBinding),
@@ -3199,8 +3199,8 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
                     if (vs_state->IsDecode() && (supported_usage & VK_IMAGE_USAGE_VIDEO_DECODE_DPB_BIT_KHR) == 0) {
                         const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession,
-                                                    reference_resource.image_view_state->image_view(),
-                                                    reference_resource.image_state->image());
+                                                    reference_resource.image_view_state->Handle(),
+                                                    reference_resource.image_state->Handle());
                         skip |= LogError(
                             "VUID-VkVideoBeginCodingInfoKHR-slotIndex-07245", objlist,
                             begin_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource).dot(Field::imageViewBinding),
@@ -3214,8 +3214,8 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
 
                     if (vs_state->IsEncode() && (supported_usage & VK_IMAGE_USAGE_VIDEO_ENCODE_DPB_BIT_KHR) == 0) {
                         const LogObjectList objlist(commandBuffer, pBeginInfo->videoSession,
-                                                    reference_resource.image_view_state->image_view(),
-                                                    reference_resource.image_state->image());
+                                                    reference_resource.image_view_state->Handle(),
+                                                    reference_resource.image_state->Handle());
                         skip |= LogError(
                             "VUID-VkVideoBeginCodingInfoKHR-slotIndex-07246", objlist,
                             begin_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource).dot(Field::imageViewBinding),
@@ -3643,8 +3643,8 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                                          "VUID-vkCmdDecodeVideoKHR-commandBuffer-07148", where);
 
         if (!IsImageCompatibleWithVideoProfile(*dst_resource.image_state, vs_state->profile)) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->image_view(),
-                                        dst_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->Handle(),
+                                        dst_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07142", objlist,
                              decode_info_loc.dot(Field::dstPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) is not compatible with the video profile the bound "
@@ -3654,8 +3654,8 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
         }
 
         if (dst_resource.image_view_state->create_info.format != vs_state->create_info.pictureFormat) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->image_view(),
-                                        dst_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->Handle(),
+                                        dst_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07143", objlist,
                              decode_info_loc.dot(Field::dstPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) format (%s) does not match the pictureFormat (%s) "
@@ -3668,8 +3668,8 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
 
         auto supported_usage = dst_resource.image_view_state->inherited_usage;
         if ((supported_usage & VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR) == 0) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->image_view(),
-                                        dst_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), dst_resource.image_view_state->Handle(),
+                                        dst_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07146", objlist,
                              decode_info_loc.dot(Field::dstPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) was not created with VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR "
@@ -4077,8 +4077,8 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                                          "VUID-vkCmdEncodeVideoKHR-commandBuffer-08212", where);
 
         if (!IsImageCompatibleWithVideoProfile(*src_resource.image_state, vs_state->profile)) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->image_view(),
-                                        src_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->Handle(),
+                                        src_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08206", objlist,
                              encode_info_loc.dot(Field::srcPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) is not compatible with the video profile the bound "
@@ -4088,8 +4088,8 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         }
 
         if (src_resource.image_view_state->create_info.format != vs_state->create_info.pictureFormat) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->image_view(),
-                                        src_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->Handle(),
+                                        src_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08207", objlist,
                              encode_info_loc.dot(Field::srcPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) format (%s) does not match the pictureFormat (%s) "
@@ -4102,8 +4102,8 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
 
         auto supported_usage = src_resource.image_view_state->inherited_usage;
         if ((supported_usage & VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR) == 0) {
-            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->image_view(),
-                                        src_resource.image_state->image());
+            const LogObjectList objlist(commandBuffer, vs_state->videoSession(), src_resource.image_view_state->Handle(),
+                                        src_resource.image_state->Handle());
             skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08210", objlist,
                              encode_info_loc.dot(Field::srcPictureResource).dot(Field::imageViewBinding),
                              "(%s created from %s) was not created with VK_IMAGE_USAGE_VIDEO_ENCODE_SRC_BIT_KHR "

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -120,13 +120,13 @@ bool CoreChecks::ValidateVideoInlineQueryInfo(const vvl::QueryPool &query_pool_s
     bool skip = false;
 
     if (query_info.firstQuery >= query_pool_state.createInfo.queryCount) {
-        skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08372", query_pool_state.pool(), loc.dot(Field::firstQuery),
+        skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08372", query_pool_state.Handle(), loc.dot(Field::firstQuery),
                          "(%u) is greater than or equal to the number of queries (%u) in %s.", query_info.firstQuery,
                          query_pool_state.createInfo.queryCount, FormatHandle(query_pool_state).c_str());
     }
 
     if (query_info.firstQuery + query_info.queryCount > query_pool_state.createInfo.queryCount) {
-        skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08373", query_pool_state.pool(), loc.dot(Field::firstQuery),
+        skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08373", query_pool_state.Handle(), loc.dot(Field::firstQuery),
                          "(%u) plus queryCount (%u) is greater than the number of queries (%u) in %s.", query_info.firstQuery,
                          query_info.queryCount, query_pool_state.createInfo.queryCount, FormatHandle(query_pool_state).c_str());
     }

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -372,7 +372,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
 
     const auto surface_caps2 =
         surface_state->GetCapabilities(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                       physical_device_state->PhysDev(), surface_caps_query_pnext, create_info_loc, this);
+                                       physical_device_state->VkHandle(), surface_caps_query_pnext, create_info_loc, this);
 
     bool skip = false;
     VkSurfaceTransformFlagBitsKHR current_transform = surface_caps2.surfaceCapabilities.currentTransform;
@@ -470,7 +470,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
             VkSurfaceProtectedCapabilitiesKHR surface_protected_capabilities = vku::InitStructHelper();
             VkSurfaceCapabilities2KHR surface_capabilities =
                 vku::InitStructHelper(&surface_protected_capabilities);
-            const VkResult result = DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device_state->PhysDev(),
+            const VkResult result = DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device_state->VkHandle(),
                                                                                      &surface_info, &surface_capabilities);
 
             log_error = (result == VK_SUCCESS) && !surface_protected_capabilities.supportsProtected;
@@ -495,7 +495,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         vvl::span<const safe_VkSurfaceFormat2KHR> formats{};
         if (surface_state) {
             formats = surface_state->GetFormats(IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2),
-                                                physical_device_state->PhysDev(), surface_caps_query_pnext, create_info_loc, this);
+                                                physical_device_state->VkHandle(), surface_caps_query_pnext, create_info_loc, this);
         } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
             formats = physical_device_state->surfaceless_query_state.formats;
         }
@@ -536,7 +536,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
             safe_VkSurfaceCapabilities2KHR cached_capabilities{};
             if (surface_state) {
                 cached_capabilities = surface_state->GetCapabilities(
-                    IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2), physical_device_state->PhysDev(),
+                    IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2), physical_device_state->VkHandle(),
                     surface_caps_query_pnext, create_info_loc, this);
             } else if (IsExtEnabled(instance_extensions.vk_google_surfaceless_query)) {
                 cached_capabilities = physical_device_state->surfaceless_query_state.capabilities;
@@ -585,7 +585,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
         VkSurfaceCapabilities2KHR capabilities2 = vku::InitStructHelper(&shared_present_capabilities);
         VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
         surface_info.surface = pCreateInfo->surface;
-        DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device_state->PhysDev(), &surface_info, &capabilities2);
+        DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(physical_device_state->VkHandle(), &surface_info, &capabilities2);
 
         if (image_usage != (image_usage & shared_present_capabilities.sharedPresentSupportedUsageFlags)) {
             if (LogError("VUID-VkSwapchainCreateInfoKHR-imageUsage-01384", device, create_info_loc.dot(Field::imageUsage),

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -735,7 +735,7 @@ void CoreChecks::PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKH
         if (swapchain_data) {
             for (const auto &swapchain_image : swapchain_data->images) {
                 if (!swapchain_image.image_state) continue;
-                qfo_release_image_barrier_map.erase(swapchain_image.image_state->image());
+                qfo_release_image_barrier_map.erase(swapchain_image.image_state->VkHandle());
             }
         }
     }
@@ -815,18 +815,18 @@ bool CoreChecks::ValidateImageAcquireWait(const vvl::SwapchainImage &swapchain_i
 
         const Location image_index_loc = present_info_loc.dot(Field::pImageIndices, image_index);
         if (semaphore && fence) {
-            const LogObjectList objlist(swapchain_image.image_state->image(), semaphore->Handle(), fence->Handle());
+            const LogObjectList objlist(swapchain_image.image_state->VkHandle(), semaphore->Handle(), fence->Handle());
             skip |= LogError(missing_acquire_wait_vuid, objlist, image_index_loc,
                              "was acquired with a semaphore %s and fence %s and neither of them have since been waited on",
                              FormatHandle(semaphore->Handle()).c_str(), FormatHandle(fence->Handle()).c_str());
         } else if (semaphore) {
-            const LogObjectList objlist(swapchain_image.image_state->image(), semaphore->Handle());
+            const LogObjectList objlist(swapchain_image.image_state->VkHandle(), semaphore->Handle());
             skip |= LogError(missing_acquire_wait_vuid, objlist, image_index_loc,
                              "was acquired with a semaphore %s that has not since been waited on",
                              FormatHandle(semaphore->Handle()).c_str());
         } else {
             assert(fence != nullptr);  // if both fence and semaphore are not provided we have an early exit
-            const LogObjectList objlist(swapchain_image.image_state->image(), fence->Handle());
+            const LogObjectList objlist(swapchain_image.image_state->VkHandle(), fence->Handle());
             skip |=
                 LogError(missing_acquire_wait_vuid, objlist, image_index_loc,
                          "was acquired with a fence %s that has not since been waited on", FormatHandle(fence->Handle()).c_str());

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -362,7 +362,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     variable->image_sampled_type_width);
             } else if (!dev_state.enabled_features.sparseImageInt64Atomics && image_view_state->image_state->sparse_residency) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, image_view_state->image_state->image());
+                const LogObjectList objlist(set, image_view, image_view_state->image_state->Handle());
                 return dev_state.LogError(vuids.image_view_sparse_64_04474, objlist, loc,
                                 "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                 ") has a OpTypeImage's Sampled Type has a width of 64 backed by a sparse Image, but "
@@ -506,7 +506,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (!view_state || view_state->Destroyed()) {
                 continue;
             }
-            const bool same_view = view_state->image_view() == image_view;
+            const bool same_view = view_state->VkHandle() == image_view;
             const bool overlapping_view = image_view_state->OverlapSubresource(*view_state);
             if (!same_view && !overlapping_view) {
                 continue;
@@ -599,13 +599,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
+                    const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
                     return dev_state.LogError(vuid, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which will be overlap written to as %s in %s attachment %" PRIu32 ".",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                    FormatHandle(view_state->image_view()).c_str(), FormatHandle(framebuffer).c_str(),
-                                    att_index);
+                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                              ") has %s which will be overlap written to as %s in %s attachment %" PRIu32 ".",
+                                              FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                                              FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(),
+                                              att_index);
                 }
             }
             const bool read_attachment = (subpass.usage & (VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT)) > 0;
@@ -620,13 +620,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
-                    return dev_state.LogError(vuids.image_subresources_subpass_write_06539, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                    FormatHandle(view_state->image_view()).c_str(), FormatHandle(framebuffer).c_str(),
-                                    att_index);
+                    const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
+                    return dev_state.LogError(
+                        vuids.image_subresources_subpass_write_06539, objlist, loc,
+                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                        ") has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.",
+                        FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                        FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(), att_index);
                 }
             }
 
@@ -641,13 +641,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, image_view, framebuffer, view_state->image_view());
+                    const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
                     return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                    FormatHandle(view_state->image_view()).c_str(), FormatHandle(framebuffer).c_str(),
-                                    att_index);
+                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                              ") has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".",
+                                              FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                                              FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(),
+                                              att_index);
                 }
             }
         }
@@ -677,14 +677,14 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (image_view_format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 || image_view_format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                 return dev_state.LogError(
                     "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                     ") has %s which has a custom border color with format = VK_FORMAT_UNDEFINED and is used to sample an image "
                     "view %s with format %s",
                     FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                    FormatHandle(image_view_state->image_view()).c_str(), string_VkFormat(image_view_format));
+                    FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
         const VkFilter sampler_mag_filter = sampler_state->createInfo.magFilter;
@@ -694,39 +694,39 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
             if (sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_filter_sampler_04553, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
-                                "to VK_FALSE, but image view's (%s) format (%s) does not contain "
-                                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                FormatHandle(image_view_state->image_view()).c_str(), string_VkFormat(image_view_format));
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
+                                          "to VK_FALSE, but image view's (%s) format (%s) does not contain "
+                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->createInfo.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
-                                "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
-                                "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                FormatHandle(image_view_state->image_view()).c_str(), string_VkFormat(image_view_format));
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
+                                          "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
+                                          "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
 
         if (sampler_mag_filter == VK_FILTER_CUBIC_EXT || sampler_min_filter == VK_FILTER_CUBIC_EXT) {
             if (!(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
-                return dev_state.LogError(vuids.cubic_sampler_02692, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
-                                "MUST contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                FormatHandle(image_view_state->image_view()).c_str(),
-                                string_VkFormat(image_view_state->create_info.format));
+                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                return dev_state.LogError(
+                    vuids.cubic_sampler_02692, objlist, loc,
+                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                    ") has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
+                    "MUST contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
+                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                    FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_state->create_info.format));
             }
 
             if (IsExtEnabled(dev_state.device_extensions.vk_ext_filter_cubic)) {
@@ -736,25 +736,27 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                      reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MAX) &&
                     !image_view_state->filter_cubic_props.filterCubicMinmax) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                     return dev_state.LogError(vuids.filter_cubic_min_max_02695, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
-                                    "(%s) doesn't support filterCubicMinmax.",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                    string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
-                                    FormatHandle(image_view_state->image_view()).c_str());
+                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
+                                              "(%s) doesn't support filterCubicMinmax.",
+                                              FormatHandle(set).c_str(), binding, index,
+                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
+                                              FormatHandle(image_view_state->Handle()).c_str());
                 }
 
                 if (!image_view_state->filter_cubic_props.filterCubic) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                     return dev_state.LogError(vuids.filter_cubic_02694, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
-                                    "doesn't support filterCubic.",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                    FormatHandle(image_view_state->image_view()).c_str());
+                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
+                                              "doesn't support filterCubic.",
+                                              FormatHandle(set).c_str(), binding, index,
+                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              FormatHandle(image_view_state->Handle()).c_str());
                 }
             }
 
@@ -763,14 +765,15 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->image_view());
+                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
                     return dev_state.LogError(vuids.img_filter_cubic_02693, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
-                                    "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
-                                    FormatHandle(image_view_state->image_view()).c_str(),
-                                    string_VkImageViewType(image_view_state->create_info.viewType));
+                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
+                                              "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
+                                              FormatHandle(set).c_str(), binding, index,
+                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              FormatHandle(image_view_state->Handle()).c_str(),
+                                              string_VkImageViewType(image_view_state->create_info.viewType));
                 }
             }
         }
@@ -789,16 +792,17 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                                     ? sampler_state->createInfo.addressModeV
                                                     : sampler_state->createInfo.addressModeW;
             auto set = descriptor_set.Handle();
-            const LogObjectList objlist(set, sampler_state->sampler(), image_state->image(), image_view_state->image_view());
+            const LogObjectList objlist(set, sampler_state->sampler(), image_state->Handle(), image_view_state->Handle());
             return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") image (%s) in image view (%s) is created with flag "
-                            "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
-                            "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
-                            "createInfo.addressMode%s set to %s.",
-                            FormatHandle(set).c_str(), binding, index, FormatHandle(image_state->image()).c_str(),
-                            FormatHandle(image_view_state->image_view()).c_str(), FormatHandle(sampler_state->sampler()).c_str(),
-                            address_mode_letter.c_str(), string_VkSamplerAddressMode(address_mode));
+                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                      ") image (%s) in image view (%s) is created with flag "
+                                      "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
+                                      "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
+                                      "createInfo.addressMode%s set to %s.",
+                                      FormatHandle(set).c_str(), binding, index, FormatHandle(image_state->Handle()).c_str(),
+                                      FormatHandle(image_view_state->Handle()).c_str(),
+                                      FormatHandle(sampler_state->sampler()).c_str(), address_mode_letter.c_str(),
+                                      string_VkSamplerAddressMode(address_mode));
         }
 
         // UnnormalizedCoordinates sampler validations

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -677,13 +677,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (image_view_format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 || image_view_format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(
                     "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                     ") has %s which has a custom border color with format = VK_FORMAT_UNDEFINED and is used to sample an image "
                     "view %s with format %s",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
                     FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
@@ -694,24 +694,24 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             !(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
             if (sampler_mag_filter == VK_FILTER_LINEAR || sampler_min_filter == VK_FILTER_LINEAR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_filter_sampler_04553, objlist, loc,
                                           "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                           ") has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
                                           "to VK_FALSE, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->createInfo.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
                                           "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                           ") has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
                                           "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
@@ -719,13 +719,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (sampler_mag_filter == VK_FILTER_CUBIC_EXT || sampler_min_filter == VK_FILTER_CUBIC_EXT) {
             if (!(image_view_state->format_features & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(
                     vuids.cubic_sampler_02692, objlist, loc,
                     "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                     ") has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
                     "MUST contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->sampler()).c_str(),
+                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
                     FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_state->create_info.format));
             }
 
@@ -736,26 +736,26 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                      reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MAX) &&
                     !image_view_state->filter_cubic_props.filterCubicMinmax) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                    const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                     return dev_state.LogError(vuids.filter_cubic_min_max_02695, objlist, loc,
                                               "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                               ") has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
                                               "(%s) doesn't support filterCubicMinmax.",
                                               FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              FormatHandle(sampler_state->Handle()).c_str(),
                                               string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
                                               FormatHandle(image_view_state->Handle()).c_str());
                 }
 
                 if (!image_view_state->filter_cubic_props.filterCubic) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                    const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                     return dev_state.LogError(vuids.filter_cubic_02694, objlist, loc,
                                               "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                               ") has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
                                               "doesn't support filterCubic.",
                                               FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              FormatHandle(sampler_state->Handle()).c_str(),
                                               FormatHandle(image_view_state->Handle()).c_str());
                 }
             }
@@ -765,13 +765,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
                     auto set = descriptor_set.Handle();
-                    const LogObjectList objlist(set, sampler_state->sampler(), image_view_state->Handle());
+                    const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                     return dev_state.LogError(vuids.img_filter_cubic_02693, objlist, loc,
                                               "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                               ") has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
                                               "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
                                               FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->sampler()).c_str(),
+                                              FormatHandle(sampler_state->Handle()).c_str(),
                                               FormatHandle(image_view_state->Handle()).c_str(),
                                               string_VkImageViewType(image_view_state->create_info.viewType));
                 }
@@ -792,7 +792,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                                     ? sampler_state->createInfo.addressModeV
                                                     : sampler_state->createInfo.addressModeW;
             auto set = descriptor_set.Handle();
-            const LogObjectList objlist(set, sampler_state->sampler(), image_state->Handle(), image_view_state->Handle());
+            const LogObjectList objlist(set, sampler_state->Handle(), image_state->Handle(), image_view_state->Handle());
             return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
                                       "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
                                       ") image (%s) in image view (%s) is created with flag "
@@ -801,7 +801,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                       "createInfo.addressMode%s set to %s.",
                                       FormatHandle(set).c_str(), binding, index, FormatHandle(image_state->Handle()).c_str(),
                                       FormatHandle(image_view_state->Handle()).c_str(),
-                                      FormatHandle(sampler_state->sampler()).c_str(), address_mode_letter.c_str(),
+                                      FormatHandle(sampler_state->Handle()).c_str(), address_mode_letter.c_str(),
                                       string_VkSamplerAddressMode(address_mode));
         }
 
@@ -813,43 +813,43 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY ||
                 image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, sampler_state->sampler());
-                return dev_state.LogError(vuids.sampler_imageview_type_08609, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") Image View %s, type %s, is used by %s.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                string_VkImageViewType(image_view_ci.viewType), FormatHandle(sampler_state->sampler()).c_str());
+                const LogObjectList objlist(set, image_view, sampler_state->Handle());
+                return dev_state.LogError(
+                    vuids.sampler_imageview_type_08609, objlist, loc,
+                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") Image View %s, type %s, is used by %s.",
+                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                    string_VkImageViewType(image_view_ci.viewType), FormatHandle(sampler_state->Handle()).c_str());
             }
 
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
             // instructions with ImplicitLod, Dref or Proj in their name
             if (variable->info.is_sampler_implicitLod_dref_proj) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(vuids.sampler_implicitLod_dref_proj_08610, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") Image View %s is used by %s that uses invalid operator.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                FormatHandle(sampler_state->sampler()).c_str());
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") Image View %s is used by %s that uses invalid operator.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str());
             }
 
             // sampler must not be used with any of the SPIR-V OpImageSample* or OpImageSparseSample*
             // instructions that includes a LOD bias or any offset values
             if (variable->info.is_sampler_bias_offset) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(vuids.sampler_bias_offset_08611, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") Image View %s is used by %s that uses invalid bias or offset operator.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                FormatHandle(sampler_state->sampler()).c_str());
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") Image View %s is used by %s that uses invalid bias or offset operator.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str());
             }
         }
 
         if (sampler_state->samplerConversion) {
             if (variable->info.is_not_sampler_sampled) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
                     vuids.image_ycbcr_sampled_06550, set, loc,
                     "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32
@@ -858,7 +858,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
             if (variable->info.is_sampler_offset) {
                 auto set = descriptor_set.Handle();
-                const LogObjectList objlist(set, image_view, sampler_state->sampler());
+                const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
                     vuids.image_ycbcr_offset_06551, set, loc,
                     "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -153,10 +153,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         for (const auto &binding : buffer_node->GetInvalidMemory()) {
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") is using buffer %s that references invalid memory %s.",
-                            FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(buffer).c_str(),
-                            FormatHandle(binding->deviceMemory()).c_str());
+                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                      ") is using buffer %s that references invalid memory %s.",
+                                      FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(buffer).c_str(),
+                                      FormatHandle(binding->Handle()).c_str());
         }
     }
     if (dev_state.enabled_features.protectedMemory == VK_TRUE) {
@@ -1087,10 +1087,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             for (const auto &mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") is using acceleration structure %s that references invalid memory %s.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
-                                FormatHandle(mem_binding->deviceMemory()).c_str());
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") is using acceleration structure %s that references invalid memory %s.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
+                                          FormatHandle(mem_binding->Handle()).c_str());
             }
         }
     } else {
@@ -1108,10 +1108,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             for (const auto &mem_binding : acc_node->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") is using acceleration structure %s that references invalid memory %s.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
-                                FormatHandle(mem_binding->deviceMemory()).c_str());
+                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
+                                          ") is using acceleration structure %s that references invalid memory %s.",
+                                          FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
+                                          FormatHandle(mem_binding->Handle()).c_str());
             }
         }
     }

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -717,7 +717,7 @@ void debug_printf::Validator::AllocateDebugPrintfResources(const VkCommandBuffer
         // may be a "pseudo layout" used to represent the union of pre-raster and fragment shader layouts, and therefore have a
         // null handle.
         const auto pipeline_layout_handle =
-            (last_bound.pipeline_layout) ? last_bound.pipeline_layout : pipeline_state->PreRasterPipelineLayoutState()->layout();
+            (last_bound.pipeline_layout) ? last_bound.pipeline_layout : pipeline_state->PreRasterPipelineLayoutState()->VkHandle();
         if (pipeline_layout->set_layouts.size() <= desc_set_bind_index) {
             DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_layout_handle, desc_set_bind_index, 1, desc_sets.data(),
                                           0, nullptr);

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -441,7 +441,7 @@ void debug_printf::CommandBuffer::Process(VkQueue queue, const Location &loc) {
 
             VkResult result = vmaMapMemory(device_state->vmaAllocator, buffer_info.output_mem_block.allocation, (void **)&data);
             if (result == VK_SUCCESS) {
-                device_state->AnalyzeAndGenerateMessages(commandBuffer(), queue, buffer_info, operation_index, (uint32_t *)data);
+                device_state->AnalyzeAndGenerateMessages(VkHandle(), queue, buffer_info, operation_index, (uint32_t *)data);
                 vmaUnmapMemory(device_state->vmaAllocator, buffer_info.output_mem_block.allocation);
             }
         }

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -711,7 +711,7 @@ bool gpuav::Validator::VerifyImageLayoutRange(const vvl::CommandBuffer &cb_state
                 // We can report all the errors for the intersected range directly
                 for (auto index : sparse_container::range_view<decltype(intersected_range)>(intersected_range)) {
                     const auto subresource = image_state.subresource_encoder.Decode(index);
-                    const LogObjectList objlist(cb_state.commandBuffer(), image_state.Handle());
+                    const LogObjectList objlist(cb_state.Handle(), image_state.Handle());
                     skip |= LogError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout", objlist, loc,
                                      "command buffer %s expects %s (subresource: aspectMask 0x%x array layer %" PRIu32
                                      ", mip level %" PRIu32

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -673,7 +673,7 @@ bool gpuav::Validator::VerifyImageLayoutRange(const vvl::CommandBuffer &cb_state
                                               const RangeFactory &range_factory, const Location &loc,
                                               const char *mismatch_layout_vuid, bool *error) const {
     bool skip = false;
-    const auto *subresource_map = cb_state.GetImageSubresourceLayoutMap(image_state.image());
+    const auto *subresource_map = cb_state.GetImageSubresourceLayoutMap(image_state.VkHandle());
     if (!subresource_map) {
         return skip;
     }

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -693,7 +693,7 @@ void gpuav::RestorablePipelineState::Create(vvl::CommandBuffer *cb_state, VkPipe
 
     LastBound &last_bound = cb_state->lastBound[lv_bind_point];
     if (last_bound.pipeline_state) {
-        pipeline = last_bound.pipeline_state->pipeline();
+        pipeline = last_bound.pipeline_state->VkHandle();
         pipeline_layout = last_bound.pipeline_layout;
         descriptor_sets.reserve(last_bound.per_set.size());
         for (std::size_t i = 0; i < last_bound.per_set.size(); i++) {

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -1084,7 +1084,7 @@ void gpu_tracker::Validator::PostCallRecordPipelineCreations(const uint32_t coun
                 // the pipeline is used, so we have to keep another copy.
                 if (module_state && module_state->spirv) code = module_state->spirv->words_;
 
-                shader_map.insert_or_assign(module_state->gpu_validation_shader_id, pipeline_state->pipeline(),
+                shader_map.insert_or_assign(module_state->gpu_validation_shader_id, pipeline_state->VkHandle(),
                                             shader_module.Cast<VkShaderModule>(), VK_NULL_HANDLE, std::move(code));
             }
         }

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -1067,13 +1067,12 @@ void gpu_tracker::Validator::PostCallRecordPipelineCreations(const uint32_t coun
             const auto pipeline_layout = pipeline_state->PipelineLayoutState();
             for (auto &stage_state : pipeline_state->stage_states) {
                 auto &module_state = stage_state.module_state;
-                const auto shader_module = module_state->Handle();
 
                 if (pipeline_state->active_slots.find(desc_set_bind_index) != pipeline_state->active_slots.end() ||
                     (pipeline_layout->set_layouts.size() >= adjusted_max_desc_sets)) {
                     auto *modified_ci = reinterpret_cast<const CreateInfo *>(modified_create_infos[pipeline].ptr());
                     auto uninstrumented_module = GetShaderModule(*modified_ci, stage_state.GetStage());
-                    assert(uninstrumented_module != shader_module.Cast<VkShaderModule>());
+                    assert(uninstrumented_module != module_state->VkHandle());
                     DispatchDestroyShaderModule(device, uninstrumented_module, pAllocator);
                 }
 
@@ -1085,7 +1084,7 @@ void gpu_tracker::Validator::PostCallRecordPipelineCreations(const uint32_t coun
                 if (module_state && module_state->spirv) code = module_state->spirv->words_;
 
                 shader_map.insert_or_assign(module_state->gpu_validation_shader_id, pipeline_state->VkHandle(),
-                                            shader_module.Cast<VkShaderModule>(), VK_NULL_HANDLE, std::move(code));
+                                            module_state->VkHandle(), VK_NULL_HANDLE, std::move(code));
             }
         }
     }

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -171,7 +171,7 @@ void gpuav::CommandBuffer::Process(VkQueue queue, const Location &loc) {
             } else {
                 assert(false);
             }
-            cmd_info->LogErrorIfAny(*device_state, queue, commandBuffer(), operation_index);
+            cmd_info->LogErrorIfAny(*device_state, queue, VkHandle(), operation_index);
         }
 
         // For each vkCmdBindDescriptorSets()...

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -596,7 +596,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndire
 
     VkPipeline validation_pipeline = VK_NULL_HANDLE;
     if (!use_shader_objects) {
-        validation_pipeline = GetDrawValidationPipeline(cb_node->activeRenderPass.get()->renderPass());
+        validation_pipeline = GetDrawValidationPipeline(cb_node->activeRenderPass.get()->VkHandle());
         if (validation_pipeline == VK_NULL_HANDLE) {
             ReportSetupProblem(device, "Could not find or create a pipeline. Aborting GPU-AV");
             aborted = true;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -529,7 +529,7 @@ gpuav::CommandResources gpuav::Validator::AllocateCommandResources(const VkComma
     if (last_bound.pipeline_layout) {
         pipeline_layout_handle = last_bound.pipeline_layout;
     } else if (pipeline_state && !pipeline_state->PreRasterPipelineLayoutState()->Destroyed()) {
-        pipeline_layout_handle = pipeline_state->PreRasterPipelineLayoutState()->layout();
+        pipeline_layout_handle = pipeline_state->PreRasterPipelineLayoutState()->VkHandle();
     }
     if ((pipeline_layout && pipeline_layout->set_layouts.size() <= desc_set_bind_index) &&
         pipeline_layout_handle != VK_NULL_HANDLE) {

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -51,7 +51,7 @@ class Buffer : public Bindable {
         }
     }
 
-    VkBuffer buffer() const { return handle_.Cast<VkBuffer>(); }
+    VkBuffer VkHandle() const { return handle_.Cast<VkBuffer>(); }
     std::optional<VkDeviceSize> ComputeValidSize(VkDeviceSize offset, VkDeviceSize size) const {
         return ::ComputeValidSize(offset, size, createInfo.size);
     }
@@ -96,7 +96,7 @@ class BufferView : public StateObject {
 
     BufferView(const BufferView &rh_obj) = delete;
 
-    VkBufferView buffer_view() const { return handle_.Cast<VkBufferView>(); }
+    VkBufferView VkHandle() const { return handle_.Cast<VkBufferView>(); }
 
     void Destroy() override {
         if (buffer_state) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -704,7 +704,7 @@ void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo
             }
 
             // Enqueue submission time DPB slot deactivation
-            video_session_updates[bound_video_session->videoSession()].emplace_back(
+            video_session_updates[bound_video_session->VkHandle()].emplace_back(
                 [deactivated_slots](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     for (const auto &slot_index : deactivated_slots) {
@@ -735,7 +735,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
             }
 
             // Enqueue submission time video session state reset/initialization
-            video_session_updates[bound_video_session->videoSession()].emplace_back(
+            video_session_updates[bound_video_session->VkHandle()].emplace_back(
                 [](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                    vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     dev_state.Reset();
@@ -749,7 +749,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
                 video_encode_rate_control_state = state;
 
                 // Enqueue rate control specific device state changes
-                video_session_updates[bound_video_session->videoSession()].emplace_back(
+                video_session_updates[bound_video_session->VkHandle()].emplace_back(
                     [state](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                             vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetRateControlState(state);
@@ -765,7 +765,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
                 video_encode_quality_level = quality_level;
 
                 // Enqueue encode quality level device state change
-                video_session_updates[bound_video_session->videoSession()].emplace_back(
+                video_session_updates[bound_video_session->VkHandle()].emplace_back(
                     [quality_level](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetEncodeQualityLevel(quality_level);
@@ -801,7 +801,7 @@ void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR *pDecodeInfo) {
 
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pDecodeInfo);
-            video_session_updates[bound_video_session->videoSession()].emplace_back(
+            video_session_updates[bound_video_session->VkHandle()].emplace_back(
                 [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {
@@ -841,7 +841,7 @@ void vvl::CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR *pEncodeInfo) {
 
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pEncodeInfo);
-            video_session_updates[bound_video_session->videoSession()].emplace_back(
+            video_session_updates[bound_video_session->VkHandle()].emplace_back(
                 [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1044,7 +1044,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, set, 1, nullptr, push_descriptor_set, 0, nullptr);
-    last_bound.pipeline_layout = pipeline_layout.layout();
+    last_bound.pipeline_layout = pipeline_layout.VkHandle();
 
     // Now that we have either the new or extant push_descriptor set ... do the write updates against it
     push_descriptor_set->PerformPushDescriptorsUpdate(descriptorWriteCount, pDescriptorWrites);
@@ -1164,7 +1164,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
     // Some useful shorthand
     const auto lv_bind_point = ConvertToLvlBindPoint(pipeline_bind_point);
     auto &last_bound = lastBound[lv_bind_point];
-    last_bound.pipeline_layout = pipeline_layout.layout();
+    last_bound.pipeline_layout = pipeline_layout.VkHandle();
     auto &pipe_compat_ids = pipeline_layout.set_compat_ids;
     // Resize binding arrays
     if (last_binding_index >= last_bound.per_set.size()) {
@@ -1245,7 +1245,7 @@ void CommandBuffer::UpdateLastBoundDescriptorBuffers(VkPipelineBindPoint pipelin
     // Some useful shorthand
     const auto lv_bind_point = ConvertToLvlBindPoint(pipeline_bind_point);
     auto &last_bound = lastBound[lv_bind_point];
-    last_bound.pipeline_layout = pipeline_layout.layout();
+    last_bound.pipeline_layout = pipeline_layout.VkHandle();
     auto &pipe_compat_ids = pipeline_layout.set_compat_ids;
     // Resize binding arrays
     if (last_binding_index >= last_bound.per_set.size()) {
@@ -1585,7 +1585,7 @@ LogObjectList CommandBuffer::GetObjectList(VkShaderStageFlagBits stage) const {
     const auto *pipeline_state = last_bound.pipeline_state;
 
     if (pipeline_state) {
-        objlist.add(pipeline_state->pipeline());
+        objlist.add(pipeline_state->Handle());
     } else if (VkShaderEXT shader = last_bound.GetShader(ConvertToShaderObjectStage(stage))) {
         objlist.add(shader);
     }
@@ -1599,7 +1599,7 @@ LogObjectList CommandBuffer::GetObjectList(VkPipelineBindPoint pipeline_bind_poi
     const auto *pipeline_state = last_bound.pipeline_state;
 
     if (pipeline_state) {
-        objlist.add(pipeline_state->pipeline());
+        objlist.add(pipeline_state->Handle());
     } else if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
         if (VkShaderEXT shader = last_bound.GetShader(ShaderObjectStage::COMPUTE)) {
             objlist.add(shader);

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -205,7 +205,7 @@ void CommandBuffer::ResetCBState() {
     transform_feedback_active = false;
 
     // Clean up the label data
-    ResetCmdDebugUtilsLabel(dev_data->report_data, commandBuffer());
+    ResetCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
 }
 
 void CommandBuffer::Reset() {
@@ -254,7 +254,7 @@ void CommandBuffer::ResetPushConstantDataIfIncompatible(const vvl::PipelineLayou
 
 void CommandBuffer::Destroy() {
     // Remove the cb debug labels
-    EraseCmdDebugUtilsLabel(dev_data->report_data, commandBuffer());
+    EraseCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
     {
         auto guard = WriteLock();
         ResetCBState();
@@ -974,7 +974,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
             }
         }
 
-        sub_cb_state->primaryCommandBuffer = commandBuffer();
+        sub_cb_state->primaryCommandBuffer = VkHandle();
         linkedCommandBuffers.insert(sub_cb_state.get());
         AddChild(sub_cb_state);
         // Add a query update that runs all the query updates that happen in the sub command buffer.

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -321,7 +321,7 @@ const ImageSubresourceLayoutMap *CommandBuffer::GetImageSubresourceLayoutMap(VkI
 
 // The non-const variant only needs the image state, as the factory requires it to construct a new entry
 ImageSubresourceLayoutMap *CommandBuffer::GetImageSubresourceLayoutMap(const vvl::Image &image_state) {
-    auto &layout_map = image_layout_map[image_state.image()];
+    auto &layout_map = image_layout_map[image_state.VkHandle()];
     if (!layout_map) {
         // Make sure we don't create a nullptr keyed entry for a zombie Image
         if (image_state.Destroyed() || !image_state.layout_range_map) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -82,7 +82,7 @@ class Event : public StateObject {
           flags(pCreateInfo->flags) {
     }
 
-    VkEvent event() const { return handle_.Cast<VkEvent>(); }
+    VkEvent VkHandle() const { return handle_.Cast<VkEvent>(); }
 };
 
 }  // namespace vvl
@@ -107,7 +107,7 @@ class CommandPool : public StateObject {
     CommandPool(ValidationStateTracker *dev, VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
-    VkCommandPool commandPool() const { return handle_.Cast<VkCommandPool>(); }
+    VkCommandPool VkHandle() const { return handle_.Cast<VkCommandPool>(); }
 
     void Allocate(const VkCommandBufferAllocateInfo *create_info, const VkCommandBuffer *command_buffers);
     void Free(uint32_t count, const VkCommandBuffer *command_buffers);
@@ -484,7 +484,7 @@ class CommandBuffer : public RefcountedStateObject {
 
     void Destroy() override;
 
-    VkCommandBuffer commandBuffer() const { return handle_.Cast<VkCommandBuffer>(); }
+    VkCommandBuffer VkHandle() const { return handle_.Cast<VkCommandBuffer>(); }
 
     vvl::ImageView *GetActiveAttachmentImageViewState(uint32_t index);
     const vvl::ImageView *GetActiveAttachmentImageViewState(uint32_t index) const;

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -378,7 +378,7 @@ class SamplerDescriptor : public Descriptor {
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
-    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
+    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->VkHandle() : VK_NULL_HANDLE; }
 
     void SetSamplerState(std::shared_ptr<vvl::Sampler> &&state) {
         sampler_state_ = std::move(state);
@@ -469,7 +469,7 @@ class ImageSamplerDescriptor : public ImageDescriptor {
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
     virtual bool IsImmutableSampler() const override { return immutable_; };
-    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->sampler() : VK_NULL_HANDLE; }
+    VkSampler GetSampler() const { return sampler_state_ ? sampler_state_->VkHandle() : VK_NULL_HANDLE; }
 
     void SetSamplerState(std::shared_ptr<vvl::Sampler> &&state) {
         sampler_state_ = std::move(state);

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -510,7 +510,7 @@ class TexelDescriptor : public Descriptor {
                      bool is_bindless) override;
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
-    VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->buffer_view() : VK_NULL_HANDLE; }
+    VkBufferView GetBufferView() const { return buffer_view_state_ ? buffer_view_state_->VkHandle() : VK_NULL_HANDLE; }
     const vvl::BufferView *GetBufferViewState() const { return buffer_view_state_.get(); }
     vvl::BufferView *GetBufferViewState() { return buffer_view_state_.get(); }
     std::shared_ptr<vvl::BufferView> GetSharedBufferViewState() const { return buffer_view_state_; }
@@ -542,7 +542,7 @@ class BufferDescriptor : public Descriptor {
                      bool is_bindless) override;
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
-    VkBuffer GetBuffer() const { return buffer_state_ ? buffer_state_->buffer() : VK_NULL_HANDLE; }
+    VkBuffer GetBuffer() const { return buffer_state_ ? buffer_state_->VkHandle() : VK_NULL_HANDLE; }
     const vvl::Buffer *GetBufferState() const { return buffer_state_.get(); }
     vvl::Buffer *GetBufferState() { return buffer_state_.get(); }
     std::shared_ptr<vvl::Buffer> GetSharedBufferState() const { return buffer_state_; }

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -422,7 +422,7 @@ class ImageDescriptor : public Descriptor {
     void CopyUpdate(DescriptorSet &set_state, const ValidationStateTracker &dev_data, const Descriptor &, bool is_bindless,
                     VkDescriptorType type) override;
     void UpdateDrawState(ValidationStateTracker *, vvl::CommandBuffer *cb_state);
-    VkImageView GetImageView() const { return image_view_state_ ? image_view_state_->image_view() : VK_NULL_HANDLE; }
+    VkImageView GetImageView() const { return image_view_state_ ? image_view_state_->VkHandle() : VK_NULL_HANDLE; }
     const vvl::ImageView *GetImageViewState() const { return image_view_state_.get(); }
     vvl::ImageView *GetImageViewState() { return image_view_state_.get(); }
     std::shared_ptr<vvl::ImageView> GetSharedImageViewState() const { return image_view_state_; }

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -81,7 +81,7 @@ class DeviceMemory : public StateObject {
     }
     bool IsDedicatedImage() const { return GetDedicatedImage() != VK_NULL_HANDLE; }
 
-    VkDeviceMemory deviceMemory() const { return handle_.Cast<VkDeviceMemory>(); }
+    VkDeviceMemory VkHandle() const { return handle_.Cast<VkDeviceMemory>(); }
 };
 
 // Generic memory binding struct to track objects bound to objects
@@ -138,7 +138,7 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
 
     const MEM_BINDING *Binding() const override { return binding_.memory_state ? &binding_ : nullptr; }
     unsigned CountDeviceMemory(VkDeviceMemory memory) const override {
-        return binding_.memory_state && binding_.memory_state->deviceMemory() == memory ? 1 : 0;
+        return binding_.memory_state && binding_.memory_state->VkHandle() == memory ? 1 : 0;
     }
 
     bool HasFullRangeBound() const override { return binding_.memory_state != nullptr; }

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -53,7 +53,7 @@ class PhysicalDevice : public StateObject {
     PhysicalDevice(VkPhysicalDevice phys_dev)
         : StateObject(phys_dev, kVulkanObjectTypePhysicalDevice), queue_family_properties(GetQueueFamilyProps(phys_dev)) {}
 
-    VkPhysicalDevice PhysDev() const { return handle_.Cast<VkPhysicalDevice>(); }
+    VkPhysicalDevice VkHandle() const { return handle_.Cast<VkPhysicalDevice>(); }
 
   private:
     const std::vector<VkQueueFamilyProperties> GetQueueFamilyProps(VkPhysicalDevice phys_dev) {
@@ -73,7 +73,7 @@ class DisplayMode : public StateObject {
     DisplayMode(VkDisplayModeKHR dm, VkPhysicalDevice phys_dev)
         : StateObject(dm, kVulkanObjectTypeDisplayModeKHR), physical_device(phys_dev) {}
 
-    VkDisplayModeKHR display_mode() const { return handle_.Cast<VkDisplayModeKHR>(); }
+    VkDisplayModeKHR VkHandle() const { return handle_.Cast<VkDisplayModeKHR>(); }
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/image_layout_map.cpp
+++ b/layers/state_tracker/image_layout_map.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2019-2023 The Khronos Group Inc.
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
- * Copyright (C) 2019-2023 Google Inc.
+/* Copyright (c) 2019-2024 The Khronos Group Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
+ * Copyright (C) 2019-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -79,7 +79,7 @@ static bool UpdateLayoutStateImpl(LayoutsMap& layouts, InitialLayoutStates& init
 InitialLayoutState::InitialLayoutState(const vvl::CommandBuffer& cb_state_, const vvl::ImageView* view_state_)
     : image_view(VK_NULL_HANDLE), aspect_mask(0), label(cb_state_.debug_label) {
     if (view_state_) {
-        image_view = view_state_->image_view();
+        image_view = view_state_->VkHandle();
         aspect_mask = view_state_->normalized_subresource_range.aspectMask;
     }
 }

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2022 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -151,7 +151,7 @@ class Image : public Bindable {
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<Image> shared_from_this() { return SharedFromThisImpl(this); }
 
-    VkImage image() const { return handle_.Cast<VkImage>(); }
+    VkImage VkHandle() const { return handle_.Cast<VkImage>(); }
 
     bool HasAHBFormat() const { return ahb_format != 0; }
     bool IsCompatibleAliasing(const Image *other_image_state) const;
@@ -298,7 +298,7 @@ class ImageView : public StateObject {
     ImageView(const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
               VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     ImageView(const ImageView &rh_obj) = delete;
-    VkImageView image_view() const { return handle_.Cast<VkImageView>(); }
+    VkImageView VkHandle() const { return handle_.Cast<VkImageView>(); }
 
     void LinkChildNodes() override {
         // Connect child node(s), which cannot safely be done in the constructor.
@@ -357,7 +357,7 @@ class Swapchain : public StateObject {
         }
     }
 
-    VkSwapchainKHR swapchain() const { return handle_.Cast<VkSwapchainKHR>(); }
+    VkSwapchainKHR VkHandle() const { return handle_.Cast<VkSwapchainKHR>(); }
 
     void PresentImage(uint32_t image_index, uint64_t present_id);
 
@@ -417,11 +417,11 @@ class Surface : public StateObject {
         }
     }
 
-    VkSurfaceKHR surface() const { return handle_.Cast<VkSurfaceKHR>(); }
+    VkSurfaceKHR VkHandle() const { return handle_.Cast<VkSurfaceKHR>(); }
     VkPhysicalDeviceSurfaceInfo2KHR GetSurfaceInfo2(const void *surface_info2_pnext = nullptr) const {
         VkPhysicalDeviceSurfaceInfo2KHR surface_info2 = vku::InitStructHelper();
         surface_info2.pNext = surface_info2_pnext;
-        surface_info2.surface = surface();
+        surface_info2.surface = VkHandle();
         return surface_info2;
     }
 

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -85,7 +85,7 @@ class PipelineLayout : public StateObject {
     template <typename Container>
     PipelineLayout(const Container &layouts) : PipelineLayout(vvl::span<const PipelineLayout *const>{layouts}) {}
 
-    VkPipelineLayout layout() const { return handle_.Cast<VkPipelineLayout>(); }
+    VkPipelineLayout VkHandle() const { return handle_.Cast<VkPipelineLayout>(); }
 
     std::shared_ptr<vvl::DescriptorSetLayout const> GetDsl(uint32_t set) const {
         std::shared_ptr<vvl::DescriptorSetLayout const> dsl = nullptr;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -905,7 +905,7 @@ bool LastBound::ValidShaderObjectCombination(const VkPipelineBindPoint bind_poin
 
 VkShaderEXT LastBound::GetShader(ShaderObjectStage stage) const {
     if (!IsValidShaderBound(stage) || GetShaderState(stage) == nullptr) return VK_NULL_HANDLE;
-    return shader_object_states[static_cast<uint32_t>(stage)]->shader();
+    return shader_object_states[static_cast<uint32_t>(stage)]->VkHandle();
 }
 
 vvl::ShaderObject *LastBound::GetShaderState(ShaderObjectStage stage) const {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -59,7 +59,7 @@ class PipelineCache : public StateObject {
     PipelineCache(VkPipelineCache pipeline_cache, const VkPipelineCacheCreateInfo *pCreateInfo)
         : StateObject(pipeline_cache, kVulkanObjectTypePipelineCache), create_info(pCreateInfo) {}
 
-    VkPipelineCache pipelineCache() const { return handle_.Cast<VkPipelineCache>(); }
+    VkPipelineCache VkHandle() const { return handle_.Cast<VkPipelineCache>(); }
 
     const safe_VkPipelineCacheCreateInfo create_info;
 };
@@ -193,7 +193,7 @@ class Pipeline : public StateObject {
     Pipeline(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
              std::shared_ptr<const vvl::PipelineLayout> &&layout, CreateShaderModuleStates *csm_states = nullptr);
 
-    VkPipeline pipeline() const { return handle_.Cast<VkPipeline>(); }
+    VkPipeline VkHandle() const { return handle_.Cast<VkPipeline>(); }
 
     void SetHandle(VkPipeline p) { handle_.handle = CastToUint64(p); }
 

--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -58,7 +58,7 @@ class QueryPool : public StateObject {
         }
     }
 
-    VkQueryPool pool() const { return handle_.Cast<VkQueryPool>(); }
+    VkQueryPool VkHandle() const { return handle_.Cast<VkQueryPool>(); }
 
     void SetQueryState(uint32_t query, uint32_t perf_pass, QueryState state) {
         auto guard = WriteLock();

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -38,7 +38,7 @@ class AccelerationStructureNV : public Bindable {
     }
     AccelerationStructureNV(const AccelerationStructureNV &rh_obj) = delete;
 
-    VkAccelerationStructureNV acceleration_structure() const { return handle_.Cast<VkAccelerationStructureNV>(); }
+    VkAccelerationStructureNV VkHandle() const { return handle_.Cast<VkAccelerationStructureNV>(); }
 
     void Build(const VkAccelerationStructureInfoNV *pInfo) {
         built = true;
@@ -82,7 +82,7 @@ class AccelerationStructureKHR : public StateObject {
         }
     }
 
-    VkAccelerationStructureKHR acceleration_structure() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
+    VkAccelerationStructureKHR VkHandle() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
 
     void LinkChildNodes() override {
         // Connect child node(s), which cannot safely be done in the constructor.

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -111,7 +111,7 @@ class RenderPass : public StateObject {
     RenderPass(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled);
     RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritanceRenderingInfo);
 
-    VkRenderPass renderPass() const { return handle_.Cast<VkRenderPass>(); }
+    VkRenderPass VkHandle() const { return handle_.Cast<VkRenderPass>(); }
 
     bool UsesColorAttachment(uint32_t subpass) const;
     bool UsesDepthStencilAttachment(uint32_t subpass) const;
@@ -133,7 +133,7 @@ class Framebuffer : public StateObject {
                 std::vector<std::shared_ptr<vvl::ImageView>> &&attachments);
     void LinkChildNodes() override;
 
-    VkFramebuffer framebuffer() const { return handle_.Cast<VkFramebuffer>(); }
+    VkFramebuffer VkHandle() const { return handle_.Cast<VkFramebuffer>(); }
 
     virtual ~Framebuffer() { Destroy(); }
 

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -68,7 +68,7 @@ class Sampler : public StateObject {
           samplerConversion(GetConversion(pci)),
           customCreateInfo(GetCustomCreateInfo(pci)) {}
 
-    VkSampler sampler() const { return handle_.Cast<VkSampler>(); }
+    VkSampler VkHandle() const { return handle_.Cast<VkSampler>(); }
 
   private:
     static inline VkSamplerYcbcrConversion GetConversion(const VkSamplerCreateInfo *pci) {
@@ -98,7 +98,7 @@ class SamplerYcbcrConversion : public StateObject {
           chromaFilter(info->chromaFilter),
           external_format(GetExternalFormat(info->pNext)) {}
 
-    VkSamplerYcbcrConversion ycbcr_conversion() const { return handle_.Cast<VkSamplerYcbcrConversion>(); }
+    VkSamplerYcbcrConversion VkHandle() const { return handle_.Cast<VkSamplerYcbcrConversion>(); }
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -667,6 +667,8 @@ struct ShaderModule : public StateObject {
         : StateObject(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
           gpu_validation_shader_id(unique_shader_id) {}
 
+    VkShaderModule VkHandle() const { return handle_.Cast<VkShaderModule>(); }
+
     // If null, means this is a empty object and no shader backing it
     // TODO - This (and vvl::ShaderObject) could be unique, but need handle multiple ValidationObjects
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6265/files

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023 Nintendo
- * Copyright (c) 2023 LunarG, Inc.
+/* Copyright (c) 2023-2024 Nintendo
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ struct ShaderObject : public StateObject {
     const PushConstantRangesId push_constant_ranges;
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
 
-    VkShaderEXT shader() const { return handle_.Cast<VkShaderEXT>(); }
+    VkShaderEXT VkHandle() const { return handle_.Cast<VkShaderEXT>(); }
     bool IsGraphicsShaderState() const { return create_info.stage != VK_SHADER_STAGE_COMPUTE_BIT; };
     VkPrimitiveTopology GetTopology() const;
 };

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1726,7 +1726,7 @@ void ValidationStateTracker::PostCallRecordCreateQueryPool(VkDevice device, cons
             }
         }
 
-        DispatchGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physical_device_state->PhysDev(), perf, &n_perf_pass);
+        DispatchGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(physical_device_state->VkHandle(), perf, &n_perf_pass);
     }
 
     VkVideoEncodeFeedbackFlagsKHR video_encode_feedback_flags = 0;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -445,7 +445,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
     } else {
         format_features = GetImageFormatFeatures(physical_device, has_format_feature2,
                                                  IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier), device,
-                                                 image_state->image(), pCreateInfo->format, image_state->createInfo.tiling);
+                                                 image_state->VkHandle(), pCreateInfo->format, image_state->createInfo.tiling);
     }
 
     // filter_cubic_props is used in CmdDraw validation. But it takes a lot of performance if it does in CmdDraw.

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -503,7 +503,7 @@ class VideoSession : public StateObject {
     VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR vs, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
-    VkVideoSessionKHR videoSession() const { return handle_.Cast<VkVideoSessionKHR>(); }
+    VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
     bool IsDecode() const { return profile->IsDecode(); }
     bool IsEncode() const { return profile->IsEncode(); }
     VkVideoCodecOperationFlagBitsKHR GetCodecOp() const { return profile->GetCodecOp(); }
@@ -680,7 +680,7 @@ class VideoSessionParameters : public StateObject {
     VideoSessionParameters(VkVideoSessionParametersKHR vsp, VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,
                            std::shared_ptr<VideoSession> &&vsstate, std::shared_ptr<VideoSessionParameters> &&vsp_template);
 
-    VkVideoSessionParametersKHR videoSessionParameters() const { return handle_.Cast<VkVideoSessionParametersKHR>(); }
+    VkVideoSessionParametersKHR VkHandle() const { return handle_.Cast<VkVideoSessionParametersKHR>(); }
 
     bool IsDecode() const { return vs_state->IsDecode(); }
     bool IsEncode() const { return vs_state->IsEncode(); }

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -380,10 +380,9 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_->SupressedBoundDescriptorWAW(hazard)) {
                             skip |= sync_state_->LogError(
-                                string_SyncHazardVUID(hazard.Hazard()), buf_view_state->buffer_view(), loc,
+                                string_SyncHazardVUID(hazard.Hazard()), buf_view_state->Handle(), loc,
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
-                                string_SyncHazard(hazard.Hazard()),
-                                sync_state_->FormatHandle(buf_view_state->buffer_view()).c_str(),
+                                string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_view_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
@@ -403,9 +402,9 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                         auto hazard = current_context_->DetectHazard(*buf_state, sync_index, range);
                         if (hazard.IsHazard() && !sync_state_->SupressedBoundDescriptorWAW(hazard)) {
                             skip |= sync_state_->LogError(
-                                string_SyncHazardVUID(hazard.Hazard()), buf_state->buffer(), loc,
+                                string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
-                                string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_state->buffer()).c_str(),
+                                string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
@@ -543,9 +542,9 @@ bool CommandBufferAccessContext::ValidateDrawVertex(const std::optional<uint32_t
             const ResourceAccessRange range = MakeRange(binding_buffer, firstVertex, vertexCount, binding_description.stride);
             auto hazard = current_context_->DetectHazard(*buf_state, SYNC_VERTEX_ATTRIBUTE_INPUT_VERTEX_ATTRIBUTE_READ, range);
             if (hazard.IsHazard()) {
-                skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->buffer(), loc,
+                skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                                               "Hazard %s for vertex %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
-                                              sync_state_->FormatHandle(buf_state->buffer()).c_str(),
+                                              sync_state_->FormatHandle(buf_state->Handle()).c_str(),
                                               sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                               FormatHazard(hazard).c_str());
             }
@@ -592,9 +591,9 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(const std::optional<uin
 
     auto hazard = current_context_->DetectHazard(*index_buf_state, SYNC_INDEX_INPUT_INDEX_READ, range);
     if (hazard.IsHazard()) {
-        skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), index_buf_state->buffer(), loc,
+        skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), index_buf_state->Handle(), loc,
                                       "Hazard %s for index %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
-                                      sync_state_->FormatHandle(index_buf_state->buffer()).c_str(),
+                                      sync_state_->FormatHandle(index_buf_state->Handle()).c_str(),
                                       sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(), FormatHazard(hazard).c_str());
     }
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -361,7 +361,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 "Hazard %s for %s, in %s, and %s, %s, type: %s, imageLayout: %s, binding #%" PRIu32
                                 ", index %" PRIu32 ". Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(img_view_state->Handle()).c_str(),
-                                sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
+                                sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), string_VkImageLayout(image_layout),
@@ -383,7 +383,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 string_SyncHazardVUID(hazard.Hazard()), buf_view_state->Handle(), loc,
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_view_state->Handle()).c_str(),
-                                sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
+                                sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
@@ -405,7 +405,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_state->Handle()).c_str(),
-                                sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
+                                sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
@@ -545,8 +545,7 @@ bool CommandBufferAccessContext::ValidateDrawVertex(const std::optional<uint32_t
                 skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                                               "Hazard %s for vertex %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                                               sync_state_->FormatHandle(buf_state->Handle()).c_str(),
-                                              sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
-                                              FormatHazard(hazard).c_str());
+                                              sync_state_->FormatHandle(cb_state_->Handle()).c_str(), FormatHazard(hazard).c_str());
             }
         }
     }
@@ -594,7 +593,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(const std::optional<uin
         skip |= sync_state_->LogError(string_SyncHazardVUID(hazard.Hazard()), index_buf_state->Handle(), loc,
                                       "Hazard %s for index %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                                       sync_state_->FormatHandle(index_buf_state->Handle()).c_str(),
-                                      sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(), FormatHazard(hazard).c_str());
+                                      sync_state_->FormatHandle(cb_state_->Handle()).c_str(), FormatHazard(hazard).c_str());
     }
 
     // TODO: For now, we detect the whole vertex buffer. Index buffer could be changed until SubmitQueue.

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -362,7 +362,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 ", index %" PRIu32 ". Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(img_view_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
-                                sync_state_->FormatHandle(pipe->pipeline()).c_str(),
+                                sync_state_->FormatHandle(pipe->Handle()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), string_VkImageLayout(image_layout),
                                 variable.decorations.binding, index, FormatHazard(hazard).c_str());
@@ -384,7 +384,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_view_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
-                                sync_state_->FormatHandle(pipe->pipeline()).c_str(),
+                                sync_state_->FormatHandle(pipe->Handle()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
                                 FormatHazard(hazard).c_str());
@@ -406,7 +406,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
                                 "Hazard %s for %s in %s, %s, and %s, type: %s, binding #%d index %d. Access info %s.",
                                 string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(buf_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->Handle()).c_str(),
-                                sync_state_->FormatHandle(pipe->pipeline()).c_str(),
+                                sync_state_->FormatHandle(pipe->Handle()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),
                                 string_VkDescriptorType(descriptor_type), variable.decorations.binding, index,
                                 FormatHazard(hazard).c_str());

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -357,10 +357,10 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
 
                         if (hazard.IsHazard() && !sync_state_->SupressedBoundDescriptorWAW(hazard)) {
                             skip |= sync_state_->LogError(
-                                string_SyncHazardVUID(hazard.Hazard()), img_view_state->image_view(), loc,
+                                string_SyncHazardVUID(hazard.Hazard()), img_view_state->Handle(), loc,
                                 "Hazard %s for %s, in %s, and %s, %s, type: %s, imageLayout: %s, binding #%" PRIu32
                                 ", index %" PRIu32 ". Access info %s.",
-                                string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(img_view_state->image_view()).c_str(),
+                                string_SyncHazard(hazard.Hazard()), sync_state_->FormatHandle(img_view_state->Handle()).c_str(),
                                 sync_state_->FormatHandle(cb_state_->commandBuffer()).c_str(),
                                 sync_state_->FormatHandle(pipe->pipeline()).c_str(),
                                 sync_state_->FormatHandle(descriptor_set->Handle()).c_str(),

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -267,11 +267,11 @@ bool SyncOpPipelineBarrier::Validate(const CommandBufferAccessContext &cb_contex
             // PHASE1 TODO -- add tag information to log msg when useful.
             const Location loc(command_);
             const auto &sync_state = cb_context.GetSyncState();
-            const auto image_handle = image_state->image();
-            skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), image_handle, loc,
+            skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), image_state->Handle(), loc,
                                         "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.",
                                         string_SyncHazard(hazard.Hazard()), image_barrier.index,
-                                        sync_state.FormatHandle(image_handle).c_str(), cb_context.FormatHazard(hazard).c_str());
+                                        sync_state.FormatHandle(image_state->Handle()).c_str(),
+                                        cb_context.FormatHazard(hazard).c_str());
         }
     }
     return skip;
@@ -643,10 +643,10 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
                     *image_state, subresource_range, sync_event->scope.exec_scope, src_access_scope, queue_id,
                     sync_event->FirstScope(), sync_event->first_scope_tag, AccessContext::DetectOptions::kDetectAll);
                 if (hazard.IsHazard()) {
-                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), image_state->image(), loc,
+                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), image_state->Handle(), loc,
                                                 "Hazard %s for image barrier %" PRIu32 " %s. Access info %s.",
                                                 string_SyncHazard(hazard.Hazard()), image_memory_barrier.index,
-                                                sync_state.FormatHandle(image_state->image()).c_str(),
+                                                sync_state.FormatHandle(image_state->Handle()).c_str(),
                                                 exec_context.FormatHazard(hazard).c_str());
                     break;
                 }

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -501,7 +501,7 @@ const char *const SyncOpWaitEvents::kIgnored = "Wait operation is ignored for th
 bool SyncOpWaitEvents::Validate(const CommandBufferAccessContext &cb_context) const {
     bool skip = false;
     const auto &sync_state = cb_context.GetSyncState();
-    const auto command_buffer_handle = cb_context.GetCBState().commandBuffer();
+    const VkCommandBuffer command_buffer_handle = cb_context.GetCBState().VkHandle();
 
     // This is only interesting at record and not replay (Execute/Submit) time.
     for (size_t barrier_set_index = 0; barrier_set_index < barriers_.size(); barrier_set_index++) {
@@ -564,7 +564,7 @@ bool SyncOpWaitEvents::DoValidate(const CommandExecutionContext &exec_context, c
         // For replay calls, don't revalidate "same command buffer" events
         if (sync_event->last_command_tag >= base_tag) continue;
 
-        const auto event_handle = sync_event->event->event();
+        const VkEvent event_handle = sync_event->event->VkHandle();
         // TODO add "destroyed" checks
 
         if (sync_event->first_scope) {
@@ -839,7 +839,7 @@ bool SyncOpResetEvent::DoValidate(const CommandExecutionContext &exec_context, c
         }
         if (vuid) {
             const Location loc(command_);
-            skip |= sync_state.LogError(vuid, event_->event(), loc, message, sync_state.FormatHandle(event_->event()).c_str(),
+            skip |= sync_state.LogError(vuid, event_->Handle(), loc, message, sync_state.FormatHandle(event_->Handle()).c_str(),
                                         CmdName(), vvl::String(sync_event->last_command));
         }
     }
@@ -961,7 +961,7 @@ bool SyncOpSetEvent::DoValidate(const CommandExecutionContext &exec_context, con
             std::string vuid("SYNC-");
             vuid.append(CmdName()).append(vuid_stem);
             skip |=
-                sync_state.LogError(vuid.c_str(), event_->event(), loc, message, sync_state.FormatHandle(event_->event()).c_str(),
+                sync_state.LogError(vuid.c_str(), event_->Handle(), loc, message, sync_state.FormatHandle(event_->Handle()).c_str(),
                                     CmdName(), vvl::String(sync_event->last_command));
         }
     }
@@ -1229,7 +1229,7 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range
         if (hazard.IsHazard()) {
             const SyncValidator &sync_state = exec_context_.GetSyncState();
             const auto handle = exec_context_.Handle();
-            const auto recorded_handle = recorded_context_.GetCBState().commandBuffer();
+            const VkCommandBuffer recorded_handle = recorded_context_.GetCBState().VkHandle();
             skip = sync_state.LogError(
                 string_SyncHazardVUID(hazard.Hazard()), handle, error_obj_.location,
                 "Hazard %s for entry %" PRIu32 ", %s, %s access info %s. Access info %s.", string_SyncHazard(hazard.Hazard()),

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -509,7 +509,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
                 current_context.DetectHazard(view_gen, AttachmentViewGen::Gen::kRenderArea,
                                              SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE, SyncOrdering::kColorAttachment);
             if (hazard.IsHazard()) {
-                const VkImageView view_handle = view_gen.GetViewState()->image_view();
+                const VkImageView view_handle = view_gen.GetViewState()->VkHandle();
                 const Location loc(command);
                 skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), view_handle, loc,
                                             "Hazard %s for %s in %s, Subpass #%d, and pColorAttachments #%d. Access info %s.",
@@ -545,7 +545,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
             if (hazard.IsHazard()) {
                 const Location loc(command);
                 skip |= sync_state.LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), view_state.image_view(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), view_state.Handle(), loc,
                     "Hazard %s for %s in %s, Subpass #%d, and depth part of pDepthStencilAttachment. Access info %s.",
                     string_SyncHazard(hazard.Hazard()), sync_state.FormatHandle(view_state).c_str(),
                     sync_state.FormatHandle(cmd_buffer).c_str(), cmd_buffer.GetActiveSubpass(),
@@ -559,7 +559,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
             if (hazard.IsHazard()) {
                 const Location loc(command);
                 skip |= sync_state.LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), view_state.image_view(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), view_state.Handle(), loc,
                     "Hazard %s for %s in %s, Subpass #%d, and stencil part of pDepthStencilAttachment. Access info %s.",
                     string_SyncHazard(hazard.Hazard()), sync_state.FormatHandle(view_state).c_str(),
                     sync_state.FormatHandle(cmd_buffer).c_str(), cmd_buffer.GetActiveSubpass(),

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019-2023 The Khronos Group Inc.
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
+/* Copyright (c) 2019-2024 The Khronos Group Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -154,14 +154,14 @@ bool RenderPassAccessContext::ValidateLayoutTransitions(const SyncValidationInfo
             const Location loc(command);
             if (hazard.Tag() == kInvalidTag) {
                 skip |= val_info.GetSyncState().LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), rp_state.renderPass(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), rp_state.Handle(), loc,
                     "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
                     " image layout transition (old_layout: %s, new_layout: %s) after store/resolve operation in subpass %" PRIu32,
                     string_SyncHazard(hazard.Hazard()), subpass, transition.attachment, string_VkImageLayout(transition.old_layout),
                     string_VkImageLayout(transition.new_layout), transition.prev_pass);
             } else {
                 skip |= val_info.GetSyncState().LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), rp_state.renderPass(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), rp_state.Handle(), loc,
                     "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
                     " image layout transition (old_layout: %s, new_layout: %s). Access info %s.",
                     string_SyncHazard(hazard.Hazard()), subpass, transition.attachment, string_VkImageLayout(transition.old_layout),
@@ -225,12 +225,12 @@ bool RenderPassAccessContext::ValidateLoadOperation(const SyncValidationInfo &va
                 const Location loc(command);
                 if (hazard.Tag() == kInvalidTag) {
                     // Hazard vs. ILT
-                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state.renderPass(), loc,
+                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state.Handle(), loc,
                                                 "Hazard %s vs. layout transition in subpass %" PRIu32 " for attachment %" PRIu32
                                                 " aspect %s during load with loadOp %s.",
                                                 string_SyncHazard(hazard.Hazard()), subpass, i, aspect, load_op_string);
                 } else {
-                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state.renderPass(), loc,
+                    skip |= sync_state.LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state.Handle(), loc,
                                                 "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
                                                 " aspect %s during load with loadOp %s. Access info %s.",
                                                 string_SyncHazard(hazard.Hazard()), subpass, i, aspect, load_op_string,
@@ -293,7 +293,7 @@ bool RenderPassAccessContext::ValidateStoreOperation(const SyncValidationInfo &v
                 const char *const op_type_string = checked_stencil ? "stencilStoreOp" : "storeOp";
                 const char *const store_op_string = string_VkAttachmentStoreOp(checked_stencil ? ci.stencilStoreOp : ci.storeOp);
                 const Location loc(command);
-                skip |= val_info.GetSyncState().LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state_->renderPass(), loc,
+                skip |= val_info.GetSyncState().LogError(string_SyncHazardVUID(hazard.Hazard()), rp_state_->Handle(), loc,
                                                          "Hazard %s in subpass %" PRIu32 " for attachment %" PRIu32
                                                          " %s aspect during store with %s %s. Access info %s",
                                                          string_SyncHazard(hazard.Hazard()), current_subpass_, i, aspect,
@@ -397,7 +397,7 @@ void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const Att
 }
 
 bool RenderPassAccessContext::ValidateResolveOperations(const SyncValidationInfo &val_info, vvl::Func command) const {
-    ValidateResolveAction validate_action(rp_state_->renderPass(), current_subpass_, CurrentContext(), val_info, command);
+    ValidateResolveAction validate_action(rp_state_->VkHandle(), current_subpass_, CurrentContext(), val_info, command);
     ResolveOperation(validate_action, *rp_state_, attachment_views_, current_subpass_);
     return validate_action.GetSkip();
 }
@@ -808,14 +808,14 @@ bool RenderPassAccessContext::ValidateFinalSubpassLayoutTransitions(const Comman
             if (hazard.Tag() == kInvalidTag) {
                 // Hazard vs. ILT
                 skip |= exec_context.GetSyncState().LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), rp_state_->renderPass(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), rp_state_->Handle(), loc,
                     "Hazard %s vs. store/resolve operations in subpass %" PRIu32 " for attachment %" PRIu32
                     " final image layout transition (old_layout: %s, new_layout: %s).",
                     string_SyncHazard(hazard.Hazard()), transition.prev_pass, transition.attachment,
                     string_VkImageLayout(transition.old_layout), string_VkImageLayout(transition.new_layout));
             } else {
                 skip |= exec_context.GetSyncState().LogError(
-                    string_SyncHazardVUID(hazard.Hazard()), rp_state_->renderPass(), loc,
+                    string_SyncHazardVUID(hazard.Hazard()), rp_state_->Handle(), loc,
                     "Hazard %s with last use subpass %" PRIu32 " for attachment %" PRIu32
                     " final image layout transition (old_layout: %s, new_layout: %s). Access info %s.",
                     string_SyncHazard(hazard.Hazard()), transition.prev_pass, transition.attachment,

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1219,7 +1219,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_
         const ResourceAccessRange range = MakeRange(offset, size);
         auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
         if (hazard.IsHazard()) {
-            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->buffer(), loc,
+            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                              "Hazard %s for indirect %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                              FormatHandle(buffer).c_str(), FormatHandle(commandBuffer).c_str(),
                              cb_context.FormatHazard(hazard).c_str());
@@ -1229,7 +1229,7 @@ bool SyncValidator::ValidateIndirectBuffer(const CommandBufferAccessContext &cb_
             const ResourceAccessRange range = MakeRange(offset + i * stride, size);
             auto hazard = context.DetectHazard(*buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
             if (hazard.IsHazard()) {
-                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->buffer(), loc,
+                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), buf_state->Handle(), loc,
                                  "Hazard %s for indirect %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                                  FormatHandle(buffer).c_str(), FormatHandle(commandBuffer).c_str(),
                                  cb_context.FormatHazard(hazard).c_str());
@@ -1268,7 +1268,7 @@ bool SyncValidator::ValidateCountBuffer(const CommandBufferAccessContext &cb_con
     auto hazard = context.DetectHazard(*count_buf_state, SYNC_DRAW_INDIRECT_INDIRECT_COMMAND_READ, range);
     if (hazard.IsHazard()) {
         skip |=
-            LogError(string_SyncHazardVUID(hazard.Hazard()), count_buf_state->buffer(), loc,
+            LogError(string_SyncHazardVUID(hazard.Hazard()), count_buf_state->Handle(), loc,
                      "Hazard %s for countBuffer %s in %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                      FormatHandle(buffer).c_str(), FormatHandle(commandBuffer).c_str(), cb_context.FormatHazard(hazard).c_str());
     }
@@ -2179,7 +2179,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         auto hazard = context->DetectHazard(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, src_range);
         if (hazard.IsHazard()) {
             // PHASE1 TODO -- add tag information to log msg when useful.
-            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), src_buffer->buffer(), decode_info_loc.dot(Field::srcBuffer),
+            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), src_buffer->Handle(), decode_info_loc.dot(Field::srcBuffer),
                              "Hazard %s for bitstream buffer %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                              FormatHandle(pDecodeInfo->srcBuffer).c_str(), cb_access_context->FormatHazard(hazard).c_str());
         }
@@ -2291,7 +2291,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         auto hazard = context->DetectHazard(*dst_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, src_range);
         if (hazard.IsHazard()) {
             // PHASE1 TODO -- add tag information to log msg when useful.
-            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), dst_buffer->buffer(), encode_info_loc.dot(Field::dstBuffer),
+            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), dst_buffer->Handle(), encode_info_loc.dot(Field::dstBuffer),
                              "Hazard %s for bitstream buffer %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                              FormatHandle(pEncodeInfo->dstBuffer).c_str(), cb_access_context->FormatHazard(hazard).c_str());
         }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -784,7 +784,7 @@ void SyncValidator::PreCallRecordCmdBeginRendering(VkCommandBuffer commandBuffer
     StateTracker::PreCallRecordCmdBeginRendering(commandBuffer, pRenderingInfo, record_obj);
     vvl::TlsGuard<syncval_state::BeginRenderingCmdState> cmd_state;
 
-    assert(cmd_state && cmd_state->cb_state && (cmd_state->cb_state->commandBuffer() == commandBuffer));
+    assert(cmd_state && cmd_state->cb_state && (cmd_state->cb_state->VkHandle() == commandBuffer));
     // Note: for fine grain locking need to to something other than cast.
     auto cb_state = std::const_pointer_cast<syncval_state::CommandBuffer>(cmd_state->cb_state);
     cb_state->access_context.RecordBeginRendering(*cmd_state, record_obj);

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -2189,7 +2189,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     if (dst_resource) {
         auto hazard = context->DetectHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
-            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), dst_resource.image_view_state->image_view(),
+            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), dst_resource.image_view_state->Handle(),
                              decode_info_loc.dot(Field::dstPictureResource), "Hazard %s for decode output picture. Access info %s.",
                              string_SyncHazard(hazard.Hazard()), cb_access_context->FormatHazard(hazard).c_str());
         }
@@ -2200,7 +2200,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         if (setup_resource && (setup_resource != dst_resource)) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
-                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), setup_resource.image_view_state->image_view(),
+                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), setup_resource.image_view_state->Handle(),
                                  decode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource),
                                  "Hazard %s for reconstructed picture. Access info %s.", string_SyncHazard(hazard.Hazard()),
                                  cb_access_context->FormatHazard(hazard).c_str());
@@ -2214,7 +2214,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
-                    skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), reference_resource.image_view_state->image_view(),
+                    skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), reference_resource.image_view_state->Handle(),
                                      decode_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource),
                                      "Hazard %s for reference picture #%u. Access info %s.", string_SyncHazard(hazard.Hazard()), i,
                                      cb_access_context->FormatHazard(hazard).c_str());
@@ -2301,7 +2301,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     if (src_resource) {
         auto hazard = context->DetectHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
-            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), src_resource.image_view_state->image_view(),
+            skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), src_resource.image_view_state->Handle(),
                              encode_info_loc.dot(Field::srcPictureResource), "Hazard %s for encode input picture. Access info %s.",
                              string_SyncHazard(hazard.Hazard()), cb_access_context->FormatHazard(hazard).c_str());
         }
@@ -2312,7 +2312,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         if (setup_resource) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
-                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), setup_resource.image_view_state->image_view(),
+                skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), setup_resource.image_view_state->Handle(),
                                  encode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource),
                                  "Hazard %s for reconstructed picture. Access info %s.", string_SyncHazard(hazard.Hazard()),
                                  cb_access_context->FormatHazard(hazard).c_str());
@@ -2326,7 +2326,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
-                    skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), reference_resource.image_view_state->image_view(),
+                    skip |= LogError(string_SyncHazardVUID(hazard.Hazard()), reference_resource.image_view_state->Handle(),
                                      encode_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource),
                                      "Hazard %s for reference picture #%u. Access info %s.", string_SyncHazard(hazard.Hazard()), i,
                                      cb_access_context->FormatHazard(hazard).c_str());

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -960,7 +960,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
 
     auto src_image = Get<ImageState>(srcImage);
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
-    const auto dst_mem = (dst_buffer && !dst_buffer->sparse) ? dst_buffer->MemState()->deviceMemory() : VK_NULL_HANDLE;
+    const auto dst_mem = (dst_buffer && !dst_buffer->sparse) ? dst_buffer->MemState()->VkHandle() : VK_NULL_HANDLE;
     for (uint32_t region = 0; region < regionCount; region++) {
         const auto &copy_region = pRegions[region];
         if (src_image) {
@@ -1025,7 +1025,7 @@ void SyncValidator::RecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, Vk
 
     auto src_image = Get<ImageState>(srcImage);
     auto dst_buffer = Get<vvl::Buffer>(dstBuffer);
-    const auto dst_mem = (dst_buffer && !dst_buffer->sparse) ? dst_buffer->MemState()->deviceMemory() : VK_NULL_HANDLE;
+    const auto dst_mem = (dst_buffer && !dst_buffer->sparse) ? dst_buffer->MemState()->VkHandle() : VK_NULL_HANDLE;
     const VulkanTypedHandle dst_handle(dst_mem, kVulkanObjectTypeDeviceMemory);
 
     for (uint32_t region = 0; region < regionCount; region++) {

--- a/layers/vulkan/generated/command_validation.cpp
+++ b/layers/vulkan/generated/command_validation.cpp
@@ -3,8 +3,8 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2021-2023 Valve Corporation
- * Copyright (c) 2021-2023 LunarG, Inc.
+ * Copyright (c) 2021-2024 Valve Corporation
+ * Copyright (c) 2021-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -1822,7 +1822,7 @@ bool CoreChecks::ValidateCmd(const vvl::CommandBuffer& cb_state, const Location&
 
         default:
             assert(loc.function != Func::Empty);
-            skip |= LogError(info.recording_vuid, cb_state.commandBuffer(), loc, "was called before vkBeginCommandBuffer().");
+            skip |= LogError(info.recording_vuid, cb_state.Handle(), loc, "was called before vkBeginCommandBuffer().");
     }
 
     // Validate the command pool from which the command buffer is from that the command is allowed for queue type

--- a/scripts/generators/command_validation_generator.py
+++ b/scripts/generators/command_validation_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2021-2023 The Khronos Group Inc.
+# Copyright (c) 2021-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -34,8 +34,8 @@ class CommandValidationOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2021-2023 Valve Corporation
-            * Copyright (c) 2021-2023 LunarG, Inc.
+            * Copyright (c) 2021-2024 Valve Corporation
+            * Copyright (c) 2021-2024 LunarG, Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.
@@ -174,7 +174,7 @@ class CommandValidationOutputGenerator(BaseGenerator):
 
                     default:
                         assert(loc.function != Func::Empty);
-                        skip |= LogError(info.recording_vuid, cb_state.commandBuffer(), loc, "was called before vkBeginCommandBuffer().");
+                        skip |= LogError(info.recording_vuid, cb_state.Handle(), loc, "was called before vkBeginCommandBuffer().");
                 }
 
                 // Validate the command pool from which the command buffer is from that the command is allowed for queue type


### PR DESCRIPTION
`Handle()` is the generic type found in all `StateObject`
`VkHandle()` is how to get it casted

No more having to guess the function name each object has