### PR TITLE
layers: Fix a crash when image resources are deleted

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1309,7 +1309,7 @@ void CommandBuffer::SetImageViewInitialLayout(const vvl::ImageView &view_state, 
         return;
     }
     vvl::Image *image_state = view_state.image_state.get();
-    auto *subresource_map = GetImageSubresourceLayoutMap(*image_state);
+    auto *subresource_map = image_state ? GetImageSubresourceLayoutMap(*image_state) : nullptr;
     if (subresource_map) {
         subresource_map->SetSubresourceRangeInitialLayout(*this, layout, view_state);
     }


### PR DESCRIPTION
Fixed a crash in Validation layers when image/imageview are deleted in a descriptor indexing scenario.

**Do:**
* Install Vulkan SDK 1.3.275.0
* Run https://github.com/corporateshark/lightweightvk/blob/main/samples/Tiny_Mesh.cpp
* Press `T`

**Observe:**

A crash in Validation layers.

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/2510143/73308477-2411-45ae-83da-dc9d54b9b8c2)
