### PR TITLE
build: Update gpu_resources.cpp to .h in BUILD.gn

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -169,7 +169,7 @@ vvl_sources = [
   "layers/gpu_validation/gpu_subclasses.cpp",
   "layers/gpu_validation/gpu_subclasses.h",
   "layers/gpu_validation/gpu_record.cpp",
-  "layers/gpu_validation/gpu_resources.cpp",
+  "layers/gpu_validation/gpu_resources.h",
   "layers/gpu_validation/gpu_settings.h",
   "layers/gpu_validation/gpu_setup.cpp",
   "layers/gpu_validation/gpu_validation.cpp",


### PR DESCRIPTION
Fixes #7523

This appears to have been a typo (it's not consistent with the
CMakeLists.txt files) and is blocking rolling in the latest
changes into the Dawn (WebGPU) project. Verified with a local
build.