### PR TITLE
layers: Reduce size of oversized VUs

### DIFF
--- a/scripts/generate_spec_error_message.py
+++ b/scripts/generate_spec_error_message.py
@@ -217,6 +217,14 @@ def make_vuid_spec_version_list(pattern, max_minor_version):
         if resolved_pattern: edition_list_out.append(edition)
     return edition_list_out
 
+# These VUs are huge because they are just listing every possible option that is valid.
+# The size of these make these VU error messages more harmful to print then helpful
+oversized_vus = {
+    'VUID-VkColorBlendEquationEXT-colorBlendOp-07361' : 'colorBlendOp and alphaBlendOp must not be a VkBlendOp from VK_EXT_blend_operation_advanced',
+    'VUID-VkDeviceCreateInfo-pNext-pNext' : 'Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid struct for extending VkDeviceCreateInfo',
+    'VUID-VkPhysicalDeviceProperties2-pNext-pNext' : 'Each pNext member of any structure (including this one) in the pNext chain must be either NULL or a pointer to a valid struct for extending VkPhysicalDeviceProperties2',
+}
+
 def GenerateSpecErrorMessage(api : str, valid_usage_json : str, out_file : str):
     val_json = ValidationJSON(valid_usage_json)
     val_json.parse()
@@ -282,6 +290,10 @@ typedef struct _vuid_spec_text_pair {{
         db_text = db_text.replace('\n', ' ')
         # Remove multiple whitespaces
         db_text = re.sub(' +', ' ', db_text)
+        # Override for large VU text messages
+        if vuid in oversized_vus:
+            db_text = oversized_vus[vuid]
+
         out.append(f'    {{"{vuid}", "{db_text}", "{spec_url_id}"}},\n')
         # For multiply-defined VUIDs, include versions with extension appended
         if len(val_json.vuid_db[vuid]) > 1:


### PR DESCRIPTION
```
// length of VUs
VUID-VkColorBlendEquationEXT-colorBlendOp-07361 - 1242
VUID-VkDeviceCreateInfo-pNext-pNext - 9068
VUID-VkPhysicalDeviceProperties2-pNext-pNext - 4224
```

These over size error message are quite obnoxious and doing more harm then good