### PR TITLE
sync: Rework debug region reporting

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1760,13 +1760,6 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
     return skip;
 }
 
-void CoreChecks::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                          const RecordObject &record_obj) {
-    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
-    cb_state->BeginLabel((pLabelInfo && pLabelInfo->pLabelName) ? pLabelInfo->pLabelName : "");
-}
-
 bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
@@ -1781,10 +1774,4 @@ bool CoreChecks::PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer command
                          "called without a corresponding vkCmdBeginDebugUtilsLabelEXT first");
     }
     return skip;
-}
-
-void CoreChecks::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) {
-    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
-    cb_state->EndLabel();
 }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2510,12 +2510,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint32_t timestampCount,
                                                    const VkCalibratedTimestampInfoEXT* pTimestampInfos, uint64_t* pTimestamps,
                                                    uint64_t* pMaxDeviation, const ErrorObject& error_obj) const override;
-
-    // Debug label APIs
-    void PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
-                                                  const RecordObject& record_obj) override;
     bool PreCallValidateCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const ErrorObject& error_obj) const override;
-    void PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
 
 #ifdef VK_USE_PLATFORM_METAL_EXT
     bool PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT* pMetalObjectsInfo,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -197,7 +197,7 @@ void CommandBuffer::ResetCBState() {
     // Clean up the label data
     debug_label.Reset();
     label_stack_depth_ = 0;
-    debug_label_commands_.clear();
+    label_commands_.clear();
 
     // Best practices info
     small_indexed_draw_call_count = 0;
@@ -1021,6 +1021,9 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
             suspendsRenderPassInstance = sub_cb_state->suspendsRenderPassInstance;
             hasRenderPassInstance |= sub_cb_state->hasRenderPassInstance;
         }
+
+        label_stack_depth_ += sub_cb_state->label_stack_depth_;
+        label_commands_.insert(label_commands_.end(), sub_cb_state->label_commands_.begin(), sub_cb_state->label_commands_.end());
     }
 }
 
@@ -1649,12 +1652,12 @@ void CommandBuffer::GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipel
 
 void CommandBuffer::BeginLabel(const char *label_name) {
     ++label_stack_depth_;
-    debug_label_commands_.push_back(DebugLabelCommand{true, label_name});
+    label_commands_.push_back(LabelCommand{true, label_name});
 }
 
 void CommandBuffer::EndLabel() {
     --label_stack_depth_;
-    debug_label_commands_.push_back(DebugLabelCommand{false, std::string()});
+    label_commands_.push_back(LabelCommand{false, std::string()});
 }
 
 }  // namespace vvl

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -690,11 +690,11 @@ class CommandBuffer : public RefcountedStateObject {
     void EndLabel();
     int LabelStackDepth() const { return label_stack_depth_; }
 
-    struct DebugLabelCommand {
+    struct LabelCommand {
         bool begin = false;      // vkCmdBeginDebugUtilsLabelEXT or vkCmdEndDebugUtilsLabelEXT
         std::string label_name;  // used when begin == true
     };
-    const std::vector<DebugLabelCommand> &GetDebugLabelCommands() const { return debug_label_commands_; }
+    const std::vector<LabelCommand> &GetLabelCommands() const { return label_commands_; }
 
   private:
     void ResetCBState();
@@ -704,7 +704,7 @@ class CommandBuffer : public RefcountedStateObject {
     // Negative value for a primary command buffer is allowed. Validation is done at submit time accross all command buffers.
     int label_stack_depth_ = 0;
     // Used during sumbit time validation.
-    std::vector<DebugLabelCommand> debug_label_commands_;
+    std::vector<LabelCommand> label_commands_;
 
     uint32_t active_subpass_;
     // Stores rasterization samples count obtained from the first pipeline with a pMultisampleState in the active subpass,

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -104,15 +104,17 @@ class Queue: public StateObject {
     const VkDeviceQueueCreateFlags flags;
     const VkQueueFamilyProperties queueFamilyProperties;
 
-    // Track command buffer label stack depth accross all command buffers submitted to this queue.
-    // Negative value indicates unbalanced usage of begin/end label commands.
+    // Track command buffer label stack accross all command buffers submitted to this queue.
     // Access to this variable relies on external queue synchronization.
-    int cmdbuf_label_stack_depth{0};
+    std::vector<std::string> cmdbuf_label_stack;
 
     // Track the last closed label. It is used in the error messages to help locate unbalanced vkCmdEndDebugUtilsLabelEXT command.
-    // Access to these variables relies on external queue synchronization.
-    std::vector<std::string> cmdbuf_label_names;
+    // Access to this variable relies on external queue synchronization.
     std::string last_closed_cmdbuf_label;
+
+    // Stop per-queue label tracking after the first label mismatch error.
+    // Access to this variable relies on external queue synchronization.
+    bool found_unbalanced_cmdbuf_label = false;
 
   private:
     using LockGuard = std::unique_lock<std::mutex>;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -987,6 +987,8 @@ class ValidationStateTracker : public ValidationObject {
                                        const RecordObject& record_obj) override;
     void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                   const RecordObject& record_obj) override;
+    void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                   const RecordObject& record_obj) override;
     void PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) override;
     void PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject& record_obj) override;
     void PostCallRecordWaitForFences(VkDevice device, uint32_t fenceCount, const VkFence* pFences, VkBool32 waitAll,
@@ -1237,6 +1239,8 @@ class ValidationStateTracker : public ValidationObject {
                                                VkDeviceAddress indirectDeviceAddress, const RecordObject& record_obj) override;
     void PostCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                 const RecordObject& record_obj) override;
+    void PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT* pLabelInfo,
+                                                  const RecordObject& record_obj) override;
     void PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
     void PostCallRecordCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                    const RecordObject& record_obj) override;
@@ -1658,6 +1662,10 @@ class ValidationStateTracker : public ValidationObject {
                                       const RecordObject& record_obj) override;
     void PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
                                    const RecordObject& record_obj) override;
+    void PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
+                                       const RecordObject& record_obj) override;
+    void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                    const RecordObject& record_obj) override;
 
     void PostCallRecordGetDescriptorSetLayoutSizeEXT(VkDevice device, VkDescriptorSetLayout layout,
                                                      VkDeviceSize* pLayoutSizeInBytes, const RecordObject& record_obj) override;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -577,8 +577,5 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                      uint64_t timeout, const RecordObject &record_obj) override;
     void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t *pSwapchainImageCount,
                                              VkImage *pSwapchainImages, const RecordObject &record_obj) override;
-    void PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const VkDebugUtilsLabelEXT *pLabelInfo,
-                                                 const RecordObject &record_obj) override;
-    void PreCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuffer commandBuffer, const RecordObject &record_obj) override;
 };
 


### PR DESCRIPTION
Previous sync validation label tracking assumed (incorrectly) that primary command buffer label commands (begin/end) are balanced. This PR implements proper label tracking as per-queue state. Reports debug labels both for prior and current access. Supports record time and submit time reporting.

Both primary and secondary command buffers are supported. Some of label tracking functionality from core validation was moved to state tracker to use in sync validation too. Added more tests and made sure it properly handles debug markers in UE5 engine as an example of non-trivial frame structure.

Only `VK_EXT_debug_utils` is supported and `VK_EXT_debug_marker` (deprecated) is not supported. For the Source engine  `-vulkan_force_enable_debug_utils` option should be used.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7390

Example of UE5 record-time error message: 
> SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0xa8574080dd0, type = VK_OBJECT_TYPE_RENDER_PASS; | MessageID = 0x5c0ec5d6 | vkCmdBeginRenderPass2KHR():  Hazard WRITE_AFTER_WRITE in subpass 0 for attachment 0 image layout transition (old_layout: VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, new_layout: VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL). Access info (usage: SYNC_IMAGE_LAYOUT_TRANSITION, prior_usage: SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, write_barriers: 0, command: vkCmdEndRenderPass, seq_no: 106, renderpass: VkRenderPass 0xa857607bed0[], reset_no: 847, **debug region: Scene::ClearDepthStencil (SceneDepthZ)::Scene.ClearDepthStencil (SceneDepthZ))**.

The same render region in RenderDoc:
<img src="https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/121836235/2e036f2e-043e-4777-be9d-811552f44062" width=60% height=60%>

Example of Counter-Strike 2 submit-time error message (FYI @danginsburg):
> [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x1895c2a6f60, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit():  Hazard WRITE_AFTER_WRITE for entry 99, VkCommandBuffer 0x189cd99c8c0[], Submitted access info (submitted_usage: SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, command: vkCmdEndRenderingKHR, seq_no: 2, reset_no: 36, **debug region: CRenderContextVulkan::MarkIssuesCommands(424):** ). Access info (prior_usage: SYNC_IMAGE_LAYOUT_TRANSITION, write_barriers: SYNC_EARLY_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_READ|SYNC_EARLY_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE, queue: VkQueue 0x1895c2a6f60[], submit: 2090, batch: 0, batch_tag: 162858, command: vkCmdPipelineBarrier, command_buffer: VkCommandBuffer 0x18975a33a20[], seq_no: 1, VkImage 0x1899a17bf80[scratchrendertarget_1118301577_1920x1080_19_1.vtex], reset_no: 22, **debug region: Image Layout Transitions (gfx)**).

CS2 has only few unique names of debug regions, so it's less useful comparing to UE5 where each sequence of command has a descriptive label, but by adding more labels this will be increasingly more useful.

