### PR TITLE
layers: Fix Null CombinedImageSampler

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2885,9 +2885,9 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
             break;
     }
 
-    if (descriptor_info.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER && descriptor_info.data.pCombinedImageSampler) {
-        const VkDescriptorImageInfo *combined_image_sampler = descriptor_info.data.pCombinedImageSampler;
-        if (!combined_image_sampler || combined_image_sampler->imageView == VK_NULL_HANDLE) {
+    const VkDescriptorImageInfo *combined_image_sampler = descriptor_info.data.pCombinedImageSampler;
+    if (descriptor_info.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER && combined_image_sampler) {
+        if (combined_image_sampler->imageView == VK_NULL_HANDLE) {
             // Only hit if using nullDescriptor
             if (size != data_size) {
                 skip |= LogError("VUID-vkGetDescriptorEXT-pDescriptorInfo-09507", device, descriptor_info_loc.dot(Field::type),
@@ -2895,7 +2895,7 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
                                  "equal to dataSize %zu",
                                  phys_dev_ext_props.descriptor_buffer_props.combinedImageSamplerDescriptorSize, data_size);
             }
-        } else if (combined_image_sampler && combined_image_sampler->imageView != VK_NULL_HANDLE) {
+        } else {
             const auto image_view_state = Get<vvl::ImageView>(combined_image_sampler->imageView);
             if (image_view_state && image_view_state->samplerConversion != VK_NULL_HANDLE) {
                 auto image_info = image_view_state->image_state->createInfo;
@@ -2922,7 +2922,7 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
             }
         }
 
-        if (combined_image_sampler && combined_image_sampler->sampler != VK_NULL_HANDLE) {
+        if (combined_image_sampler->sampler != VK_NULL_HANDLE) {
             const auto sampler_state = Get<vvl::Sampler>(combined_image_sampler->sampler);
             if (sampler_state && (0 != (sampler_state->createInfo.flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT))) {
                 size = phys_dev_ext_props.descriptor_buffer_density_props.combinedImageSamplerDensityMapDescriptorSize;

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -1508,12 +1508,9 @@ TEST_F(NegativeDescriptorBuffer, NullCombinedImageSampler) {
     VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
     dgi.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     dgi.data.pCombinedImageSampler = nullptr;
-    // TODO -Being discussed if allowed or not
-    // https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6393#note_452227
-    //
-    // m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetDescriptorEXT-pDescriptorInfo-09507");
-    // vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.combinedImageSamplerDescriptorSize / 2, &out);
-    // m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDescriptorGetInfoEXT-pCombinedImageSampler-parameter");
+    vk::GetDescriptorEXT(m_device->device(), &dgi, descriptor_buffer_properties.combinedImageSamplerDescriptorSize / 2, &out);
+    m_errorMonitor->VerifyFound();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
     const VkDescriptorImageInfo dii = {sampler.handle(), VK_NULL_HANDLE, VK_IMAGE_LAYOUT_GENERAL};


### PR DESCRIPTION
Was discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6431

`pCombinedImageSampler` can't be null (when using `VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER`)