### PR TITLE
layers: Create vk_object_types.cpp

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -423,6 +423,7 @@ source_set("vulkan_layer_utils") {
     "layers/vulkan/generated/vk_extension_helper.h",
     "layers/vulkan/generated/vk_layer_dispatch_table.h",
     "layers/vulkan/generated/vk_object_types.h",
+    "layers/vulkan/generated/vk_object_types.cpp",
     "layers/vulkan/generated/vk_safe_struct.h",
     "layers/vulkan/generated/vk_validation_error_messages.h",
   ]

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -48,6 +48,7 @@ target_sources(VkLayer_utils PRIVATE
     ${API_TYPE}/generated/vk_safe_struct_ext.cpp
     ${API_TYPE}/generated/vk_safe_struct_vendor.cpp
     ${API_TYPE}/generated/vk_object_types.h
+    ${API_TYPE}/generated/vk_object_types.cpp
     ${API_TYPE}/generated/vk_api_version.h
     ${API_TYPE}/generated/vk_extension_helper.h
     utils/cast_utils.h

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -28,8 +28,8 @@
 bool CoreChecks::VerifyBoundMemoryIsValid(const vvl::DeviceMemory *mem_state, const LogObjectList &objlist,
                                           const VulkanTypedHandle &typed_handle, const Location &loc, const char *vuid) const {
     bool result = false;
-    auto type_name = object_string[typed_handle.type];
     if (!mem_state) {
+        const char *type_name = string_VulkanObjectType(typed_handle.type);
         result |=
             LogError(vuid, objlist, loc, "(%s) is used with no memory bound. Memory should be bound by calling vkBind%sMemory().",
                      FormatHandle(typed_handle).c_str(), type_name + 2);

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2050,7 +2050,7 @@ class ValidatorState {
                 return invalid;
         }
     }
-    const char *GetTypeString() const { return object_string[barrier_handle_.type]; }
+    const char *GetTypeString() const { return string_VulkanObjectType(barrier_handle_.type); }
     VkSharingMode GetSharingMode() const { return sharing_mode_; }
 
   protected:

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -245,7 +245,7 @@ typedef struct _debug_report_data {
     }
 
     std::string FormatHandle(const VulkanTypedHandle &handle) const {
-        return FormatHandle(object_string[handle.type], handle.handle);
+        return FormatHandle(string_VulkanObjectType(handle.type), handle.handle);
     }
 
     std::string FormatHandle(const TypedHandleWrapper &wrapper) const { return FormatHandle(wrapper.Handle()); }

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -86,7 +86,7 @@ class ObjectLifetimes : public ValidationObject {
                            "Couldn't insert %s Object 0x%" PRIxLEAST64
                            ", already existed. This should not happen and may indicate a "
                            "race condition in the application.",
-                           object_string[object_type], object_handle);
+                           string_VulkanObjectType(object_type), object_handle);
         }
     }
 
@@ -183,13 +183,13 @@ class ObjectLifetimes : public ValidationObject {
                     skip |= LogError(expected_custom_allocator_code, object_handle, loc,
                                      "Custom allocator not specified while destroying %s obj 0x%" PRIxLEAST64
                                      " but specified at creation.",
-                                     object_string[object_type], object);
+                                     string_VulkanObjectType(object_type), object);
 
                 } else if (!allocated_with_custom && custom_allocator && expected_default_allocator_code != kVUIDUndefined) {
                     skip |= LogError(expected_default_allocator_code, object_handle, loc,
                                      "Custom allocator specified while destroying %s obj 0x%" PRIxLEAST64
                                      " but not specified at creation.",
-                                     object_string[object_type], object);
+                                     string_VulkanObjectType(object_type), object);
                 }
             }
         }

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -73,8 +73,8 @@ bool ObjectLifetimes::CheckObjectValidity(uint64_t object_handle, VulkanObjectTy
 
     // Object was not found anywhere
     if (!other_lifetimes) {
-        return LogError(invalid_handle_vuid, instance, loc, "Invalid %s Object 0x%" PRIxLEAST64 ".", object_string[object_type],
-                        object_handle);
+        return LogError(invalid_handle_vuid, instance, loc, "Invalid %s Object 0x%" PRIxLEAST64 ".",
+                        string_VulkanObjectType(object_type), object_handle);
     }
     // Anonymous object validation does not check parent, only that the object exists
     if (wrong_parent_vuid == kVUIDUndefined) {
@@ -105,7 +105,7 @@ bool ObjectLifetimes::CheckObjectValidity(uint64_t object_handle, VulkanObjectTy
                     "(%s 0x%" PRIxLEAST64
                     ") was created, allocated or retrieved from %s, but command is using (or its dispatchable parameter is "
                     "associated with) %s",
-                    object_string[object_type], object_handle, other_handle_str.c_str(), handle_str.c_str());
+                    string_VulkanObjectType(object_type), object_handle, other_handle_str.c_str(), handle_str.c_str());
 }
 
 void ObjectLifetimes::DestroyObjectSilently(uint64_t object, VulkanObjectType object_type) {
@@ -119,7 +119,7 @@ void ObjectLifetimes::DestroyObjectSilently(uint64_t object, VulkanObjectType ob
         (void)LogError("UNASSIGNED-ObjectTracker-Destroy", device, loc,
                        "Couldn't destroy %s Object 0x%" PRIxLEAST64
                        ", not found. This should not happen and may indicate a race condition in the application.",
-                       object_string[object_type], object);
+                       string_VulkanObjectType(object_type), object);
 
         return;
     }
@@ -437,7 +437,7 @@ bool ObjectLifetimes::PreCallValidateDestroyInstance(VkInstance instance, const 
         auto node = iit.second;
 
         VkDevice device = reinterpret_cast<VkDevice>(node->handle);
-        VkDebugReportObjectTypeEXT debug_object_type = get_debug_report_enum[node->object_type];
+        VkDebugReportObjectTypeEXT debug_object_type = GetDebugReport(node->object_type);
 
         skip |=
             LogError("VUID-vkDestroyInstance-instance-00629", instance, error_obj.location, "%s object %s has not been destroyed.",

--- a/layers/thread_tracker/thread_safety_validation.h
+++ b/layers/thread_tracker/thread_safety_validation.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -120,7 +120,7 @@ class counter {
             object_data->LogError("UNASSIGNED-Threading-Info", object, loc,
                                   "Couldn't find %s Object 0x%" PRIxLEAST64
                                   ". This should not happen and may indicate a bug in the application.",
-                                  object_string[object_type], (uint64_t)(object));
+                                  string_VulkanObjectType(object_type), (uint64_t)(object));
             return nullptr;
         }
     }
@@ -217,7 +217,7 @@ class counter {
   private:
     std::string GetErrorMessage(std::thread::id tid, std::thread::id other_tid) const {
         std::stringstream err_str;
-        err_str << "THREADING ERROR : object of type " << object_string[object_type]
+        err_str << "THREADING ERROR : object of type " << string_VulkanObjectType(object_type)
                 << " is simultaneously used in current thread " << tid << " and thread " << other_tid;
         return err_str.str();
     }

--- a/layers/vulkan/generated/vk_object_types.cpp
+++ b/layers/vulkan/generated/vk_object_types.cpp
@@ -1,0 +1,143 @@
+// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+// See object_types_generator.py for modifications
+
+/***************************************************************************
+ *
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ ****************************************************************************/
+
+// NOLINTBEGIN
+
+#include <vulkan/vulkan_core.h>
+#include "vk_object_types.h"
+
+// Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version
+static const VkDebugReportObjectTypeEXT kDebugReportLookup[kVulkanObjectTypeMax] = {
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeUnknown
+    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,                      // kVulkanObjectTypeBuffer
+    VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,                       // kVulkanObjectTypeImage
+    VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,                    // kVulkanObjectTypeInstance
+    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,             // kVulkanObjectTypePhysicalDevice
+    VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,                      // kVulkanObjectTypeDevice
+    VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT,                       // kVulkanObjectTypeQueue
+    VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,                   // kVulkanObjectTypeSemaphore
+    VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,              // kVulkanObjectTypeCommandBuffer
+    VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,                       // kVulkanObjectTypeFence
+    VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT,               // kVulkanObjectTypeDeviceMemory
+    VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT,                       // kVulkanObjectTypeEvent
+    VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT,                  // kVulkanObjectTypeQueryPool
+    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT,                 // kVulkanObjectTypeBufferView
+    VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT,                  // kVulkanObjectTypeImageView
+    VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT,               // kVulkanObjectTypeShaderModule
+    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT,              // kVulkanObjectTypePipelineCache
+    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT,             // kVulkanObjectTypePipelineLayout
+    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,                    // kVulkanObjectTypePipeline
+    VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,                 // kVulkanObjectTypeRenderPass
+    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT,       // kVulkanObjectTypeDescriptorSetLayout
+    VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT,                     // kVulkanObjectTypeSampler
+    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT,              // kVulkanObjectTypeDescriptorSet
+    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,             // kVulkanObjectTypeDescriptorPool
+    VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT,                 // kVulkanObjectTypeFramebuffer
+    VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT,                // kVulkanObjectTypeCommandPool
+    VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT,    // kVulkanObjectTypeSamplerYcbcrConversion
+    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT,  // kVulkanObjectTypeDescriptorUpdateTemplate
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypePrivateDataSlot
+    VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT,                 // kVulkanObjectTypeSurfaceKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,               // kVulkanObjectTypeSwapchainKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT,                 // kVulkanObjectTypeDisplayKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT,            // kVulkanObjectTypeDisplayModeKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeVideoSessionKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeVideoSessionParametersKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeDeferredOperationKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT,   // kVulkanObjectTypeDebugReportCallbackEXT
+    VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT,               // kVulkanObjectTypeCuModuleNVX
+    VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT,             // kVulkanObjectTypeCuFunctionNVX
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeDebugUtilsMessengerEXT
+    VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT,        // kVulkanObjectTypeValidationCacheEXT
+    VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT,   // kVulkanObjectTypeAccelerationStructureNV
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypePerformanceConfigurationINTEL
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeIndirectCommandsLayoutNV
+    VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_MODULE_NV_EXT,              // kVulkanObjectTypeCudaModuleNV
+    VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_FUNCTION_NV_EXT,            // kVulkanObjectTypeCudaFunctionNV
+    VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT,  // kVulkanObjectTypeAccelerationStructureKHR
+    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT,   // kVulkanObjectTypeBufferCollectionFUCHSIA
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeMicromapEXT
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeOpticalFlowSessionNV
+    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeShaderEXT
+};
+
+// Array of object name strings for OBJECT_TYPE enum conversion
+static const char* const kVulkanObjectTypeStrings[kVulkanObjectTypeMax] = {
+    "VkNonDispatchableHandle",
+    "VkBuffer",
+    "VkImage",
+    "VkInstance",
+    "VkPhysicalDevice",
+    "VkDevice",
+    "VkQueue",
+    "VkSemaphore",
+    "VkCommandBuffer",
+    "VkFence",
+    "VkDeviceMemory",
+    "VkEvent",
+    "VkQueryPool",
+    "VkBufferView",
+    "VkImageView",
+    "VkShaderModule",
+    "VkPipelineCache",
+    "VkPipelineLayout",
+    "VkPipeline",
+    "VkRenderPass",
+    "VkDescriptorSetLayout",
+    "VkSampler",
+    "VkDescriptorSet",
+    "VkDescriptorPool",
+    "VkFramebuffer",
+    "VkCommandPool",
+    "VkSamplerYcbcrConversion",
+    "VkDescriptorUpdateTemplate",
+    "VkPrivateDataSlot",
+    "VkSurfaceKHR",
+    "VkSwapchainKHR",
+    "VkDisplayKHR",
+    "VkDisplayModeKHR",
+    "VkVideoSessionKHR",
+    "VkVideoSessionParametersKHR",
+    "VkDeferredOperationKHR",
+    "VkDebugReportCallbackEXT",
+    "VkCuModuleNVX",
+    "VkCuFunctionNVX",
+    "VkDebugUtilsMessengerEXT",
+    "VkValidationCacheEXT",
+    "VkAccelerationStructureNV",
+    "VkPerformanceConfigurationINTEL",
+    "VkIndirectCommandsLayoutNV",
+    "VkCudaModuleNV",
+    "VkCudaFunctionNV",
+    "VkAccelerationStructureKHR",
+    "VkBufferCollectionFUCHSIA",
+    "VkMicromapEXT",
+    "VkOpticalFlowSessionNV",
+    "VkShaderEXT",
+};
+
+VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type) { return kDebugReportLookup[type]; }
+
+const char* string_VulkanObjectType(VulkanObjectType type) { return kVulkanObjectTypeStrings[type]; }
+
+// NOLINTEND

--- a/layers/vulkan/generated/vk_object_types.h
+++ b/layers/vulkan/generated/vk_object_types.h
@@ -20,7 +20,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  ****************************************************************************/
-// NOLINTBEGIN// clang-format off
+
+// NOLINTBEGIN
+
 #pragma once
 #include "utils/cast_utils.h"
 
@@ -80,118 +82,11 @@ typedef enum VulkanObjectType {
     kVulkanObjectTypeMax = 51
 } VulkanObjectType;
 
-// Array of object name strings for OBJECT_TYPE enum conversion
-static const char* const object_string[kVulkanObjectTypeMax] = {
-    "VkNonDispatchableHandle",
-    "VkBuffer",
-    "VkImage",
-    "VkInstance",
-    "VkPhysicalDevice",
-    "VkDevice",
-    "VkQueue",
-    "VkSemaphore",
-    "VkCommandBuffer",
-    "VkFence",
-    "VkDeviceMemory",
-    "VkEvent",
-    "VkQueryPool",
-    "VkBufferView",
-    "VkImageView",
-    "VkShaderModule",
-    "VkPipelineCache",
-    "VkPipelineLayout",
-    "VkPipeline",
-    "VkRenderPass",
-    "VkDescriptorSetLayout",
-    "VkSampler",
-    "VkDescriptorSet",
-    "VkDescriptorPool",
-    "VkFramebuffer",
-    "VkCommandPool",
-    "VkSamplerYcbcrConversion",
-    "VkDescriptorUpdateTemplate",
-    "VkPrivateDataSlot",
-    "VkSurfaceKHR",
-    "VkSwapchainKHR",
-    "VkDisplayKHR",
-    "VkDisplayModeKHR",
-    "VkVideoSessionKHR",
-    "VkVideoSessionParametersKHR",
-    "VkDeferredOperationKHR",
-    "VkDebugReportCallbackEXT",
-    "VkCuModuleNVX",
-    "VkCuFunctionNVX",
-    "VkDebugUtilsMessengerEXT",
-    "VkValidationCacheEXT",
-    "VkAccelerationStructureNV",
-    "VkPerformanceConfigurationINTEL",
-    "VkIndirectCommandsLayoutNV",
-    "VkCudaModuleNV",
-    "VkCudaFunctionNV",
-    "VkAccelerationStructureKHR",
-    "VkBufferCollectionFUCHSIA",
-    "VkMicromapEXT",
-    "VkOpticalFlowSessionNV",
-    "VkShaderEXT",
-};
-
-// Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version
-const VkDebugReportObjectTypeEXT get_debug_report_enum[] = {
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeUnknown
-    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT,                      // kVulkanObjectTypeBuffer
-    VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_EXT,                       // kVulkanObjectTypeImage
-    VK_DEBUG_REPORT_OBJECT_TYPE_INSTANCE_EXT,                    // kVulkanObjectTypeInstance
-    VK_DEBUG_REPORT_OBJECT_TYPE_PHYSICAL_DEVICE_EXT,             // kVulkanObjectTypePhysicalDevice
-    VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_EXT,                      // kVulkanObjectTypeDevice
-    VK_DEBUG_REPORT_OBJECT_TYPE_QUEUE_EXT,                       // kVulkanObjectTypeQueue
-    VK_DEBUG_REPORT_OBJECT_TYPE_SEMAPHORE_EXT,                   // kVulkanObjectTypeSemaphore
-    VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_BUFFER_EXT,              // kVulkanObjectTypeCommandBuffer
-    VK_DEBUG_REPORT_OBJECT_TYPE_FENCE_EXT,                       // kVulkanObjectTypeFence
-    VK_DEBUG_REPORT_OBJECT_TYPE_DEVICE_MEMORY_EXT,               // kVulkanObjectTypeDeviceMemory
-    VK_DEBUG_REPORT_OBJECT_TYPE_EVENT_EXT,                       // kVulkanObjectTypeEvent
-    VK_DEBUG_REPORT_OBJECT_TYPE_QUERY_POOL_EXT,                  // kVulkanObjectTypeQueryPool
-    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_VIEW_EXT,                 // kVulkanObjectTypeBufferView
-    VK_DEBUG_REPORT_OBJECT_TYPE_IMAGE_VIEW_EXT,                  // kVulkanObjectTypeImageView
-    VK_DEBUG_REPORT_OBJECT_TYPE_SHADER_MODULE_EXT,               // kVulkanObjectTypeShaderModule
-    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_CACHE_EXT,              // kVulkanObjectTypePipelineCache
-    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_LAYOUT_EXT,             // kVulkanObjectTypePipelineLayout
-    VK_DEBUG_REPORT_OBJECT_TYPE_PIPELINE_EXT,                    // kVulkanObjectTypePipeline
-    VK_DEBUG_REPORT_OBJECT_TYPE_RENDER_PASS_EXT,                 // kVulkanObjectTypeRenderPass
-    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_LAYOUT_EXT,       // kVulkanObjectTypeDescriptorSetLayout
-    VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_EXT,                     // kVulkanObjectTypeSampler
-    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_SET_EXT,              // kVulkanObjectTypeDescriptorSet
-    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_POOL_EXT,             // kVulkanObjectTypeDescriptorPool
-    VK_DEBUG_REPORT_OBJECT_TYPE_FRAMEBUFFER_EXT,                 // kVulkanObjectTypeFramebuffer
-    VK_DEBUG_REPORT_OBJECT_TYPE_COMMAND_POOL_EXT,                // kVulkanObjectTypeCommandPool
-    VK_DEBUG_REPORT_OBJECT_TYPE_SAMPLER_YCBCR_CONVERSION_EXT,    // kVulkanObjectTypeSamplerYcbcrConversion
-    VK_DEBUG_REPORT_OBJECT_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_EXT,  // kVulkanObjectTypeDescriptorUpdateTemplate
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypePrivateDataSlot
-    VK_DEBUG_REPORT_OBJECT_TYPE_SURFACE_KHR_EXT,                 // kVulkanObjectTypeSurfaceKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_SWAPCHAIN_KHR_EXT,               // kVulkanObjectTypeSwapchainKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_KHR_EXT,                 // kVulkanObjectTypeDisplayKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_DISPLAY_MODE_KHR_EXT,            // kVulkanObjectTypeDisplayModeKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeVideoSessionKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeVideoSessionParametersKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeDeferredOperationKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_DEBUG_REPORT_CALLBACK_EXT_EXT,   // kVulkanObjectTypeDebugReportCallbackEXT
-    VK_DEBUG_REPORT_OBJECT_TYPE_CU_MODULE_NVX_EXT,               // kVulkanObjectTypeCuModuleNVX
-    VK_DEBUG_REPORT_OBJECT_TYPE_CU_FUNCTION_NVX_EXT,             // kVulkanObjectTypeCuFunctionNVX
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeDebugUtilsMessengerEXT
-    VK_DEBUG_REPORT_OBJECT_TYPE_VALIDATION_CACHE_EXT_EXT,        // kVulkanObjectTypeValidationCacheEXT
-    VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_NV_EXT,   // kVulkanObjectTypeAccelerationStructureNV
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypePerformanceConfigurationINTEL
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeIndirectCommandsLayoutNV
-    VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_MODULE_NV_EXT,              // kVulkanObjectTypeCudaModuleNV
-    VK_DEBUG_REPORT_OBJECT_TYPE_CUDA_FUNCTION_NV_EXT,            // kVulkanObjectTypeCudaFunctionNV
-    VK_DEBUG_REPORT_OBJECT_TYPE_ACCELERATION_STRUCTURE_KHR_EXT,  // kVulkanObjectTypeAccelerationStructureKHR
-    VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_COLLECTION_FUCHSIA_EXT,   // kVulkanObjectTypeBufferCollectionFUCHSIA
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeMicromapEXT
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeOpticalFlowSessionNV
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT,                     // kVulkanObjectTypeShaderEXT
-};
+VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type);
+const char* string_VulkanObjectType(VulkanObjectType type);
 
 // Helper function to get Official Vulkan VkObjectType enum from the internal layers version
-static inline VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {
+static constexpr VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {
     switch (internal_type) {
         case kVulkanObjectTypeBuffer:
             return VK_OBJECT_TYPE_BUFFER;
@@ -299,7 +194,7 @@ static inline VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType inte
 }
 
 // Helper function to get internal layers object ids from the official Vulkan VkObjectType enum
-static inline VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulkan_object_type) {
+static constexpr VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulkan_object_type) {
     switch (vulkan_object_type) {
         case VK_OBJECT_TYPE_BUFFER:
             return kVulkanObjectTypeBuffer;
@@ -405,8 +300,7 @@ static inline VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulk
             return kVulkanObjectTypeUnknown;
     }
 }
-
-static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
+static constexpr VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
     switch (core_report_obj) {
         case VK_OBJECT_TYPE_UNKNOWN:
             return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
@@ -495,7 +389,7 @@ static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(Vk
     }
 }
 
-static inline VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
+static constexpr VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
     switch (debug_obj) {
         case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT:
             return kVulkanObjectTypeUnknown;
@@ -585,7 +479,7 @@ static inline VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugRep
 }
 
 // Helper function to get Instance object types
-static inline bool IsInstanceVkObjectType(VkObjectType type) {
+static constexpr bool IsInstanceVkObjectType(VkObjectType type) {
     switch (type) {
         case VK_OBJECT_TYPE_INSTANCE:
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:
@@ -1253,4 +1147,5 @@ struct VulkanTypedHandle {
     VulkanTypedHandle() : handle(CastToUint64(VK_NULL_HANDLE)), type(kVulkanObjectTypeUnknown) {}
     operator bool() const { return handle != 0; }
 };
-// clang-format on// NOLINTEND
+
+// NOLINTEND

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -191,6 +191,10 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
             'generator' : ObjectTypesOutputGenerator,
             'genCombined': True,
         },
+        'vk_object_types.cpp' : {
+            'generator' : ObjectTypesOutputGenerator,
+            'genCombined': True,
+        },
         'vk_extension_helper.h' : {
             'generator' : ExtensionHelperOutputGenerator,
             'genCombined': True,

--- a/scripts/generators/object_types_generator.py
+++ b/scripts/generators/object_types_generator.py
@@ -25,21 +25,20 @@ from generators.generator_utils import PlatformGuardHelper
 class ObjectTypesOutputGenerator(BaseGenerator):
     def __init__(self):
         BaseGenerator.__init__(self)
-
-    def generate(self):
         # Helper for VkDebugReportObjectTypeEXT
         # Maps [ 'VkBuffer' : 'VK_DEBUG_REPORT_OBJECT_TYPE_BUFFER_EXT' ]
         # Will be 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT' if no type
-        debugReportObject = dict()
+        self.debugReportObject = dict()
 
+
+    def generate(self):
         # Search all fields of the Enum to see if has a DEBUG_REPORT_OBJECT
         for handle in self.vk.handles.values():
             debugObjects = ([enum.name for enum in self.vk.enums['VkDebugReportObjectTypeEXT'].fields if f'{handle.type[3:]}_EXT' in enum.name])
             object = 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT' if len(debugObjects) == 0 else debugObjects[0]
-            debugReportObject[handle.name] = object
+            self.debugReportObject[handle.name] = object
 
-        out = []
-        out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
+        self.write(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
             // See {os.path.basename(__file__)} for modifications
 
             /***************************************************************************
@@ -61,175 +60,218 @@ class ObjectTypesOutputGenerator(BaseGenerator):
             * See the License for the specific language governing permissions and
             * limitations under the License.
             ****************************************************************************/\n''')
-        out.append('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
-        out.append('// clang-format off')
+
+        self.write('// NOLINTBEGIN') # Wrap for clang-tidy to ignore
+
+        if self.filename == 'vk_object_types.h':
+            self.generateHeader()
+        elif self.filename == 'vk_object_types.cpp':
+            self.generateSource()
+        else:
+            self.write(f'\nFile name {self.filename} has no code to generate\n')
+
+        self.write('// NOLINTEND') # Wrap for clang-tidy to ignore
+
+    def generateHeader(self):
+        out = []
         out.append('''
-#pragma once
-#include "utils/cast_utils.h"
-\n''')
+            #pragma once
+            #include "utils/cast_utils.h"
+
+            ''')
 
         out.append('''
-// Object Type enum for validation layer internal object handling
-typedef enum VulkanObjectType {
-    kVulkanObjectTypeUnknown = 0,\n''')
+            // Object Type enum for validation layer internal object handling
+            typedef enum VulkanObjectType {
+                kVulkanObjectTypeUnknown = 0,
+            ''')
         for count, handle in enumerate(self.vk.handles.values(), start=1):
             out.append(f'    kVulkanObjectType{handle.name[2:]} = {count},\n')
         out.append(f'    kVulkanObjectTypeMax = {len(self.vk.handles) + 1}\n')
-        out.append('} VulkanObjectType;\n')
+        out.append('} VulkanObjectType;\n\n')
+
+        out.append('VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type);\n')
+        out.append('const char* string_VulkanObjectType(VulkanObjectType type);\n')
 
         out.append('''
-// Array of object name strings for OBJECT_TYPE enum conversion
-static const char * const object_string[kVulkanObjectTypeMax] = {
-    "VkNonDispatchableHandle",\n''')
-        out.extend([f'    "{handle.name}",\n' for handle in self.vk.handles.values()])
-        out.append('};\n')
+            // Helper function to get Official Vulkan VkObjectType enum from the internal layers version
+            static constexpr VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {
+                switch (internal_type) {
+                        ''')
+        out.extend([f'case kVulkanObjectType{handle.name[2:]}: return {handle.type};\n' for handle in self.vk.handles.values()])
+        out.append('''default: return VK_OBJECT_TYPE_UNKNOWN;
+                }
+            }\n''')
 
         out.append('''
-// Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version
-const VkDebugReportObjectTypeEXT get_debug_report_enum[] = {
-    VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, // kVulkanObjectTypeUnknown\n''')
-        out.extend([f'    {debugReportObject[handle.name]},   // kVulkanObjectType{handle.name[2:]}\n' for handle in self.vk.handles.values()])
-        out.append('};\n')
+            // Helper function to get internal layers object ids from the official Vulkan VkObjectType enum
+            static constexpr VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulkan_object_type) {
+                switch (vulkan_object_type) {
+            ''')
+        out.extend([f'case {handle.type}: return kVulkanObjectType{handle.name[2:]};\n' for handle in self.vk.handles.values()])
+        out.append('''default: return kVulkanObjectTypeUnknown;
+                }
+            }''')
 
         out.append('''
-// Helper function to get Official Vulkan VkObjectType enum from the internal layers version
-static inline VkObjectType ConvertVulkanObjectToCoreObject(VulkanObjectType internal_type) {
-    switch (internal_type) {\n''')
-        out.extend([f'        case kVulkanObjectType{handle.name[2:]}: return {handle.type};\n' for handle in self.vk.handles.values()])
-        out.append('''        default: return VK_OBJECT_TYPE_UNKNOWN;
-    }
-}\n''')
-
-        out.append('''
-// Helper function to get internal layers object ids from the official Vulkan VkObjectType enum
-static inline VulkanObjectType ConvertCoreObjectToVulkanObject(VkObjectType vulkan_object_type) {
-    switch (vulkan_object_type) {\n''')
-        out.extend([f'        case {handle.type}: return kVulkanObjectType{handle.name[2:]};\n' for handle in self.vk.handles.values()])
-        out.append('''        default: return kVulkanObjectTypeUnknown;
-    }
-}\n''')
-
-        out.append('''
-static inline VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
-    switch (core_report_obj) {
-        case VK_OBJECT_TYPE_UNKNOWN: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;\n''')
+            static constexpr VkDebugReportObjectTypeEXT ConvertCoreObjectToDebugReportObject(VkObjectType core_report_obj) {
+                switch (core_report_obj) {
+                    case VK_OBJECT_TYPE_UNKNOWN: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+            ''')
         for handle in self.vk.handles.values():
-            object = debugReportObject[handle.name]
+            object = self.debugReportObject[handle.name]
             if object != 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT':
-                out.append(f'        case {handle.type}: return {object};\n')
-        out.append('''        default: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
-    }
-}\n''')
+                out.append(f'case {handle.type}: return {object};\n')
+        out.append('''default: return VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+                }
+            }\n''')
 
         out.append('''
-static inline VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
-    switch (debug_obj) {
-        case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT: return kVulkanObjectTypeUnknown;\n''')
+            static constexpr VulkanObjectType ConvertDebugReportObjectToVulkanObject(VkDebugReportObjectTypeEXT debug_obj) {
+                switch (debug_obj) {
+                    case VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT: return kVulkanObjectTypeUnknown;
+            ''')
         for handle in self.vk.handles.values():
-            object = debugReportObject[handle.name]
+            object = self.debugReportObject[handle.name]
             if object != 'VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT':
-                out.append(f'        case {object}: return kVulkanObjectType{handle.name[2:]};\n')
-        out.append('''        default: return kVulkanObjectTypeUnknown;
-    }
-}\n''')
+                out.append(f'case {object}: return kVulkanObjectType{handle.name[2:]};\n')
+        out.append('''default: return kVulkanObjectTypeUnknown;
+            }
+        }\n''')
 
         out.append('''
-// Helper function to get Instance object types
-static inline bool IsInstanceVkObjectType(VkObjectType type) {
-    switch (type) {\n''')
-        out.extend([f'        case {handle.type}:\n' for handle in self.vk.handles.values() if handle.instance])
-        out.append('''            return true;''')
-        out.append('''        default: return false;
-    }
-}\n''')
+            // Helper function to get Instance object types
+            static constexpr bool IsInstanceVkObjectType(VkObjectType type) {
+                switch (type) {
+            ''')
+        out.extend([f'case {handle.type}:\n' for handle in self.vk.handles.values() if handle.instance])
+        out.append('''    return true;''')
+        out.append('''default: return false;
+            }
+        }\n''')
 
         out.append('''
-// Traits objects from each type statically map from Vk<handleType> to the various enums
-template <typename VkType> struct VkHandleInfo {};
-template <VulkanObjectType id> struct VulkanObjectTypeInfo {};
+            // Traits objects from each type statically map from Vk<handleType> to the various enums
+            template <typename VkType> struct VkHandleInfo {};
+            template <VulkanObjectType id> struct VulkanObjectTypeInfo {};
 
-// The following line must match the vulkan_core.h condition guarding VK_DEFINE_NON_DISPATCHABLE_HANDLE
-#if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
-    defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
-#define TYPESAFE_NONDISPATCHABLE_HANDLES
-#else
-VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkNonDispatchableHandle)
+            // The following line must match the vulkan_core.h condition guarding VK_DEFINE_NON_DISPATCHABLE_HANDLE
+            #if defined(__LP64__) || defined(_WIN64) || (defined(__x86_64__) && !defined(__ILP32__)) || defined(_M_X64) || defined(__ia64) || \
+                defined(_M_IA64) || defined(__aarch64__) || defined(__powerpc64__)
+            #define TYPESAFE_NONDISPATCHABLE_HANDLES
+            #else
+            VK_DEFINE_NON_DISPATCHABLE_HANDLE(VkNonDispatchableHandle)
 
-template <> struct VkHandleInfo<VkNonDispatchableHandle> {
-    static const VulkanObjectType kVulkanObjectType = kVulkanObjectTypeUnknown;
-    static const VkDebugReportObjectTypeEXT kDebugReportObjectType = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
-    static const VkObjectType kVkObjectType = VK_OBJECT_TYPE_UNKNOWN;
-    static const char* Typename() {
-        return "VkNonDispatchableHandle";
-    }
-};
-template <> struct VulkanObjectTypeInfo<kVulkanObjectTypeUnknown> {
-    typedef VkNonDispatchableHandle Type;
-};
+            template <> struct VkHandleInfo<VkNonDispatchableHandle> {
+                static const VulkanObjectType kVulkanObjectType = kVulkanObjectTypeUnknown;
+                static const VkDebugReportObjectTypeEXT kDebugReportObjectType = VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT;
+                static const VkObjectType kVkObjectType = VK_OBJECT_TYPE_UNKNOWN;
+                static const char* Typename() {
+                    return "VkNonDispatchableHandle";
+                }
+            };
+            template <> struct VulkanObjectTypeInfo<kVulkanObjectTypeUnknown> {
+                typedef VkNonDispatchableHandle Type;
+            };
 
-#endif //  VK_DEFINE_HANDLE logic duplication\n''')
+            #endif //  VK_DEFINE_HANDLE logic duplication
+            ''')
         guard_helper = PlatformGuardHelper()
         for handle in [x for x in self.vk.handles.values() if x.dispatchable]:
             out.extend(guard_helper.add_guard(handle.protect))
             out.append(f'''
-template <> struct VkHandleInfo<{handle.name}> {{
-    static const VulkanObjectType kVulkanObjectType = kVulkanObjectType{handle.name[2:]};
-    static const VkDebugReportObjectTypeEXT kDebugReportObjectType = {debugReportObject[handle.name]};
-    static const VkObjectType kVkObjectType = {handle.type};
-    static const char* Typename() {{
-        return "{handle.name}";
-    }}
-}};
-template <> struct VulkanObjectTypeInfo<kVulkanObjectType{handle.name[2:]}> {{
-    typedef {handle.name} Type;
-}};\n''')
+                template <> struct VkHandleInfo<{handle.name}> {{
+                    static const VulkanObjectType kVulkanObjectType = kVulkanObjectType{handle.name[2:]};
+                    static const VkDebugReportObjectTypeEXT kDebugReportObjectType = {self.debugReportObject[handle.name]};
+                    static const VkObjectType kVkObjectType = {handle.type};
+                    static const char* Typename() {{
+                        return "{handle.name}";
+                    }}
+                }};
+                template <> struct VulkanObjectTypeInfo<kVulkanObjectType{handle.name[2:]}> {{
+                    typedef {handle.name} Type;
+                }};
+                ''')
         out.extend(guard_helper.add_guard(None))
         out.append('#ifdef TYPESAFE_NONDISPATCHABLE_HANDLES\n')
 
         for handle in [x for x in self.vk.handles.values() if not x.dispatchable]:
             out.extend(guard_helper.add_guard(handle.protect))
             out.append(f'''
-template <> struct VkHandleInfo<{handle.name}> {{
-    static const VulkanObjectType kVulkanObjectType = kVulkanObjectType{handle.name[2:]};
-    static const VkDebugReportObjectTypeEXT kDebugReportObjectType = {debugReportObject[handle.name]};
-    static const VkObjectType kVkObjectType = {handle.type};
-    static const char* Typename() {{
-        return "{handle.name}";
-    }}
-}};
-template <> struct VulkanObjectTypeInfo<kVulkanObjectType{handle.name[2:]}> {{
-    typedef {handle.name} Type;
-}};\n''')
+                template <> struct VkHandleInfo<{handle.name}> {{
+                    static const VulkanObjectType kVulkanObjectType = kVulkanObjectType{handle.name[2:]};
+                    static const VkDebugReportObjectTypeEXT kDebugReportObjectType = {self.debugReportObject[handle.name]};
+                    static const VkObjectType kVkObjectType = {handle.type};
+                    static const char* Typename() {{
+                        return "{handle.name}";
+                    }}
+                }};
+                template <> struct VulkanObjectTypeInfo<kVulkanObjectType{handle.name[2:]}> {{
+                    typedef {handle.name} Type;
+                }};
+                ''')
         out.extend(guard_helper.add_guard(None))
         out.append('#endif // TYPESAFE_NONDISPATCHABLE_HANDLES\n')
 
         out.append('''
-struct VulkanTypedHandle {
-    uint64_t handle;
-    VulkanObjectType type;
-    template <typename Handle>
-    VulkanTypedHandle(Handle handle_, VulkanObjectType type_) :
-        handle(CastToUint64(handle_)),
-        type(type_) {
-#ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
-        // For 32 bit it's not always safe to check for traits <-> type
-        // as all non-dispatchable handles have the same type-id and thus traits,
-        // but on 64 bit we can validate the passed type matches the passed handle
-        assert(type == VkHandleInfo<Handle>::kVulkanObjectType);
-#endif // TYPESAFE_NONDISPATCHABLE_HANDLES
-    }
-    template <typename Handle>
-    Handle Cast() const {
-#ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
-        assert(type == VkHandleInfo<Handle>::kVulkanObjectType);
-#endif // TYPESAFE_NONDISPATCHABLE_HANDLES
-        return CastFromUint64<Handle>(handle);
-    }
-    VulkanTypedHandle() :
-        handle(CastToUint64(VK_NULL_HANDLE)),
-        type(kVulkanObjectTypeUnknown) {}
-    operator bool() const { return handle != 0; }
-};\n''')
-        out.append('// clang-format on')
-        out.append('// NOLINTEND') # Wrap for clang-tidy to ignore
+            struct VulkanTypedHandle {
+                uint64_t handle;
+                VulkanObjectType type;
+                template <typename Handle>
+                VulkanTypedHandle(Handle handle_, VulkanObjectType type_) :
+                    handle(CastToUint64(handle_)),
+                    type(type_) {
+            #ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
+                    // For 32 bit it's not always safe to check for traits <-> type
+                    // as all non-dispatchable handles have the same type-id and thus traits,
+                    // but on 64 bit we can validate the passed type matches the passed handle
+                    assert(type == VkHandleInfo<Handle>::kVulkanObjectType);
+            #endif // TYPESAFE_NONDISPATCHABLE_HANDLES
+                }
+                template <typename Handle>
+                Handle Cast() const {
+            #ifdef TYPESAFE_NONDISPATCHABLE_HANDLES
+                    assert(type == VkHandleInfo<Handle>::kVulkanObjectType);
+            #endif // TYPESAFE_NONDISPATCHABLE_HANDLES
+                    return CastFromUint64<Handle>(handle);
+                }
+                VulkanTypedHandle() :
+                    handle(CastToUint64(VK_NULL_HANDLE)),
+                    type(kVulkanObjectTypeUnknown) {}
+                operator bool() const { return handle != 0; }
+            };\n''')
+        self.write("".join(out))
+
+    def generateSource(self):
+        out = []
+        out.append('''
+            #include <vulkan/vulkan_core.h>
+            #include "vk_object_types.h"
+
+            ''')
+
+        out.append('''
+            // Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version
+            static const VkDebugReportObjectTypeEXT kDebugReportLookup[kVulkanObjectTypeMax] = {
+                VK_DEBUG_REPORT_OBJECT_TYPE_UNKNOWN_EXT, // kVulkanObjectTypeUnknown\n''')
+        out.extend([f'    {self.debugReportObject[handle.name]},   // kVulkanObjectType{handle.name[2:]}\n' for handle in self.vk.handles.values()])
+        out.append('};\n')
+
+        out.append('''
+            // Array of object name strings for OBJECT_TYPE enum conversion
+            static const char * const kVulkanObjectTypeStrings[kVulkanObjectTypeMax] = {
+                "VkNonDispatchableHandle",
+            ''')
+        out.extend([f'    "{handle.name}",\n' for handle in self.vk.handles.values()])
+        out.append('};\n')
+
+        out.append('''
+            VkDebugReportObjectTypeEXT GetDebugReport(VulkanObjectType type) {
+                return kDebugReportLookup[type];
+            }
+
+            const char* string_VulkanObjectType(VulkanObjectType type) {
+                return kVulkanObjectTypeStrings[type];
+            }
+            ''')
         self.write("".join(out))


### PR DESCRIPTION
inspired by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7363

creates a `vk_object_types.cpp` and move 2 array over that didn't need to be in the global namespace