### PR TITLE
layers: Fix no-attachment subpass

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -344,8 +344,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                         const uint32_t subpass = cb_state->GetActiveSubpass();
                         // if render pass uses no attachment, verify that all bound pipelines referencing this subpass have the same
                         // pMultisampleState->rasterizationSamples.
-                        if (!render_pass->UsesDynamicRendering() && !render_pass->UsesColorAttachment(subpass) &&
-                            !render_pass->UsesDepthStencilAttachment(subpass)) {
+                        if (render_pass->UsesNoAttachment(subpass)) {
                             // If execution ends up here, GetActiveSubpassRasterizationSampleCount() can still be empty if this is
                             // the first bound pipeline with the previous conditions holding. Rasterization samples count for the
                             // subpass will be updated in PostCallRecordCmdBindPipeline, if it is empty.
@@ -355,7 +354,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                                 *subpass_rasterization_samples != multisample_state->rasterizationSamples) {
                                 const LogObjectList objlist(device, render_pass->Handle(), pipeline_state.Handle());
                                 skip |= LogError(
-                                    "VUID-VkGraphicsPipelineCreateInfo-subpass-00758", objlist, error_obj.location,
+                                    "VUID-vkCmdBindPipeline-pipeline-00781", objlist, error_obj.location,
                                     "variableMultisampleRate is VK_FALSE "
                                     "and "
                                     "pipeline has pMultisampleState->rasterizationSamples equal to %s, while a previously bound "

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1977,6 +1977,17 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                                  msrtss_info->rasterizationSamples, ms_loc.dot(Field::rasterizationSamples).Fields().c_str(),
                                  multisample_state->rasterizationSamples);
             }
+
+            if (rp_state->UsesNoAttachment(pipeline.Subpass())) {
+                if ((multisample_state->rasterizationSamples & phys_dev_props.limits.framebufferNoAttachmentsSampleCounts) == 0) {
+                    skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-subpass-00758", rp_state->Handle(),
+                                     ms_loc.dot(Field::rasterizationSamples),
+                                     "(%s) is not in "
+                                     "framebufferNoAttachmentsSampleCounts (%s) but attempting to use a zero-attachment subpass.",
+                                     string_VkSampleCountFlagBits(multisample_state->rasterizationSamples),
+                                     string_VkSampleCountFlags(phys_dev_props.limits.framebufferNoAttachmentsSampleCounts).c_str());
+                }
+            }
         }
 
         // VK_NV_fragment_coverage_to_color

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -343,6 +343,12 @@ bool RenderPass::UsesDepthStencilAttachment(uint32_t subpass_num) const {
         }
     }
     return result;
+}
+
+// vkspec.html#renderpass-noattachments
+bool RenderPass::UsesNoAttachment(uint32_t subpass) const {
+    // If using dynamic rendering, there is no subpass, so return 'false'
+    return !UsesColorAttachment(subpass) && !UsesDepthStencilAttachment(subpass) && !UsesDynamicRendering();
 }
 
 uint32_t RenderPass::GetDynamicRenderingColorAttachmentCount() const {

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -115,6 +115,7 @@ class RenderPass : public StateObject {
 
     bool UsesColorAttachment(uint32_t subpass) const;
     bool UsesDepthStencilAttachment(uint32_t subpass) const;
+    bool UsesNoAttachment(uint32_t subpass) const;
     // prefer this to checking the individual flags unless you REALLY need to check one or the other
     bool UsesDynamicRendering() const { return use_dynamic_rendering || use_dynamic_rendering_inherited; }
     uint32_t GetDynamicRenderingColorAttachmentCount() const;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2282,8 +2282,7 @@ void ValidationStateTracker::PostCallRecordCmdBindPipeline(VkCommandBuffer comma
                 // if render pass uses no attachment, all bound pipelines in the same subpass must have the same
                 // pMultisampleState->rasterizationSamples. To check that, record pMultisampleState->rasterizationSamples of the
                 // first bound pipeline.
-                if (!render_pass->UsesDynamicRendering() && !render_pass->UsesColorAttachment(subpass) &&
-                    !render_pass->UsesDepthStencilAttachment(subpass)) {
+                if (render_pass->UsesNoAttachment(subpass)) {
                     if (std::optional<VkSampleCountFlagBits> subpass_rasterization_samples =
                             cb_state->GetActiveSubpassRasterizationSampleCount();
                         !subpass_rasterization_samples) {

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -499,7 +499,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     // VkPhysicalDeviceFeatures::variableMultisampleRate is false,
     // the two pipelines refer to the same subpass, one that does not use any attachment,
     // BUT the secondly created pipeline has a different sample samples count than the 1st, this is illegal
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-subpass-00758");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-pipeline-00781");
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_2.Handle());
     m_errorMonitor->VerifyFound();
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6844

- We were not checking for dynamic rendering when checking for "no-attachment subpasses" so made a common util function
- `VUID-VkGraphicsPipelineCreateInfo-subpass-00758` was mislabeled as `VUID-vkCmdBindPipeline-pipeline-00781`
- Added `VUID-VkGraphicsPipelineCreateInfo-subpass-00758`