### PR TITLE
layers: Improve RenderPass Compatibility messages

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -399,6 +399,7 @@ source_set("vulkan_layer_utils") {
     "layers/containers/sparse_containers.h",
     "layers/error_message/error_location.cpp",
     "layers/error_message/error_location.h",
+    "layers/error_message/error_strings.h",
     "layers/error_message/logging.cpp",
     "layers/error_message/logging.h",
     "layers/error_message/record_object.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -27,6 +27,7 @@ target_sources(VkLayer_utils PRIVATE
     error_message/logging.cpp
     error_message/error_location.cpp
     error_message/error_location.h
+    error_message/error_strings.h
     error_message/record_object.h
     external/xxhash.h
     ${API_TYPE}/generated/error_location_helper.cpp

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -19,6 +19,7 @@
 
 #include "best_practices/best_practices_validation.h"
 #include "best_practices/best_practices_error_enums.h"
+#include "error_message/error_strings.h"
 
 static inline bool RenderPassUsesAttachmentAsResolve(const safe_VkRenderPassCreateInfo2& createInfo, uint32_t attachment) {
     for (uint32_t subpass = 0; subpass < createInfo.subpassCount; subpass++) {
@@ -206,11 +207,10 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
                                           "%s %s: Attachment #%u in render pass has begun with VK_ATTACHMENT_LOAD_OP_LOAD.\n"
                                           "Submitting this renderpass will cause the driver to inject a readback of the attachment "
                                           "which will copy in total %u pixels (renderArea = "
-                                          "{ %" PRId32 ", %" PRId32 ", %" PRIu32 ", %" PRIu32 " }) to the tile buffer.",
+                                          "{ %s }) to the tile buffer.",
                                           VendorSpecificTag(kBPVendorArm), VendorSpecificTag(kBPVendorIMG), att,
                                           pRenderPassBegin->renderArea.extent.width * pRenderPassBegin->renderArea.extent.height,
-                                          pRenderPassBegin->renderArea.offset.x, pRenderPassBegin->renderArea.offset.y,
-                                          pRenderPassBegin->renderArea.extent.width, pRenderPassBegin->renderArea.extent.height);
+                                          string_VkRect2D(pRenderPassBegin->renderArea).c_str());
             }
         }
 

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -94,8 +94,8 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                     if (framebuffer->createInfo.renderPass != info->renderPass) {
                         auto render_pass = Get<vvl::RenderPass>(info->renderPass);
                         // renderPass that framebuffer was created with must be compatible with local renderPass
-                        skip |= ValidateRenderPassCompatibility("framebuffer", *framebuffer->rp_state.get(), "command buffer",
-                                                                *render_pass.get(), inheritance_loc,
+                        skip |= ValidateRenderPassCompatibility(framebuffer->Handle(), *framebuffer->rp_state.get(),
+                                                                cb_state->Handle(), *render_pass.get(), inheritance_loc,
                                                                 "VUID-VkCommandBufferBeginInfo-flags-00055");
                     }
                 }
@@ -897,8 +897,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         // Make sure render pass is compatible with parent command buffer pass if secondary command buffer has
                         // "render pass continue" usage flag
                         if (cb_state.activeRenderPass->VkHandle() != secondary_rp_state->VkHandle()) {
-                            skip |= ValidateRenderPassCompatibility("primary command buffer", *cb_state.activeRenderPass.get(),
-                                                                    "secondary command buffer", *secondary_rp_state.get(), cb_loc,
+                            skip |= ValidateRenderPassCompatibility(cb_state.Handle(), *cb_state.activeRenderPass.get(),
+                                                                    secondary_rp_state->Handle(), *secondary_rp_state.get(), cb_loc,
                                                                     "VUID-vkCmdExecuteCommands-pBeginInfo-06020");
                         }
                         //  If framebuffer for secondary CB is not NULL, then it must match active FB from primaryCB

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -50,8 +50,8 @@ struct ImageRegionIntersection {
         std::stringstream ss;
         ss << "{ subresource { aspectMask: " << string_VkImageAspectFlags(subresource.aspectMask)
            << ", mipLevel: " << subresource.mipLevel << ", baseArrayLayer: " << subresource.baseArrayLayer
-           << ", layerCount: " << subresource.layerCount << " }, offset {" << offset.x << ", " << offset.y << ", " << offset.z
-           << "}, extent {" << extent.width << ", " << extent.height << ", " << extent.depth << "} }";
+           << ", layerCount: " << subresource.layerCount << " }, offset {" << string_VkOffset3D(offset) << "}, extent {"
+           << string_VkExtent3D(extent) << "} }";
         return ss.str();
     }
 };
@@ -3065,9 +3065,8 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(VkDevice device, const vvl::Im
     }
     if ((src_info.extent.width != dst_info.extent.width) || (src_info.extent.height != dst_info.extent.height) ||
         (src_info.extent.depth != dst_info.extent.depth)) {
-        mismatch_stream << "srcImage extent.width = " << src_info.extent.width << " extent.height = " << src_info.extent.height
-                        << " extent.depth = " << src_info.extent.depth << " but dstImage extent.width = " << dst_info.extent.width
-                        << " extent.height = " << dst_info.extent.height << " extent.depth = " << dst_info.extent.depth << "\n";
+        mismatch_stream << "srcImage extent = (" << string_VkExtent3D(src_info.extent) << ") but dstImage exten = ("
+                        << string_VkExtent3D(dst_info.extent) << ")\n";
     }
     if (src_info.mipLevels != dst_info.mipLevels) {
         mismatch_stream << "srcImage mipLevels = " << src_info.mipLevels << "and dstImage mipLevels = " << dst_info.mipLevels

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -25,6 +25,7 @@
 #include "core_validation.h"
 #include "generated/chassis.h"
 #include "generated/pnext_chain_extraction.h"
+#include "error_message/error_strings.h"
 
 bool CoreChecks::ValidateImageFormatFeatures(const VkImageCreateInfo *pCreateInfo, const Location &loc) const {
     bool skip = false;
@@ -1024,13 +1025,6 @@ static inline bool ContainsRect(VkRect2D rect, VkRect2D sub_rect) {
         return false;
     }
     return true;
-}
-
-static std::string string_VkRect2D(VkRect2D rect) {
-    std::stringstream ss;
-    ss << "offset.x: " << rect.offset.x << ", offset.y: " << rect.offset.y << ", extent.width: " << rect.extent.width
-       << ", extent.height: " << rect.extent.height;
-    return ss.str();
 }
 
 bool CoreChecks::ValidateClearAttachmentExtent(const vvl::CommandBuffer &cb_state, const VkRect2D &render_area,

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3404,7 +3404,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
     // TODO: AMD extension codes are included here, but actual function entrypoints are not yet intercepted
     if (cb_state.activeRenderPass->VkHandle() != rp_state->VkHandle()) {
         // renderPass that PSO was created with must be compatible with active renderPass that PSO is being used with
-        skip |= ValidateRenderPassCompatibility("active render pass", *cb_state.activeRenderPass.get(), "pipeline state object",
+        skip |= ValidateRenderPassCompatibility(cb_state.Handle(), *cb_state.activeRenderPass.get(), pipeline.Handle(),
                                                 *rp_state.get(), loc, vuid.render_pass_compatible_02684);
     }
     const auto subpass = pipeline.Subpass();

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -25,6 +25,7 @@
 #include <vulkan/vk_enum_string_helper.h>
 #include "generated/chassis.h"
 #include "core_validation.h"
+#include "error_message/error_strings.h"
 
 static bool IsExtentInsideBounds(VkExtent2D extent, VkExtent2D min, VkExtent2D max) {
     if ((extent.width < min.width) || (extent.width > max.width) || (extent.height < min.height) || (extent.height > max.height)) {
@@ -129,15 +130,12 @@ bool CoreChecks::ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR pres
     auto pres_scale_ci = vku::FindStructInPNextChain<VkSwapchainPresentScalingCreateInfoEXT>(create_info->pNext);
     if ((!pres_scale_ci) || (pres_scale_ci && (pres_scale_ci->scalingBehavior == 0))) {
         if (!IsExtentInsideBounds(create_info->imageExtent, capabilities->minImageExtent, capabilities->maxImageExtent)) {
-            skip |= LogError("VUID-VkSwapchainCreateInfoKHR-pNext-07781", device, create_info_loc.dot(Field::imageExtent),
-                             "(%" PRIu32 ",%" PRIu32
-                             "), which is outside the bounds returned by "
-                             "vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (%" PRIu32 ",%" PRIu32
-                             "), minImageExtent = (%" PRIu32 ",%" PRIu32 "), maxImageExtent = (%" PRIu32 ",%" PRIu32 ").",
-                             create_info->imageExtent.width, create_info->imageExtent.height, capabilities->currentExtent.width,
-                             capabilities->currentExtent.height, capabilities->minImageExtent.width,
-                             capabilities->minImageExtent.height, capabilities->maxImageExtent.width,
-                             capabilities->maxImageExtent.height);
+            skip |= LogError(
+                "VUID-VkSwapchainCreateInfoKHR-pNext-07781", device, create_info_loc.dot(Field::imageExtent),
+                "(%s), which is outside the bounds returned by "
+                "vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (%s), minImageExtent = (%s), maxImageExtent = (%s).",
+                string_VkExtent2D(create_info->imageExtent).c_str(), string_VkExtent2D(capabilities->currentExtent).c_str(),
+                string_VkExtent2D(capabilities->minImageExtent).c_str(), string_VkExtent2D(capabilities->maxImageExtent).c_str());
         }
     }
 
@@ -231,12 +229,12 @@ bool CoreChecks::ValidateSwapchainPresentScalingCreateInfo(VkPresentModeKHR pres
             (!IsExtentInsideBounds(create_info->imageExtent, scaling_caps.minScaledImageExtent,
                                    scaling_caps.maxScaledImageExtent))) {
             if (LogError("VUID-VkSwapchainCreateInfoKHR-pNext-07782", device, create_info_loc.dot(Field::imageExtent),
-                         "(%" PRIu32 ",%" PRIu32 "), which is outside the bounds returned in "
-                         "VkSurfacePresentScalingCapabilitiesEXT minScaledImageExtent = (%" PRIu32 ",%" PRIu32 "), "
-                         "maxScaledImageExtent = (%" PRIu32 ",%" PRIu32 ").",
-                         create_info->imageExtent.width, create_info->imageExtent.height, scaling_caps.minScaledImageExtent.width,
-                         scaling_caps.minScaledImageExtent.height, scaling_caps.maxScaledImageExtent.width,
-                         scaling_caps.maxScaledImageExtent.height)) {
+                         "(%s), which is outside the bounds returned in "
+                         "VkSurfacePresentScalingCapabilitiesEXT minScaledImageExtent = (%s), "
+                         "maxScaledImageExtent = (%s).",
+                         string_VkExtent2D(create_info->imageExtent).c_str(),
+                         string_VkExtent2D(scaling_caps.minScaledImageExtent).c_str(),
+                         string_VkExtent2D(scaling_caps.maxScaledImageExtent).c_str())) {
                 skip |= true;
             }
         }
@@ -330,7 +328,7 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
 
     if ((pCreateInfo->imageExtent.width == 0) || (pCreateInfo->imageExtent.height == 0)) {
         if (LogError("VUID-VkSwapchainCreateInfoKHR-imageExtent-01689", device, create_info_loc.dot(Field::imageExtent),
-                     "width (%d) and height (%d) is invalid.", pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height)) {
+                     "(%s) is invalid.", string_VkExtent2D(pCreateInfo->imageExtent).c_str())) {
             return true;
         }
     }
@@ -544,17 +542,14 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
             if (!IsExtentInsideBounds(pCreateInfo->imageExtent, cached_capabilities.surfaceCapabilities.minImageExtent,
                                       cached_capabilities.surfaceCapabilities.maxImageExtent)) {
                 // TODO - Combine VUs with other same VUID
-                skip |= LogError(
-                    "VUID-VkSwapchainCreateInfoKHR-pNext-07781", device, create_info_loc.dot(Field::imageExtent),
-                    "(%" PRIu32 ", %" PRIu32
-                    "), which is outside the bounds returned by "
-                    "vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (%" PRIu32 ",%" PRIu32
-                    "), minImageExtent = (%" PRIu32 ",%" PRIu32 "), maxImageExtent = (%" PRIu32 ",%" PRIu32 ").",
-                    pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height,
-                    surface_caps2.surfaceCapabilities.currentExtent.width, surface_caps2.surfaceCapabilities.currentExtent.height,
-                    surface_caps2.surfaceCapabilities.minImageExtent.width, surface_caps2.surfaceCapabilities.minImageExtent.height,
-                    surface_caps2.surfaceCapabilities.maxImageExtent.width,
-                    surface_caps2.surfaceCapabilities.maxImageExtent.height);
+                skip |= LogError("VUID-VkSwapchainCreateInfoKHR-pNext-07781", device, create_info_loc.dot(Field::imageExtent),
+                                 "(%s), which is outside the bounds returned by "
+                                 "vkGetPhysicalDeviceSurfaceCapabilitiesKHR(): currentExtent = (%s), minImageExtent = (%s), "
+                                 "maxImageExtent = (%s).",
+                                 string_VkExtent2D(pCreateInfo->imageExtent).c_str(),
+                                 string_VkExtent2D(surface_caps2.surfaceCapabilities.currentExtent).c_str(),
+                                 string_VkExtent2D(surface_caps2.surfaceCapabilities.minImageExtent).c_str(),
+                                 string_VkExtent2D(surface_caps2.surfaceCapabilities.maxImageExtent).c_str());
             }
         }
     } else {
@@ -681,11 +676,11 @@ bool CoreChecks::ValidateCreateSwapchain(VkSwapchainCreateInfoKHR const *pCreate
     if ((pCreateInfo->imageExtent.width > image_properties.maxExtent.width) ||
         (pCreateInfo->imageExtent.height > image_properties.maxExtent.height)) {
         if (LogError("VUID-VkSwapchainCreateInfoKHR-imageFormat-01778", device, create_info_loc.dot(Field::imageExtent),
-                     "(%d,%d), which is bigger than max extent (%d,%d)"
+                     "(%s), which is bigger than max extent (%s)"
                      "returned by vkGetPhysicalDeviceImageFormatProperties(): "
                      "for imageFormat %s with tiling VK_IMAGE_TILING_OPTIMAL.",
-                     pCreateInfo->imageExtent.width, pCreateInfo->imageExtent.height, image_properties.maxExtent.width,
-                     image_properties.maxExtent.height, string_VkFormat(pCreateInfo->imageFormat))) {
+                     string_VkExtent2D(pCreateInfo->imageExtent).c_str(), string_VkExtent3D(image_properties.maxExtent).c_str(),
+                     string_VkFormat(pCreateInfo->imageFormat))) {
             return true;
         }
     }
@@ -886,14 +881,11 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
                             image_state->createInfo.extent.width ||
                         display_present_info->srcRect.offset.y + display_present_info->srcRect.extent.height >
                             image_state->createInfo.extent.height) {
-                        skip |= LogError("VUID-VkDisplayPresentInfoKHR-srcRect-01257", queue, swapchain_loc,
-                                         "vkQueuePresentKHR(): VkDisplayPresentInfoKHR::srcRect (offset (%" PRIu32 ", %" PRIu32
-                                         "), extent (%" PRIu32 ", %" PRIu32
-                                         ")) in the pNext chain of VkPresentInfoKHR is not a subset of the image begin presented "
-                                         "(extent (%" PRIu32 ", %" PRIu32 ")).",
-                                         display_present_info->srcRect.offset.x, display_present_info->srcRect.offset.y,
-                                         display_present_info->srcRect.extent.width, display_present_info->srcRect.extent.height,
-                                         image_state->createInfo.extent.width, image_state->createInfo.extent.height);
+                        skip |= LogError("VUID-VkDisplayPresentInfoKHR-srcRect-01257", queue,
+                                         present_info_loc.pNext(Struct::VkDisplayPresentInfoKHR, Field::srcRect),
+                                         "(%s) is not a subset of the image begin presented extent (%s).",
+                                         string_VkRect2D(display_present_info->srcRect).c_str(),
+                                         string_VkExtent3D(image_state->createInfo.extent).c_str());
                     }
                 }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -266,30 +266,23 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDrawDynamicStatePipeline(const LastBound& last_bound_state, const Location& loc) const;
     bool ValidateDrawDynamicStateShaderObject(const LastBound& last_bound_state, const Location& loc) const;
     bool ValidateRayTracingDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const;
-    bool LogInvalidAttachmentMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                     const vvl::RenderPass& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
-                                     const char* msg, const Location& loc, const char* error_code) const;
-    bool LogInvalidPnextMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                const vvl::RenderPass& rp2_state, const char* msg, const Location& loc,
-                                const char* error_code) const;
-    bool LogInvalidDependencyMessage(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                     const vvl::RenderPass& rp2_state, const char* msg, const Location& loc,
-                                     const char* error_code) const;
     bool ValidateStageMaskHost(const Location& stage_mask_loc, VkPipelineStageFlags2KHR stageMask) const;
     bool ValidateMapMemory(const vvl::DeviceMemory& mem_info, VkDeviceSize offset, VkDeviceSize size, const Location& offset_loc,
                            const Location& size_loc) const;
     bool ValidateRenderPassDAG(const VkRenderPassCreateInfo2* pCreateInfo, const ErrorObject& error_obj) const;
-    bool ValidateAttachmentCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                         const vvl::RenderPass& rp2_state, uint32_t primary_attach, uint32_t secondary_attach,
-                                         const Location& loc, const char* error_code) const;
-    bool ValidateSubpassCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                      const vvl::RenderPass& rp2_state, const int subpass, const Location& loc,
-                                      const char* error_code) const;
-    bool ValidateDependencyCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                         const vvl::RenderPass& rp2_state, const uint32_t dependency, const Location& loc,
-                                         const char* error_code) const;
-    bool ValidateRenderPassCompatibility(const char* type1_string, const vvl::RenderPass& rp1_state, const char* type2_string,
-                                         const vvl::RenderPass& rp2_state, const Location& loc, const char* vuid) const;
+    bool ValidateAttachmentCompatibility(const VulkanTypedHandle& rp1_object, const vvl::RenderPass& rp1_state,
+                                         const VulkanTypedHandle& rp2_object, const vvl::RenderPass& rp2_state,
+                                         uint32_t primary_attachment, uint32_t secondary_attachment, const Location& caller_loc,
+                                         const Location& attachment_loc, const char* vuid) const;
+    bool ValidateSubpassCompatibility(const VulkanTypedHandle& rp1_object, const vvl::RenderPass& rp1_state,
+                                      const VulkanTypedHandle& rp2_object, const vvl::RenderPass& rp2_state, const int subpass,
+                                      const Location& loc, const char* vuid) const;
+    bool ValidateDependencyCompatibility(const VulkanTypedHandle& rp1_object, const vvl::RenderPass& rp1_state,
+                                         const VulkanTypedHandle& rp2_object, const vvl::RenderPass& rp2_state,
+                                         const uint32_t dependency, const Location& loc, const char* vuid) const;
+    bool ValidateRenderPassCompatibility(const VulkanTypedHandle& rp1_object, const vvl::RenderPass& rp1_state,
+                                         const VulkanTypedHandle& rp2_object, const vvl::RenderPass& rp2_state, const Location& loc,
+                                         const char* vuid) const;
     bool ReportInvalidCommandBuffer(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const;
     bool ValidateQueueFamilyIndex(const vvl::PhysicalDevice* pd_state, uint32_t requested_queue_family, const char* vuid,
                                   const Location& loc) const;

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -1,0 +1,51 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <string>
+
+[[maybe_unused]] static std::string string_Attachment(uint32_t attachment) {
+    if (attachment == VK_ATTACHMENT_UNUSED) {
+        return "VK_ATTACHMENT_UNUSED";
+    } else {
+        return std::to_string(attachment);
+    }
+}
+
+[[maybe_unused]] static std::string string_VkExtent2D(VkExtent2D extent) {
+    std::stringstream ss;
+    ss << "Width = " << extent.width << ", Height = " << extent.height;
+    return ss.str();
+}
+
+[[maybe_unused]] static std::string string_VkExtent3D(VkExtent3D extent) {
+    std::stringstream ss;
+    ss << "Width = " << extent.width << ", Height = " << extent.height << ", Depth = " << extent.depth;
+    return ss.str();
+}
+
+[[maybe_unused]] static std::string string_VkOffset2D(VkOffset2D offset) {
+    std::stringstream ss;
+    ss << "x = " << offset.x << ", y = " << offset.y;
+    return ss.str();
+}
+
+[[maybe_unused]] static std::string string_VkOffset3D(VkOffset3D offset) {
+    std::stringstream ss;
+    ss << "x = " << offset.x << ", y = " << offset.y << ", z = " << offset.z;
+    return ss.str();
+}

--- a/layers/error_message/error_strings.h
+++ b/layers/error_message/error_strings.h
@@ -28,13 +28,13 @@
 
 [[maybe_unused]] static std::string string_VkExtent2D(VkExtent2D extent) {
     std::stringstream ss;
-    ss << "Width = " << extent.width << ", Height = " << extent.height;
+    ss << "width = " << extent.width << ", height = " << extent.height;
     return ss.str();
 }
 
 [[maybe_unused]] static std::string string_VkExtent3D(VkExtent3D extent) {
     std::stringstream ss;
-    ss << "Width = " << extent.width << ", Height = " << extent.height << ", Depth = " << extent.depth;
+    ss << "width = " << extent.width << ", height = " << extent.height << ", depth = " << extent.depth;
     return ss.str();
 }
 
@@ -47,5 +47,12 @@
 [[maybe_unused]] static std::string string_VkOffset3D(VkOffset3D offset) {
     std::stringstream ss;
     ss << "x = " << offset.x << ", y = " << offset.y << ", z = " << offset.z;
+    return ss.str();
+}
+
+[[maybe_unused]] static std::string string_VkRect2D(VkRect2D rect) {
+    std::stringstream ss;
+    ss << "offset.x = " << rect.offset.x << ", offset.y = " << rect.offset.y << ", extent.width = " << rect.extent.width
+       << ", extent.height = " << rect.extent.height;
     return ss.str();
 }


### PR DESCRIPTION
The renderpass compatibility error messages were not well written and even I had to look at the code to understand them

This both unifies how we print things and adds some useful utils for printing other error strings