### PR TITLE
tests: Add test binding for pipeline caches

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -989,6 +989,12 @@ Shader::Shader(const Device &dev, const VkShaderStageFlagBits stage, const std::
     init(dev, createInfo);
 }
 
+NON_DISPATCHABLE_HANDLE_DTOR(PipelineCache, vk::DestroyPipelineCache)
+
+void PipelineCache::init(const Device &dev, const VkPipelineCacheCreateInfo &info) {
+    NON_DISPATCHABLE_HANDLE_INIT(vk::CreatePipelineCache, dev, &info);
+}
+
 NON_DISPATCHABLE_HANDLE_DTOR(Pipeline, vk::DestroyPipeline)
 
 void Pipeline::init(const Device &dev, const VkGraphicsPipelineCreateInfo &info) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -60,6 +60,7 @@ class BufferView;
 class Image;
 class ImageView;
 class DepthStencilView;
+class PipelineCache;
 class Pipeline;
 class PipelineDelta;
 class Sampler;
@@ -762,6 +763,16 @@ class Shader : public internal::NonDispHandle<VkShaderEXT> {
     // vkCreateShaderModule()
     void init(const Device &dev, const VkShaderCreateInfoEXT &info);
     VkResult init_try(const Device &dev, const VkShaderCreateInfoEXT &info);
+};
+
+class PipelineCache : public internal::NonDispHandle<VkPipelineCache> {
+  public:
+    PipelineCache() = default;
+    PipelineCache(const Device &dev, const VkPipelineCacheCreateInfo &info) { init(dev, info); }
+    ~PipelineCache() noexcept;
+    void destroy() noexcept;
+
+    void init(const Device &dev, const VkPipelineCacheCreateInfo &info);
 };
 
 class Pipeline : public internal::NonDispHandle<VkPipeline> {


### PR DESCRIPTION
This was simply missing before.