### PR TITLE
tests: Remove init from instance extensions test

### DIFF
--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -41,8 +41,6 @@ TEST_F(PositiveInstance, TwoInstances) {
 }
 
 TEST_F(PositiveInstance, ValidationInstanceExtensions) {
-    RETURN_IF_SKIP(Init());
-
     std::string layer_name = "VK_LAYER_KHRONOS_validation";
     std::vector<std::string> extensions = {VK_EXT_DEBUG_UTILS_EXTENSION_NAME, VK_EXT_DEBUG_REPORT_EXTENSION_NAME,
                                            VK_EXT_LAYER_SETTINGS_EXTENSION_NAME, VK_EXT_VALIDATION_FEATURES_EXTENSION_NAME};


### PR DESCRIPTION
Initialization is not required in this test and in the profiles repository had a similar test that only failed if an instance was not created before calling `vkEnumerateInstanceExtensionProperties`