### PR TITLE
sync: Add layout transition access to ALL_COMMANDS scope

### DIFF
--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -972,6 +972,10 @@ SyncExecScope SyncExecScope::MakeSrc(VkQueueFlags queue_flags, VkPipelineStageFl
     result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags, disabled_feature_mask);
     result.exec_scope = sync_utils::WithEarlierPipelineStages(result.expanded_mask);
     result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
+    // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
+    if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
+        result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    }
     return result;
 }
 
@@ -981,6 +985,10 @@ SyncExecScope SyncExecScope::MakeDst(VkQueueFlags queue_flags, VkPipelineStageFl
     result.expanded_mask = sync_utils::ExpandPipelineStages(mask_param, queue_flags);
     result.exec_scope = sync_utils::WithLaterPipelineStages(result.expanded_mask);
     result.valid_accesses = SyncStageAccess::AccessScopeByStage(result.expanded_mask);
+    // ALL_COMMANDS stage includes all accesses performed by the gpu, not only accesses defined by the stages
+    if (mask_param & VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT) {
+        result.valid_accesses |= SYNC_IMAGE_LAYOUT_TRANSITION_BIT;
+    }
     return result;
 }
 


### PR DESCRIPTION
`ALL_COMMANDS` includes all operations performed on the gpu, not only operations performed by the official stages.
This was also mentioned here (internal link): https://gitlab.khronos.org/vulkan/vulkan/-/issues/3783#note_453947

The issue was that `ALL_COMMANDS`, when used by the semaphore, did not protect the image layout transition (WRITE) done in the first submission from the shader READ access in the second submission.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7456
