### PR TITLE
gpuav: Fix speed regression

### DIFF
--- a/layers/gpu_validation/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu_validation/spirv/bindless_descriptor_pass.cpp
@@ -429,21 +429,5 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
     return true;
 }
 
-void BindlessDescriptorPass::Run() {
-    for (const auto& function : module_.functions_) {
-        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
-            for (auto inst_it = (*block_it)->instructions_.begin(); inst_it != (*block_it)->instructions_.end(); ++inst_it) {
-                if (AnalyzeInstruction(*(function.get()), *(inst_it->get()))) {
-                    block_it = InjectFunctionCheck(function.get(), block_it, inst_it);
-
-                    // will start searching again from newly split merge block
-                    block_it--;
-                    break;
-                }
-            }
-        }
-    }
-}
-
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpu_validation/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu_validation/spirv/bindless_descriptor_pass.h
@@ -34,15 +34,14 @@ struct Type;
 class BindlessDescriptorPass : public Pass {
   public:
     BindlessDescriptorPass(Module& module) : Pass(module) {}
-    void Run() override;
 
   private:
+    bool AnalyzeInstruction(const Function& function, const Instruction& inst) override;
     uint32_t CreateFunctionCall(BasicBlock& block) override;
     void Reset() override;
 
     uint32_t FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride = 0, bool col_major = false, bool in_matrix = false);
     uint32_t GetLastByte(BasicBlock& block);
-    bool AnalyzeInstruction(const Function& function, const Instruction& inst);
 
     uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();

--- a/layers/gpu_validation/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpu_validation/spirv/buffer_device_address_pass.cpp
@@ -97,21 +97,5 @@ bool BufferDeviceAddressPass::AnalyzeInstruction(const Function& function, const
     return true;
 }
 
-void BufferDeviceAddressPass::Run() {
-    for (const auto& function : module_.functions_) {
-        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
-            for (auto inst_it = (*block_it)->instructions_.begin(); inst_it != (*block_it)->instructions_.end(); ++inst_it) {
-                if (AnalyzeInstruction(*(function.get()), *(inst_it->get()))) {
-                    block_it = InjectFunctionCheck(function.get(), block_it, inst_it);
-
-                    // will start searching again from newly split merge block
-                    block_it--;
-                    break;
-                }
-            }
-        }
-    }
-}
-
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpu_validation/spirv/buffer_device_address_pass.h
+++ b/layers/gpu_validation/spirv/buffer_device_address_pass.h
@@ -56,13 +56,11 @@ struct Intruction;
 class BufferDeviceAddressPass : public Pass {
   public:
     BufferDeviceAddressPass(Module& module) : Pass(module) {}
-    void Run() override;
 
   private:
+    bool AnalyzeInstruction(const Function& function, const Instruction& inst) override;
     uint32_t CreateFunctionCall(BasicBlock& block) override;
     void Reset() override;
-
-    bool AnalyzeInstruction(const Function& function, const Instruction& inst);
 
     uint32_t link_function_id = 0;
     uint32_t GetLinkFunctionId();

--- a/layers/gpu_validation/spirv/function_basic_block.cpp
+++ b/layers/gpu_validation/spirv/function_basic_block.cpp
@@ -48,6 +48,8 @@ BasicBlock::BasicBlock(Module& module, Function& function) : function_(function)
     CreateInstruction(spv::OpLabel, {new_label_id});
 }
 
+uint32_t BasicBlock::GetLabelId() { return (*(instructions_[0])).ResultId(); }
+
 void BasicBlock::CreateInstruction(spv::Op opcode, const std::vector<uint32_t>& words, InstructionIt* inst_it) {
     const bool add_to_end = inst_it == nullptr;
     InstructionIt last_inst = instructions_.end();

--- a/layers/gpu_validation/spirv/function_basic_block.h
+++ b/layers/gpu_validation/spirv/function_basic_block.h
@@ -41,7 +41,7 @@ struct BasicBlock {
 
     void ToBinary(std::vector<uint32_t>& out);
 
-    const Instruction& GetLabel() { return *instructions_[0].get(); }
+    uint32_t GetLabelId();
 
     // Creates instruction and inserts it before the Instruction, updates poistion after new instruciton.
     // If no InstructionIt is provided, it will add it to the end of the block.

--- a/layers/gpu_validation/spirv/pass.cpp
+++ b/layers/gpu_validation/spirv/pass.cpp
@@ -323,10 +323,9 @@ BasicBlockIt Pass::InjectFunctionCheck(Function* function, BasicBlockIt block_it
     invalid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
 
     // move all remaining instructions to the newly created merge block
-    while (inst_it != original_block.instructions_.end()) {
-        merge_block.instructions_.emplace_back(std::move(*inst_it));
-        inst_it = original_block.instructions_.erase(inst_it);
-    }
+    merge_block.instructions_.insert(merge_block.instructions_.end(), std::make_move_iterator(inst_it),
+                                     std::make_move_iterator(original_block.instructions_.end()));
+    original_block.instructions_.erase(inst_it, original_block.instructions_.end());
 
     // Go back to original Block and add function call and branch from the bool result
     const uint32_t function_result = CreateFunctionCall(original_block);

--- a/layers/gpu_validation/spirv/pass.h
+++ b/layers/gpu_validation/spirv/pass.h
@@ -28,7 +28,7 @@ struct BasicBlock;
 // Common helpers for all passes
 class Pass {
   public:
-    virtual void Run() = 0;
+    void Run();
 
     // Finds (and creates if needed) decoration and returns the OpVariable it points to
     const Variable& GetBuiltinVariable(uint32_t built_in);
@@ -50,6 +50,8 @@ class Pass {
 
     BasicBlockIt InjectFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it);
 
+    // Each pass decides if the instruction should needs to have its function check injected
+    virtual bool AnalyzeInstruction(const Function& function, const Instruction& inst) = 0;
     // A callback from the function injection logic.
     // Each pass creates a OpFunctionCall and returns its result id.
     virtual uint32_t CreateFunctionCall(BasicBlock& block) = 0;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7506

The use of `insert` and `std::make_move_iterator` showed a 20x speed up and mostly got performance on par. The current way we do injection is not ideal for cases where we have tons of access in a huge Function block, but there are other things planned I have to help mitigate that