### PR TITLE
layers: Inline UnsupportedStructureTypeString

### DIFF
--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -210,7 +210,8 @@ bool StatelessValidation::ValidateStructPnext(const Location &loc, const void *n
                     }
                     if (!custom) {
                         if (std::find(start, end, current->sType) == end) {
-                            if (type_name.compare(UnsupportedStructureTypeString) == 0) {
+                            // String returned by string_VkStructureType for an unrecognized type.
+                            if (type_name.compare("Unhandled VkStructureType") == 0) {
                                 std::string message = "chain includes a structure with unknown VkStructureType (%" PRIu32 "). ";
                                 message += disclaimer;
                                 skip |= LogError(pnext_vuid, device, pNext_loc, message.c_str(), current->sType, header_version,

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -27,9 +27,6 @@
 
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
 
-// String returned by string_VkStructureType for an unrecognized type.
-const std::string UnsupportedStructureTypeString = "Unhandled VkStructureType";
-
 class StatelessValidation : public ValidationObject {
     using Func = vvl::Func;
     using Struct = vvl::Struct;


### PR DESCRIPTION
part 2 of 2 for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7363

Inline `UnsupportedStructureTypeString` - it is only used in one spot and currently being loaded into everyone who includes `stateless_validation.h`