### PR TITLE
Cleanup of tests and add |= to skip 

### DIFF
--- a/docs/fine_grained_locking.md
+++ b/docs/fine_grained_locking.md
@@ -1,4 +1,4 @@
-<!-- Copyright 2021-2023 LunarG, Inc. -->
+<!-- Copyright 2021-2024 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -441,7 +441,7 @@ bool CoreChecks::PreCallValidateCmdSetScissorWithCount(VkCommandBuffer commandBu
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
     // BUG: This helper method also called GetRead<>(), which will deadlock
-    skip = ValidateExtendedDynamicState(commandBuffer, CMD_SETSCISSORWITHCOUNT, ...);
+    skip |= ValidateExtendedDynamicState(commandBuffer, CMD_SETSCISSORWITHCOUNT, ...);
     skip |= ForbidInheritedViewportScissor(cb_state.get(), "VUID-vkCmdSetScissorWithCount-commandBuffer-04820", error_obj.location);
 
     return skip;
@@ -452,7 +452,7 @@ This code will deadlock if the code is compiled using C++11, which uses std::mut
 The recommended fix for this case is to not make helper methods that call GetRead<>, instead pass in a reference to the state object:
 
 ```
-      skip = ValidateExtendedDynamicState(*cb_state, CMD_SETSCISSORWITHCOUNT, ...);
+      skip |= ValidateExtendedDynamicState(*cb_state, CMD_SETSCISSORWITHCOUNT, ...);
 ```
 
 Note that not all legacy code, such as `ForbidInheritedViewportScissor()` has been completely cleaned up yet. That method takes both the vulkan handle and a state object pointer as arguments, which is safe but redundant.

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -417,9 +417,7 @@ bool BestPractices::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer c
                                                                VkBuffer countBuffer, VkDeviceSize countBufferOffset,
                                                                uint32_t maxDrawCount, uint32_t stride,
                                                                const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -467,9 +465,7 @@ bool BestPractices::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer c
                                                                uint32_t firstInstance, VkBuffer counterBuffer,
                                                                VkDeviceSize counterBufferOffset, uint32_t counterOffset,
                                                                uint32_t vertexStride, const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer commandBuffer, uint32_t instanceCount,
@@ -484,9 +480,7 @@ void BestPractices::PostCallRecordCmdDrawIndirectByteCountEXT(VkCommandBuffer co
 bool BestPractices::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                         VkBuffer countBuffer, VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                         uint32_t stride, const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -531,9 +525,7 @@ bool BestPractices::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuff
                                                                    VkDeviceSize offset, VkBuffer countBuffer,
                                                                    VkDeviceSize countBufferOffset, uint32_t maxDrawCount,
                                                                    uint32_t stride, const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer commandBuffer, VkBuffer buffer,
@@ -548,9 +540,7 @@ void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectCountNV(VkCommandBuffe
 bool BestPractices::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
                                                               uint32_t drawCount, uint32_t stride,
                                                               const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -561,9 +551,7 @@ void BestPractices::PostCallRecordCmdDrawMeshTasksIndirectNV(VkCommandBuffer com
 
 bool BestPractices::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
                                                       const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer, uint32_t taskCount, uint32_t firstTask,
@@ -576,9 +564,7 @@ bool BestPractices::PreCallValidateCmdDrawMultiIndexedEXT(VkCommandBuffer comman
                                                           const VkMultiDrawIndexedInfoEXT* pIndexInfo, uint32_t instanceCount,
                                                           uint32_t firstInstance, uint32_t stride, const int32_t* pVertexOffset,
                                                           const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
@@ -597,9 +583,7 @@ void BestPractices::PostCallRecordCmdDrawMultiIndexedEXT(VkCommandBuffer command
 bool BestPractices::PreCallValidateCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,
                                                    const VkMultiDrawInfoEXT* pVertexInfo, uint32_t instanceCount,
                                                    uint32_t firstInstance, uint32_t stride, const ErrorObject& error_obj) const {
-    bool skip = ValidateCmdDrawType(commandBuffer, error_obj.location);
-
-    return skip;
+    return ValidateCmdDrawType(commandBuffer, error_obj.location);
 }
 
 void BestPractices::PostCallRecordCmdDrawMultiEXT(VkCommandBuffer commandBuffer, uint32_t drawCount,

--- a/layers/best_practices/bp_framebuffer.cpp
+++ b/layers/best_practices/bp_framebuffer.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -80,8 +80,8 @@ bool BestPractices::PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
 
     auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     if (rp_state && !(pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
-        skip = ValidateAttachments(rp_state->createInfo.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
-                                   error_obj.location);
+        skip |= ValidateAttachments(rp_state->createInfo.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
+                                    error_obj.location);
     }
 
     return skip;

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -176,7 +176,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
         if (rp_state->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
             const VkRenderPassAttachmentBeginInfo* rpabi = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
             if (rpabi) {
-                skip = ValidateAttachments(rp_state->createInfo.ptr(), rpabi->attachmentCount, rpabi->pAttachments, loc);
+                skip |= ValidateAttachments(rp_state->createInfo.ptr(), rpabi->attachmentCount, rpabi->pAttachments, loc);
             }
         }
         // Check if any attachments have LOAD operation on them

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -129,7 +129,7 @@ bool BestPractices::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandBuffer,
                                                   const VkDependencyInfo* pDependencyInfos, const ErrorObject& error_obj) const {
     bool skip = false;
     for (uint32_t i = 0; i < eventCount; i++) {
-        skip = CheckDependencyInfo(error_obj.location.dot(Field::pDependencyInfos, i), pDependencyInfos[i]);
+        skip |= CheckDependencyInfo(error_obj.location.dot(Field::pDependencyInfos, i), pDependencyInfos[i]);
     }
 
     return skip;

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -435,7 +435,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;
-    skip = ValidateGraphicsDynamicStateSetStatus(last_bound_state, loc);
+    skip |= ValidateGraphicsDynamicStateSetStatus(last_bound_state, loc);
     // Dynamic state was not set, will produce garbage when trying to read to values
     if (skip) return skip;
 
@@ -1891,9 +1891,9 @@ bool CoreChecks::PreCallValidateCmdSetViewportWithCountEXT(VkCommandBuffer comma
                                                            const VkViewport* pViewports, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(*cb_state, error_obj.location,
-                                        enabled_features.extendedDynamicState || enabled_features.shaderObject,
-                                        "VUID-vkCmdSetViewportWithCount-None-08971", "extendedDynamicState or shaderObject");
+    skip |= ValidateExtendedDynamicState(*cb_state, error_obj.location,
+                                         enabled_features.extendedDynamicState || enabled_features.shaderObject,
+                                         "VUID-vkCmdSetViewportWithCount-None-08971", "extendedDynamicState or shaderObject");
     skip |= ForbidInheritedViewportScissor(*cb_state, "VUID-vkCmdSetViewportWithCount-commandBuffer-04819", error_obj.location);
 
     return skip;
@@ -1903,7 +1903,7 @@ bool CoreChecks::PreCallValidateCmdSetViewportWithCount(VkCommandBuffer commandB
                                                         const VkViewport* pViewports, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(*cb_state, error_obj.location, VK_TRUE, nullptr, nullptr);
+    skip |= ValidateExtendedDynamicState(*cb_state, error_obj.location, VK_TRUE, nullptr, nullptr);
     skip |= ForbidInheritedViewportScissor(*cb_state, "VUID-vkCmdSetViewportWithCount-commandBuffer-04819", error_obj.location);
 
     return skip;
@@ -1913,9 +1913,9 @@ bool CoreChecks::PreCallValidateCmdSetScissorWithCountEXT(VkCommandBuffer comman
                                                           const VkRect2D* pScissors, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(*cb_state, error_obj.location,
-                                        enabled_features.extendedDynamicState || enabled_features.shaderObject,
-                                        "VUID-vkCmdSetScissorWithCount-None-08971", "extendedDynamicState or shaderObject");
+    skip |= ValidateExtendedDynamicState(*cb_state, error_obj.location,
+                                         enabled_features.extendedDynamicState || enabled_features.shaderObject,
+                                         "VUID-vkCmdSetScissorWithCount-None-08971", "extendedDynamicState or shaderObject");
     skip |= ForbidInheritedViewportScissor(*cb_state, "VUID-vkCmdSetScissorWithCount-commandBuffer-04820", error_obj.location);
 
     return skip;
@@ -1925,7 +1925,7 @@ bool CoreChecks::PreCallValidateCmdSetScissorWithCount(VkCommandBuffer commandBu
                                                        const VkRect2D* pScissors, const ErrorObject& error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     bool skip = false;
-    skip = ValidateExtendedDynamicState(*cb_state, error_obj.location, VK_TRUE, nullptr, nullptr);
+    skip |= ValidateExtendedDynamicState(*cb_state, error_obj.location, VK_TRUE, nullptr, nullptr);
     skip |= ForbidInheritedViewportScissor(*cb_state, "VUID-vkCmdSetScissorWithCount-commandBuffer-04820", error_obj.location);
 
     return skip;
@@ -2648,9 +2648,9 @@ bool CoreChecks::PreCallValidateCmdSetAttachmentFeedbackLoopEnableEXT(VkCommandB
                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    skip = ValidateExtendedDynamicState(*cb_state, error_obj.location, enabled_features.attachmentFeedbackLoopDynamicState,
-                                        "VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-attachmentFeedbackLoopDynamicState-08862",
-                                        "attachmentFeedbackLoopDynamicState");
+    skip |= ValidateExtendedDynamicState(*cb_state, error_obj.location, enabled_features.attachmentFeedbackLoopDynamicState,
+                                         "VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-attachmentFeedbackLoopDynamicState-08862",
+                                         "attachmentFeedbackLoopDynamicState");
 
     if (aspectMask != VK_IMAGE_ASPECT_NONE && !enabled_features.attachmentFeedbackLoopLayout) {
         skip |= LogError("VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-attachmentFeedbackLoopLayout-08864", commandBuffer,

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1856,8 +1856,8 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
     const LogObjectList dst_objlist(commandBuffer, dstImage);
     const LogObjectList all_objlist(commandBuffer, srcImage, dstImage);
 
-    skip = ValidateImageCopyData(commandBuffer, regionCount, pRegions, *src_image_state, *dst_image_state, false, loc);
-    skip = ValidateCopyImageCommon(commandBuffer, *src_image_state, *dst_image_state, regionCount, pRegions, loc);
+    skip |= ValidateImageCopyData(commandBuffer, regionCount, pRegions, *src_image_state, *dst_image_state, false, loc);
+    skip |= ValidateCopyImageCommon(commandBuffer, *src_image_state, *dst_image_state, regionCount, pRegions, loc);
 
     bool has_stencil_aspect = false;
     bool has_non_stencil_aspect = false;

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -419,11 +419,11 @@ bool CoreChecks::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDevic
             for (uint32_t i = 0; i < device_group_ci->physicalDeviceCount - 1; ++i) {
                 for (uint32_t j = i + 1; j < device_group_ci->physicalDeviceCount; ++j) {
                     if (device_group_ci->pPhysicalDevices[i] == device_group_ci->pPhysicalDevices[j]) {
-                        // skip |= LogError("VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00375", pd_state->Handle(),
-                        //                  error_obj.location,
-                        //                  "VkDeviceGroupDeviceCreateInfo has a duplicated physical device "
-                        //                  "in pPhysicalDevices [%" PRIu32 "] and [%" PRIu32 "].",
-                        //                  i, j);
+                        skip |= LogError("VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00375", pd_state->Handle(),
+                                         error_obj.location,
+                                         "VkDeviceGroupDeviceCreateInfo has a duplicated physical device "
+                                         "in pPhysicalDevices [%" PRIu32 "] and [%" PRIu32 "].",
+                                         i, j);
                     }
                 }
             }

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -419,11 +419,11 @@ bool CoreChecks::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDevic
             for (uint32_t i = 0; i < device_group_ci->physicalDeviceCount - 1; ++i) {
                 for (uint32_t j = i + 1; j < device_group_ci->physicalDeviceCount; ++j) {
                     if (device_group_ci->pPhysicalDevices[i] == device_group_ci->pPhysicalDevices[j]) {
-                        skip |= LogError("VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00375", pd_state->Handle(),
-                                         error_obj.location,
-                                         "VkDeviceGroupDeviceCreateInfo has a duplicated physical device "
-                                         "in pPhysicalDevices [%" PRIu32 "] and [%" PRIu32 "].",
-                                         i, j);
+                        // skip |= LogError("VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00375", pd_state->Handle(),
+                        //                  error_obj.location,
+                        //                  "VkDeviceGroupDeviceCreateInfo has a duplicated physical device "
+                        //                  "in pPhysicalDevices [%" PRIu32 "] and [%" PRIu32 "].",
+                        //                  i, j);
                     }
                 }
             }
@@ -620,7 +620,8 @@ bool CoreChecks::PreCallValidateGetPhysicalDeviceImageFormatProperties2(VkPhysic
                                                                         VkImageFormatProperties2 *pImageFormatProperties,
                                                                         const ErrorObject &error_obj) const {
     // Can't wrap AHB-specific validation in a device extension check here, but no harm
-    bool skip = ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(pImageFormatInfo, pImageFormatProperties, error_obj);
+    bool skip = false;
+    skip |= ValidateGetPhysicalDeviceImageFormatProperties2ANDROID(pImageFormatInfo, pImageFormatProperties, error_obj);
     skip |= ValidateGetPhysicalDeviceImageFormatProperties2(pImageFormatInfo, pImageFormatProperties, error_obj);
     return skip;
 }

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -664,12 +664,12 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
 
     auto buffer_state = Get<vvl::Buffer>(buffer);
     if (!buffer_state) {
-        return false;
+        return skip;
     }
     const bool bind_buffer_mem_2 = loc.function != Func::vkBindBufferMemory;
 
     // Track objects tied to memory
-    skip = ValidateSetMemBinding(memory, *buffer_state, loc);
+    skip |= ValidateSetMemBinding(memory, *buffer_state, loc);
 
     // Validate memory requirements alignment
     if (SafeModulo(memoryOffset, buffer_state->requirements.alignment) != 0) {
@@ -1901,8 +1901,9 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const 
 
 bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const &image_state, VkImageSubresource const &subresource,
                                                                const Location &bind_loc, const Location &subresource_loc) const {
-    bool skip = ValidateImageAspectMask(image_state.VkHandle(), image_state.createInfo.format, subresource.aspectMask,
-                                        image_state.disjoint, bind_loc, "VUID-VkSparseImageMemoryBind-subresource-01106");
+    bool skip = false;
+    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.createInfo.format, subresource.aspectMask,
+                                    image_state.disjoint, bind_loc, "VUID-VkSparseImageMemoryBind-subresource-01106");
 
     if (subresource.mipLevel >= image_state.createInfo.mipLevels) {
         skip |=

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -287,7 +287,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, V
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
@@ -493,7 +493,7 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffe
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     if (offset & 3) {
@@ -1220,7 +1220,7 @@ bool CoreChecks::PreCallValidateCmdTraceRaysIndirect2KHR(VkCommandBuffer command
                          indirectDeviceAddress);
     }
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, error_obj.location);
     return skip;
 }
 
@@ -1239,7 +1239,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksNV(VkCommandBuffer commandBuffer
             "), must be less than or equal to VkPhysicalDeviceMeshShaderPropertiesNV::maxDrawMeshTasksCount (0x%" PRIxLEAST32 ").",
             taskCount, phys_dev_ext_props.mesh_shader_props_nv.maxDrawMeshTasksCount);
     }
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateMeshShaderStage(cb_state, error_obj.location, true);
     return skip;
 }
@@ -1252,7 +1252,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
@@ -1313,7 +1313,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
                          "(%" PRIu64 "), is not a multiple of 4.", countBufferOffset);
     }
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
@@ -1337,7 +1337,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksEXT(VkCommandBuffer commandBuffe
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateMeshShaderStage(cb_state, error_obj.location, false);
 
     if (groupCountX > phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupCount[0]) {
@@ -1401,7 +1401,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
@@ -1450,7 +1450,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer
     skip |= ValidateCmd(cb_state, error_obj.location);
     if (skip) return skip;  // basic validation failed, might have null pointers
 
-    skip = ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
+    skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1281,12 +1281,10 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                                                                              const vvl::CommandBuffer *prim_cb,
                                                                              const vvl::Framebuffer *) {
                     assert(rectCount == clear_rect_copy->size());
-                    bool skip = false;
-                    skip = ValidateClearAttachmentExtent(
+                    return ValidateClearAttachmentExtent(
                         secondary, prim_cb->activeRenderPass->dynamic_rendering_begin_rendering_info.renderArea,
                         prim_cb->activeRenderPass->dynamic_rendering_begin_rendering_info.layerCount, rectCount,
                         clear_rect_copy->data(), record_obj.location);
-                    return skip;
                 };
                 cb_state_ptr->cmd_execute_commands_functions.emplace_back(val_fn);
             }
@@ -1321,8 +1319,8 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                     bool skip = false;
 
                     if (fb && prim_cb->IsPrimary()) {
-                        skip = ValidateClearAttachmentExtent(secondary, render_area, fb->createInfo.layers, rectCount,
-                                                             clear_rect_copy->data(), record_obj.location);
+                        skip |= ValidateClearAttachmentExtent(secondary, render_area, fb->createInfo.layers, rectCount,
+                                                              clear_rect_copy->data(), record_obj.location);
                     }
                     return skip;
                 };
@@ -2481,7 +2479,7 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     if (pSubresource && pLayout && image_state) {
-        skip = ValidateGetImageSubresourceLayout(*image_state, *pSubresource, error_obj.location.dot(Field::pSubresource));
+        skip |= ValidateGetImageSubresourceLayout(*image_state, *pSubresource, error_obj.location.dot(Field::pSubresource));
         if ((image_state->createInfo.tiling != VK_IMAGE_TILING_LINEAR) &&
             (image_state->createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)) {
             skip |= LogError("VUID-vkGetImageSubresourceLayout-image-07790", image, error_obj.location,
@@ -2498,8 +2496,8 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout2KHR(VkDevice device, V
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     if (pSubresource && pLayout && image_state) {
-        skip = ValidateGetImageSubresourceLayout(*image_state, pSubresource->imageSubresource,
-                                                 error_obj.location.dot(Field::pSubresource).dot(Field::imageSubresource));
+        skip |= ValidateGetImageSubresourceLayout(*image_state, pSubresource->imageSubresource,
+                                                  error_obj.location.dot(Field::pSubresource).dot(Field::imageSubresource));
     }
     return skip;
 }

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -1101,8 +1101,9 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
     assert(cb_state);
     assert(dst_buff_state);
     const LogObjectList buffer_objlist(commandBuffer, dstBuffer);
-    bool skip = ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buff_state, error_obj.location.dot(Field::dstBuffer),
-                                              "VUID-vkCmdCopyQueryPoolResults-dstBuffer-00826");
+    bool skip = false;
+    skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buff_state, error_obj.location.dot(Field::dstBuffer),
+                                          "VUID-vkCmdCopyQueryPoolResults-dstBuffer-00826");
     skip |= ValidateQueryPoolStride("VUID-vkCmdCopyQueryPoolResults-flags-00822", "VUID-vkCmdCopyQueryPoolResults-flags-00823",
                                     stride, "dstOffset", dstOffset, flags, error_obj.location);
     // Validate that DST buffer has correct usage flags set

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -137,11 +137,11 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
     {
         auto fence_state = Get<vvl::Fence>(fence);
         const LogObjectList objlist(queue, fence);
-        skip = ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueSubmit-fence-00064", "VUID-vkQueueSubmit-fence-00063",
-                                      objlist, error_obj.location);
+        skip |= ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueSubmit-fence-00064", "VUID-vkQueueSubmit-fence-00063",
+                                       objlist, error_obj.location);
     }
     if (skip) {
-        return true;
+        return skip;
     }
 
     auto queue_state = Get<vvl::Queue>(queue);
@@ -264,11 +264,11 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
     {
         auto fence_state = Get<vvl::Fence>(fence);
         const LogObjectList objlist(queue, fence);
-        skip = ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueSubmit2-fence-04895", "VUID-vkQueueSubmit2-fence-04894",
-                                      objlist, error_obj.location);
+        skip |= ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueSubmit2-fence-04895", "VUID-vkQueueSubmit2-fence-04894",
+                                       objlist, error_obj.location);
     }
     if (skip) {
-        return true;
+        return skip;
     }
 
     if (!enabled_features.synchronization2) {
@@ -602,11 +602,11 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
     {
         auto fence_state = Get<vvl::Fence>(fence);
         const LogObjectList objlist(queue, fence);
-        skip = ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueBindSparse-fence-01114", "VUID-vkQueueBindSparse-fence-01113",
-                                      objlist, error_obj.location);
+        skip |= ValidateFenceForSubmit(fence_state.get(), "VUID-vkQueueBindSparse-fence-01114",
+                                       "VUID-vkQueueBindSparse-fence-01113", objlist, error_obj.location);
     }
     if (skip) {
-        return true;
+        return skip;
     }
 
     auto queue_data = Get<vvl::Queue>(queue);

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -143,9 +143,9 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureHandleNV(VkDevice device
 
     auto as_state = Get<vvl::AccelerationStructureNV>(accelerationStructure);
     if (as_state != nullptr) {
-        skip = VerifyBoundMemoryIsValid(as_state->MemState(), LogObjectList(accelerationStructure), as_state->Handle(),
-                                        error_obj.location.dot(Field::accelerationStructure),
-                                        "VUID-vkGetAccelerationStructureHandleNV-accelerationStructure-02787");
+        skip |= VerifyBoundMemoryIsValid(as_state->MemState(), LogObjectList(accelerationStructure), as_state->Handle(),
+                                         error_obj.location.dot(Field::accelerationStructure),
+                                         "VUID-vkGetAccelerationStructureHandleNV-accelerationStructure-02787");
     }
 
     return skip;
@@ -1890,9 +1890,9 @@ bool CoreChecks::ValidateGeometryAABBNV(const VkGeometryAABBNV &aabbs, const Loc
 bool CoreChecks::ValidateGeometryNV(const VkGeometryNV &geometry, const Location &loc) const {
     bool skip = false;
     if (geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_NV) {
-        skip = ValidateGeometryTrianglesNV(geometry.geometry.triangles, loc);
+        skip |= ValidateGeometryTrianglesNV(geometry.geometry.triangles, loc);
     } else if (geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_NV) {
-        skip = ValidateGeometryAABBNV(geometry.geometry.aabbs, loc);
+        skip |= ValidateGeometryAABBNV(geometry.geometry.aabbs, loc);
     }
     return skip;
 }

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -517,8 +517,7 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
 
 bool CoreChecks::PreCallValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                    VkSubpassContents contents, const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, error_obj);
-    return skip;
+    return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
@@ -530,8 +529,7 @@ bool CoreChecks::PreCallValidateCmdBeginRenderPass2KHR(VkCommandBuffer commandBu
 bool CoreChecks::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                     const VkSubpassBeginInfo *pSubpassBeginInfo,
                                                     const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, error_obj);
-    return skip;
+    return ValidateCmdBeginRenderPass(commandBuffer, pRenderPassBegin, error_obj);
 }
 
 void CoreChecks::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
@@ -785,8 +783,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
 }
 
 bool CoreChecks::PreCallValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdEndRenderPass(commandBuffer, VK_NULL_HANDLE, error_obj);
-    return skip;
+    return ValidateCmdEndRenderPass(commandBuffer, VK_NULL_HANDLE, error_obj);
 }
 
 bool CoreChecks::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
@@ -796,8 +793,7 @@ bool CoreChecks::PreCallValidateCmdEndRenderPass2KHR(VkCommandBuffer commandBuff
 
 bool CoreChecks::PreCallValidateCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo,
                                                   const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdEndRenderPass(commandBuffer, pSubpassEndInfo, error_obj);
-    return skip;
+    return ValidateCmdEndRenderPass(commandBuffer, pSubpassEndInfo, error_obj);
 }
 
 void CoreChecks::RecordCmdEndRenderPassLayouts(VkCommandBuffer commandBuffer) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -119,7 +119,7 @@ bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_
     }
     switch (semaphore_state->type) {
         case VK_SEMAPHORE_TYPE_BINARY:
-            skip = ValidateBinaryWait(wait_semaphore_loc, queue, *semaphore_state);
+            skip |= ValidateBinaryWait(wait_semaphore_loc, queue, *semaphore_state);
             break;
         case VK_SEMAPHORE_TYPE_TIMELINE: {
             uint64_t bad_value = 0;

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -32,7 +32,7 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
                             ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
                             FormatHandle(set).c_str(), binding_info.first, index);
         }
-        skip = ValidateDescriptor(binding_info, index, binding.type, descriptor);
+        skip |= ValidateDescriptor(binding_info, index, binding.type, descriptor);
     }
     return skip;
 }
@@ -45,23 +45,22 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             // Can't validate the descriptor because it may not have been updated.
             break;
         case DescriptorClass::GeneralBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding));
             break;
         case DescriptorClass::ImageSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::ImageSamplerBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::ImageSamplerBinding &>(binding));
             break;
         case DescriptorClass::Image:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::ImageBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::ImageBinding &>(binding));
             break;
         case DescriptorClass::PlainSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding));
             break;
         case DescriptorClass::TexelBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding));
             break;
         case DescriptorClass::AccelerationStructure:
-            skip = ValidateDescriptors(binding_info,
-                                       static_cast<const vvl::AccelerationStructureBinding &>(binding));
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::AccelerationStructureBinding &>(binding));
             break;
         default:
             break;
@@ -83,7 +82,7 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
                             ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
                             FormatHandle(set).c_str(), binding_info.first, index);
         }
-        skip = ValidateDescriptor(binding_info, index, binding.type, descriptor);
+        skip |= ValidateDescriptor(binding_info, index, binding.type, descriptor);
     }
     return skip;
 }
@@ -97,7 +96,7 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             // Can't validate the descriptor because it may not have been updated.
             break;
         case DescriptorClass::GeneralBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding), indices);
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::BufferBinding &>(binding), indices);
             break;
         case DescriptorClass::ImageSampler: {
             auto &imgs_binding = static_cast<vvl::ImageSamplerBinding &>(binding);
@@ -105,7 +104,7 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
                 auto &descriptor = imgs_binding.descriptors[index];
                 descriptor.UpdateDrawState(&dev_state, &cb_state);
             }
-            skip = ValidateDescriptors(binding_info, imgs_binding, indices);
+            skip |= ValidateDescriptors(binding_info, imgs_binding, indices);
             break;
         }
         case DescriptorClass::Image: {
@@ -114,18 +113,17 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
                 auto &descriptor = img_binding.descriptors[index];
                 descriptor.UpdateDrawState(&dev_state, &cb_state);
             }
-            skip = ValidateDescriptors(binding_info, img_binding, indices);
+            skip |= ValidateDescriptors(binding_info, img_binding, indices);
             break;
         }
         case DescriptorClass::PlainSampler:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding), indices);
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::SamplerBinding &>(binding), indices);
             break;
         case DescriptorClass::TexelBuffer:
-            skip = ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding), indices);
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::TexelBinding &>(binding), indices);
             break;
         case DescriptorClass::AccelerationStructure:
-            skip = ValidateDescriptors(binding_info,
-                                       static_cast<const vvl::AccelerationStructureBinding &>(binding), indices);
+            skip |= ValidateDescriptors(binding_info, static_cast<const vvl::AccelerationStructureBinding &>(binding), indices);
             break;
         default:
             break;
@@ -898,12 +896,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index,
                                     VkDescriptorType descriptor_type,
                                     const vvl::ImageSamplerDescriptor &descriptor) const {
-    bool skip = ValidateDescriptor(binding_info, index, descriptor_type,
-                                   static_cast<const vvl::ImageDescriptor &>(descriptor));
-    if (!skip) {
-        skip = ValidateSamplerDescriptor(binding_info, index, descriptor.GetSampler(),
-                                         descriptor.IsImmutableSampler(), descriptor.GetSamplerState());
+    bool skip = false;
+    skip |= ValidateDescriptor(binding_info, index, descriptor_type, static_cast<const vvl::ImageDescriptor &>(descriptor));
+    if (skip) {
+        return skip;
     }
+    skip |= ValidateSamplerDescriptor(binding_info, index, descriptor.GetSampler(), descriptor.IsImmutableSampler(),
+                                      descriptor.GetSamplerState());
     return skip;
 }
 

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -86,9 +86,9 @@ bool StatelessValidation::ValidateGeometryNV(const VkGeometryNV &geometry, VkAcc
                                              const Location &loc) const {
     bool skip = false;
     if (geometry.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_NV) {
-        skip = ValidateGeometryTrianglesNV(geometry.geometry.triangles, object_handle, loc);
+        skip |= ValidateGeometryTrianglesNV(geometry.geometry.triangles, object_handle, loc);
     } else if (geometry.geometryType == VK_GEOMETRY_TYPE_AABBS_NV) {
-        skip = ValidateGeometryAABBNV(geometry.geometry.aabbs, object_handle, loc);
+        skip |= ValidateGeometryAABBNV(geometry.geometry.aabbs, object_handle, loc);
     }
     return skip;
 }

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -455,15 +455,13 @@ bool StatelessValidation::ValidateCmdBeginRenderPass(const VkRenderPassBeginInfo
 
 bool StatelessValidation::manual_PreCallValidateCmdBeginRenderPass(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                                    VkSubpassContents, const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdBeginRenderPass(pRenderPassBegin, error_obj);
-    return skip;
+    return ValidateCmdBeginRenderPass(pRenderPassBegin, error_obj);
 }
 
 bool StatelessValidation::manual_PreCallValidateCmdBeginRenderPass2(VkCommandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                                                     const VkSubpassBeginInfo *,
                                                                     const ErrorObject &error_obj) const {
-    bool skip = ValidateCmdBeginRenderPass(pRenderPassBegin, error_obj);
-    return skip;
+    return ValidateCmdBeginRenderPass(pRenderPassBegin, error_obj);
 }
 
 static bool UniqueRenderingInfoImageViews(const VkRenderingInfo *pRenderingInfo, VkImageView imageView) {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -755,7 +755,7 @@ bool CommandBufferAccessContext::ValidateClearAttachment(const Location &loc, co
 
     ClearAttachmentInfo clear_info = GetClearAttachmentInfo(clear_attachment, rect);
     if (clear_info.IsValid()) {
-        skip = ValidateClearAttachment(loc, clear_info);
+        skip |= ValidateClearAttachment(loc, clear_info);
     }
 
     return skip;

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -1175,7 +1175,8 @@ bool SyncOpEndRenderPass::ReplayValidate(ReplayState &replay, ResourceUsageTag r
     // Any store/resolve operations happen before the EndRenderPass tag so we can ignore them
     // Only the layout transitions happen at the replay tag
     ResourceUsageRange first_use_range = {recorded_tag, recorded_tag + 1};
-    bool skip = replay.DetectFirstUseHazard(first_use_range);
+    bool skip = false;
+    skip |= replay.DetectFirstUseHazard(first_use_range);
 
     // We can cleanup here as the recorded tag represents the final layout transition (which is the last operation or the RP
     replay.EndRenderPassReplayCleanup();
@@ -1230,7 +1231,7 @@ bool ReplayState::DetectFirstUseHazard(const ResourceUsageRange &first_use_range
             const SyncValidator &sync_state = exec_context_.GetSyncState();
             const auto handle = exec_context_.Handle();
             const VkCommandBuffer recorded_handle = recorded_context_.GetCBState().VkHandle();
-            skip = sync_state.LogError(
+            skip |= sync_state.LogError(
                 string_SyncHazardVUID(hazard.Hazard()), handle, error_obj_.location,
                 "Hazard %s for entry %" PRIu32 ", %s, %s access info %s. Access info %s.", string_SyncHazard(hazard.Hazard()),
                 index_, sync_state.FormatHandle(recorded_handle).c_str(), exec_context_.ExecutionTypeString(),

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -451,7 +451,7 @@ bool QueueBatchContext::DoQueuePresentValidate(const Location& loc, const Presen
             const auto queue_handle = queue_state_->Handle();
             const auto swap_handle = vvl::StateObject::Handle(presented.swapchain_state.lock());
             const auto image_handle = vvl::StateObject::Handle(presented.image);
-            skip = sync_state_->LogError(
+            skip |= sync_state_->LogError(
                 string_SyncHazardVUID(hazard.Hazard()), queue_handle, loc,
                 "Hazard %s for present pSwapchains[%" PRIu32 "] , swapchain %s, image index %" PRIu32 " %s, Access info %s.",
                 string_SyncHazard(hazard.Hazard()), presented.present_index, sync_state_->FormatHandle(swap_handle).c_str(),

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -464,7 +464,7 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier(
                                            dstStageMask, dependencyFlags, memoryBarrierCount, pMemoryBarriers,
                                            bufferMemoryBarrierCount, pBufferMemoryBarriers, imageMemoryBarrierCount,
                                            pImageMemoryBarriers);
-    skip = pipeline_barrier.Validate(*cb_access_context);
+    skip |= pipeline_barrier.Validate(*cb_access_context);
     return skip;
 }
 
@@ -499,7 +499,7 @@ bool SyncValidator::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer commandBu
 
     SyncOpPipelineBarrier pipeline_barrier(error_obj.location.function, *this, cb_access_context->GetQueueFlags(),
                                            *pDependencyInfo);
-    skip = pipeline_barrier.Validate(*cb_access_context);
+    skip |= pipeline_barrier.Validate(*cb_access_context);
     return skip;
 }
 
@@ -554,7 +554,7 @@ bool SyncValidator::ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const
     const auto cb_state = Get<syncval_state::CommandBuffer>(commandBuffer);
     if (cb_state) {
         SyncOpBeginRenderPass sync_op(error_obj.location.function, *this, pRenderPassBegin, pSubpassBeginInfo);
-        skip = sync_op.Validate(cb_state->access_context);
+        skip |= sync_op.Validate(cb_state->access_context);
     }
     return skip;
 }
@@ -770,7 +770,7 @@ bool SyncValidator::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuff
     cmd_state->AddRenderingInfo(*this, *pRenderingInfo);
 
     // We need to set skip, because the TlsGuard destructor is looking at the skip value for RAII cleanup.
-    skip = cmd_state->cb_state->access_context.ValidateBeginRendering(error_obj, *cmd_state);
+    skip |= cmd_state->cb_state->access_context.ValidateBeginRendering(error_obj, *cmd_state);
     return skip;
 }
 
@@ -800,7 +800,7 @@ bool SyncValidator::PreCallValidateCmdEndRendering(VkCommandBuffer commandBuffer
     assert(cb_state);
     if (!cb_state) return skip;
 
-    skip = cb_state->access_context.ValidateEndRendering(error_obj);
+    skip |= cb_state->access_context.ValidateEndRendering(error_obj);
     return skip;
 }
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -4369,7 +4369,6 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     VkImageObj image(m_device);
     image.init_no_mem(*m_device, image_create_info);
 
-    VkDeviceMemory image_mem;
     VkMemoryRequirements mem_reqs;
     vk::GetImageMemoryRequirements(m_device->device(), image.handle(), &mem_reqs);
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper(nullptr);
@@ -4382,7 +4381,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
         }
     }
 
-    vk::AllocateMemory(device(), &mem_alloc, NULL, &image_mem);
+    vkt::DeviceMemory image_mem(*m_device, mem_alloc);
 
     VkRect2D splitInstanceBindregion = {{0, 0}, {16, 16}};
     VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = vku::InitStructHelper();
@@ -4392,7 +4391,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     VkBindImageMemoryInfo bindInfo = vku::InitStructHelper();
     bindInfo.pNext = &bind_devicegroup_info;
     bindInfo.image = image.handle();
-    bindInfo.memory = image_mem;
+    bindInfo.memory = image_mem.handle();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryDeviceGroupInfo-splitInstanceBindRegionCount-01636");
     vk::BindImageMemory2KHR(device(), 1, &bindInfo);
@@ -4559,8 +4558,7 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
         GTEST_SKIP() << "Failed to set memory type.";
     }
 
-    vkt::DeviceMemory memory;
-    memory.init(*m_device, mem_alloc);
+    vkt::DeviceMemory memory(*m_device, mem_alloc);
 
     uint32_t deviceIndex = 0;
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -550,8 +550,8 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     image.init_no_mem(*m_device, imageCreateInfo);
 
     VkBindImageMemoryDeviceGroupInfo bind_devicegroup_info = vku::InitStructHelper();
-    bind_devicegroup_info.deviceIndexCount = 1;
-    std::array<uint32_t, 2> deviceIndices = {{0}};
+    bind_devicegroup_info.deviceIndexCount = physical_device_group[0].physicalDeviceCount;
+    std::array<uint32_t, 8> deviceIndices = {{0}};
     bind_devicegroup_info.pDeviceIndices = deviceIndices.data();
     bind_devicegroup_info.splitInstanceBindRegionCount = 0;
     bind_devicegroup_info.pSplitInstanceBindRegions = nullptr;

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2241,8 +2241,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
     buffer_alloc_info.memoryTypeIndex = 0;
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
 
-    VkDeviceMemory buffer_memory;
-    vk::AllocateMemory(m_device->device(), &buffer_alloc_info, nullptr, &buffer_memory);
+    vkt::DeviceMemory buffer_memory(*m_device, buffer_alloc_info);
 
     std::vector<uint32_t> device_indices(create_device_pnext.physicalDeviceCount);
 
@@ -2252,7 +2251,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
 
     VkBindBufferMemoryInfo bind_buffer_info = vku::InitStructHelper(&bind_buffer_memory_device_group);
     bind_buffer_info.buffer = buffer.handle();
-    bind_buffer_info.memory = buffer_memory;
+    bind_buffer_info.memory = buffer_memory.handle();
     bind_buffer_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindBufferMemoryDeviceGroupInfo-deviceIndexCount-01606");
@@ -2288,8 +2287,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
     image_alloc_info.memoryTypeIndex = 0;
     image_alloc_info.allocationSize = image_mem_reqs.size;
 
-    VkDeviceMemory image_memory;
-    vk::AllocateMemory(m_device->device(), &image_alloc_info, nullptr, &image_memory);
+    vkt::DeviceMemory image_memory(*m_device, image_alloc_info);
 
     VkBindImageMemoryDeviceGroupInfo bind_image_memory_device_group = vku::InitStructHelper();
     bind_image_memory_device_group.deviceIndexCount = 1;
@@ -2297,7 +2295,7 @@ TEST_F(NegativeMemory, BindBufferMemoryDeviceGroup) {
 
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper(&bind_image_memory_device_group);
     bind_image_info.image = image.handle();
-    bind_image_info.memory = image_memory;
+    bind_image_info.memory = image_memory.handle();
     bind_image_info.memoryOffset = 0;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBindImageMemoryDeviceGroupInfo-deviceIndexCount-01634");


### PR DESCRIPTION
I was trying to cleanup the Device Group tests, there I found a bug because we went `skip = ValidateSomething();` instead of `skip |=`

I have found sometimes we move around code and having `|=` everywhere is a good counter measure for future code refactoring 