### PR TITLE
sync: Fix label code crash when timeline semaphores are used

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -911,7 +911,8 @@ BatchAccessLog::AccessRecord BatchAccessLog::operator[](ResourceUsageTag tag) co
 }
 
 std::string BatchAccessLog::CBSubmitLog::GetDebugRegionName(const ResourceUsageRecord& record) const {
-    const auto& label_commands = (*cbs_)[0]->GetLabelCommands();
+    // const auto& label_commands = (*cbs_)[0]->GetLabelCommands();
+    const auto& label_commands = label_commands_;  // TODO: use the above line when timelines are supported
     return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index, initial_label_stack_);
 }
 
@@ -932,7 +933,9 @@ BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch,
 
 BatchAccessLog::CBSubmitLog::CBSubmitLog(const BatchRecord& batch, const CommandBufferAccessContext& cb,
                                          const std::vector<std::string>& initial_label_stack)
-    : batch_(batch), cbs_(cb.GetCBReferencesShared()), log_(cb.GetAccessLogShared()), initial_label_stack_(initial_label_stack) {}
+    : batch_(batch), cbs_(cb.GetCBReferencesShared()), log_(cb.GetAccessLogShared()), initial_label_stack_(initial_label_stack) {
+    label_commands_ = (*cbs_)[0]->GetLabelCommands();  // TODO: when timelines are supported use cbs directly
+}
 
 PresentedImage::PresentedImage(const SyncValidator& sync_state, const std::shared_ptr<QueueBatchContext> batch_,
                                VkSwapchainKHR swapchain, uint32_t image_index_, uint32_t present_index_, ResourceUsageTag tag_)

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -190,6 +190,16 @@ class BatchAccessLog {
         std::shared_ptr<const CommandExecutionContext::AccessLog> log_;
         // label stack at the point when command buffer is submitted to the queue
         std::vector<std::string> initial_label_stack_;
+
+        // TODO: remove this field and use (*cbs_)[0]->GetLabelCommands() directly
+        // when timeline semaphore support is implemented.
+        //
+        // Until then, there is no guarantee command buffers stored in cbs_ are what
+        // they are supposed to be when timeline semaphores are used (they can be reused
+        // after wait on timeline semaphore). When this happens, validation might report
+        // false positives (which is okay for unsupported feeature), but label code can crash.
+        // Make a copy of label commands as a temporary protection measure.
+        std::vector<vvl::CommandBuffer::LabelCommand> label_commands_;
     };
 
     ResourceUsageTag Import(const BatchRecord &batch, const CommandBufferAccessContext &cb_access,


### PR DESCRIPTION
Timeline semaphores are not supported yet but the code should not crash

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7502
