### PR TITLE
gpuav: Add debug env variable for shaders

### DIFF
--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -104,7 +104,12 @@ void gpuav::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo) {
     BaseClass::CreateDevice(pCreateInfo);
     Location loc(vvl::Func::vkCreateDevice);
 
-    validate_instrumented_shaders = (GetEnvironment("VK_LAYER_GPUAV_VALIDATE_INSTRUMENTED_SHADERS").size() > 0);
+    debug_validate_instrumented_shaders = !GetEnvironment("VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS").empty();
+    debug_dump_instrumented_shaders = !GetEnvironment("VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS").empty();
+    if (debug_validate_instrumented_shaders || debug_dump_instrumented_shaders) {
+        // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
+        gpuav_settings.cache_instrumented_shaders = false;
+    }
 
     if (api_version < VK_API_VERSION_1_1) {
         ReportSetupProblem(device, "GPU-Assisted validation requires Vulkan 1.1 or later.  GPU-Assisted Validation disabled.");

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -454,7 +454,6 @@ class Validator : public gpu_tracker::Validator {
                                 const char* mismatch_layout_vuid, bool* error) const;
 
     VkBool32 shaderInt64 = false;
-    bool validate_instrumented_shaders = false;
     std::string instrumented_shader_cache_path{};
     AccelerationStructureBuildValidationState acceleration_structure_validation_state{};
     CommonDrawResources common_draw_resources{};
@@ -467,6 +466,9 @@ class Validator : public gpu_tracker::Validator {
     bool buffer_device_address_enabled = false;
 
     std::optional<DescriptorHeap> desc_heap{};  // optional only to defer construction
+
+    bool debug_validate_instrumented_shaders = false;
+    bool debug_dump_instrumented_shaders = false;
 };
 
 struct RestorablePipelineState {


### PR DESCRIPTION
adds a `VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS` 

also organizes GPU-AV Debug settings we might want to add to later