### PR TITLE
CI fix: Try manual feature init

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -6077,9 +6077,10 @@ TEST_F(NegativeSyncVal, QSTransitionHazardsPreviousBatch_BinarySemaphore) {
         "execution dependency and can hazard with accesses in the first batch.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredFeature(vkt::Feature::synchronization2);
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
+    sync2_features.synchronization2 = VK_TRUE;
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
     VkImageObj image(m_device);
     image.Init(64, 64, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -6171,10 +6172,12 @@ TEST_F(NegativeSyncVal, QSTransitionHazardsPreviousBatch_TimelineSemaphore) {
         "execution dependency and can hazard with accesses in the first batch.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredFeature(vkt::Feature::synchronization2);
-    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_features = vku::InitStructHelper();
+    timeline_features.timelineSemaphore = VK_TRUE;
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper(&timeline_features);
+    sync2_features.synchronization2 = VK_TRUE;
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
     VkImageObj image(m_device);
     image.Init(64, 64, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -6268,9 +6271,10 @@ TEST_F(NegativeSyncVal, QSTransitionHazardsPreviousBatch_TimelineSemaphore) {
 TEST_F(NegativeSyncVal, UseShaderReadAccessForUniformBuffer) {
     TEST_DESCRIPTION("SHADER_READ_BIT barrier cannot protect UNIFORM_READ_BIT accesses");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    AddRequiredFeature(vkt::Feature::synchronization2);
+    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
+    sync2_features.synchronization2 = VK_TRUE;
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
     constexpr VkDeviceSize size = 1024;
     const vkt::Buffer staging_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);


### PR DESCRIPTION
This workarounds CI failures according to the statistic I gathered so far.
Manual feature initialization: no failures in 7-8 runs. 
Automatic feature initialization 3 failures in 5 runs.

~~Still I feel it could be luck and the reason is different, but so far good data to test this version.~~
More testing suggest this PR correctly determines the area that causes the issue.

I don't know details of automatic feature implementation but if it can enable *other* features in addition to requested ones then it can enable a feature that is not very stable for specific device/driver (Arno hopefully can clarify details).

The failures happen only on GalaxyS23Ultra Android CI.

@arno-lunarg 
