### PR TITLE
layers: Remove old unassigned now codegen

### DIFF
--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -511,14 +511,6 @@ bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice ph
             "rayTracingPipelineShaderGroupHandleCaptureReplay "
             "must also be VK_TRUE.");
     }
-    auto vertex_attribute_divisor_features = vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>(pCreateInfo->pNext);
-    if (vertex_attribute_divisor_features && (!IsExtEnabled(device_extensions.vk_ext_vertex_attribute_divisor) &&
-                                              !IsExtEnabled(device_extensions.vk_khr_vertex_attribute_divisor))) {
-        skip |= LogError(
-            kVUID_PVError_ExtensionNotEnabled, physicalDevice, error_obj.location,
-            "pNext includes a VkPhysicalDeviceVertexAttributeDivisorFeaturesKHR "
-            "struct, VK_KHR_vertex_attribute_divisor or VK_EXT_vertex_attribute_divisor must be enabled when it creates a device.");
-    }
 
     const auto *vulkan_11_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan11Features>(pCreateInfo->pNext);
     if (vulkan_11_features) {

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -847,40 +847,6 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                     }
                 }
 
-                if (has_dynamic_viewport_w_scaling_nv && !IsExtEnabled(device_extensions.vk_nv_clip_space_w_scaling)) {
-                    skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc,
-                                     "pCreateInfos[%" PRIu32
-                                     "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV, but "
-                                     "VK_NV_clip_space_w_scaling extension is not enabled.",
-                                     i);
-                }
-
-                if (vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT) &&
-                    !IsExtEnabled(device_extensions.vk_ext_discard_rectangles)) {
-                    skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc,
-                                     "pCreateInfos[%" PRIu32
-                                     "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT, but "
-                                     "VK_EXT_discard_rectangles extension is not enabled.",
-                                     i);
-                }
-
-                if (vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT) &&
-                    !IsExtEnabled(device_extensions.vk_ext_sample_locations)) {
-                    skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc,
-                                     "pCreateInfos[%" PRIu32
-                                     "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, but "
-                                     "VK_EXT_sample_locations extension is not enabled.",
-                                     i);
-                }
-
-                if (has_dynamic_exclusive_scissor_nv && !IsExtEnabled(device_extensions.vk_nv_scissor_exclusive)) {
-                    skip |= LogError(kVUID_PVError_ExtensionNotEnabled, device, create_info_loc,
-                                     "pCreateInfos[%" PRIu32
-                                     "].pDynamicState->pDynamicStates contains VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV, but "
-                                     "VK_NV_scissor_exclusive extension is not enabled.",
-                                     i);
-                }
-
                 if (coarse_sample_order_struct) {
                     const Location coarse_sample_loc =
                         viewport_loc.pNext(Struct::VkPipelineViewportCoarseSampleOrderStateCreateInfoNV);

--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -22,7 +22,7 @@ bool StatelessValidation::CheckPromotedApiAgainstVulkanVersion(VkInstance instan
                                                                const uint32_t promoted_version) const {
     bool skip = false;
     if (api_version < promoted_version) {
-        skip |= LogError(kVUID_PVError_ApiVersionViolation, instance, loc,
+        skip |= LogError("UNASSIGNED-API-Version-Violation", instance, loc,
                          "Attempted to call with an effective API version of %s"
                          "but this API was not promoted until version %s.",
                          StringAPIVersion(api_version).c_str(), StringAPIVersion(promoted_version).c_str());
@@ -38,7 +38,7 @@ bool StatelessValidation::CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice 
         auto effective_api_version = std::min(APIVersion(target_pdev->second->apiVersion), api_version);
         if (effective_api_version < promoted_version) {
             skip |= LogError(
-                kVUID_PVError_ApiVersionViolation, instance, loc,
+                "UNASSIGNED-API-Version-Violation", instance, loc,
                 "Attempted to call with an effective API version of %s, "
                 "which is the minimum of version requested in pApplicationInfo (%s) and supported by this physical device (%s), "
                 "but this API was not promoted until version %s.",
@@ -50,7 +50,7 @@ bool StatelessValidation::CheckPromotedApiAgainstVulkanVersion(VkPhysicalDevice 
 }
 
 bool StatelessValidation::OutputExtensionError(const Location &loc, const vvl::Extensions &exentsions) const {
-    return LogError(kVUID_PVError_ExtensionNotEnabled, instance, loc,
+    return LogError("UNASSIGNED-GeneralParameterError-ExtensionNotEnabled", instance, loc,
                     "function required extension %s which has not been enabled.\n", String(exentsions).c_str());
 }
 

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -22,9 +22,6 @@
 #include "sync/sync_utils.h"
 #include "state_tracker/cmd_buffer_state.h"
 
-[[maybe_unused]] static const char *kVUID_PVError_ExtensionNotEnabled = "UNASSIGNED-GeneralParameterError-ExtensionNotEnabled";
-[[maybe_unused]] static const char *kVUID_PVError_ApiVersionViolation = "UNASSIGNED-API-Version-Violation";
-
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
 
 class StatelessValidation : public ValidationObject {


### PR DESCRIPTION
These are now codegen, no need to keep these old one-off VU checks (these are VERY old)