### PR TITLE
bp: Remove UNASSIGNED from BP

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -23,285 +23,285 @@
 // clang-format off
 
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_ExtensionMismatch =
-    "UNASSIGNED-BestPractices-vkCreateInstance-extension-mismatch";
+    "BestPractices-vkCreateInstance-extension-mismatch";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_ExtensionMismatch =
-    "UNASSIGNED-BestPractices-vkCreateDevice-extension-mismatch";
+    "BestPractices-vkCreateDevice-extension-mismatch";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_DeprecatedExtension =
-    "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension";
+    "BestPractices-vkCreateInstance-deprecated-extension";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_DeprecatedExtension =
-    "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension";
+    "BestPractices-vkCreateDevice-deprecated-extension";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_SpecialUseExtension_CADSupport =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-cadsupport";
+    "BestPractices-vkCreateInstance-specialuse-extension-cadsupport";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_SpecialUseExtension_D3DEmulation =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-d3demulation";
+    "BestPractices-vkCreateInstance-specialuse-extension-d3demulation";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_SpecialUseExtension_DevTools =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-devtools";
+    "BestPractices-vkCreateInstance-specialuse-extension-devtools";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_SpecialUseExtension_Debugging =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-debugging";
+    "BestPractices-vkCreateInstance-specialuse-extension-debugging";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateInstance_SpecialUseExtension_GLEmulation =
-    "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-glemulation";
+    "BestPractices-vkCreateInstance-specialuse-extension-glemulation";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_SpecialUseExtension_CADSupport =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-cadsupport";
+    "BestPractices-vkCreateDevice-specialuse-extension-cadsupport";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_SpecialUseExtension_D3DEmulation =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-d3demulation";
+    "BestPractices-vkCreateDevice-specialuse-extension-d3demulation";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_SpecialUseExtension_DevTools =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-devtools";
+    "BestPractices-vkCreateDevice-specialuse-extension-devtools";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_SpecialUseExtension_Debugging =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-debugging";
+    "BestPractices-vkCreateDevice-specialuse-extension-debugging";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_SpecialUseExtension_GLEmulation =
-    "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-glemulation";
+    "BestPractices-vkCreateDevice-specialuse-extension-glemulation";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_API_Mismatch =
-    "UNASSIGNED-BestPractices-vkCreateDevice-API-version-mismatch";
-[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_MustQueryCount = "UNASSIGNED-BestPractices-DevLimit-MustQueryCount";
-[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_CountMismatch = "UNASSIGNED-BestPractices-DevLimit-CountMismatch";
-[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_MissingQueryCount = "UNASSIGNED-BestPractices-DevLimit-MissingQueryCount";
+    "BestPractices-vkCreateDevice-API-version-mismatch";
+[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_MustQueryCount = "BestPractices-DevLimit-MustQueryCount";
+[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_CountMismatch = "BestPractices-DevLimit-CountMismatch";
+[[maybe_unused]] static const char *kVUID_BestPractices_DevLimit_MissingQueryCount = "BestPractices-DevLimit-MissingQueryCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_SharingModeExclusive =
-    "UNASSIGNED-BestPractices-vkCreateBuffer-sharing-mode-exclusive";
+    "BestPractices-vkCreateBuffer-sharing-mode-exclusive";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_Attatchment =
-    "UNASSIGNED-BestPractices-vkCreateRenderPass-attatchment";
+    "BestPractices-vkCreateRenderPass-attatchment";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateMemory_TooManyObjects =
-    "UNASSIGNED-BestPractices-vkAllocateMemory-too-many-objects";
+    "BestPractices-vkAllocateMemory-too-many-objects";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_MultiplePipelines =
-    "UNASSIGNED-BestPractices-vkCreatePipelines-multiple-pipelines-no-cache";
-[[maybe_unused]] static const char *kVUID_BestPractices_PipelineStageFlags = "UNASSIGNED-BestPractices-pipeline-stage-flags";
+    "BestPractices-vkCreatePipelines-multiple-pipelines-no-cache";
+[[maybe_unused]] static const char *kVUID_BestPractices_PipelineStageFlags = "BestPractices-pipeline-stage-flags";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdDraw_InstanceCountZero =
-    "UNASSIGNED-BestPractices-vkCmdDraw-instance-count-zero";
-[[maybe_unused]] static const char *kVUID_BestPractices_CmdDraw_DrawCountZero = "UNASSIGNED-BestPractices-vkCmdDraw-draw-count-zero";
+    "BestPractices-vkCmdDraw-instance-count-zero";
+[[maybe_unused]] static const char *kVUID_BestPractices_CmdDraw_DrawCountZero = "BestPractices-vkCmdDraw-draw-count-zero";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdDispatch_GroupCountZero =
-    "UNASSIGNED-BestPractices-vkCmdDispatch-group-count-zero";
+    "BestPractices-vkCmdDispatch-group-count-zero";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_PDFeaturesNotCalled =
-    "UNASSIGNED-BestPractices-vkCreateDevice-physical-device-features-not-retrieved";
+    "BestPractices-vkCreateDevice-physical-device-features-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_Swapchain_GetSurfaceNotCalled =
-    "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved";
+    "BestPractices-vkCreateSwapchainKHR-surface-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_DisplayPlane_PropertiesNotCalled =
-    "UNASSIGNED-BestPractices-vkGetDisplayPlaneSupportedDisplaysKHR-properties-not-retrieved";
-[[maybe_unused]] static const char *kVUID_BestPractices_MemTrack_InvalidState = "UNASSIGNED-BestPractices-MemTrack-InvalidState";
+    "BestPractices-vkGetDisplayPlaneSupportedDisplaysKHR-properties-not-retrieved";
+[[maybe_unused]] static const char *kVUID_BestPractices_MemTrack_InvalidState = "BestPractices-MemTrack-InvalidState";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindAccelNV_NoMemReqQuery =
-    "UNASSIGNED-BestPractices-BindAccelerationStructureMemoryNV-requirements-not-retrieved";
+    "BestPractices-BindAccelerationStructureMemoryNV-requirements-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_GetVideoSessionMemReqCountNotRetrieved =
-    "UNASSIGNED-BestPractices-vkGetVideoSessionMemoryRequirementsKHR-count-not-retrieved";
+    "BestPractices-vkGetVideoSessionMemoryRequirementsKHR-count-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindVideoSessionMemReqCountNotRetrieved =
-    "UNASSIGNED-BestPractices-vkBindVideoSessionMemoryKHR-requirements-count-not-retrieved";
+    "BestPractices-vkBindVideoSessionMemoryKHR-requirements-count-not-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindVideoSessionMemReqNotAllBindingsRetrieved =
-    "UNASSIGNED-BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved";
+    "BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved";
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_VtxIndexOutOfBounds =
-    "UNASSIGNED-BestPractices-DrawState-VtxIndexOutOfBounds";
+    "BestPractices-DrawState-VtxIndexOutOfBounds";
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_ClearCmdBeforeDraw =
-    "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw";
+    "BestPractices-DrawState-ClearCmdBeforeDraw";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateCommandPool_CommandBufferReset =
-    "UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset";
+    "BestPractices-vkCreateCommandPool-command-buffer-reset";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateCommandBuffers_UnusableSecondary =
-    "UNASSIGNED-BestPractices-vkAllocateCommandBuffers-unusable-secondary";
+    "BestPractices-vkAllocateCommandBuffers-unusable-secondary";
 [[maybe_unused]] static const char *kVUID_BestPractices_BeginCommandBuffer_SimultaneousUse =
-    "UNASSIGNED-BestPractices-vkBeginCommandBuffer-simultaneous-use";
+    "BestPractices-vkBeginCommandBuffer-simultaneous-use";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateMemory_SmallAllocation =
-    "UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation";
+    "BestPractices-vkAllocateMemory-small-allocation";
 [[maybe_unused]] static const char *kVUID_BestPractices_SmallDedicatedAllocation =
-    "UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation";
+    "BestPractices-vkBindMemory-small-dedicated-allocation";
 [[maybe_unused]] static const char *kVUID_BestPractices_NonLazyTransientImage =
-    "UNASSIGNED-BestPractices-vkBindImageMemory-non-lazy-transient-image";
+    "BestPractices-vkBindImageMemory-non-lazy-transient-image";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateRenderPass_ImageRequiresMemory =
-    "UNASSIGNED-BestPractices-vkCreateRenderPass-image-requires-memory";
+    "BestPractices-vkCreateRenderPass-image-requires-memory";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateFramebuffer_AttachmentShouldBeTransient =
-    "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-be-transient";
+    "BestPractices-vkCreateFramebuffer-attachment-should-be-transient";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateFramebuffer_AttachmentShouldNotBeTransient =
-    "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient";
+    "BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_TooManyInstancedVertexBuffers =
-    "UNASSIGNED-BestPractices-vkCreateGraphicsPipelines-too-many-instanced-vertex-buffers";
+    "BestPractices-vkCreateGraphicsPipelines-too-many-instanced-vertex-buffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearAttachments_ClearAfterLoad =
-    "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load";
-[[maybe_unused]] static const char *kVUID_BestPractices_Error_Result = "UNASSIGNED-BestPractices-Error-Result";
-[[maybe_unused]] static const char *kVUID_BestPractices_Failure_Result = "UNASSIGNED-BestPractices-Failure-Result";
-[[maybe_unused]] static const char *kVUID_BestPractices_Verbose_Success_Logging = "UNASSIGNED-BestPractices-Verbose-Success-Logging";
-[[maybe_unused]] static const char *kVUID_BestPractices_SuboptimalSwapchain = "UNASSIGNED-BestPractices-SuboptimalSwapchain";
+    "BestPractices-vkCmdClearAttachments-clear-after-load";
+[[maybe_unused]] static const char *kVUID_BestPractices_Error_Result = "BestPractices-Error-Result";
+[[maybe_unused]] static const char *kVUID_BestPractices_Failure_Result = "BestPractices-Failure-Result";
+[[maybe_unused]] static const char *kVUID_BestPractices_Verbose_Success_Logging = "BestPractices-Verbose-Success-Logging";
+[[maybe_unused]] static const char *kVUID_BestPractices_SuboptimalSwapchain = "BestPractices-SuboptimalSwapchain";
 [[maybe_unused]] static const char *kVUID_BestPractices_SuboptimalSwapchainImageCount =
-    "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count";
+    "BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count";
 [[maybe_unused]] static const char *kVUID_BestPractices_NoVkSwapchainPresentModesCreateInfoEXTProvided =
-    "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-no-VkSwapchainPresentModesCreateInfoEXT-provided";
+    "BestPractices-vkCreateSwapchainKHR-no-VkSwapchainPresentModesCreateInfoEXT-provided";
 [[maybe_unused]] static const char *kVUID_BestPractices_SubpassResolve_NonOptimalFormat =
-    "UNASSIGNED-BestPractices-vkCreateRenderPass-SubpassResolve-NonOptimalFormat";
+    "BestPractices-vkCreateRenderPass-SubpassResolve-NonOptimalFormat";
 
-[[maybe_unused]] static const char *kVUID_BestPractices_Swapchain_InvalidCount = "UNASSIGNED-BestPractices-SwapchainInvalidCount";
-[[maybe_unused]] static const char *kVUID_BestPractices_Swapchain_PriorCount = "UNASSIGNED-BestPractices-SwapchainPriorCount";
-[[maybe_unused]] static const char *kVUID_BestPractices_DepthBiasNoAttachment = "UNASSIGNED-BestPractices-DepthBiasNoAttachment";
+[[maybe_unused]] static const char *kVUID_BestPractices_Swapchain_InvalidCount = "BestPractices-SwapchainInvalidCount";
+[[maybe_unused]] static const char *kVUID_BestPractices_Swapchain_PriorCount = "BestPractices-SwapchainPriorCount";
+[[maybe_unused]] static const char *kVUID_BestPractices_DepthBiasNoAttachment = "BestPractices-DepthBiasNoAttachment";
 [[maybe_unused]] static const char *kVUID_BestPractices_SpirvDeprecated_WorkgroupSize =
-    "UNASSIGNED-BestPractices-SpirvDeprecated_WorkgroupSize";
-[[maybe_unused]] static const char *kVUID_BestPractices_ImageCreateFlags = "UNASSIGNED-BestPractices-ImageCreateFlags";
+    "BestPractices-SpirvDeprecated_WorkgroupSize";
+[[maybe_unused]] static const char *kVUID_BestPractices_ImageCreateFlags = "BestPractices-ImageCreateFlags";
 [[maybe_unused]] static const char *kVUID_BestPractices_TransitionUndefinedToReadOnly =
-    "UNASSIGNED-BestPractices-TransitionUndefinedToReadOnly";
-[[maybe_unused]] static const char *kVUID_BestPractices_SemaphoreCount = "UNASSIGNED-BestPractices-SemaphoreCount";
-[[maybe_unused]] static const char *kVUID_BestPractices_PushConstants = "UNASSIGNED-BestPractices-PushConstants";
+    "BestPractices-TransitionUndefinedToReadOnly";
+[[maybe_unused]] static const char *kVUID_BestPractices_SemaphoreCount = "BestPractices-SemaphoreCount";
+[[maybe_unused]] static const char *kVUID_BestPractices_PushConstants = "BestPractices-PushConstants";
 [[maybe_unused]] static const char *kVUID_BestPractices_EmptyDescriptorPool =
-    "UNASSIGNED-BestPractices-EmptyDescriptorPool";
-[[maybe_unused]] static const char *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
-[[maybe_unused]] static const char *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
-[[maybe_unused]] static const char *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";
-[[maybe_unused]] static const char *kVUID_BestPractices_ConcurrentUsageOfExclusiveImage = "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage";
+    "BestPractices-EmptyDescriptorPool";
+[[maybe_unused]] static const char *kVUID_BestPractices_ClearValueWithoutLoadOpClear = "BestPractices-vkCmdBeginRenderPass-ClearValueWithoutLoadOpClear";
+[[maybe_unused]] static const char *kVUID_BestPractices_ClearValueCountHigherThanAttachmentCount = "BestPractices-vkCmdBeginRenderPass-ClearValueCountHigherThanAttachmentCount";
+[[maybe_unused]] static const char *kVUID_BestPractices_StoreOpDontCareThenLoadOpLoad = "BestPractices-vkCmdBeginRenderPass-StoreOpDontCareThenLoadOpLoad";
+[[maybe_unused]] static const char *kVUID_BestPractices_ConcurrentUsageOfExclusiveImage = "BestPractices-ConcurrentUsageOfExclusiveImage";
 [[maybe_unused]] static const char *kVUID_BestPractices_ImageBarrierAccessLayout =
-    "UNASSIGNED-BestPractices-ImageBarrierAccessLayout";
-[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_SwapchainImagesNotFound = "UNASSIGNED-BestPractices-DrawState-SwapchainImagesNotFound";
-[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_MismatchedImageType = "UNASSIGNED-BestPractices-DrawState-MismatchedImageType";
-[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_InvalidExtents = "UNASSIGNED-BestPractices-DrawState-InvalidExtents";
-[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_InvalidCommandBufferSimultaneousUse = "UNASSIGNED-BestPractices-DrawState-InvalidCommandBufferSimultaneousUse";
-[[maybe_unused]] static const char *kVUID_BestPractices_Pipeline_NoRendering = "UNASSIGNED-BestPractices-Pipeline-NoRendering";
-[[maybe_unused]] static const char *kVUID_BestPractices_QueryPool_Unavailable = "UNASSIGNED-BestPractices-QueryPool-Unavailable";
+    "BestPractices-ImageBarrierAccessLayout";
+[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_SwapchainImagesNotFound = "BestPractices-DrawState-SwapchainImagesNotFound";
+[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_MismatchedImageType = "BestPractices-DrawState-MismatchedImageType";
+[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_InvalidExtents = "BestPractices-DrawState-InvalidExtents";
+[[maybe_unused]] static const char *kVUID_BestPractices_DrawState_InvalidCommandBufferSimultaneousUse = "BestPractices-DrawState-InvalidCommandBufferSimultaneousUse";
+[[maybe_unused]] static const char *kVUID_BestPractices_Pipeline_NoRendering = "BestPractices-Pipeline-NoRendering";
+[[maybe_unused]] static const char *kVUID_BestPractices_QueryPool_Unavailable = "BestPractices-QueryPool-Unavailable";
 [[maybe_unused]] static const char *kVUID_BestPractices_Shader_MissingInputAttachment =
-    "UNASSIGNED-BestPractices-Shader-MissingInputAttachment";
+    "BestPractices-Shader-MissingInputAttachment";
 
 // Arm-specific best practice
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =
-    "UNASSIGNED-BestPractices-vkAllocateDescriptorSets-suboptimal-reuse";
+    "BestPractices-vkAllocateDescriptorSets-suboptimal-reuse";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateComputePipelines_ComputeThreadGroupAlignment =
-    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment";
+    "BestPractices-vkCreateComputePipelines-compute-thread-group-alignment";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateComputePipelines_ComputeWorkGroupSize =
-    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size";
+    "BestPractices-vkCreateComputePipelines-compute-work-group-size";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateComputePipelines_ComputeSpatialLocality =
-    "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-spatial-locality";
+    "BestPractices-vkCreateComputePipelines-compute-spatial-locality";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_MultisampledBlending =
-    "UNASSIGNED-BestPractices-vkCreatePipelines-multisampled-blending";
+    "BestPractices-vkCreatePipelines-multisampled-blending";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateImage_TooLargeSampleCount =
-    "UNASSIGNED-BestPractices-vkCreateImage-too-large-sample-count";
+    "BestPractices-vkCreateImage-too-large-sample-count";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateImage_NonTransientMSImage =
-    "UNASSIGNED-BestPractices-vkCreateImage-non-transient-ms-image";
+    "BestPractices-vkCreateImage-non-transient-ms-image";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_DifferentWrappingModes =
-    "UNASSIGNED-BestPractices-vkCreateSampler-different-wrapping-modes";
+    "BestPractices-vkCreateSampler-different-wrapping-modes";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_LodClamping =
-    "UNASSIGNED-BestPractices-vkCreateSampler-lod-clamping";
-[[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_LodBias = "UNASSIGNED-BestPractices-vkCreateSampler-lod-bias";
+    "BestPractices-vkCreateSampler-lod-clamping";
+[[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_LodBias = "BestPractices-vkCreateSampler-lod-bias";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_BorderClampColor =
-    "UNASSIGNED-BestPractices-vkCreateSampler-border-clamp-color";
+    "BestPractices-vkCreateSampler-border-clamp-color";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_UnnormalizedCoordinates =
-    "UNASSIGNED-BestPractices-vkCreateSampler-unnormalized-coordinates";
+    "BestPractices-vkCreateSampler-unnormalized-coordinates";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSampler_Anisotropy =
-    "UNASSIGNED-BestPractices-vkCreateSampler-anisotropy";
+    "BestPractices-vkCreateSampler-anisotropy";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdResolveImage_ResolvingImage =
-    "UNASSIGNED-BestPractices-vkCmdResolveImage-resolving-image";
+    "BestPractices-vkCmdResolveImage-resolving-image";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdDrawIndexed_ManySmallIndexedDrawcalls =
-    "UNASSIGNED-BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls";
+    "BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdDrawIndexed_SparseIndexBuffer =
-    "UNASSIGNED-BestPractices-vkCmdDrawIndexed-sparse-index-buffer";
+    "BestPractices-vkCmdDrawIndexed-sparse-index-buffer";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdDrawIndexed_PostTransformCacheThrashing =
-    "UNASSIGNED-BestPractices-vkCmdDrawIndexed-post-transform-cache-thrashing";
+    "BestPractices-vkCmdDrawIndexed-post-transform-cache-thrashing";
 [[maybe_unused]] static const char *kVUID_BestPractices_BeginCommandBuffer_OneTimeSubmit =
-    "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit";
+    "BestPractices-vkBeginCommandBuffer-one-time-submit";
 [[maybe_unused]] static const char *kVUID_BestPractices_BeginRenderPass_ZeroSizeRenderArea =
-    "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-zero-size-render-area";
+    "BestPractices-vkCmdBeginRenderPass-zero-size-render-area";
 [[maybe_unused]] static const char *kVUID_BestPractices_BeginRenderPass_AttachmentNeedsReadback =
-    "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback";
+    "BestPractices-vkCmdBeginRenderPass-attachment-needs-readback";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateSwapchain_PresentMode =
-    "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo";
+    "BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_DepthBias_Zero =
-    "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero";
+    "BestPractices-vkCreatePipelines-depthbias-zero";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_RobustBufferAccess =
-    "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess";
+    "BestPractices-vkCreateDevice-RobustBufferAccess";
 [[maybe_unused]] static const char *kVUID_BestPractices_EndRenderPass_DepthPrePassUsage =
-    "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage";
+    "BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage";
 [[maybe_unused]] static const char *kVUID_BestPractices_EndRenderPass_RedundantAttachmentOnTile =
-    "UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile";
+    "BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_RedundantStore =
-    "UNASSIGNED-BestPractices-RenderPass-redundant-store";
+    "BestPractices-RenderPass-redundant-store";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_RedundantClear =
-    "UNASSIGNED-BestPractices-RenderPass-redundant-clear";
+    "BestPractices-RenderPass-redundant-clear";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_InefficientClear =
-    "UNASSIGNED-BestPractices-RenderPass-inefficient-clear";
+    "BestPractices-RenderPass-inefficient-clear";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_BlitImage_LoadOpLoad =
-    "UNASSIGNED-BestPractices-RenderPass-blitimage-loadopload";
+    "BestPractices-RenderPass-blitimage-loadopload";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_CopyImage_LoadOpLoad =
-    "UNASSIGNED-BestPractices-RenderPass-copyimage-loadopload";
+    "BestPractices-RenderPass-copyimage-loadopload";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderPass_ResolveImage_LoadOpLoad =
-    "UNASSIGNED-BestPractices-RenderPass-resolveimage-loadopload";
+    "BestPractices-RenderPass-resolveimage-loadopload";
 
 
 // AMD-specific best practice
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_AvoidTinyCmdBuffers =
-    "UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers";
+    "BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_AvoidSecondaryCmdBuffers =
-    "UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers";
+    "BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_AvoidSmallSecondaryCmdBuffers =
-    "UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers";
+    "BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_AvoidClearSecondaryCmdBuffers =
-    "UNASSIGNED-BestPractices-VkCommandBuffer-AvoidClearSecondaryCmdBuffers";
+    "BestPractices-VkCommandBuffer-AvoidClearSecondaryCmdBuffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_DrawState_AvoidVertexBindEveryDraw =
-    "UNASSIGNED-BestPractices-DrawState-AvoidVertexBindEveryDraw";
+    "BestPractices-DrawState-AvoidVertexBindEveryDraw";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdPool_DisparateSizedCmdBuffers =
-    "UNASSIGNED-BestPractices-CmdPool-DisparateSizedCmdBuffers";
+    "BestPractices-CmdPool-DisparateSizedCmdBuffers";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_TooManyPipelines =
-    "UNASSIGNED-BestPractices-CreatePipelines-TooManyPipelines";
+    "BestPractices-CreatePipelines-TooManyPipelines";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_MultiplePipelineCaches =
-    "UNASSIGNED-BestPractices-vkCreatePipelines-multiple-pipelines-caches";
+    "BestPractices-vkCreatePipelines-multiple-pipelines-caches";
 [[maybe_unused]] static const char *kVUID_BestPractices_vkImage_DontUseMutableRenderTargets =
-    "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets";
+    "BestPractices-vkImage-DontUseMutableRenderTargets";
 [[maybe_unused]] static const char *kVUID_BestPractices_vkImage_AvoidImageToImageCopy =
-    "UNASSIGNED-BestPractices-vkImage-AvoidImageToImageCopy";
+    "BestPractices-vkImage-AvoidImageToImageCopy";
 [[maybe_unused]] static const char *kVUID_BestPractices_vkImage_AvoidConcurrentRenderTargets =
-    "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets";
+    "BestPractices-vkImage-AvoidConcurrentRenderTargets";
 [[maybe_unused]] static const char *kVUID_BestPractices_vkImage_DontUseStorageRenderTargets =
-    "UNASSIGNED-BestPractices-vkImage-DontUseStorageRenderTargets";
-[[maybe_unused]] static const char *kVUID_BestPractices_vkImage_AvoidGeneral = "UNASSIGNED-BestPractices-vkImage-AvoidGeneral";
+    "BestPractices-vkImage-DontUseStorageRenderTargets";
+[[maybe_unused]] static const char *kVUID_BestPractices_vkImage_AvoidGeneral = "BestPractices-vkImage-AvoidGeneral";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_AvoidPrimitiveRestart =
-    "UNASSIGNED-BestPractices-CreatePipelines-AvoidPrimitiveRestart";
+    "BestPractices-CreatePipelines-AvoidPrimitiveRestart";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelines_MinimizeNumDynamicStates =
-    "UNASSIGNED-BestPractices-CreatePipelines-MinimizeNumDynamicStates";
+    "BestPractices-CreatePipelines-MinimizeNumDynamicStates";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelinesLayout_KeepLayoutSmall =
-    "UNASSIGNED-BestPractices-CreatePipelinesLayout-KeepLayoutSmall";
+    "BestPractices-CreatePipelinesLayout-KeepLayoutSmall";
 [[maybe_unused]] static const char *kVUID_BestPractices_UpdateDescriptors_AvoidCopyingDescriptors =
-    "UNASSIGNED-BestPractices-UpdateDescriptors-AvoidCopyingDescriptors";
+    "BestPractices-UpdateDescriptors-AvoidCopyingDescriptors";
 [[maybe_unused]] static const char *kVUID_BestPractices_UpdateDescriptors_PreferNonTemplate =
-    "UNASSIGNED-BestPractices-UpdateDescriptors-PreferNonTemplate";
+    "BestPractices-UpdateDescriptors-PreferNonTemplate";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearAttachment_FastClearValues =
-    "UNASSIGNED-BestPractices-ClearAttachment-FastClearValues";
+    "BestPractices-ClearAttachment-FastClearValues";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearAttachment_ClearImage =
-    "UNASSIGNED-BestPractices-ClearAttachment-ClearImage";
+    "BestPractices-ClearAttachment-ClearImage";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_backToBackBarrier =
-    "UNASSIGNED-BestPractices-CmdBuffer-backToBackBarrier";
+    "BestPractices-CmdBuffer-backToBackBarrier";
 [[maybe_unused]] static const char *kVUID_BestPractices_CmdBuffer_highBarrierCount =
-    "UNASSIGNED-BestPractices-CmdBuffer-highBarrierCount";
+    "BestPractices-CmdBuffer-highBarrierCount";
 [[maybe_unused]] static const char *kVUID_BestPractices_PipelineBarrier_readToReadBarrier =
-    "UNASSIGNED-BestPractices-PipelineBarrier-readToReadBarrier";
+    "BestPractices-PipelineBarrier-readToReadBarrier";
 [[maybe_unused]] static const char *kVUID_BestPractices_Submission_ReduceNumberOfSubmissions =
-    "UNASSIGNED-BestPractices-Submission-ReduceNumberOfSubmissions";
-[[maybe_unused]] static const char *kVUID_BestPractices_Pipeline_SortAndBind = "UNASSIGNED-BestPractices-Pipeline-SortAndBind";
+    "BestPractices-Submission-ReduceNumberOfSubmissions";
+[[maybe_unused]] static const char *kVUID_BestPractices_Pipeline_SortAndBind = "BestPractices-Pipeline-SortAndBind";
 [[maybe_unused]] static const char *kVUID_BestPractices_Pipeline_WorkPerPipelineChange =
-    "UNASSIGNED-BestPractices-Pipeline-WorkPerPipelineChange";
+    "BestPractices-Pipeline-WorkPerPipelineChange";
 [[maybe_unused]] static const char *kVUID_BestPractices_SyncObjects_HighNumberOfFences =
-    "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfFences";
+    "BestPractices-SyncObjects-HighNumberOfFences";
 [[maybe_unused]] static const char *kVUID_BestPractices_SyncObjects_HighNumberOfSemaphores =
-    "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfSemaphores";
+    "BestPractices-SyncObjects-HighNumberOfSemaphores";
 [[maybe_unused]] static const char *kVUID_BestPractices_DynamicRendering_NotSupported =
-    "UNASSIGNED-BestPractices-DynamicRendering-NotSupported";
+    "BestPractices-DynamicRendering-NotSupported";
 [[maybe_unused]] static const char *kVUID_BestPractices_LocalWorkgroup_Multiple64 =
-    "UNASSIGNED-BestPractices-LocalWorkgroup-Multiple64";
+    "BestPractices-LocalWorkgroup-Multiple64";
 
 // Imagination Technologies best practices
 [[maybe_unused]] static const char *kVUID_BestPractices_Texture_Format_PVRTC_Outdated =
-    "UNASSIGNED-BestPractices-Texture-Format-PVRTC-Outdated";
+    "BestPractices-Texture-Format-PVRTC-Outdated";
 
 // NVIDIA-specific best practices
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateDevice_PageableDeviceLocalMemory =
-    "UNASSIGNED-BestPractices-CreateDevice-PageableDeviceLocalMemory";
+    "BestPractices-CreateDevice-PageableDeviceLocalMemory";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateImage_TilingLinear =
-    "UNASSIGNED-BestPractices-CreateImage-TilingLinear";
+    "BestPractices-CreateImage-TilingLinear";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreateImage_Depth32Format =
-    "UNASSIGNED-BestPractices-CreateImage-Depth32Format";
+    "BestPractices-CreateImage-Depth32Format";
 [[maybe_unused]] static const char *kVUID_BestPractices_QueueBindSparse_NotAsync =
-    "UNASSIGNED-BestPractices-QueueBindSparse-NotAsync";
+    "BestPractices-QueueBindSparse-NotAsync";
 [[maybe_unused]] static const char *kVUID_BestPractices_AccelerationStructure_NotAsync =
-    "UNASSIGNED-BestPractices-AccelerationStructure-NotAsync";
+    "BestPractices-AccelerationStructure-NotAsync";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateMemory_SetPriority =
-    "UNASSIGNED-BestPractices-AllocateMemory-SetPriority";
+    "BestPractices-AllocateMemory-SetPriority";
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateMemory_ReuseAllocations =
-    "UNASSIGNED-BestPractices-AllocateMemory-ReuseAllocations";
+    "BestPractices-AllocateMemory-ReuseAllocations";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindMemory_NoPriority =
-    "UNASSIGNED-BestPractices-BindMemory-NoPriority";
+    "BestPractices-BindMemory-NoPriority";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelineLayout_SeparateSampler =
-    "UNASSIGNED-BestPractices-CreatePipelineLayout-SeparateSampler";
+    "BestPractices-CreatePipelineLayout-SeparateSampler";
 [[maybe_unused]] static const char *kVUID_BestPractices_CreatePipelinesLayout_LargePipelineLayout =
-    "UNASSIGNED-BestPractices-CreatePipelineLayout-LargePipelineLayout";
+    "BestPractices-CreatePipelineLayout-LargePipelineLayout";
 [[maybe_unused]] static const char *kVUID_BestPractices_BindPipeline_SwitchTessGeometryMesh =
-    "UNASSIGNED-BestPractices-BindPipeline-SwitchTessGeometryMesh";
+    "BestPractices-BindPipeline-SwitchTessGeometryMesh";
 [[maybe_unused]] static const char *kVUID_BestPractices_Zcull_LessGreaterRatio =
-    "UNASSIGNED-BestPractices-Zcull-LessGreaterRatio";
+    "BestPractices-Zcull-LessGreaterRatio";
 [[maybe_unused]] static const char *kVUID_BestPractices_ClearColor_NotCompressed =
-    "UNASSIGNED-BestPractices-ClearColor-NotCompressed";
+    "BestPractices-ClearColor-NotCompressed";
 
 // clang-format on

--- a/scripts/vk_validation_stats.py
+++ b/scripts/vk_validation_stats.py
@@ -227,7 +227,10 @@ class ValidationTests:
                         for sub_str in line_list:
                             if any(prefix in sub_str for prefix in vuid_prefixes):
                                 vuid_str = sub_str.strip(',);:"*')
-                                if vuid_str.startswith('kVUID_'): vuid_str = kvuid_dict[vuid_str]
+                                if 'BestPractices' in vuid_str:
+                                    continue
+                                if vuid_str.startswith('kVUID_'):
+                                    vuid_str = kvuid_dict[vuid_str]
                                 self.vuid_to_tests[vuid_str].add(testname)
                                 if (vuid_str.startswith('VUID-')):
                                     vuid_number = vuid_str[-5:]
@@ -545,7 +548,6 @@ def main(argv):
     test_source_files = glob.glob(os.path.join(repo_relative('tests/unit'), '*.cpp'))
 
     unassigned_vuid_files = [repo_relative(path) for path in [
-        'layers/best_practices/best_practices_error_enums.h',
         'layers/stateless/stateless_validation.h',
         'layers/object_tracker/object_lifetime_validation.h'
     ]]

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -38,7 +38,7 @@ TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
         if (i == 1) {
             // check that the second pipeline helper cache was detected
             m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                                 "UNASSIGNED-BestPractices-vkCreatePipelines-multiple-pipelines-caches");
+                                                 "BestPractices-vkCreatePipelines-multiple-pipelines-caches");
         }
         CreatePipelineHelper pipe(*this);
         pipe.InitState();
@@ -47,8 +47,7 @@ TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
         if (i == 1) {
             // change check to too many pipelines
             m_errorMonitor->VerifyFound();
-            m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                                 "UNASSIGNED-BestPractices-CreatePipelines-TooManyPipelines");
+            m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CreatePipelines-TooManyPipelines");
         }
     }
 
@@ -62,8 +61,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-DontUseMutableRenderTargets");
 
     // create a colot attachment image with mutable bit set
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -85,8 +83,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
     vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-DontUseMutableRenderTargets");
     // create a depth attachment image with mutable bit set
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                 nullptr,
@@ -107,8 +104,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UseMutableRT) {
     vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseMutableRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-DontUseMutableRenderTargets");
     // create a storage image with mutable bit set
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                nullptr,
@@ -145,7 +141,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
         queueFamilies[i] = i;
     }
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-AvoidConcurrentRenderTargets");
 
     // create a render target image with mutable bit set
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -167,7 +163,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
     vk::CreateImage(m_device->handle(), &img_info, nullptr, &test_image);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkImage-AvoidConcurrentRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-AvoidConcurrentRenderTargets");
     // create a render target image with mutable bit set
     img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                 nullptr,
@@ -195,8 +191,7 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageStorageRT) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-DontUseStorageRenderTargets");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-DontUseStorageRenderTargets");
 
     // create a render target image with mutable bit set
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -225,8 +220,7 @@ TEST_F(VkAmdBestPracticesLayerTest, PrimitiveRestart) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-CreatePipelines-AvoidPrimitiveRestart");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CreatePipelines-AvoidPrimitiveRestart");
 
     CreatePipelineHelper pipe(*this);
     pipe.InitState();
@@ -242,8 +236,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumDynamicStates) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-CreatePipelines-MinimizeNumDynamicStates");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CreatePipelines-MinimizeNumDynamicStates");
 
     // fill the dynamic array with the first 8 types in the enum
     // imitates a case where the user have set most dynamic states unnecessarily
@@ -272,8 +265,7 @@ TEST_F(VkAmdBestPracticesLayerTest, KeepLayoutSmall) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-CreatePipelinesLayout-KeepLayoutSmall");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CreatePipelinesLayout-KeepLayoutSmall");
 
     // create a layout of 15 DWORDS (40 bytes push constants (10 DWORDS), a descriptor set (1 DWORD), and 2 dynamic buffers (4
     // DWORDS)
@@ -317,8 +309,7 @@ TEST_F(VkAmdBestPracticesLayerTest, CopyingDescriptors) {
 
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-UpdateDescriptors-AvoidCopyingDescriptors");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-UpdateDescriptors-AvoidCopyingDescriptors");
 
     VkDescriptorPoolSize ds_type_count = {};
     ds_type_count.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC;
@@ -403,8 +394,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
         image_range.levelCount = 1;
         image_range.layerCount = 1;
 
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                             "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-ClearAttachment-ClearImage");
 
         vk::CmdClearColorImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, &clear_value, 1,
                                &image_range);
@@ -445,8 +435,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
         image_range.levelCount = 1;
         image_range.layerCount = 1;
 
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                             "UNASSIGNED-BestPractices-ClearAttachment-ClearImage");
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-ClearAttachment-ClearImage");
 
         vk::CmdClearDepthStencilImage(m_commandBuffer->handle(), image_1D.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL,
                                       &clear_value, 1, &image_range);
@@ -492,8 +481,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
     m_commandBuffer->begin();
 
     image1D_1.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-AvoidImageToImageCopy");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-AvoidImageToImageCopy");
 
     VkImageCopy copy{};
     copy.extent = img_info.extent;
@@ -528,9 +516,8 @@ TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
                                  VK_IMAGE_LAYOUT_UNDEFINED};
     VkImageObj image_1D(m_device);
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkImage-AvoidGeneral");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-AvoidGeneral");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
 
     // the init function initializes to general layout
     image_1D.init(&img_info);
@@ -541,8 +528,7 @@ TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
 TEST_F(VkAmdBestPracticesLayerTest, RobustAccessOn) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCreateDevice-RobustBufferAccess");
 
     VkPhysicalDeviceFeatures features = {};
     features.robustBufferAccess = true;
@@ -593,9 +579,8 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
 
     m_commandBuffer->begin();
     // check for read-to-read barrier
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-PipelineBarrier-readToReadBarrier");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-CmdBuffer-backToBackBarrier");  // we already test for this above
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-PipelineBarrier-readToReadBarrier");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-CmdBuffer-backToBackBarrier");  // we already test for this above
     image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
 
@@ -610,9 +595,8 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
         image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     }
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-CmdBuffer-highBarrierCount");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-CmdBuffer-backToBackBarrier");  // we already test for this above
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CmdBuffer-highBarrierCount");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-CmdBuffer-backToBackBarrier");  // we already test for this above
     image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     m_errorMonitor->VerifyFound();
 
@@ -668,8 +652,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
     present_info.pImageIndices = &current_buffer;
     present_info.pResults = NULL;
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-Submission-ReduceNumberOfSubmissions");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-Submission-ReduceNumberOfSubmissions");
     m_errorMonitor->SetUnexpectedError("VUID-VkPresentInfoKHR-pImageIndices-01430");
 
     vk::QueuePresentKHR(m_default_queue->handle(), &present_info);
@@ -688,8 +671,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     for (int i = 0; i < fence_warn_limit - 1; ++i) {
         test_fences[i].init(*m_device, fence_ci);
     }
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfFences");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-SyncObjects-HighNumberOfFences");
     test_fences[fence_warn_limit - 1].init(*m_device, fence_ci);
     m_errorMonitor->VerifyFound();
 
@@ -699,8 +681,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumSyncPrimitives) {
     for (int i = 0; i < semaphore_warn_limit - 1; ++i) {
         test_semaphores[i].init(*m_device, semaphore_ci);
     }
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-SyncObjects-HighNumberOfSemaphores");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-SyncObjects-HighNumberOfSemaphores");
     test_semaphores[semaphore_warn_limit - 1].init(*m_device, semaphore_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -761,9 +742,8 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
 
     vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_cmd_buf.handle());
 
@@ -795,7 +775,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
                                   "void main() {}\n",
                                   VK_SHADER_STAGE_COMPUTE_BIT);
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-LocalWorkgroup-Multiple64");
+                                             "BestPractices-LocalWorkgroup-Multiple64");
         make_pipeline_with_shader(pipe, compute_4_1_1.GetStageCreateInfo());
         m_errorMonitor->VerifyFound();
     }

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -102,7 +102,7 @@ TEST_F(VkArmBestPracticesLayerTest, TooManySamples) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateImage-too-large-sample-count");
+                                         "BestPractices-vkCreateImage-too-large-sample-count");
 
     VkImageCreateInfo image_info{};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -132,7 +132,7 @@ TEST_F(VkArmBestPracticesLayerTest, NonTransientMSImage) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateImage-non-transient-ms-image");
+                                         "BestPractices-vkCreateImage-non-transient-ms-image");
 
     VkImageCreateInfo image_info{};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -158,15 +158,13 @@ TEST_F(VkArmBestPracticesLayerTest, SamplerCreation) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSampler-different-wrapping-modes");
+                                         "BestPractices-vkCreateSampler-different-wrapping-modes");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-vkCreateSampler-lod-clamping");
+    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-vkCreateSampler-lod-bias");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSampler-lod-clamping");
+                                         "BestPractices-vkCreateSampler-border-clamp-color");
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSampler-lod-bias");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSampler-border-clamp-color");
-    m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSampler-unnormalized-coordinates");
+                                         "BestPractices-vkCreateSampler-unnormalized-coordinates");
 
     VkSamplerCreateInfo sampler_info{};
     sampler_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
@@ -192,7 +190,7 @@ TEST_F(VkArmBestPracticesLayerTest, MultisampledBlending) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreatePipelines-multisampled-blending");
+                                         "BestPractices-vkCreatePipelines-multisampled-blending");
 
     VkAttachmentDescription attachment{};
     attachment.samples = VK_SAMPLE_COUNT_4_BIT;
@@ -261,10 +259,10 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+                                         "BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
 
     // NOTE: VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT should be set for all tests in this file because
-    // otherwise UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit will be triggered.
+    // otherwise BestPractices-vkBeginCommandBuffer-one-time-submit will be triggered.
     m_commandBuffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle());
 
@@ -275,11 +273,11 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls");
+                                         "BestPractices-vkCmdDrawIndexed-many-small-indexed-drawcalls");
 
     // This test may also trigger other warnings
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
 
     InitRenderTarget();
 
@@ -380,7 +378,7 @@ TEST_F(VkArmBestPracticesLayerTest, SuboptimalDescriptorReuseTest) {
     alloc_info.pSetLayouts = ds_layouts.data();
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkAllocateDescriptorSets-suboptimal-reuse");
+                                         "BestPractices-vkAllocateDescriptorSets-suboptimal-reuse");
 
     err = vk::AllocateDescriptorSets(m_device->device(), &alloc_info, ds);
 
@@ -462,7 +460,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
         ibo.memory().map();
         if (expect_error) {
             m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                                 "UNASSIGNED-BestPractices-vkCmdDrawIndexed-sparse-index-buffer");
+                                                 "BestPractices-vkCmdDrawIndexed-sparse-index-buffer");
         }
         vk::CmdDrawIndexed(m_commandBuffer->handle(), index_count, 0, 0, 0, 0);
         if (expect_error) {
@@ -473,7 +471,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
 
         if (expect_error) {
             m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                                 "UNASSIGNED-BestPractices-vkCmdDrawIndexed-sparse-index-buffer");
+                                                 "BestPractices-vkCmdDrawIndexed-sparse-index-buffer");
         }
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pr_pipe.pipeline_);
         vk::CmdBindIndexBuffer(m_commandBuffer->handle(), ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
@@ -550,7 +548,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     // the validation layer will only be able to analyse mapped memory, it's too expensive otherwise to do in the layer itself
     worst_ibo.memory().map();
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCmdDrawIndexed-post-transform-cache-thrashing");
+                                         "BestPractices-vkCmdDrawIndexed-post-transform-cache-thrashing");
     vk::CmdDrawIndexed(m_commandBuffer->handle(), worst_indices.size(), 0, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     worst_ibo.memory().unmap();
@@ -612,7 +610,7 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
+                                             "BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
         const auto err = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
 
@@ -638,13 +636,13 @@ TEST_F(VkArmBestPracticesLayerTest, PipelineDepthBiasZeroTest) {
     pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero");
+                                         "BestPractices-vkCreatePipelines-depthbias-zero");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
     pipe.rs_state_ci_.depthBiasEnable = VK_FALSE;
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreatePipelines-depthbias-zero");
+                                         "BestPractices-vkCreatePipelines-depthbias-zero");
     pipe.CreateGraphicsPipeline();
 }
 
@@ -675,7 +673,7 @@ TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
     vk::GetPhysicalDeviceFeatures(this->gpu(), &supported_features);
     if (supported_features.robustBufferAccess) {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkCreateDevice-RobustBufferAccess");
+                                             "BestPractices-vkCreateDevice-RobustBufferAccess");
         VkPhysicalDeviceFeatures device_features = {};
         device_features.robustBufferAccess = VK_TRUE;
         dev_info.pEnabledFeatures = &device_features;
@@ -758,9 +756,8 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     // record a command buffer which records a significant number of depth pre-passes
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdEndRenderPass-depth-pre-pass-usage");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
 
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_depth_only.pipeline_);
     for (size_t i = 0; i < 30; i++) vk::CmdDrawIndexed(m_commandBuffer->handle(), indices.size(), 1000, 0, 0, 0);
@@ -816,13 +813,13 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
     // these two pipelines should not cause any warning
     makePipelineWithShader(pipe, compute_4_1_1.GetStageCreateInfo());
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCreateComputePipelines-compute-work-group-size");
     makePipelineWithShader(pipe, compute_16_8_1.GetStageCreateInfo());
 
     // this pipeline should cause a warning due to bad work group alignment
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+                                         "BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
     makePipelineWithShader(pipe, compute_4_1_3.GetStageCreateInfo());
     m_errorMonitor->VerifyFound();
 }
@@ -869,13 +866,13 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadCountTest) {
     // these two pipelines should not cause any warning
     make_pipeline_with_shader(pipe, compute_4_1_1.GetStageCreateInfo());
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCreateComputePipelines-compute-thread-group-alignment");
     make_pipeline_with_shader(pipe, compute_4_1_3.GetStageCreateInfo());
 
     // this pipeline should cause a warning due to the total workgroup count
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-work-group-size");
+                                         "BestPractices-vkCreateComputePipelines-compute-work-group-size");
     make_pipeline_with_shader(pipe, compute_16_8_1.GetStageCreateInfo());
     m_errorMonitor->VerifyFound();
 }
@@ -935,9 +932,8 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadSpatialLocalityTest) {
     auto test_spatial_locality = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage,
                                      bool positive_test) {
         if (!positive_test) {
-            this_ptr->m_errorMonitor->SetDesiredFailureMsg(
-                VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                "UNASSIGNED-BestPractices-vkCreateComputePipelines-compute-spatial-locality");
+            this_ptr->m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
+                                                           "BestPractices-vkCreateComputePipelines-compute-spatial-locality");
         }
         make_pipeline_with_shader(pipe, stage);
         if (!positive_test) {
@@ -956,8 +952,8 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-store");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -969,7 +965,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
     renderpasses.push_back(CreateRenderPass(FMT, VK_ATTACHMENT_LOAD_OP_CLEAR, VK_ATTACHMENT_STORE_OP_STORE));
     framebuffers.push_back(CreateFramebuffer(WIDTH, HEIGHT, view0, renderpasses[0]));
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindImageMemory-non-lazy-transient-image");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindImageMemory-non-lazy-transient-image");
     auto img = std::unique_ptr<VkImageObj>(new VkImageObj(m_device));
     img->Init(WIDTH, HEIGHT, 1, FMT, VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
@@ -1064,7 +1060,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-redundant-clear");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-RenderPass-redundant-clear");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -1137,9 +1133,9 @@ TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-RenderPass-inefficient-clear");
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -1227,8 +1223,8 @@ TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-RenderPass-inefficient-clear");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -1384,12 +1380,12 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-RenderPass-blitimage-loadopload");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
+                                         "BestPractices-RenderPass-blitimage-loadopload");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
     m_commandBuffer->begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1555,7 +1551,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
     // Only color is redundant.
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+                                             "BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_depth.pipeline_);
         vk::CmdDraw(m_commandBuffer->handle(), 1, 1, 0, 0);
@@ -1569,7 +1565,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
     // Only depth is redundant.
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+                                             "BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_color.pipeline_);
         vk::CmdDraw(m_commandBuffer->handle(), 1, 1, 0, 0);
@@ -1583,7 +1579,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
     // Only stencil is redundant.
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
+                                             "BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
         m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
 
         // Test that clear attachments counts as an access.

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -65,7 +65,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
     // Only run this test if this super-wierd format is not supported
     if (VK_SUCCESS != result) {
-        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-Error-Result");
+        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-Error-Result");
         vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
         m_errorMonitor->VerifyFound();
     }
@@ -84,7 +84,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     format_count -= 1;
     formats.resize(format_count);
 
-    m_errorMonitor->SetDesiredFailureMsg(kVerboseBit, "UNASSIGNED-BestPractices-Verbose-Success-Logging");
+    m_errorMonitor->SetDesiredFailureMsg(kVerboseBit, "BestPractices-Verbose-Success-Logging");
     result = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, formats.data());
     ASSERT_TRUE(result > VK_SUCCESS);
     m_errorMonitor->VerifyFound();
@@ -106,10 +106,10 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     // Create a 1.1 vulkan instance and request an extension promoted to core in 1.1
     if (IsExtensionsEnabled(VK_EXT_DEBUG_REPORT_EXTENSION_NAME)) {
         // Extra error if VK_EXT_debug_report is used on Android still
-        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension");
+        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateInstance-deprecated-extension");
     }
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-deprecated-extension");
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateInstance-specialuse-extension-debugging");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateInstance-deprecated-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateInstance-specialuse-extension-debugging");
     VkInstance dummy;
     auto features = features_;
     auto ici = GetInstanceCreateInfo();
@@ -119,8 +119,8 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedInstanceExtensions) {
     m_errorMonitor->VerifyFound();
 
     // Create a 1.0 vulkan instance and request an extension promoted to core in 1.1
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-khronos-Validation-debug-build-warning-message");
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-khronos-Validation-fine-grained-locking-warning-message");
+    m_errorMonitor->SetUnexpectedError("khronos-Validation-debug-build-warning-message");
+    m_errorMonitor->SetUnexpectedError("khronos-Validation-fine-grained-locking-warning-message");
     VkApplicationInfo new_info{};
     new_info.apiVersion = VK_API_VERSION_1_0;
     new_info.pApplicationName = ici.pApplicationInfo->pApplicationName;
@@ -161,9 +161,9 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     // One for VK_KHR_buffer_device_address
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateDevice-deprecated-extension");
     // One for the dependency extension VK_KHR_device_group
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateDevice-deprecated-extension");
     vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }
@@ -192,7 +192,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
     dev_info.enabledExtensionCount = m_device_extension_names.size();
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-specialuse-extension-d3demulation");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateDevice-specialuse-extension-d3demulation");
     vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }
@@ -220,7 +220,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
     // Call for full-sized FB Color attachment prior to issuing a Draw
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
 
     vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
     m_errorMonitor->VerifyFound();
@@ -262,10 +262,10 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
         // Small clears which don't cover the render area should not trigger the warning.
         vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect_small);
         // Call for full-sized FB Color attachment prior to issuing a Draw
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
         // This test may also trigger other warnings
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers");
 
         vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
         m_errorMonitor->VerifyFound();
@@ -284,11 +284,11 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
         // Small clears which don't cover the render area should not trigger the warning.
         vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_small_clear.handle());
         // Call for full-sized FB Color attachment prior to issuing a Draw
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
         // This test may also trigger other warnings
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-CmdPool-DisparateSizedCmdBuffers");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidSecondaryCmdBuffers");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidSmallSecondaryCmdBuffers");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-CmdPool-DisparateSizedCmdBuffers");
 
         vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_full_clear.handle());
         m_errorMonitor->VerifyFound();
@@ -350,7 +350,7 @@ TEST_F(VkBestPracticesLayerTest, CmdResolveImageTypeMismatch) {
     resolveRegion.extent.height = 1;
     resolveRegion.extent.depth = 1;
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-MismatchedImageType");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-MismatchedImageType");
     vk::CmdResolveImage(m_commandBuffer->handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
     m_errorMonitor->VerifyFound();
@@ -379,8 +379,8 @@ TEST_F(VkBestPracticesLayerTest, ZeroSizeBlitRegion) {
     blit_region.dstOffsets[1] = {128, 128, 1};
 
     m_commandBuffer->begin();
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DrawState-InvalidExtents");
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DrawState-InvalidExtents");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-DrawState-InvalidExtents");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-DrawState-InvalidExtents");
     vk::CmdBlitImage(m_commandBuffer->handle(), image_src.handle(), image_src.Layout(), image_dst.handle(), image_dst.Layout(), 1,
                      &blit_region, VK_FILTER_LINEAR);
     m_errorMonitor->VerifyFound();
@@ -394,7 +394,7 @@ TEST_F(VkBestPracticesLayerTest, CmdBeginRenderPassZeroSizeRenderArea) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCmdBeginRenderPass-zero-size-render-area");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCmdBeginRenderPass-zero-size-render-area");
 
     m_commandBuffer->begin();
     m_renderPassBeginInfo.renderArea.extent.width = 0;
@@ -407,12 +407,12 @@ TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-VtxIndexOutOfBounds");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-VtxIndexOutOfBounds");
 
     // This test may also trigger other warnings
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
 
     InitRenderTarget();
 
@@ -450,8 +450,7 @@ TEST_F(VkBestPracticesLayerTest, CommandBufferReset) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateCommandPool-command-buffer-reset");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCreateCommandPool-command-buffer-reset");
 
     VkCommandPool command_pool;
     VkCommandPoolCreateInfo pool_create_info{};
@@ -499,7 +498,7 @@ TEST_F(VkBestPracticesLayerTest, SecondaryCommandBuffer) {
     alloc_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
     alloc_info.commandBufferCount = 1;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkAllocateCommandBuffers-unusable-secondary");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkAllocateCommandBuffers-unusable-secondary");
     vk::AllocateCommandBuffers(m_device->device(), &alloc_info, &command_buffer);
     m_errorMonitor->VerifyFound();
 
@@ -512,9 +511,9 @@ TEST_F(VkBestPracticesLayerTest, SimultaneousUse) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkBeginCommandBuffer-simultaneous-use");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkBeginCommandBuffer-simultaneous-use");
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBeginCommandBuffer-one-time-submit");
 
     VkCommandBufferBeginInfo cmd_begin_info{};
     cmd_begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
@@ -530,7 +529,7 @@ TEST_F(VkBestPracticesLayerTest, SmallAllocation) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkAllocateMemory-small-allocation");
 
     // Find appropriate memory type for given reqs
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
@@ -561,10 +560,9 @@ TEST_F(VkBestPracticesLayerTest, SmallDedicatedAllocation) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkBindMemory-small-dedicated-allocation");
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
 
     VkImageCreateInfo image_info{};
     image_info.sType = VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO;
@@ -595,8 +593,7 @@ TEST_F(VkBestPracticesLayerTest, MSImageRequiresMemory) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateRenderPass-image-requires-memory");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCreateRenderPass-image-requires-memory");
 
     VkAttachmentDescription attachment{};
     attachment.samples = VK_SAMPLE_COUNT_4_BIT;
@@ -628,13 +625,13 @@ TEST_F(VkBestPracticesLayerTest, AttachmentShouldNotBeTransient) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient");
+                                         "BestPractices-vkCreateFramebuffer-attachment-should-not-be-transient");
 
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindImageMemory-non-lazy-transient-image");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkImage-AvoidGeneral");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindImageMemory-non-lazy-transient-image");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkImage-AvoidGeneral");
 
     VkAttachmentDescription attachment{};
     attachment.samples = VK_SAMPLE_COUNT_1_BIT;
@@ -689,15 +686,15 @@ TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateGraphicsPipelines-too-many-instanced-vertex-buffers");
+                                         "BestPractices-vkCreateGraphicsPipelines-too-many-instanced-vertex-buffers");
 
     // This test may also trigger the small allocation warnings
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
 
     // This test does not need for the shader to consume the vertex input
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-Shader-OutputNotConsumed");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-Shader-OutputNotConsumed");
 
     InitRenderTarget();
 
@@ -753,14 +750,14 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     rp.CreateRenderPass();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
 
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load");
 
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-store");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-clear");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-redundant-clear");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-inefficient-clear");
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), m_width, m_height);
@@ -786,10 +783,10 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     RETURN_IF_SKIP(InitState());
 
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-store");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-redundant-clear");
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-RenderPass-inefficient-clear");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-redundant-store");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-redundant-clear");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-inefficient-clear");
 
     VkImageObj image(m_device);
     image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -835,8 +832,8 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
 
     // Plain clear after load.
     m_commandBuffer->BeginRenderPass(render_pass_begin_info);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
     {
         vk::CmdClearAttachments(m_commandBuffer->handle(), 1, &color_attachment, 1, &clear_rect);
         m_errorMonitor->VerifyFound();
@@ -845,7 +842,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
 
     // Test that a masked write is ignored before clear
     m_commandBuffer->BeginRenderPass(render_pass_begin_info);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load");
     {
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_masked.pipeline_);
         vk::CmdDraw(m_commandBuffer->handle(), 1, 0, 0, 0);
@@ -893,8 +890,8 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
 
     // Plain clear after load.
     m_commandBuffer->BeginRenderPass(render_pass_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
     {
         vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_clear.handle());
         m_errorMonitor->VerifyFound();
@@ -903,7 +900,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
 
     // Test that a masked write is ignored before clear
     m_commandBuffer->BeginRenderPass(render_pass_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
-    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-vkCmdClearAttachments-clear-after-load");
+    m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCmdClearAttachments-clear-after-load");
     {
         vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_draw_masked.handle());
         vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary_clear.handle());
@@ -927,7 +924,7 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count");
+                                         "BestPractices-vkCreateSwapchainKHR-suboptimal-swapchain-image-count");
     RETURN_IF_SKIP(InitSurface());
     InitSwapchainInfo();
 
@@ -1023,10 +1020,10 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     swapchain_create_info.imageExtent = {m_surface_capabilities.minImageExtent.width, m_surface_capabilities.minImageExtent.height};
 
     // GetPhysicalDeviceSurfacePresentModesKHR() not called before trying to create a swapchain
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateSwapchainKHR-surface-not-retrieved");
 
     // Warning is thrown any time the present mode is not VK_PRESENT_MODE_FIFO_KHR, but only with ARM BP
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCreateSwapchainKHR-swapchain-presentmode-not-fifo");
 
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     m_errorMonitor->VerifyFound();
@@ -1084,12 +1081,12 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     uint32_t queue_count = static_cast<uint32_t>(queue_family_props.size());
 
     // might only be a queue_count of 1, so check and then do "real" test to make sure error is detected
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-BestPractices-DevLimit-CountMismatch");
+    m_errorMonitor->SetUnexpectedError("BestPractices-DevLimit-CountMismatch");
     vk::GetPhysicalDeviceQueueFamilyProperties(phys_device_obj.handle(), &queue_count, queue_family_props.data());
     m_errorMonitor->VerifyFound();
 
     if (queue_count > 1) {
-        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DevLimit-CountMismatch");
+        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-DevLimit-CountMismatch");
         vk::GetPhysicalDeviceQueueFamilyProperties(phys_device_obj.handle(), &queue_count, queue_family_props.data());
         m_errorMonitor->VerifyFound();
     }
@@ -1118,8 +1115,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     device_ci.pEnabledFeatures = &all_features;
 
     // vkGetPhysicalDeviceFeatures has not been called, so this should produce a warning
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateDevice-physical-device-features-not-retrieved");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateDevice-physical-device-features-not-retrieved");
     VkDevice device;
     vk::CreateDevice(phys_device_obj.handle(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
@@ -1234,8 +1230,7 @@ TEST_F(VkBestPracticesLayerTest, WorkgroupSizeDeprecated) {
         helper.cs_ =
             std::make_unique<VkShaderObj>(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     };
-    CreateComputePipelineHelper::OneshotTest(*this, set_info, kWarningBit,
-                                             "UNASSIGNED-BestPractices-SpirvDeprecated_WorkgroupSize");
+    CreateComputePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "BestPractices-SpirvDeprecated_WorkgroupSize");
 }
 
 TEST_F(VkBestPracticesLayerTest, CreatePipelineWithoutRenderPass) {
@@ -1380,7 +1375,7 @@ TEST_F(VkBestPracticesLayerTest, TransitionFromUndefinedToReadOnly) {
 
     vk::CmdClearColorImage(m_commandBuffer->handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &color_clear_value, 1, &clear_range);
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-TransitionUndefinedToReadOnly");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-TransitionUndefinedToReadOnly");
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &img_barrier);
     m_errorMonitor->VerifyFound();
@@ -1450,7 +1445,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
     signal_submit_info.signalSemaphoreCount = 0;
     signal_submit_info.pSignalSemaphores = &semaphore_handle;
 
-    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "UNASSIGNED-BestPractices-SemaphoreCount");
+    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "BestPractices-SemaphoreCount");
     vk::QueueSubmit(m_default_queue->handle(), 1, &signal_submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
@@ -1461,7 +1456,7 @@ TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
     wait_submit_info.waitSemaphoreCount = 0;
     wait_submit_info.pWaitSemaphores = &semaphore_handle;
 
-    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "UNASSIGNED-BestPractices-SemaphoreCount");
+    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "BestPractices-SemaphoreCount");
     vk::QueueSubmit(m_default_queue->handle(), 1, &wait_submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
@@ -1504,7 +1499,7 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     alloc_info.descriptorSetCount = 2;
     alloc_info.descriptorPool = ds_pool.handle();
     alloc_info.pSetLayouts = set_layouts;
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-EmptyDescriptorPool");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-EmptyDescriptorPool");
     vk::AllocateDescriptorSets(m_device->device(), &alloc_info, descriptor_sets);
     m_errorMonitor->VerifyFound();
 }
@@ -1802,9 +1797,9 @@ TEST_F(VkBestPracticesLayerTest, LoadDeprecatedExtension) {
     dev_info.enabledExtensionCount = 1;
     dev_info.ppEnabledExtensionNames = &extension;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-vkCreateDevice-deprecated-extension");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkCreateDevice-deprecated-extension");
     // api version != device version
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkCreateDevice-API-version-mismatch");
+    m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCreateDevice-API-version-mismatch");
 
     VkDevice device = VK_NULL_HANDLE;
     vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
@@ -1956,7 +1951,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     compute_buffer.end();
 
     // Warning should trigger as we are potentially accessing undefined resources
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
     compute_buffer.QueueCommandBuffer();
     m_errorMonitor->VerifyFound();
 
@@ -2008,7 +2003,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     compute_buffer.end();
 
     // Warning shouldn't trigger
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ConcurrentUsageOfExclusiveImage");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
     compute_buffer.QueueCommandBuffer();
     m_errorMonitor->Finish();
 }
@@ -2075,7 +2070,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     // PRESENT_SRC_KHR	- Must be 0
     img_barrier.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
     img_barrier.dstAccessMask = VK_ACCESS_MEMORY_READ_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ImageBarrierAccessLayout");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ImageBarrierAccessLayout");
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &img_barrier);
     m_errorMonitor->VerifyFound();
@@ -2107,7 +2102,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
         img_barrier2.dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT;
         img_barrier2.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
 
-        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ImageBarrierAccessLayout");
+        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ImageBarrierAccessLayout");
         vk::CmdPipelineBarrier2KHR(m_commandBuffer->handle(), &dependency_info);
         m_errorMonitor->VerifyFound();
 
@@ -2118,7 +2113,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
         // make sure bits above UINT32_MAX are detected
         img_barrier2.newLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
         img_barrier2.dstAccessMask = VK_ACCESS_2_SHADER_STORAGE_WRITE_BIT;
-        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-ImageBarrierAccessLayout");
+        m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ImageBarrierAccessLayout");
         vk::CmdPipelineBarrier2KHR(m_commandBuffer->handle(), &dependency_info);
         m_errorMonitor->VerifyFound();
 
@@ -2147,7 +2142,7 @@ TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
     };
 
     m_commandBuffer->begin(&cbbi);
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-DrawState-InvalidCommandBufferSimultaneousUse");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-DrawState-InvalidCommandBufferSimultaneousUse");
     vk::CmdExecuteCommands(m_commandBuffer->handle(), 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
@@ -2162,8 +2157,8 @@ TEST_F(VkBestPracticesLayerTest, NoCreateSwapchainPresentModes) {
 
     RETURN_IF_SKIP(InitState());
     RETURN_IF_SKIP(InitSurface());
-    m_errorMonitor->SetDesiredFailureMsg(
-        kWarningBit, "UNASSIGNED-BestPractices-vkCreateSwapchainKHR-no-VkSwapchainPresentModesCreateInfoEXT-provided");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
+                                         "BestPractices-vkCreateSwapchainKHR-no-VkSwapchainPresentModesCreateInfoEXT-provided");
     CreateSwapchain(m_surface, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_SURFACE_TRANSFORM_IDENTITY_BIT_KHR, m_swapchain);
     m_errorMonitor->VerifyFound();
 }
@@ -2181,7 +2176,7 @@ TEST_F(VkBestPracticesLayerTest, PipelineWithoutRenderPassOrRenderingInfo) {
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-Pipeline-NoRendering");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-Pipeline-NoRendering");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -2202,7 +2197,7 @@ TEST_F(VkBestPracticesLayerTest, GetQueryPoolResultsWithoutBegin) {
     m_default_queue->wait();
 
     uint32_t data = 0u;
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-QueryPool-Unavailable");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-QueryPool-Unavailable");
     vk::GetQueryPoolResults(*m_device, query_pool.handle(), 0u, 1u, sizeof(uint32_t), &data, sizeof(uint32_t), 0u);
     m_errorMonitor->VerifyFound();
 }
@@ -2261,7 +2256,7 @@ TEST_F(VkBestPracticesLayerTest, NonOptimalResolveFormat) {
 
     VkRenderPass render_pass;
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
-                                         "UNASSIGNED-BestPractices-vkCreateRenderPass-SubpassResolve-NonOptimalFormat");
+                                         "BestPractices-vkCreateRenderPass-SubpassResolve-NonOptimalFormat");
     vk::CreateRenderPass(*m_device, &render_pass_ci, nullptr, &render_pass);
     m_errorMonitor->VerifyFound();
 }
@@ -2413,7 +2408,7 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineInputAttachmentTypeMismatch) {
     pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.renderPass = render_pass.handle();
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "UNASSIGNED-BestPractices-Shader-MissingInputAttachment");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-Shader-MissingInputAttachment");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -41,7 +41,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateDevice-PageableDeviceLocalMemory");
+                                             "BestPractices-CreateDevice-PageableDeviceLocalMemory");
         VkDevice test_device = VK_NULL_HANDLE;
         VkResult err = vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
         m_errorMonitor->VerifyFound();
@@ -57,7 +57,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateDevice-PageableDeviceLocalMemory");
+                                             "BestPractices-CreateDevice-PageableDeviceLocalMemory");
         vkt::Device test_device(gpu(), device_ci);
         m_errorMonitor->Finish();
     }
@@ -78,8 +78,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateImage-TilingLinear");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-CreateImage-TilingLinear");
         vkt::Image image(*m_device, image_ci, vkt::no_mem);
         m_errorMonitor->Finish();
     }
@@ -87,8 +86,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
     image_ci.tiling = VK_IMAGE_TILING_LINEAR;
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateImage-TilingLinear");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-CreateImage-TilingLinear");
         vkt::Image image(*m_device, image_ci, vkt::no_mem);
         m_errorMonitor->VerifyFound();
     }
@@ -111,7 +109,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateImage-Depth32Format");
+                                             "BestPractices-CreateImage-Depth32Format");
         vkt::Image image(*m_device, image_ci, vkt::no_mem);
         m_errorMonitor->Finish();
     }
@@ -122,7 +120,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
         image_ci.format = format;
 
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreateImage-Depth32Format");
+                                             "BestPractices-CreateImage-Depth32Format");
         vkt::Image image(*m_device, image_ci, vkt::no_mem);
         m_errorMonitor->VerifyFound();
     }
@@ -226,8 +224,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     bind_info.pBufferBinds = &sparse_buffer_bind;
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-QueueBindSparse-NotAsync");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-QueueBindSparse-NotAsync");
         vk::QueueBindSparse(transfer_queue, 1, &bind_info, VK_NULL_HANDLE);
         m_errorMonitor->Finish();
     }
@@ -235,8 +232,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     test_device.wait();
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-QueueBindSparse-NotAsync");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-QueueBindSparse-NotAsync");
         vk::QueueBindSparse(graphics_queue, 1, &bind_info, VK_NULL_HANDLE);
         m_errorMonitor->VerifyFound();
     }
@@ -282,11 +278,11 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
 
         // Those 3 are triggered when allocating memory for the destination acceleration structure buffer and the scratch buffer.
         // This is expected.
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkAllocateMemory-small-allocation");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-vkBindMemory-small-dedicated-allocation");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-AllocateMemory-SetPriority");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkAllocateMemory-small-allocation");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkBindMemory-small-dedicated-allocation");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-AllocateMemory-SetPriority");
 
-        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "UNASSIGNED-BestPractices-AccelerationStructure-NotAsync");
+        m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-AccelerationStructure-NotAsync");
         build_geometry_info.BuildCmdBuffer(cmd_buffer.handle());
 
         if (queue == compute_queue) {
@@ -309,7 +305,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-AllocateMemory-SetPriority");
+                                             "BestPractices-AllocateMemory-SetPriority");
         vkt::DeviceMemory memory(*m_device, memory_ai);
         m_errorMonitor->VerifyFound();
     }
@@ -320,7 +316,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-AllocateMemory-SetPriority");
+                                             "BestPractices-AllocateMemory-SetPriority");
         vkt::DeviceMemory memory(*m_device, memory_ai);
         m_errorMonitor->Finish();
     }
@@ -339,7 +335,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
     memory_ai.pNext = &priority;
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-AllocateMemory-ReuseAllocations");
+                                         "BestPractices-AllocateMemory-ReuseAllocations");
     { vkt::DeviceMemory memory(*m_device, memory_ai); }
 
     std::this_thread::sleep_for(std::chrono::seconds{6});
@@ -349,7 +345,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
     m_errorMonitor->Finish();
 
     m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                         "UNASSIGNED-BestPractices-AllocateMemory-ReuseAllocations");
+                                         "BestPractices-AllocateMemory-ReuseAllocations");
 
     { vkt::DeviceMemory memory(*m_device, memory_ai); }
 
@@ -413,8 +409,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     vkt::DeviceMemory memory(test_device, memory_ai);
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-BindMemory-NoPriority");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-BindMemory-NoPriority");
         vk::BindBufferMemory(test_device.handle(), buffer_a.handle(), memory.handle(), 0);
         m_errorMonitor->VerifyFound();
     }
@@ -422,8 +417,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     vk::SetDeviceMemoryPriorityEXT(test_device.handle(), memory.handle(), 0.5f);
 
     {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-BindMemory-NoPriority");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-BindMemory-NoPriority");
         vk::BindBufferMemory(test_device.handle(), buffer_b.handle(), memory.handle(), 0);
         m_errorMonitor->Finish();
     }
@@ -471,14 +465,14 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreatePipelineLayout-SeparateSampler");
+                                             "BestPractices-CreatePipelineLayout-SeparateSampler");
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci, {&separate_set_layout});
         m_errorMonitor->VerifyFound();
     }
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreatePipelineLayout-SeparateSampler");
+                                             "BestPractices-CreatePipelineLayout-SeparateSampler");
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci, {&combined_set_layout});
         m_errorMonitor->Finish();
     }
@@ -516,14 +510,14 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout)
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreatePipelineLayout-LargePipelineLayout");
+                                             "BestPractices-CreatePipelineLayout-LargePipelineLayout");
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci, {&large_set_layout});
         m_errorMonitor->VerifyFound();
     }
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-CreatePipelineLayout-LargePipelineLayout");
+                                             "BestPractices-CreatePipelineLayout-LargePipelineLayout");
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci, {&small_set_layout});
         m_errorMonitor->Finish();
     }
@@ -581,16 +575,16 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
     m_commandBuffer->begin();
 
     {
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-Pipeline-SortAndBind");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-Pipeline-SortAndBind");
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-BindPipeline-SwitchTessGeometryMesh");
+                                             "BestPractices-BindPipeline-SwitchTessGeometryMesh");
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, vsPipe.pipeline_);
         m_errorMonitor->Finish();
     }
     {
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-Pipeline-SortAndBind");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-Pipeline-SortAndBind");
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-BindPipeline-SwitchTessGeometryMesh");
+                                             "BestPractices-BindPipeline-SwitchTessGeometryMesh");
         for (int i = 0; i < 10; ++i) {
             vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, vgsPipe.pipeline_);
             vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, vsPipe.pipeline_);
@@ -676,8 +670,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
     discard_dependency_info.pImageMemoryBarriers = &discard_barrier2;
 
     auto set_desired_failure_msg = [this] {
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-Zcull-LessGreaterRatio");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-Zcull-LessGreaterRatio");
     };
 
     VkPipelineDepthStencilStateCreateInfo depth_stencil_state_ci = vku::InitStructHelper();
@@ -986,8 +979,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
 
     auto set_desired = [this] {
         m_errorMonitor->Finish();
-        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "UNASSIGNED-BestPractices-ClearColor-NotCompressed");
-        m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-BestPractices-DrawState-ClearCmdBeforeDraw");
+        m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT, "BestPractices-ClearColor-NotCompressed");
+        m_errorMonitor->SetAllowedFailureMsg("BestPractices-DrawState-ClearCmdBeforeDraw");
     };
 
     VkImageObj image(m_device);
@@ -1104,7 +1097,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit");
+                                             "BestPractices-vkBeginCommandBuffer-one-time-submit");
 
         command_buffer0.begin(&begin_info);
         command_buffer0.end();
@@ -1117,7 +1110,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
     }
     {
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit");
+                                             "BestPractices-vkBeginCommandBuffer-one-time-submit");
 
         command_buffer1.begin(&begin_info);
         command_buffer1.end();
@@ -1133,7 +1126,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
     {
         begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         m_errorMonitor->SetDesiredFailureMsg(VK_DEBUG_REPORT_PERFORMANCE_WARNING_BIT_EXT,
-                                             "UNASSIGNED-BestPractices-vkBeginCommandBuffer-one-time-submit");
+                                             "BestPractices-vkBeginCommandBuffer-one-time-submit");
 
         command_buffer2.begin(&begin_info);
         command_buffer2.end();

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -12472,8 +12472,7 @@ TEST_F(NegativeVideoBestPractices, GetVideoSessionMemoryRequirements) {
     auto mem_req = vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>();
     uint32_t mem_req_count = 1;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
-                                         "UNASSIGNED-BestPractices-vkGetVideoSessionMemoryRequirementsKHR-count-not-retrieved");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkGetVideoSessionMemoryRequirementsKHR-count-not-retrieved");
     context.vk.GetVideoSessionMemoryRequirementsKHR(m_device->device(), context.Session(), &mem_req_count, &mem_req);
     m_errorMonitor->VerifyFound();
 }
@@ -12510,8 +12509,7 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
     bind_info.memoryOffset = 0;
     bind_info.memorySize = alloc_info.allocationSize;
 
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
-                                         "UNASSIGNED-BestPractices-vkBindVideoSessionMemoryKHR-requirements-count-not-retrieved");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-vkBindVideoSessionMemoryKHR-requirements-count-not-retrieved");
     context.vk.BindVideoSessionMemoryKHR(m_device->device(), context.Session(), 1, &bind_info);
     m_errorMonitor->VerifyFound();
 
@@ -12520,7 +12518,7 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
 
     if (mem_req_count > 0) {
         m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
-                                             "UNASSIGNED-BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved");
+                                             "BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved");
         context.vk.BindVideoSessionMemoryKHR(m_device->device(), context.Session(), 1, &bind_info);
         m_errorMonitor->VerifyFound();
 
@@ -12530,8 +12528,8 @@ TEST_F(NegativeVideoBestPractices, BindVideoSessionMemory) {
 
             context.vk.GetVideoSessionMemoryRequirementsKHR(m_device->device(), context.Session(), &mem_req_count, &mem_req);
 
-            m_errorMonitor->SetDesiredFailureMsg(
-                kWarningBit, "UNASSIGNED-BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved");
+            m_errorMonitor->SetDesiredFailureMsg(kWarningBit,
+                                                 "BestPractices-vkBindVideoSessionMemoryKHR-requirements-not-all-retrieved");
             context.vk.BindVideoSessionMemoryKHR(m_device->device(), context.Session(), 1, &bind_info);
             m_errorMonitor->VerifyFound();
         }


### PR DESCRIPTION
There is no reason to have `UNASSIGNED` to all the Best Practice labels... they will never be assigned, it is just cluttering and only there because the first one had it and everyone just copied-and-pasted the rest