### PR TITLE
gpuav: Fix creating invalid SPIR-V from loop headers

### DIFF
--- a/layers/gpu_validation/spirv/function_basic_block.h
+++ b/layers/gpu_validation/spirv/function_basic_block.h
@@ -49,6 +49,8 @@ struct BasicBlock {
 
     InstructionList instructions_;
     Function& function_;
+
+    bool loop_header_ = false;
 };
 
 using BasicBlockList = std::vector<std::unique_ptr<BasicBlock>>;

--- a/layers/gpu_validation/spirv/module.cpp
+++ b/layers/gpu_validation/spirv/module.cpp
@@ -122,6 +122,10 @@ Module::Module(std::vector<uint32_t> words, uint32_t shader_id, uint32_t output_
             function_end_found = true;
         }
 
+        if (opcode == spv::OpLoopMerge) {
+            current_block->loop_header_ = true;
+        }
+
         if (opcode == spv::OpLabel) {
             block_found = true;
             auto new_block = std::make_unique<BasicBlock>(std::move(new_inst), *current_function);

--- a/layers/gpu_validation/spirv/pass.cpp
+++ b/layers/gpu_validation/spirv/pass.cpp
@@ -342,7 +342,11 @@ BasicBlockIt Pass::InjectFunctionCheck(Function* function, BasicBlockIt block_it
 void Pass::Run() {
     for (const auto& function : module_.functions_) {
         for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
-            for (auto inst_it = (*block_it)->instructions_.begin(); inst_it != (*block_it)->instructions_.end(); ++inst_it) {
+            if ((*block_it)->loop_header_) {
+                continue;  // Currently can't properly handle injecting CFG logic into a loop header block
+            }
+            auto& block_instructions = (*block_it)->instructions_;
+            for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
                 if (AnalyzeInstruction(*(function.get()), *(inst_it->get()))) {
                     block_it = InjectFunctionCheck(function.get(), block_it, inst_it);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/gpu_av_oob.cpp
     unit/gpu_av_oob_positive.cpp
     unit/gpu_av_positive.cpp
+    unit/gpu_av_spirv.cpp
     unit/gpu_av_spirv_positive.cpp
     unit/graphics_library.cpp
     unit/graphics_library_positive.cpp

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -1,0 +1,118 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "../framework/pipeline_helper.h"
+#include "../framework/descriptor_helper.h"
+#include "../framework/gpu_av_helper.h"
+
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462
+TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
+    TEST_DESCRIPTION("Require injection in the Loop Header block that contains a Phi");
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // The folling HLSL:
+    //
+    // RWStructuredBuffer<int> data : register(u0);
+    // [numthreads(1, 1, 1)]
+    // void main() {
+    //     int i = 0;
+    //     for (i = 0; i < data[i]; i++) {
+    //         data[0] += i;
+    //     }
+    // }
+    //
+    // Produces a required OOB check in the Loop Header block
+    // The issue is the OpPhi inside the loop header, it needs to be
+    // in the OpLoopMerge block for the back edge (%19) to be valid.
+    // This means doing a if/else like normal breaks this.
+    const char *cs_source = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %data
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %data DescriptorSet 0
+               OpDecorate %data Binding 0
+               OpDecorate %runtimearr ArrayStride 4
+               OpMemberDecorate %type_RWStructuredBuffer 0 Offset 0
+               OpDecorate %type_RWStructuredBuffer Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+      %int_1 = OpConstant %int 1
+%runtimearr = OpTypeRuntimeArray %int
+%type_RWStructuredBuffer = OpTypeStruct %runtimearr
+%ptr_RWStructuredBuffer = OpTypePointer StorageBuffer %type_RWStructuredBuffer
+       %void = OpTypeVoid
+         %12 = OpTypeFunction %void
+%ptr_StorageBuffer = OpTypePointer StorageBuffer %int
+       %bool = OpTypeBool
+       %data = OpVariable %ptr_RWStructuredBuffer StorageBuffer
+       %main = OpFunction %void None %12
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %int %int_0 %15 %18 %19
+         %20 = OpBitcast %uint %17
+         %21 = OpAccessChain %ptr_StorageBuffer %data %int_0 %20
+         %22 = OpLoad %int %21
+         %23 = OpSLessThan %bool %17 %22
+               OpLoopMerge %24 %19 None
+               OpBranchConditional %23 %19 %24
+         %19 = OpLabel
+         %25 = OpAccessChain %ptr_StorageBuffer %data %int_0 %uint_0
+         %26 = OpLoad %int %25
+         %27 = OpIAdd %int %26 %17
+               OpStore %25 %27
+         %18 = OpIAdd %int %17 %int_1
+               OpBranch %16
+         %24 = OpLabel
+               OpReturn
+               OpFunctionEnd
+        )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.InitState();
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
+    uint32_t *data = (uint32_t *)buffer.memory().map();
+    // Will get to data[4] in loop and can crash
+    data[0] = 32;  // data[0]
+    data[1] = 32;  // data[1]
+    data[2] = 32;  // data[2]
+    data[3] = 32;  // data[3]
+    buffer.memory().unmap();
+
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
+    m_commandBuffer->end();
+
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
+}

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -21,7 +21,7 @@
 #include "../framework/gpu_av_helper.h"
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462
-TEST_F(PositiveGpuAVSpirv, DISABLED_LoopPhi) {
+TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     TEST_DESCRIPTION("Loop that has the Phi parent pointed to itself");
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
@@ -46,7 +46,7 @@ TEST_F(PositiveGpuAVSpirv, DISABLED_LoopPhi) {
     descriptor_set.UpdateDescriptorSets();
 
     // compiled with
-    //  dxc -spirv -T ps_6_0 -E psmain -fspv-target-env=vulkan1.1 a.hlsl -fo a.spv
+    //  dxc -spirv -T ps_6_0 -E psmain -fspv-target-env=vulkan1.1
     //
     //  struct SceneData {
     //      uint lightCount;
@@ -170,6 +170,100 @@ TEST_F(PositiveGpuAVSpirv, DISABLED_LoopPhi) {
 
     m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
+}
+
+TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
+    TEST_DESCRIPTION("Require injection in the Loop Header block that contains a Phi");
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // The folling HLSL:
+    //
+    // RWStructuredBuffer<int> data : register(u0);
+    // [numthreads(1, 1, 1)]
+    // void main() {
+    //     int i = 0;
+    //     for (i = 0; i < data[i]; i++) {
+    //         data[0] += i;
+    //     }
+    // }
+    const char *cs_source = R"(
+               OpCapability Shader
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main" %data
+               OpExecutionMode %main LocalSize 1 1 1
+               OpDecorate %data DescriptorSet 0
+               OpDecorate %data Binding 0
+               OpDecorate %runtimearr ArrayStride 4
+               OpMemberDecorate %type_RWStructuredBuffer 0 Offset 0
+               OpDecorate %type_RWStructuredBuffer Block
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+       %uint = OpTypeInt 32 0
+     %uint_0 = OpConstant %uint 0
+      %int_1 = OpConstant %int 1
+%runtimearr = OpTypeRuntimeArray %int
+%type_RWStructuredBuffer = OpTypeStruct %runtimearr
+%ptr_RWStructuredBuffer = OpTypePointer StorageBuffer %type_RWStructuredBuffer
+       %void = OpTypeVoid
+         %12 = OpTypeFunction %void
+%ptr_StorageBuffer = OpTypePointer StorageBuffer %int
+       %bool = OpTypeBool
+       %data = OpVariable %ptr_RWStructuredBuffer StorageBuffer
+       %main = OpFunction %void None %12
+         %15 = OpLabel
+               OpBranch %16
+         %16 = OpLabel
+         %17 = OpPhi %int %int_0 %15 %18 %19
+         %20 = OpBitcast %uint %17
+         %21 = OpAccessChain %ptr_StorageBuffer %data %int_0 %20
+         %22 = OpLoad %int %21
+         %23 = OpSLessThan %bool %17 %22
+               OpLoopMerge %24 %19 None
+               OpBranchConditional %23 %19 %24
+         %19 = OpLabel
+         %25 = OpAccessChain %ptr_StorageBuffer %data %int_0 %uint_0
+         %26 = OpLoad %int %25
+         %27 = OpIAdd %int %26 %17
+               OpStore %25 %27
+         %18 = OpIAdd %int %17 %int_1
+               OpBranch %16
+         %24 = OpLabel
+               OpReturn
+               OpFunctionEnd
+        )";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
+    pipe.InitState();
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
+    pipe.CreateComputePipeline();
+
+    VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
+    vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
+    uint32_t *data = (uint32_t *)buffer.memory().map();
+    data[0] = 1;  // data[0]
+    data[1] = 2;  // data[1]
+    data[2] = 3;  // data[2]
+    data[3] = 0;  // data[3]
+    buffer.memory().unmap();
+
+    pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipe.descriptor_set_->UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
+                              &pipe.descriptor_set_->set_, 0, nullptr);
+    vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
+    m_commandBuffer->end();
+
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
+
+    data = (uint32_t *)buffer.memory().map();
+    ASSERT_EQ(4u, data[0]);
+    buffer.memory().unmap();
 }
 
 TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {


### PR DESCRIPTION
> "when you look at the edge cases and the things that make control flow hard, 95% of them come from loops"
>
> ~ https://youtu.be/7C4PmtqBVqo?si=PNeLcGijKCNgqBdV&t=973

closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4827

I found that when dealing with a `OpPhi` inside a `Loop header block` it gets really tricky to generate valid SPIR-V that still injects the needed function call.

Since this is a rare case, I rather just ignore it for now (tracked in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462) as generating invalid Control Flow is much worse