### PR TITLE
layers: Fix GPL StageCount check

### DIFF
--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -251,6 +251,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
 
         if (!IsExtEnabled(device_extensions.vk_ext_graphics_pipeline_library)) {
             if (create_info.stageCount == 0) {
+                // Because not using GPL, this will always have a complete state and require a shader
                 skip |=
                     LogError("VUID-VkGraphicsPipelineCreateInfo-stageCount-06604", device, create_info_loc.dot(Field::stageCount),
                              "is 0, but %s is not enabled", VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
@@ -290,11 +291,10 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
             }
         }
 
-        if (graphics_lib_info && (graphics_lib_info->flags & (VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT |
-                                                              VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT))) {
-            skip |=
-                ValidateArray(create_info_loc.dot(Field::stageCount), create_info_loc.dot(Field::pStages), create_info.stageCount,
-                              &create_info.pStages, false, true, kVUIDUndefined, "VUID-VkGraphicsPipelineCreateInfo-flags-06640");
+        if (graphics_lib_info && (graphics_lib_info->flags & (VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT))) {
+            skip |= ValidateArray(create_info_loc.dot(Field::stageCount), create_info_loc.dot(Field::pStages),
+                                  create_info.stageCount, &create_info.pStages, true, true,
+                                  "VUID-VkGraphicsPipelineCreateInfo-flags-06644", "VUID-VkGraphicsPipelineCreateInfo-flags-06640");
         }
 
         // <VkDynamicState, index in pDynamicStates, hash for enum key>

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -869,6 +869,22 @@ TEST_F(NegativeGraphicsLibrary, FragmentStateWithPreRaster) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeGraphicsLibrary, StageCount) {
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+    InitRenderTarget();
+
+    CreatePipelineHelper pre_raster_lib(*this);
+    const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
+    vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
+    pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
+    pre_raster_lib.InitState();
+    pre_raster_lib.gp_ci_.stageCount = 0;
+    pre_raster_lib.gp_ci_.layout = pre_raster_lib.pipeline_layout_.handle();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06644");
+    pre_raster_lib.CreateGraphicsPipeline(false);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeGraphicsLibrary, NullStages) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
     InitRenderTarget();
@@ -894,6 +910,7 @@ TEST_F(NegativeGraphicsLibrary, MissingShaderStages) {
         pipe.InitState();
 
         // set in stateless
+        m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-flags-06644");
         // 02096 is effectively unrelated, but gets triggered due to lack of mesh shader extension
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-stage-02096");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-06896");

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -755,6 +755,20 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
     m_commandBuffer->end();
 }
 
+TEST_F(PositiveGraphicsLibrary, FragmentShaderNoStageCount) {
+    TEST_DESCRIPTION("Don't need a stageCount if only have fragment shader library");
+    RETURN_IF_SKIP(InitBasicGraphicsLibrary());
+    InitRenderTarget();
+
+    vkt::PipelineLayout pipeline_layout(*m_device);
+    CreatePipelineHelper frag_shader_lib(*this);
+    frag_shader_lib.InitFragmentLibInfo(nullptr);
+    frag_shader_lib.gp_ci_.stageCount = 0;
+    frag_shader_lib.shader_stages_.clear();
+    frag_shader_lib.gp_ci_.layout = pipeline_layout.handle();
+    frag_shader_lib.CreateGraphicsPipeline(false);
+}
+
 TEST_F(PositiveGraphicsLibrary, LinkingInputAttachment) {
     TEST_DESCRIPTION("Make sure OpCapability InputAttachment is not detected at linking time");
     SetTargetApiVersion(VK_API_VERSION_1_3);


### PR DESCRIPTION
In https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7276 we made our adjustment incorrectly

https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6427 is fixing the spec, but the idea is `stageCount` still needs to be non-zero for pre-rasterization, but you aren't required to have it for a fragment shader