### PR TITLE
layers: Add 08935 03504 09541 09542

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1550,6 +1550,9 @@ class CoreChecks : public ValidationStateTracker {
                                                           const ErrorObject& error_obj) const override;
     bool PreCallValidateGetAccelerationStructureHandleNV(VkDevice device, VkAccelerationStructureNV accelerationStructure,
                                                          size_t dataSize, void* pData, const ErrorObject& error_obj) const override;
+    bool PreCallValidateGetAccelerationStructureDeviceAddressKHR(VkDevice device,
+                                                                 const VkAccelerationStructureDeviceAddressInfoKHR* pInfo,
+                                                                 const ErrorObject& error_obj) const override;
     // Validate buffers accessed using a device address
     bool ValidateAccelerationBuffers(VkCommandBuffer cmd_buffer, uint32_t info_i,
                                      const VkAccelerationStructureBuildGeometryInfoKHR& info,

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -176,7 +176,7 @@ GeometryKHR &GeometryKHR::SetInstanceDeviceAccelStructRef(const vkt::Device &dev
     assert(vkGetAccelerationStructureDeviceAddressKHR);
     VkAccelerationStructureDeviceAddressInfoKHR as_address_info = vku::InitStructHelper();
     as_address_info.accelerationStructure = bottom_level_as;
-    VkDeviceAddress as_address = vkGetAccelerationStructureDeviceAddressKHR(device.handle(), &as_address_info);
+    const VkDeviceAddress as_address = vkGetAccelerationStructureDeviceAddressKHR(device.handle(), &as_address_info);
     instance_.vk_instance = std::make_unique<VkAccelerationStructureInstanceKHR>();
     instance_.vk_instance->accelerationStructureReference = static_cast<uint64_t>(as_address);
     // leave other instance_ attributes to 0
@@ -277,6 +277,13 @@ VkDeviceAddress AccelerationStructureKHR::GetBufferDeviceAddress() const {
     assert(device_buffer_.initialized());
     assert(device_buffer_.create_info().size > 0);
     return device_buffer_.address();
+}
+
+VkDeviceAddress AccelerationStructureKHR::GetAccelerationStructureDeviceAddress() const {
+    VkAccelerationStructureDeviceAddressInfoKHR as_address_info = vku::InitStructHelper();
+    as_address_info.accelerationStructure = handle();
+    const VkDeviceAddress as_address = vk::GetAccelerationStructureDeviceAddressKHR(*device_, &as_address_info);
+    return as_address;
 }
 
 void AccelerationStructureKHR::Build() {

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -127,6 +127,7 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     AccelerationStructureKHR& SetBufferUsageFlags(VkBufferUsageFlags usage_flags);
 
     VkDeviceAddress GetBufferDeviceAddress() const;
+    VkDeviceAddress GetAccelerationStructureDeviceAddress() const;
 
     // Null check is done in BuildGeometryInfoKHR::Build(). Object is build iff it is not null.
     void SetNull(bool is_null) { is_null_ = is_null; }
@@ -135,7 +136,7 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     bool IsBuilt() const { return initialized(); }
     void Destroy();
 
-    const auto& GetBuffer() const { return device_buffer_; }
+    auto& GetBuffer() { return device_buffer_; }
 
   private:
     const vkt::Device* device_;

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -1006,6 +1006,30 @@ TEST_F(NegativeRayTracing, CreateAccelerationStructureKHRReplayFeature) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeRayTracing, GetAccelerationStructureAddressBabBuffer) {
+    TEST_DESCRIPTION(
+        "Call vkGetAccelerationStructureDeviceAddressKHR on an acceleration structure whose buffer is missing usage "
+        "VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, and whose memory has been destroyed");
+
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayQuery);
+    RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
+    RETURN_IF_SKIP(InitState());
+
+    auto blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    blas->SetBufferUsageFlags(VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
+    blas->Build();
+
+    blas->GetBuffer().memory().destroy();
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09541");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09542");
+    (void)blas->GetAccelerationStructureDeviceAddress();
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     TEST_DESCRIPTION("Validate vkCmdTraceRaysKHR.");
 


### PR DESCRIPTION
Part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7361

VUID-vkGetAccelerationStructureDeviceAddressKHR-accelerationStructure-08935
The [VkPhysicalDeviceAccelerationStructureFeaturesKHR::accelerationStructure](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-accelerationStructure) feature must be enabled

VUID-vkGetAccelerationStructureDeviceAddressKHR-device-03504
If device was created with multiple physical devices, then the [bufferDeviceAddressMultiDevice](https://registry.khronos.org/vulkan/specs/1.3-extensions/html/vkspec.html#features-bufferDeviceAddressMultiDevice) feature must be enabled

VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09541
If the buffer on which pInfo->accelerationStructure was placed is non-sparse then it must be bound completely and contiguously to a single VkDeviceMemory object

VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09542
The buffer on which pInfo->accelerationStructure was placed must have been created with the VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT usage flag