### PR TITLE
sync: Handle command without debug label and simplify code

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1675,7 +1675,14 @@ void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand> &lab
     }
 }
 
-std::string CommandBuffer::GetDebugRegionNameForLabelStack(const std::vector<std::string> &label_stack) {
+std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &label_commands, uint32_t label_command_index,
+                                              const std::vector<std::string> &initial_label_stack) {
+    assert(label_command_index < label_commands.size());
+
+    auto commands_to_replay = vvl::make_span(label_commands.data(), label_command_index + 1);
+    auto label_stack = initial_label_stack;
+    vvl::CommandBuffer::ReplayLabelCommands(commands_to_replay, label_stack);
+
     std::string debug_region;
     for (const std::string &label_name : label_stack) {
         if (!debug_region.empty()) {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -699,8 +699,9 @@ class CommandBuffer : public RefcountedStateObject {
     // Applies label commands to the label_stack: for "begin label" command it pushes
     // a label on the stack, and for the "end label" command it removes the top label.
     static void ReplayLabelCommands(const vvl::span<const LabelCommand> &label_commands, std::vector<std::string> &label_stack);
-    // Forms a debug  region name which is a concatenation of all nested labels (label_stack) separated by a delimiter.
-    static std::string GetDebugRegionNameForLabelStack(const std::vector<std::string> &label_stack);
+    // Computes debug region by replaying given commands on top initial label stack.
+    static std::string GetDebugRegionName(const std::vector<LabelCommand> &label_commands, uint32_t label_command_index,
+                                          const std::vector<std::string> &initial_label_stack = {});
 
   private:
     void ResetCBState();

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -913,12 +913,7 @@ ResourceUsageTag CommandBufferAccessContext::NextIndexedCommandTag(vvl::Func com
 std::string CommandBufferAccessContext::GetDebugRegionName(const ResourceUsageRecord &record) const {
     const bool use_proxy = !proxy_label_commands_.empty();
     const auto &label_commands = use_proxy ? proxy_label_commands_ : cb_state_->GetLabelCommands();
-    assert(record.label_command_index < label_commands.size());
-    auto command_to_replay = vvl::make_span(label_commands.data(), record.label_command_index + 1);
-    std::vector<std::string> label_stack;
-    vvl::CommandBuffer::ReplayLabelCommands(command_to_replay, label_stack);
-    const auto debug_region = vvl::CommandBuffer::GetDebugRegionNameForLabelStack(label_stack);
-    return debug_region;
+    return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index);
 }
 
 void CommandBufferAccessContext::RecordSyncOp(SyncOpPointer &&sync_op) {

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -164,7 +164,7 @@ class BatchAccessLog {
         const BatchRecord *batch;
         const ResourceUsageRecord *record;
         const DebugNameProvider *debug_name_provider;
-        bool IsValid() const { return batch && record && debug_name_provider; }
+        bool IsValid() const { return batch && record; }
     };
 
     struct CBSubmitLog : DebugNameProvider {


### PR DESCRIPTION
If there is no debug label for a specific position in the command
stream, we use `Uint32Max` as a label command index. We need to check
this case and skip debug region reporting. It was done in one place
but was missing in another place.

Adding necessary check allowed to simplify implementation. Two
implementations of `GetDebugRegionName` became almost identical
(in` CommandBuffer` and `QueueBatch` context). The main logic was moved
into a shared helper function.

Addresses the first part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7502
