### PR TITLE
layers: Add Struct extension check

### DIFF
--- a/layers/stateless/sl_external_object.cpp
+++ b/layers/stateless/sl_external_object.cpp
@@ -293,7 +293,7 @@ bool StatelessValidation::manual_PreCallValidateExportMetalObjectsEXT(VkDevice d
     skip |=
         ValidateStructPnext(error_obj.location.dot(Field::pMetalObjectsInfo), pMetalObjectsInfo->pNext, allowed_structs.size(),
                             allowed_structs.data(), GeneratedVulkanHeaderVersion, "VUID-VkExportMetalObjectsInfoEXT-pNext-pNext",
-                            "VUID-VkExportMetalObjectsInfoEXT-sType-unique", false, true);
+                            "VUID-VkExportMetalObjectsInfoEXT-sType-unique", VK_NULL_HANDLE, true);
     return skip;
 }
 #endif  // VK_USE_PLATFORM_METAL_EXT

--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -158,12 +158,12 @@ bool StatelessValidation::ValidateStringArray(const Location &count_loc, const L
  * @param allowed_type_count Total number of allowed structure types.
  * @param allowed_types Array of structure types allowed for pNext.
  * @param header_version Version of header defining the pNext validation rules.
- * @param is_physdev_api True if the first parameter of the function is a VkPhysicalDevice (ex vkCreateDevice)
  * @return Boolean value indicating that the call should be skipped.
  */
 bool StatelessValidation::ValidateStructPnext(const Location &loc, const void *next, size_t allowed_type_count,
                                               const VkStructureType *allowed_types, uint32_t header_version, const char *pnext_vuid,
-                                              const char *stype_vuid, const bool is_physdev_api, const bool is_const_param) const {
+                                              const char *stype_vuid, VkPhysicalDevice caller_physical_device,
+                                              const bool is_const_param) const {
     bool skip = false;
     const Location pNext_loc = loc.dot(Field::pNext);
     const char *api_name = loc.StringFunc();
@@ -224,7 +224,7 @@ bool StatelessValidation::ValidateStructPnext(const Location &loc, const void *n
                             }
                         }
                         // Send Location without pNext field so the pNext() connector can be used
-                        skip |= ValidatePnextStructContents(loc, current, pnext_vuid, is_physdev_api, is_const_param);
+                        skip |= ValidatePnextStructContents(loc, current, pnext_vuid, caller_physical_device, is_const_param);
                     }
                 }
                 current = reinterpret_cast<const VkBaseOutStructure *>(current->pNext);

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -366,11 +366,11 @@ class StatelessValidation : public ValidationObject {
     bool SupportedByPdev(const VkPhysicalDevice physical_device, vvl::Extension extension) const;
 
     bool ValidatePnextStructContents(const Location &loc, const VkBaseOutStructure *header, const char *pnext_vuid,
-                                     bool is_physdev_api = false, bool is_const_param = true) const;
+                                     VkPhysicalDevice caller_physical_device = VK_NULL_HANDLE, bool is_const_param = true) const;
 
     bool ValidateStructPnext(const Location &loc, const void *next, size_t allowed_type_count, const VkStructureType *allowed_types,
                              uint32_t header_version, const char *pnext_vuid, const char *stype_vuid,
-                             const bool is_physdev_api = false, const bool is_const_param = true) const;
+                             VkPhysicalDevice caller_physical_device = VK_NULL_HANDLE, const bool is_const_param = true) const;
 
     bool ValidateBool32(const Location &loc, VkBool32 value) const;
 

--- a/scripts/generators/valid_flag_values_generator.py
+++ b/scripts/generators/valid_flag_values_generator.py
@@ -101,12 +101,12 @@ class ValidFlagValuesOutputGenerator(BaseGenerator):
             for expression, names in expressionMap.items():
                 extensions = expression.split(',')
                 checkExpression = []
-                for extesion in extensions:
-                    checkExpression.append(f'!IsExtEnabled(device_extensions.{extesion.lower()})')
+                for extension in extensions:
+                    checkExpression.append(f'!IsExtEnabled(device_extensions.{extension.lower()})')
                 checkExpression = " && ".join(checkExpression)
                 resultExpression = []
-                for extesion in extensions:
-                    resultExpression.append(f'vvl::Extension::_{extesion}')
+                for extension in extensions:
+                    resultExpression.append(f'vvl::Extension::_{extension}')
                 resultExpression = ", ".join(resultExpression)
 
                 out.append(f'if (value & ({" | ".join(names)})) {{\n')
@@ -149,12 +149,12 @@ class ValidFlagValuesOutputGenerator(BaseGenerator):
             for expression, names in expressionMap.items():
                 extensions = expression.split(',')
                 checkExpression = []
-                for extesion in extensions:
-                    checkExpression.append(f'!IsExtEnabled(device_extensions.{extesion.lower()})')
+                for extension in extensions:
+                    checkExpression.append(f'!IsExtEnabled(device_extensions.{extension.lower()})')
                 checkExpression = " && ".join(checkExpression)
                 resultExpression = []
-                for extesion in extensions:
-                    resultExpression.append(f'vvl::Extension::_{extesion}')
+                for extension in extensions:
+                    resultExpression.append(f'vvl::Extension::_{extension}')
                 resultExpression = ", ".join(resultExpression)
 
                 out.append(f'if (value & ({" | ".join(names)})) {{\n')

--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -48,7 +48,7 @@ CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, uint32_t color_att
     vp_state_ci_.pScissors = &scissor_;
 
     // InitRasterizationInfo
-    rs_state_ci_ = vku::InitStructHelper(&line_state_ci_);
+    rs_state_ci_ = vku::InitStructHelper();
     rs_state_ci_.flags = 0;
     rs_state_ci_.depthClampEnable = VK_FALSE;
     rs_state_ci_.rasterizerDiscardEnable = VK_FALSE;
@@ -64,6 +64,10 @@ CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, uint32_t color_att
     line_state_ci_.stippledLineEnable = VK_FALSE;
     line_state_ci_.lineStippleFactor = 0;
     line_state_ci_.lineStipplePattern = 0;
+    if (test.IsExtensionsEnabled(VK_EXT_LINE_RASTERIZATION_EXTENSION_NAME) ||
+        test.IsExtensionsEnabled(VK_KHR_LINE_RASTERIZATION_EXTENSION_NAME)) {
+        rs_state_ci_.pNext = &line_state_ci_;
+    }
 
     // InitBlendStateInfo
     cb_ci_ = vku::InitStructHelper();

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -118,6 +118,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
 TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types from NVIDIA extension");
 
+    AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -2074,6 +2074,7 @@ TEST_F(NegativeMemory, MemoryRequirements) {
 
 TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkDeviceMemory mem;
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
@@ -2081,19 +2082,30 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
     mem_alloc.allocationSize = 4;
 
     // pNext chain includes both VkExportMemoryAllocateInfo and VkExportMemoryAllocateInfoNV
-    {
-        VkExportMemoryAllocateInfoNV export_memory_info_nv = vku::InitStructHelper();
-        export_memory_info_nv.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV;
+    VkExportMemoryAllocateInfoNV export_memory_info_nv = vku::InitStructHelper();
+    export_memory_info_nv.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT_NV;
 
-        VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper(&export_memory_info_nv);
-        export_memory_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
+    VkExportMemoryAllocateInfo export_memory_info = vku::InitStructHelper(&export_memory_info_nv);
+    export_memory_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
-        m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
-        mem_alloc.pNext = &export_memory_info;
-        vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
-        m_errorMonitor->VerifyFound();
-    }
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkMemoryAllocateInfo-pNext-00640");
+    mem_alloc.pNext = &export_memory_info;
+    vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
+    m_errorMonitor->VerifyFound();
+}
+
 #ifdef VK_USE_PLATFORM_WIN32_KHR
+TEST_F(NegativeMemory, MemoryAllocatepNextChainWin32) {
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
+    AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    VkDeviceMemory mem;
+    VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
+    mem_alloc.memoryTypeIndex = 0;
+    mem_alloc.allocationSize = 4;
+
     // pNext chain includes both VkExportMemoryAllocateInfo and VkExportMemoryWin32HandleInfoNV
     {
         VkExportMemoryWin32HandleInfoNV export_memory_info_win32_nv = vku::InitStructHelper();
@@ -2122,8 +2134,8 @@ TEST_F(NegativeMemory, MemoryAllocatepNextChain) {
         vk::AllocateMemory(m_device->device(), &mem_alloc, NULL, &mem);
         m_errorMonitor->VerifyFound();
     }
-#endif  // VK_USE_PLATFORM_WIN32_KHR
 }
+#endif  // VK_USE_PLATFORM_WIN32_KHR
 
 TEST_F(NegativeMemory, DeviceImageMemoryRequirementsSwapchain) {
     TEST_DESCRIPTION("Validate usage of VkDeviceImageMemoryRequirementsKHR.");

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1702,7 +1702,8 @@ TEST_F(PositivePipeline, ShaderModuleIdentifierZeroLength) {
 
 TEST_F(PositivePipeline, IgnoredPipelineCreateFlags) {
     TEST_DESCRIPTION("Create pipeline with invalid flags when allowed");
-
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -541,7 +541,8 @@ TEST_F(NegativeVertexInput, AttributeDescriptions) {
 
 TEST_F(NegativeVertexInput, UsingProvokingVertexModeLastVertexExtDisabled) {
     TEST_DESCRIPTION("Test using VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT but it doesn't enable provokingVertexLast.");
-
+    AddRequiredExtensions(VK_EXT_PROVOKING_VERTEX_EXTENSION_NAME);
+    AddDisabledFeature(vkt::Feature::provokingVertexLast);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7433
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5012

Adds logic to check if a struct is being used when you didn't enable the extension