### PR TITLE
sync: Fix ordered accesses for depth-stencil resolve

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -216,6 +216,8 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
         for (uint32_t i = 0; i < attachment_count && !skip; i++) {
             const auto &attachment = info.attachments[i];
             if (attachment.resolve_gen) {
+                const bool is_color = attachment.type == syncval_state::AttachmentType::kColor;
+                const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
                 // The logic about whether to resolve is embedded in the Attachment constructor
                 assert(attachment.view);
                 HazardResult hazard = access_context->DetectHazard(attachment.view_gen, kResolveRead, kResolveOrder);
@@ -263,6 +265,8 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
         for (uint32_t i = 0; i < attachment_count; i++) {
             const auto &attachment = info.attachments[i];
             if (attachment.resolve_gen) {
+                const bool is_color = attachment.type == syncval_state::AttachmentType::kColor;
+                const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
                 access_context->UpdateAccessState(attachment.view_gen, kResolveRead, kResolveOrder, store_tag);
                 access_context->UpdateAccessState(*attachment.resolve_gen, kResolveWrite, kResolveOrder, store_tag);
             }

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -243,7 +243,11 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     using SyncOpPointer = std::shared_ptr<SyncOpBase>;
     constexpr static SyncStageAccessIndex kResolveRead = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ;
     constexpr static SyncStageAccessIndex kResolveWrite = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE;
-    constexpr static SyncOrdering kResolveOrder = SyncOrdering::kColorAttachment;
+    constexpr static SyncOrdering kColorResolveOrder = SyncOrdering::kColorAttachment;
+    // Although depth resolve runs on the color attachment output stage and uses color accesses, depth accesses
+    // still participate in the ordering. That's why using raster and not only color attachment ordering
+    constexpr static SyncOrdering kDepthStencilResolveOrder = SyncOrdering::kRaster;
+
     constexpr static SyncOrdering kStoreOrder = SyncOrdering::kRaster;
 
     struct SyncOpEntry {


### PR DESCRIPTION
A unique thing about resolve operations is that they happen on the `COLOR_OUTPUT` stage both for color and depth attachments and use color-specific accesses. This requirement forced ordered accesses to be also color-specific. But for depth-stencil attachment, the participation of depth-stencil accesses is still possible. In the reported issue, it is a `LoadOp::Clear` write which did not pass color ordering barrier. The fix includes both Color and Depth accesses in `OrderingBarrier` for depth-stencil attachment during resolve operation.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7441

@jzulauf-lunarg DEFCON 4