### PR TITLE
tests: Remove VkImageObj

### DIFF
--- a/tests/framework/barrier_queue_family.h
+++ b/tests/framework/barrier_queue_family.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -34,7 +34,7 @@ class BarrierQueueFamilyBase {
         void Reset();
     };
 
-    BarrierQueueFamilyBase(Context *context) : context_(context), image_(context->layer_test->DeviceObj()) {}
+    BarrierQueueFamilyBase(Context *context) : context_(context) {}
 
     QueueFamilyObjs *GetQueueFamilyInfo(Context *context, uint32_t qfi);
 
@@ -46,7 +46,7 @@ class BarrierQueueFamilyBase {
 
     static const uint32_t kInvalidQueueFamily = vvl::kU32Max;
     Context *context_;
-    VkImageObj image_;
+    vkt::Image image_;
     vkt::Buffer buffer_;
 };
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -216,7 +216,7 @@ class Device : public internal::Handle<VkDevice> {
     const PhysicalDevice &phy() const { return phy_; }
 
     std::vector<const char *> GetEnabledExtensions() { return enabled_extensions_; }
-    bool IsEnabledExtension(const char *extension);
+    bool IsEnabledExtension(const char *extension) const;
 
     // vkGetDeviceProcAddr()
     PFN_vkVoidFunction get_proc(const char *name) const { return vk::GetDeviceProcAddr(handle(), name); }
@@ -247,9 +247,10 @@ class Device : public internal::Handle<VkDevice> {
         VkImageTiling tiling;
         VkFlags features;
     };
-    // vkGetFormatInfo()
-    VkFormatProperties format_properties(VkFormat format);
-    const std::vector<Format> &formats() const { return formats_; }
+
+    VkFormatFeatureFlags2 FormatFeaturesLinear(VkFormat format) const;
+    VkFormatFeatureFlags2 FormatFeaturesOptimal(VkFormat format) const;
+    VkFormatFeatureFlags2 FormatFeaturesBuffer(VkFormat format) const;
 
     // vkDeviceWaitIdle()
     void wait() const;
@@ -293,13 +294,11 @@ class Device : public internal::Handle<VkDevice> {
     };
 
     void init_queues(const VkDeviceCreateInfo &info);
-    void init_formats();
 
     std::vector<const char *> enabled_extensions_;
 
     QueueFamilies queue_families_;
     std::vector<Queue *> queues_[QUEUE_COUNT];
-    std::vector<Format> formats_;
 };
 
 class Queue : public internal::Handle<VkQueue> {
@@ -347,7 +346,7 @@ class DeviceMemory : public internal::NonDispHandle<VkDeviceMemory> {
     void unmap() const;
 	const auto &get_memory_allocate_info() { return memory_allocate_info_; }
 
-        static VkMemoryAllocateInfo get_resource_alloc_info(const vkt::Device &dev, const VkMemoryRequirements &reqs,
+        static VkMemoryAllocateInfo get_resource_alloc_info(const Device &dev, const VkMemoryRequirements &reqs,
                                                             VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
 
       private:
@@ -453,6 +452,8 @@ class QueryPool : public internal::NonDispHandle<VkQueryPool> {
 
 struct NoMemT {};
 static constexpr NoMemT no_mem{};
+struct SetLayoutT {};
+static constexpr SetLayoutT set_layout{};
 
 class Buffer : public internal::NonDispHandle<VkBuffer> {
   public:
@@ -577,21 +578,32 @@ inline VkBufferViewCreateInfo BufferView::createInfo(VkBuffer buffer, VkFormat f
 
 class Image : public internal::NonDispHandle<VkImage> {
   public:
-    explicit Image() : NonDispHandle(), format_features_(0) {}
-    explicit Image(const Device &dev, const VkImageCreateInfo &info) : format_features_(0) { init(dev, info); }
+    explicit Image() : NonDispHandle() {}
+    explicit Image(const Device &dev, const VkImageCreateInfo &info);
     explicit Image(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props,
                    void *alloc_info_pnext = nullptr);
-    explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT) : format_features_(0) { init_no_mem(dev, info); }
+    explicit Image(const Device &dev, uint32_t const width, uint32_t const height, uint32_t const mip_levels, VkFormat const format,
+                   VkFlags const usage);
+
+    explicit Image(const Device &dev, const VkImageCreateInfo &info, NoMemT);
+    explicit Image(const Device &dev, const VkImageCreateInfo &info, SetLayoutT);
 
     ~Image() noexcept;
     void destroy() noexcept;
 
-    // vkCreateImage()
     void init(const Device &dev, const VkImageCreateInfo &info, VkMemoryPropertyFlags mem_props, void *alloc_info_pnext = nullptr);
-    void init(const Device &dev, const VkImageCreateInfo &info) { init(dev, info, 0); }
+    void Init(const Device &dev, uint32_t const width, uint32_t const height, uint32_t const mip_levels, VkFormat const format,
+              VkFlags const usage);
     void init_no_mem(const Device &dev, const VkImageCreateInfo &info);
 
+    static VkImageCreateInfo ImageCreateInfo2D(uint32_t const width, uint32_t const height, uint32_t const mip_levels,
+                                               uint32_t const layers, VkFormat const format, VkFlags const usage,
+                                               VkImageTiling const requested_tiling = VK_IMAGE_TILING_OPTIMAL,
+                                               const std::vector<uint32_t> *queue_families = nullptr);
+
     VkImage image() const { return handle(); }
+
+    static bool IsCompatible(const Device &dev, VkImageUsageFlags usages, VkFormatFeatureFlags2 features);
 
     // get the internal memory
     const DeviceMemory &memory() const { return internal_mem_; }
@@ -607,23 +619,13 @@ class Image : public internal::NonDispHandle<VkImage> {
     // Bind to existing memory object
     void bind_memory(const DeviceMemory &mem, VkDeviceSize mem_offset);
 
-    // vkGetImageSubresourceLayout()
-    VkSubresourceLayout subresource_layout(const VkImageSubresource &subres) const;
-    VkSubresourceLayout subresource_layout(const VkImageSubresourceLayers &subres) const;
-
-    VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect) const { return subresource_range(create_info_, aspect); }
-
-    VkExtent3D extent() const { return create_info_.extent; }
     uint32_t width() const { return create_info_.extent.width; }
     uint32_t height() const { return create_info_.extent.height; }
     VkFormat format() const { return create_info_.format; }
-    uint32_t mip_levels() const { return create_info_.mipLevels; }
-    uint32_t array_layers() const { return create_info_.arrayLayers; }
     VkImageUsageFlags usage() const { return create_info_.usage; }
+
     VkImageMemoryBarrier image_memory_barrier(VkFlags output_mask, VkFlags input_mask, VkImageLayout old_layout,
-                                              VkImageLayout new_layout, const VkImageSubresourceRange &range,
-                                              uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-                                              uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED) const {
+                                              VkImageLayout new_layout, const VkImageSubresourceRange &range) const {
         VkImageMemoryBarrier barrier = vku::InitStructHelper();
         barrier.srcAccessMask = output_mask;
         barrier.dstAccessMask = input_mask;
@@ -631,17 +633,15 @@ class Image : public internal::NonDispHandle<VkImage> {
         barrier.newLayout = new_layout;
         barrier.image = handle();
         barrier.subresourceRange = range;
-        barrier.srcQueueFamilyIndex = srcQueueFamilyIndex;
-        barrier.dstQueueFamilyIndex = dstQueueFamilyIndex;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         return barrier;
     }
 
     VkImageMemoryBarrier2KHR image_memory_barrier(VkPipelineStageFlags2KHR src_stage, VkPipelineStageFlags2KHR dst_stage,
                                                   VkAccessFlags2KHR src_access, VkAccessFlags2KHR dst_access,
                                                   VkImageLayout old_layout, VkImageLayout new_layout,
-                                                  const VkImageSubresourceRange &range,
-                                                  uint32_t srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED,
-                                                  uint32_t dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED) const {
+                                                  const VkImageSubresourceRange &range) const {
         VkImageMemoryBarrier2KHR barrier = vku::InitStructHelper();
         barrier.srcStageMask = src_stage;
         barrier.dstStageMask = dst_stage;
@@ -651,18 +651,25 @@ class Image : public internal::NonDispHandle<VkImage> {
         barrier.newLayout = new_layout;
         barrier.image = handle();
         barrier.subresourceRange = range;
-        barrier.srcQueueFamilyIndex = srcQueueFamilyIndex;
-        barrier.dstQueueFamilyIndex = dstQueueFamilyIndex;
+        barrier.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+        barrier.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
         return barrier;
     }
 
+    void ImageMemoryBarrier(CommandBuffer *cmd, VkImageAspectFlags aspect, VkFlags output_mask, VkFlags input_mask,
+                            VkImageLayout image_layout, VkPipelineStageFlags src_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
+                            VkPipelineStageFlags dest_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
+
     static VkImageCreateInfo create_info();
+
     static VkImageSubresource subresource(VkImageAspectFlags aspect, uint32_t mip_level, uint32_t array_layer);
     static VkImageSubresource subresource(const VkImageSubresourceRange &range, uint32_t mip_level, uint32_t array_layer);
     static VkImageSubresourceLayers subresource(VkImageAspectFlags aspect, uint32_t mip_level, uint32_t array_layer,
                                                 uint32_t array_size);
     static VkImageSubresourceLayers subresource(const VkImageSubresourceRange &range, uint32_t mip_level, uint32_t array_layer,
                                                 uint32_t array_size);
+
+    VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect) const { return subresource_range(create_info_, aspect); }
     static VkImageSubresourceRange subresource_range(VkImageAspectFlags aspect_mask, uint32_t base_mip_level, uint32_t mip_levels,
                                                      uint32_t base_array_layer, uint32_t num_layers);
     static VkImageSubresourceRange subresource_range(const VkImageCreateInfo &info, VkImageAspectFlags aspect_mask);
@@ -670,24 +677,27 @@ class Image : public internal::NonDispHandle<VkImage> {
 
     static VkImageAspectFlags aspect_mask(VkFormat format);
 
-    static VkExtent2D extent(int32_t width, int32_t height);
-    static VkExtent2D extent(const VkExtent3D &extent);
+    void Layout(VkImageLayout const layout) { image_layout_ = layout; }
+    VkImageLayout Layout() const { return image_layout_; }
 
-    static VkExtent3D extent(int32_t width, int32_t height, int32_t depth);
+    void SetLayout(CommandBuffer *cmd_buf, VkImageAspectFlags aspect, VkImageLayout image_layout);
+    void SetLayout(VkImageAspectFlags aspect, VkImageLayout image_layout);
+    void SetLayout(VkImageLayout image_layout) { SetLayout(aspect_mask(format()), image_layout); };
 
-    static VkImageMemoryBarrier transition_to_present(VkImage swapchain_image, VkImageLayout old_layout = VK_IMAGE_LAYOUT_UNDEFINED,
-                                                      VkAccessFlags src_access_mask = 0);
-    static VkImageMemoryBarrier2 transition_to_present_2(
-        VkImage swapchain_image, VkImageLayout old_layout = VK_IMAGE_LAYOUT_UNDEFINED,
-        VkPipelineStageFlags2 src_stage_mask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT, VkAccessFlags2 src_access_mask = 0);
+    VkImageViewCreateInfo BasicViewCreatInfo(VkImageAspectFlags aspect_mask = VK_IMAGE_ASPECT_COLOR_BIT) const;
+    ImageView CreateView(VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT) const;
+    ImageView CreateView(VkImageViewType type, uint32_t baseMipLevel = 0, uint32_t levelCount = VK_REMAINING_MIP_LEVELS,
+                         uint32_t baseArrayLayer = 0, uint32_t layerCount = VK_REMAINING_ARRAY_LAYERS,
+                         VkImageAspectFlags aspect = VK_IMAGE_ASPECT_COLOR_BIT) const;
 
   private:
-    void init_info(const Device &dev, const VkImageCreateInfo &info);
+    // We need this to do ImageView and SetLayout actions
+    const Device *device_ = nullptr;
 
     VkImageCreateInfo create_info_;
-    VkFlags format_features_;
 
     DeviceMemory internal_mem_;
+    VkImageLayout image_layout_ = VK_IMAGE_LAYOUT_GENERAL;
 };
 
 class ImageView : public internal::NonDispHandle<VkImageView> {
@@ -727,8 +737,8 @@ class AccelerationStructureNV : public internal::NonDispHandle<VkAccelerationStr
 
     const VkDevice &dev() const { return device(); }
 
-    [[nodiscard]] vkt::Buffer create_scratch_buffer(const Device &device, VkBufferCreateInfo *pCreateInfo = nullptr,
-                                                    bool buffer_device_address = false) const;
+    [[nodiscard]] Buffer create_scratch_buffer(const Device &device, VkBufferCreateInfo *pCreateInfo = nullptr,
+                                               bool buffer_device_address = false) const;
 
   private:
     VkAccelerationStructureInfoNV info_;
@@ -950,7 +960,7 @@ class CommandPool : public internal::NonDispHandle<VkCommandPool> {
     explicit CommandPool() : NonDispHandle() {}
     explicit CommandPool(const Device &dev, const VkCommandPoolCreateInfo &info) { init(dev, info); }
     explicit CommandPool(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags = 0) {
-        init(dev, vkt::CommandPool::create_info(queue_family_index, flags));
+        init(dev, CommandPool::create_info(queue_family_index, flags));
     }
 
     void init(const Device &dev, const VkCommandPoolCreateInfo &info);
@@ -972,9 +982,9 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
 
     explicit CommandBuffer() : Handle() {}
     explicit CommandBuffer(const Device &dev, const VkCommandBufferAllocateInfo &info) { init(dev, info); }
-    explicit CommandBuffer(Device *device, const CommandPool *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+    explicit CommandBuffer(const Device &dev, const CommandPool *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
                            Queue *queue = nullptr) {
-        Init(device, pool, level, queue);
+        Init(dev, pool, level, queue);
     }
     CommandBuffer(CommandBuffer &&rhs) noexcept : Handle(std::move(rhs)) {
         dev_handle_ = rhs.dev_handle_;
@@ -987,7 +997,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
 
     // vkAllocateCommandBuffers()
     void init(const Device &dev, const VkCommandBufferAllocateInfo &info);
-    void Init(Device *device, const CommandPool *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+    void Init(const Device &dev, const CommandPool *pool, VkCommandBufferLevel level = VK_COMMAND_BUFFER_LEVEL_PRIMARY,
               Queue *queue = nullptr);
 
     // vkBeginCommandBuffer()
@@ -1211,23 +1221,6 @@ inline VkImageSubresourceRange Image::subresource_range(const VkImageCreateInfo 
 
 inline VkImageSubresourceRange Image::subresource_range(const VkImageSubresource &subres) {
     return subresource_range(subres.aspectMask, subres.mipLevel, 1, subres.arrayLayer, 1);
-}
-
-inline VkExtent2D Image::extent(int32_t width, int32_t height) {
-    VkExtent2D extent = {};
-    extent.width = width;
-    extent.height = height;
-    return extent;
-}
-
-inline VkExtent2D Image::extent(const VkExtent3D &extent) { return Image::extent(extent.width, extent.height); }
-
-inline VkExtent3D Image::extent(int32_t width, int32_t height, int32_t depth) {
-    VkExtent3D extent = {};
-    extent.width = width;
-    extent.height = height;
-    extent.depth = depth;
-    return extent;
 }
 
 inline VkShaderModuleCreateInfo ShaderModule::create_info(size_t code_size, const uint32_t *code, VkFlags flags) {

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -247,7 +247,7 @@ class VkBestPracticesLayerTest : public VkLayerTest {
 class VkAmdBestPracticesLayerTest : public VkBestPracticesLayerTest {};
 class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
   public:
-    std::unique_ptr<VkImageObj> CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
+    std::unique_ptr<vkt::Image> CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
                                             VkImageUsageFlags attachment_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     VkRenderPass CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op = VK_ATTACHMENT_LOAD_OP_CLEAR,
                                   VkAttachmentStoreOp store_op = VK_ATTACHMENT_STORE_OP_STORE);
@@ -618,6 +618,7 @@ class WsiTest : public VkLayerTest {
   public:
     // most tests need images in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout
     void SetImageLayoutPresentSrc(VkImage image);
+    VkImageMemoryBarrier TransitionToPresent(VkImage swapchain_image, VkImageLayout old_layout, VkAccessFlags src_access_mask);
 };
 class NegativeWsi : public WsiTest {};
 class PositiveWsi : public WsiTest {};

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Que
 }
 
 VkCommandBuffer QSTestContext::InitFromPool(vkt::CommandBuffer& cb_obj) {
-    cb_obj.Init(dev, &pool);
+    cb_obj.Init(*dev, &pool);
     return cb_obj.handle();
 }
 
@@ -101,7 +101,7 @@ void QSTestContext::Copy(vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy&
     vk::CmdCopyBuffer(current_cb->handle(), from.handle(), to.handle(), 1, &copy_region);
 }
 
-void QSTestContext::CopyGeneral(const VkImageObj& from, const VkImageObj& to, const VkImageCopy& region) {
+void QSTestContext::CopyGeneral(const vkt::Image& from, const vkt::Image& to, const VkImageCopy& region) {
     vk::CmdCopyImage(current_cb->handle(), from.handle(), VK_IMAGE_LAYOUT_GENERAL, to.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
                      &region);
 }

--- a/tests/framework/queue_submit_context.h
+++ b/tests/framework/queue_submit_context.h
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,8 +13,6 @@
 
 #pragma once
 #include "test_common.h"
-
-class VkImageObj;
 
 struct QSTestContext {
     vkt::Device* dev;
@@ -67,8 +65,7 @@ struct QSTestContext {
     void CopyCToA() { Copy(buffer_c, buffer_a); }
     void CopyCToB() { Copy(buffer_c, buffer_b); }
 
-    void CopyGeneral(const VkImageObj& from, const VkImageObj& to, const VkImageCopy& region);
-    ;
+    void CopyGeneral(const vkt::Image& from, const vkt::Image& to, const VkImageCopy& region);
 
     VkBufferMemoryBarrier InitBufferBarrier(const vkt::Buffer& buffer, VkAccessFlags src, VkAccessFlags dst);
     VkBufferMemoryBarrier InitBufferBarrierRAW(const vkt::Buffer& buffer);

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,8 +35,6 @@
 
 // Can be used by tests to record additional details / description of test
 #define TEST_DESCRIPTION(desc) RecordProperty("description", desc)
-
-class VkImageObj;
 
 class VkTestFramework : public ::testing::Test {
   public:

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -1927,7 +1927,7 @@ class VideoContext {
           cmd_pool_(
               *device, queue_.get_family_index(),
               VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | (protected_content ? VK_COMMAND_POOL_CREATE_PROTECTED_BIT : 0)),
-          cmd_buffer_(device, &cmd_pool_, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &queue_),
+          cmd_buffer_(*device, &cmd_pool_, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &queue_),
           session_(VK_NULL_HANDLE),
           session_memory_(),
           session_params_(VK_NULL_HANDLE),

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -381,9 +381,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       0,
                                       nullptr,
                                       VK_IMAGE_LAYOUT_UNDEFINED};
-        VkImageObj image_1D(m_device);
-        image_1D.init(&img_info);
-        ASSERT_TRUE(image_1D.initialized());
+        vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
         m_commandBuffer->begin();
         image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -421,9 +419,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       0,
                                       nullptr,
                                       VK_IMAGE_LAYOUT_UNDEFINED};
-        VkImageObj image_1D(m_device);
-        image_1D.init(&img_info);
-        ASSERT_TRUE(image_1D.initialized());
+        vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
         m_commandBuffer->begin();
         image_1D.SetLayout(m_commandBuffer, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
@@ -465,15 +461,11 @@ TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
                                   0,
                                   nullptr,
                                   VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image1D_1(m_device);
-    image1D_1.init(&img_info);
-    ASSERT_TRUE(image1D_1.initialized());
+    vkt::Image image1D_1(*m_device, img_info, vkt::set_layout);
 
     img_info.tiling = VK_IMAGE_TILING_LINEAR;
     img_info.usage = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
-
-    VkImageObj image_1D_2(m_device);
-    image_1D_2.init(&img_info);
+    vkt::Image image_1D_2(*m_device, img_info, vkt::set_layout);
     if (!image_1D_2.initialized()) {
         GTEST_SKIP() << "Could not initilize Linear image, skipping image to image copy test";
     }
@@ -500,27 +492,26 @@ TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
     InitRenderTarget();
 
     VkImageCreateInfo img_info = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
-                                 nullptr,
-                                 0,
-                                 VK_IMAGE_TYPE_2D,
-                                 VK_FORMAT_R8G8B8A8_UNORM,
-                                 {1024, 1024, 1},
-                                 1,
-                                 1,
-                                 VK_SAMPLE_COUNT_1_BIT,
-                                 VK_IMAGE_TILING_OPTIMAL,
-                                 VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-                                 VK_SHARING_MODE_EXCLUSIVE,
-                                 0,
-                                 nullptr,
-                                 VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image_1D(m_device);
-
+                                  nullptr,
+                                  0,
+                                  VK_IMAGE_TYPE_2D,
+                                  VK_FORMAT_R8G8B8A8_UNORM,
+                                  {1024, 1024, 1},
+                                  1,
+                                  1,
+                                  VK_SAMPLE_COUNT_1_BIT,
+                                  VK_IMAGE_TILING_OPTIMAL,
+                                  VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+                                  VK_SHARING_MODE_EXCLUSIVE,
+                                  0,
+                                  nullptr,
+                                  VK_IMAGE_LAYOUT_UNDEFINED};
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkImage-AvoidGeneral");
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-VkCommandBuffer-AvoidTinyCmdBuffers");
 
     // the init function initializes to general layout
-    image_1D.init(&img_info);
+    vkt::Image image_1D(*m_device, img_info);
+    image_1D.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     m_errorMonitor->VerifyFound();
 }
@@ -573,9 +564,7 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
         0,
         nullptr,
         VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image_1D(m_device);
-    image_1D.init(&img_info);
-    ASSERT_TRUE(image_1D.initialized());
+    vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
     m_commandBuffer->begin();
     // check for read-to-read barrier
@@ -627,9 +616,7 @@ TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
                                  0,
                                  nullptr,
                                  VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image_1D(m_device);
-    image_1D.init(&img_info);
-    ASSERT_TRUE(image_1D.initialized());
+    vkt::Image image_1D(*m_device, img_info);
 
     uint32_t warn_limit = 11;
 
@@ -708,7 +695,7 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
     pipe.CreateGraphicsPipeline();
 
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);
-    vkt::CommandBuffer secondary_cmd_buf(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary_cmd_buf(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkCommandBufferInheritanceInfo iinfo = vku::InitStructHelper();
     iinfo.renderPass = m_renderPassBeginInfo.renderPass;

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -306,9 +306,7 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     external_format.externalFormat++;  // create wrong format
@@ -316,8 +314,7 @@ TEST_F(NegativeAndroidExternalResolve, Framebuffer) {
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -386,9 +383,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     external_format.externalFormat++;  // create wrong format
@@ -396,8 +391,7 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -513,16 +507,13 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -622,17 +613,14 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRendering) {
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -719,21 +707,17 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    VkImageObj bad_resolve_image(m_device);
-    bad_resolve_image.Init(image_ci);
+    vkt::Image bad_resolve_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView bad_resolve_view = bad_resolve_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -885,17 +869,14 @@ TEST_F(NegativeAndroidExternalResolve, MissingImageUsage) {
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT; // missing VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -964,17 +945,14 @@ TEST_F(NegativeAndroidExternalResolve, ClearAttachment) {
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -1054,17 +1032,14 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -1168,15 +1143,12 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.format = format_resolve_prop.colorAttachmentFormat;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView resolve_view = resolve_image.CreateView();
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -1267,16 +1239,13 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -1372,16 +1341,13 @@ TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,15 +78,13 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -159,16 +157,13 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -267,17 +262,14 @@ TEST_F(PositiveAndroidExternalResolve, DynamicRendering) {
     image_ci.samples = VK_SAMPLE_COUNT_4_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;
@@ -358,16 +350,13 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-
-    VkImageObj color_image(m_device);
-    color_image.Init(image_ci);
+    vkt::Image color_image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView color_view = color_image.CreateView();
 
     image_ci.pNext = &external_format;
     image_ci.format = VK_FORMAT_UNDEFINED;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj resolve_image(m_device);
-    resolve_image.Init(image_ci);
+    vkt::Image resolve_image(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo sycci = vku::InitStructHelper(&external_format);
     sycci.format = VK_FORMAT_UNDEFINED;

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -140,9 +140,7 @@ TEST_F(NegativeAndroidHardwareBuffer, FetchUnboundImageInfo) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_LINEAR;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     // attempt to fetch layout from unbound image
     VkImageSubresource sub_rsrc = {};
@@ -254,8 +252,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageColor) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -311,8 +308,7 @@ TEST_F(NegativeAndroidHardwareBuffer, DedicatedUsageDS) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -367,8 +363,7 @@ TEST_F(NegativeAndroidHardwareBuffer, MipmapChainComplete) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -418,8 +413,7 @@ TEST_F(NegativeAndroidHardwareBuffer, NoMipmapChain) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -471,8 +465,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ImageDimensions) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -515,8 +508,7 @@ TEST_F(NegativeAndroidHardwareBuffer, UnknownFormat) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -578,8 +570,7 @@ TEST_F(NegativeAndroidHardwareBuffer, GpuUsage) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -629,8 +620,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportMemoryAllocateImage) {
     ici.samples = VK_SAMPLE_COUNT_1_BIT;
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, ici);
+    vkt::Image image(*m_device, ici, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo dedicated_allocation_info = vku::InitStructHelper();
     dedicated_allocation_info.image = image.handle();
@@ -1015,7 +1005,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     VkExternalMemoryImageCreateInfo ext_image_info = vku::InitStructHelper();
     ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&ext_image_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -1028,7 +1017,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = vku::InitStructHelper();
     memory_dedicated_info.image = image.handle();
@@ -1169,7 +1158,6 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportImageHandleType) {
     vkt::AHB ahb(AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM, AHARDWAREBUFFER_USAGE_GPU_SAMPLED_IMAGE, 64, 64);
 
     // Create buffer without VkExternalMemoryImageCreateInfo
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -1182,7 +1170,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ImportImageHandleType) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = vku::InitStructHelper();
     memory_dedicated_info.image = image.handle();

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -75,7 +75,6 @@ TEST_F(PositiveAndroidHardwareBuffer, DepthStencil) {
     }
 
     // Create a Depth/Stencil image
-    VkImageObj ds_image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&ext_image_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -88,7 +87,7 @@ TEST_F(PositiveAndroidHardwareBuffer, DepthStencil) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    ds_image.init_no_mem(*m_device, image_create_info);
+    vkt::Image ds_image(*m_device, image_create_info, vkt::no_mem);
     if (ds_image.handle() == VK_NULL_HANDLE) {
         GTEST_SKIP() << "Was not able to create a D16 AHB framebuffer";
     }
@@ -209,7 +208,6 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportImage) {
     VkExternalMemoryImageCreateInfo ext_image_info = vku::InitStructHelper();
     ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&ext_image_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -222,7 +220,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportImage) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = vku::InitStructHelper();
     memory_dedicated_info.image = image.handle();
@@ -288,7 +286,6 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalImage) {
     VkExternalMemoryImageCreateInfo ext_image_info = vku::InitStructHelper(&ext_format);
     ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&ext_image_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -301,7 +298,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalImage) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = vku::InitStructHelper();
     memory_dedicated_info.image = image.handle();
@@ -358,7 +355,6 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     VkExternalMemoryImageCreateInfo ext_image_info = vku::InitStructHelper(&ext_format);
     ext_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper(&ext_image_info);
     image_create_info.flags = 0;
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -371,7 +367,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExternalCameraFormat) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryDedicatedAllocateInfo memory_dedicated_info = vku::InitStructHelper();
     memory_dedicated_info.image = image.handle();

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -325,8 +325,8 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
     pipe.InitState();
     pipe.CreateComputePipeline();
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R32_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R32_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
@@ -376,8 +376,8 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
     pipe.CreateComputePipeline();
 
     // "64-bit integer atomic support is guaranteed for optimally tiled images with the VK_FORMAT_R64_UINT"
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
@@ -451,8 +451,7 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_STORAGE_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::no_mem);
     vkt::ImageView image_view = image.CreateView();
     pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                    VK_IMAGE_LAYOUT_GENERAL);
@@ -518,8 +517,8 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
     pipe.CreateGraphicsPipeline();
 
     // "64-bit integer atomic support is guaranteed for optimally tiled images with the VK_FORMAT_R64_UINT"
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
@@ -1181,7 +1180,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
     VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT;
     VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;  // The format doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT to
                                                        // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
-    auto image_ci = VkImageObj::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
 
     if (ImageFormatIsSupported(instance(), gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
@@ -1202,8 +1201,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
         GTEST_SKIP() << "vertexPipelineStoresAndAtomics & fragmentStoresAndAtomics NOT supported";
     }
 
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -126,8 +126,7 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_STORAGE_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::no_mem);
     vkt::ImageView image_view = image.CreateView();
     pipe.descriptor_set_->WriteDescriptorImageInfo(1, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                    VK_IMAGE_LAYOUT_GENERAL);
@@ -827,9 +826,8 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
     formatProps.optimalTilingFeatures &= ~VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT;
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), format, formatProps);
 
-    auto image_ci = VkImageObj::ImageCreateInfo2D(64, 64, 1, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     const char *spv_source = R"(

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -182,8 +182,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, ImageInputAttachmentLayout) {
 
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
     VkImageMemoryBarrier image_memory_barrier = vku::InitStructHelper();
     image_memory_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -228,9 +228,7 @@ TEST_F(NegativeBuffer, BufferViewObject) {
 TEST_F(NegativeBuffer, CreateBufferViewNoMemoryBoundToBuffer) {
     TEST_DESCRIPTION("Attempt to create a buffer view with a buffer that has no memory bound to it.");
 
-    VkResult err;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
-                                         " used with no memory bound. Memory should be bound by calling vkBindBufferMemory().");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkBufferViewCreateInfo-buffer-00935");
 
     RETURN_IF_SKIP(Init());
 
@@ -239,10 +237,7 @@ TEST_F(NegativeBuffer, CreateBufferViewNoMemoryBoundToBuffer) {
     VkBufferCreateInfo buff_ci = vku::InitStructHelper();
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
     buff_ci.size = 256;
-    buff_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-    VkBuffer buffer;
-    err = vk::CreateBuffer(m_device->device(), &buff_ci, NULL, &buffer);
-    ASSERT_EQ(VK_SUCCESS, err);
+    vkt::Buffer buffer(*m_device, buff_ci, vkt::no_mem);
 
     VkBufferViewCreateInfo buff_view_ci = vku::InitStructHelper();
     buff_view_ci.buffer = buffer;
@@ -250,7 +245,6 @@ TEST_F(NegativeBuffer, CreateBufferViewNoMemoryBoundToBuffer) {
     buff_view_ci.range = VK_WHOLE_SIZE;
     vkt::BufferView buffer_view(*m_device, buff_view_ci);
     m_errorMonitor->VerifyFound();
-    vk::DestroyBuffer(m_device->device(), buffer, NULL);
 }
 
 TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
@@ -810,7 +804,7 @@ TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
     vkt::Queue *queue = m_device->queue_family_queues(transfer.value())[0].get();
 
     vkt::CommandPool pool(*m_device, transfer.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+    vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     cb.begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdFillBuffer-apiVersion-07894");

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
     vkt::Queue *no_gfx_queue = m_device->queue_family_queues(no_gfx.value())[0].get();
 
     vkt::CommandPool no_gfx_pool(*m_device, no_gfx.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer no_gfx_cb(m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, no_gfx_queue);
+    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, no_gfx_queue);
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
     auto buffer_barrier = buffer.buffer_memory_barrier(0, 0, 0, VK_WHOLE_SIZE);

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -472,13 +472,13 @@ TEST_F(NegativeDebugExtensions, DebugLabelPrimaryCommandBuffer2) {
 
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "regionA";
-    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    vkt::CommandBuffer cb0(*m_device, m_commandPool);
     cb0.begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
     cb0.end();
     m_default_queue->submit(cb0);
 
-    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    vkt::CommandBuffer cb1(*m_device, m_commandPool);
     cb1.begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
     vk::CmdEndDebugUtilsLabelEXT(cb1);
@@ -496,13 +496,13 @@ TEST_F(NegativeDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
 
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "regionA";
-    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    vkt::CommandBuffer cb0(*m_device, m_commandPool);
     cb0.begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
     vk::CmdEndDebugUtilsLabelEXT(cb0);
     cb0.end();
 
-    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    vkt::CommandBuffer cb1(*m_device, m_commandPool);
     label.pLabelName = "regionB";
     cb1.begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb1, &label);
@@ -520,7 +520,7 @@ TEST_F(NegativeDebugExtensions, DebugLabelSecondaryCommandBuffer) {
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer cb(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     cb.begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913");
     vk::CmdEndDebugUtilsLabelEXT(cb);

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -107,13 +107,13 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer2) {
 
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
-    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    vkt::CommandBuffer cb0(*m_device, m_commandPool);
     cb0.begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
     cb0.end();
     m_default_queue->submit(cb0);
 
-    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    vkt::CommandBuffer cb1(*m_device, m_commandPool);
     cb1.begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
     cb1.end();
@@ -129,12 +129,12 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
 
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
-    vkt::CommandBuffer cb0(m_device, m_commandPool);
+    vkt::CommandBuffer cb0(*m_device, m_commandPool);
     cb0.begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
     cb0.end();
 
-    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    vkt::CommandBuffer cb1(*m_device, m_commandPool);
     cb1.begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
     cb1.end();
@@ -146,7 +146,7 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
 TEST_F(PositiveDebugExtensions, DebugLabelSecondaryCommandBuffer) {
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer cb(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     cb.begin();
     {
         VkDebugUtilsLabelEXT label = vku::InitStructHelper();

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -386,8 +386,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         image_create_info.format = VK_FORMAT_D32_SFLOAT;
         image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
-        vkt::Image temp_image;
-        temp_image.init(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        vkt::Image temp_image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
         VkImageCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
         icddi.image = temp_image.handle();
@@ -412,8 +411,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_create_info.format = VK_FORMAT_D32_SFLOAT;
         image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-        vkt::Image temp_image;
-        temp_image.init(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        vkt::Image temp_image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
         VkImageViewCreateInfo dsvci = vku::InitStructHelper();
         // dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
@@ -710,7 +708,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
             if (no_gfx_qfi) {
                 vkt::CommandPool command_pool(*m_device, no_gfx_qfi.value());
                 ASSERT_TRUE(command_pool.initialized());
-                vkt::CommandBuffer command_buffer(m_device, &command_pool);
+                vkt::CommandBuffer command_buffer(*m_device, &command_pool);
 
                 index = 0;
                 offset = 0;
@@ -964,7 +962,7 @@ TEST_F(NegativeDescriptorBuffer, BindPoint) {
 
         vkt::CommandPool command_pool(*m_device, no_gfx_qfi.value());
         ASSERT_TRUE(command_pool.initialized());
-        vkt::CommandBuffer command_buffer(m_device, &command_pool);
+        vkt::CommandBuffer command_buffer(*m_device, &command_pool);
 
         command_buffer.begin();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -117,8 +117,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
 
     // Image Case
     {
-        VkImageObj image(m_device);
-        image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+        vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
         vkt::ImageView view = image.CreateView();
 
         OneOffDescriptorSet descriptor_set(m_device, {
@@ -589,9 +588,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -683,8 +680,7 @@ TEST_F(PositiveDescriptors, UpdateImageDescriptorSetThatHasImageViewUsage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkImageViewUsageCreateInfo image_view_usage_ci = vku::InitStructHelper();
     image_view_usage_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -719,10 +715,8 @@ TEST_F(PositiveDescriptors, MultipleThreadsUsingHostOnlyDescriptorSet) {
     AddRequiredFeature(vkt::Feature::mutableDescriptorType);
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image1(m_device);
-    VkImageObj image2(m_device);
-    image1.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    image2.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image1(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image2(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     vkt::ImageView view1 = image1.CreateView();
     vkt::ImageView view2 = image2.CreateView();
@@ -794,8 +788,8 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
 
-    VkImageObj image_input(m_device);
-    image_input.Init(width, height, 1, format, usage);
+    vkt::Image image_input(*m_device, width, height, 1, format, usage);
+    image_input.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view_input = image_input.CreateView();
 
     // Create render pass with a subpass that has input attachment.
@@ -851,8 +845,8 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    vkt::CommandBuffer cb0(m_device, m_commandPool);
-    vkt::CommandBuffer cb1(m_device, m_commandPool);
+    vkt::CommandBuffer cb0(*m_device, m_commandPool);
+    vkt::CommandBuffer cb1(*m_device, m_commandPool);
 
     for (int mode = 0; mode < 2; mode++) {
         const bool use_single_command_buffer = (mode == 0);
@@ -1022,9 +1016,9 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     RETURN_IF_SKIP(InitState(nullptr, &afll_features));
 
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format,
-               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT);
+    vkt::Image image(
+        *m_device, 32, 32, 1, format,
+        VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT);
 
     vkt::ImageView image_view = image.CreateView();
 

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -320,7 +320,7 @@ TEST_F(NegativeDeviceQueue, BindPipeline) {
         GTEST_SKIP() << "Only VK_QUEUE_TRANSFER_BIT Queue is not supported";
     }
     vkt::CommandPool commandPool(*m_device, only_transfer_queueFamilyIndex);
-    vkt::CommandBuffer commandBuffer(m_device, &commandPool);
+    vkt::CommandBuffer commandBuffer(*m_device, &commandPool);
 
     CreatePipelineHelper g_pipe(*this);
     g_pipe.InitState();
@@ -454,7 +454,7 @@ TEST_F(NegativeDeviceQueue, MismatchedQueueFamiliesOnSubmit) {
     vk::GetDeviceQueue(m_device->device(), other_queue_family, 0, &other_queue);
 
     vkt::CommandPool cmd_pool(*m_device, queue_family);
-    vkt::CommandBuffer cmd_buff(m_device, &cmd_pool);
+    vkt::CommandBuffer cmd_buff(*m_device, &cmd_pool);
 
     cmd_buff.begin();
     cmd_buff.end();

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -167,8 +167,7 @@ TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     RETURN_IF_SKIP(Init());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj depth_image(m_device);
-    depth_image.Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     InitRenderTarget(1, &depth_image_view.handle());
@@ -195,8 +194,7 @@ TEST_F(NegativeDynamicState, StencilReadNotBound) {
         "Run a simple draw calls to validate failure when Stencil Read dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj depth_image(m_device);
-    depth_image.Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     InitRenderTarget(1, &depth_image_view.handle());
@@ -223,8 +221,7 @@ TEST_F(NegativeDynamicState, StencilWriteNotBound) {
         "Run a simple draw calls to validate failure when Stencil Write dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj depth_image(m_device);
-    depth_image.Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     InitRenderTarget(1, &depth_image_view.handle());
@@ -251,8 +248,7 @@ TEST_F(NegativeDynamicState, StencilRefNotBound) {
         "Run a simple draw calls to validate failure when Stencil Ref dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj depth_image(m_device);
-    depth_image.Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     InitRenderTarget(1, &depth_image_view.handle());
@@ -418,7 +414,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    vkt::CommandBuffer commandBuffer(m_device, m_commandPool);
+    vkt::CommandBuffer commandBuffer(*m_device, m_commandPool);
     commandBuffer.begin();
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetCullModeEXT, "VUID-vkCmdSetCullMode-None-08971",
@@ -572,7 +568,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
     std::vector<VkBuffer> buffers(m_device->phy().limits_.maxVertexInputBindings + 1ull, buffer.handle());
     std::vector<VkDeviceSize> offsets(buffers.size(), 0);
 
-    vkt::CommandBuffer commandBuffer(m_device, m_commandPool);
+    vkt::CommandBuffer commandBuffer(*m_device, m_commandPool);
     commandBuffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindVertexBuffers2-firstBinding-03355");
@@ -821,7 +817,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
 
     InitRenderTarget();
 
-    vkt::CommandBuffer commandBuffer(m_device, m_commandPool);
+    vkt::CommandBuffer commandBuffer(*m_device, m_commandPool);
     commandBuffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetViewportWithCount-viewportCount-03395");
@@ -870,7 +866,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetRasterizerDiscardEnable-None-08970");
@@ -913,7 +909,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetPatchControlPointsEXT-None-09422");
@@ -948,7 +944,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetLogicOpEXT-None-09422");
@@ -995,7 +991,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
             pipe.InitState();
             pipe.CreateGraphicsPipeline();
 
-            vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+            vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
             command_buffer.begin();
             command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -1048,7 +1044,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
         pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
-        vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+        vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
         command_buffer.begin();
         command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -1102,7 +1098,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
         pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
-        vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+        vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
         command_buffer.begin();
         command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -1315,7 +1311,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState3CmdSetFeatureDisabled) {
     InitRenderTarget();
 
     // Check feature is enable for each set command.
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
     {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdSetTessellationDomainOriginEXT-None-09423");
@@ -2851,11 +2847,9 @@ TEST_F(NegativeDynamicState, SampleLocations) {
 
     image_create_info.flags = 0;  // image will not have needed flag
     image_create_info.format = depth_format;
-    VkImageObj depth_image(m_device);
-    depth_image.init(&image_create_info);
+    vkt::Image depth_image(*m_device, image_create_info, vkt::set_layout);
 
-    VkImageObj color_image(m_device);
-    color_image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image color_image(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
@@ -3586,8 +3580,9 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt,
-                         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_LINEAR);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
+                         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -3641,8 +3636,9 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt,
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -4767,12 +4763,11 @@ TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    std::vector<std::unique_ptr<VkImageObj>> images(attachment_count);
+    std::vector<std::unique_ptr<vkt::Image>> images(attachment_count);
     std::vector<vkt::ImageView> image_views(attachment_count);
     std::vector<VkRenderingAttachmentInfo> rendering_attachment_info(attachment_count);
     for (uint32_t i = 0; i < attachment_count; ++i) {
-        images[i] = std::make_unique<VkImageObj>(m_device);
-        images[i]->init(&image_ci);
+        images[i] = std::make_unique<vkt::Image>(*m_device, image_ci);
         image_views[i] = images[i]->CreateView();
         rendering_attachment_info[i] = vku::InitStructHelper();
         rendering_attachment_info[i].imageView = image_views[i];
@@ -4838,8 +4833,8 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
         GTEST_SKIP() << "Required foramt features not available";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32u, 32u, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32u, 32u, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     VkClearValue clear_value;
@@ -5104,8 +5099,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     RenderPassSingleSubpass rp(*this);
@@ -5206,8 +5200,8 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
 
     VkFormat format = FindSupportedDepthStencilFormat(gpu());
 
-    VkImageObj image(m_device);
-    image.Init(32u, 32u, 1u, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32u, 32u, 1u, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     RenderPassSingleSubpass rp(*this);
@@ -5405,8 +5399,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
         GTEST_SKIP() << "Required sample count not supported";
     }
 
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     CreatePipelineHelper pipe(*this);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -225,7 +225,8 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -282,13 +283,11 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
 TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     RETURN_IF_SKIP(InitBasicExtendedDynamicState());
 
-    VkImageObj color_image(m_device);
-    color_image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image color_image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto color_view = color_image.CreateView();
 
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj ds_image(m_device);
-    ds_image.Init(m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image ds_image(*m_device, m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     auto ds_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     RenderPassSingleSubpass rp(*this);
@@ -328,13 +327,11 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     TEST_DESCRIPTION("setting vkCmdSetDepthTestEnable to false cancels what ever is written to vkCmdSetDepthWriteEnable.");
     RETURN_IF_SKIP(InitBasicExtendedDynamicState());
 
-    VkImageObj color_image(m_device);
-    color_image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image color_image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto color_view = color_image.CreateView();
 
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj ds_image(m_device);
-    ds_image.Init(m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image ds_image(*m_device, m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     auto ds_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     RenderPassSingleSubpass rp(*this);
@@ -388,7 +385,7 @@ TEST_F(PositiveDynamicState, DynamicStateDoublePipelineBind) {
     pipe_no_dynamic.InitState();
     pipe_no_dynamic.CreateGraphicsPipeline();
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
     vk::CmdSetPrimitiveRestartEnableEXT(command_buffer.handle(), VK_TRUE);
     command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -830,8 +827,9 @@ TEST_F(PositiveDynamicState, DepthBoundsTestEnableState) {
     // Need to set format framework uses for InitRenderTarget
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt,
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -872,8 +870,8 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
     pipe.CreateGraphicsPipeline();
 
-    vkt::CommandBuffer cmd_buffer(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    vkt::CommandBuffer set_state(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer cmd_buffer(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer set_state(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     const VkViewport viewports[2] = {{0.0f, 0.0f, 100.0f, 100.0f, 0.0f, 1.0f}, {0.0f, 0.0f, 100.0f, 100.0f, 0.0f, 1.0f}};
     const VkRect2D scissors[2] = {{{0, 0}, {100u, 100u}}, {{0, 0}, {100u, 100u}}};

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -190,7 +190,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
 
     // Create an image with one of the handle types
     external_image_info.handleTypes = handle_type;
-    vkt::Image image(*m_device, image_info, vkt::NoMemT{});
+    vkt::Image image(*m_device, image_info, vkt::no_mem);
 
     // Create export memory with a different handle type
     VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
@@ -423,7 +423,7 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
 
     // Create a buffer with one of the handle types
     external_info.handleTypes = handle_type;
-    vkt::Buffer buffer(*m_device, buffer_info, vkt::NoMemT{});
+    vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     // Check if dedicated allocation is required
     const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(gpu(), buffer_info, handle_type2);
@@ -1226,8 +1226,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     }
     external_image_info.handleTypes = wrong_image_handle_type;
 
-    VkImageObj image_import(m_device);
-    image_import.init_no_mem(*m_device, image_info);
+    vkt::Image image_import(*m_device, image_info, vkt::no_mem);
 
 #ifdef _WIN32
     // Export memory to handle
@@ -1776,11 +1775,11 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
         }
     }
 
-    VkImageObj image(m_device);
+    vkt::Image image;
     {
         VkExternalMemoryImageCreateInfo external_info = vku::InitStructHelper();
         external_info.handleTypes = handle_type;
-        auto create_info = VkImageObj::create_info();
+        auto create_info = vkt::Image::create_info();
         create_info.pNext = &external_info;
         create_info.imageType = VK_IMAGE_TYPE_2D;
         create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -2051,7 +2050,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32ImageNoDedicated) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    auto image_info = VkImageObj::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    auto image_info = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     const auto handle_types = FindSupportedExternalMemoryHandleTypes(
         gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
@@ -2063,8 +2062,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32ImageNoDedicated) {
     external_image_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     image_info.pNext = &external_image_info;
 
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_info);
+    vkt::Image image(*m_device, image_info, vkt::no_mem);
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
@@ -2442,12 +2440,11 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdImageSupport) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    VkImageObj image(m_device);
-    auto image_info = VkImageObj::create_info();
+    auto image_info = vkt::Image::create_info();
     image_info.extent.width = 1024;
     image_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
-    image.init_no_mem(*m_device, image_info);
+    vkt::Image image(*m_device, image_info, vkt::no_mem);
 
     if (FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Need image with no import support";
@@ -2690,8 +2687,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     buff_view_ci.pNext = &metal_object_create_info;
     CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-pNext-06782"});
 
-    VkImageObj image_obj(m_device);
-    image_obj.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image_obj(*m_device, 256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image_obj.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -2748,8 +2744,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     VkExportMetalObjectCreateInfoEXT export_metal_object_create_info = vku::InitStructHelper();
     export_metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT;
     ici.pNext = &export_metal_object_create_info;
-    VkImageObj export_image_obj(m_device);
-    export_image_obj.Init(ici);
+    vkt::Image export_image_obj(*m_device, ici);
     vkt::BufferView export_buffer_view;
     buff_view_ci.pNext = &export_metal_object_create_info;
     export_buffer_view.init(*m_device, buff_view_ci);
@@ -2799,8 +2794,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     m_errorMonitor->VerifyFound();
 
     ici.format = VK_FORMAT_B8G8R8A8_UNORM;
-    VkImageObj single_plane_export_image_obj(m_device);
-    single_plane_export_image_obj.Init(ici);
+    vkt::Image single_plane_export_image_obj(*m_device, ici);
     metal_texture_info.plane = VK_IMAGE_ASPECT_PLANE_1_BIT;
     metal_texture_info.image = single_plane_export_image_obj.handle();
     // metal_texture_info.plane not plane_0 for single plane image
@@ -2862,8 +2856,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
         ici.tiling = VK_IMAGE_TILING_OPTIMAL;
         ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
         ici.pNext = &export_metal_object_create_info;
-        VkImageObj mp_image_obj(m_device);
-        mp_image_obj.init(&ici);
+        vkt::Image mp_image_obj(*m_device, ici);
 
         metal_texture_info.bufferView = VK_NULL_HANDLE;
         metal_texture_info.imageView = VK_NULL_HANDLE;

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -409,9 +409,7 @@ TEST_F(PositiveExternalMemorySync, ExportMetalObjects) {
         ici.samples = VK_SAMPLE_COUNT_1_BIT;
         ici.tiling = VK_IMAGE_TILING_LINEAR;
         ici.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        VkImageObj image(m_device);
-        image.Init(ici);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, ici, vkt::set_layout);
 
         VkExportMetalIOSurfaceInfoEXT surfaceInfo = vku::InitStructHelper();
         surfaceInfo.image = image.handle();

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -409,8 +409,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapLayerCount) {
 
     vkt::RenderPass rp(*m_device, rpci);
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(image.ImageCreateInfo2D(32, 32, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT));
+    auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, image_ci);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, VK_REMAINING_MIP_LEVELS, 0, 2);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
@@ -570,9 +570,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     image_create_info.flags = 0;
     image_create_info.mipLevels = 1;
     image_create_info.usage = VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT;
-    VkImageObj densityImage(m_device);
-    densityImage.init(&image_create_info);
-    ASSERT_TRUE(densityImage.initialized());
+    vkt::Image densityImage(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = densityImage.handle();
@@ -588,9 +586,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
     if (features2.features.sparseResidencyImage2D) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT;
-        VkImageObj image(m_device);
-        image.init_no_mem(*m_device, image_create_info);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
         ivci.image = image.handle();
         CreateImageViewTest(*this, &ivci, "VUID-VkImageViewCreateInfo-flags-04116");
@@ -611,9 +607,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapEnabled) {
             image_create_info.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
             image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
             image_create_info.arrayLayers = density_map2_properties.maxSubsampledArrayLayers + 1;
-            VkImageObj image(m_device);
-            image.init(&image_create_info);
-            ASSERT_TRUE(image.initialized());
+            vkt::Image image(*m_device, image_create_info, vkt::set_layout);
             ivci.image = image.handle();
             ivci.flags = 0;
             ivci.subresourceRange.layerCount = density_map2_properties.maxSubsampledArrayLayers + 1;
@@ -642,10 +636,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDisabled) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image2D(m_device);
-    image2D.init(&image_create_info);
-    ASSERT_TRUE(image2D.initialized());
+    vkt::Image image2D(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image2D.handle();
@@ -724,9 +715,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapReferenceAttachment) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 4);
 
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
@@ -874,8 +863,7 @@ TEST_F(NegativeFragmentShadingRate, FramebufferUsage) {
     rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkFramebufferCreateInfo-flags-04548");
@@ -904,10 +892,9 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensions) {
     rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.CreateRenderPass();
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ici =
-        VkImageObj::ImageCreateInfo2D(1, 1, 1, 2, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
-    image.InitNoLayout(ici);
+        vkt::Image::ImageCreateInfo2D(1, 1, 1, 2, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+    vkt::Image image(*m_device, ici);
     auto image_view_ci = image.BasicViewCreatInfo();
     image_view_ci.subresourceRange.layerCount = 2;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -961,10 +948,9 @@ TEST_F(NegativeFragmentShadingRate, FramebufferDimensionsMultiview) {
     rp.SetViewMask(0x4);
     rp.CreateRenderPass();
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ici =
-        VkImageObj::ImageCreateInfo2D(1, 1, 1, 2, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
-    image.InitNoLayout(ici);
+        vkt::Image::ImageCreateInfo2D(1, 1, 1, 2, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+    vkt::Image image(*m_device, ici);
     auto image_view_ci = image.BasicViewCreatInfo();
     image_view_ci.subresourceRange.layerCount = 2;
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -1174,8 +1160,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     rp_fsr_2.AddFragmentShadingRateAttachment(0, texel_size_2);
     rp_fsr_2.CreateRenderPass();
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
 
     // Create a frame buffer with a render pass with FSR attachment
@@ -1185,7 +1170,7 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     vkt::Framebuffer framebuffer_no_fsr(*m_device, rp_no_fsr.Handle(), 1, &imageView.handle());
 
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     // Inheritance info without FSR attachment
     const VkCommandBufferInheritanceInfo cmdbuff_ii_no_fsr = {
@@ -1306,11 +1291,9 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
                                                    &imageFormatProperties) == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "Format not supported";
     }
-
-    VkImageObj image(m_device);
     // Initialize image with transfer source usage
-    image.Init(128, 128, 1, format, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, format, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewCreateInfo createinfo = vku::InitStructHelper();
     createinfo.image = image.handle();
@@ -1338,10 +1321,9 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
             GTEST_SKIP() << "Test not supported by MockICD, doesn't correctly advertise format support for fragment shading "
                             "rate attachments";
         } else {
-            VkImageObj image2(m_device);
-            image2.Init(VkImageObj::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_R8_UINT,
-                                                      VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR));
-            ASSERT_TRUE(image2.initialized());
+            auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_R8_UINT,
+                                                          VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+            vkt::Image image2(*m_device, image_ci);
 
             createinfo.image = image2.handle();
             createinfo.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -1841,47 +1823,29 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     image_create_info.usage = VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT;
     image_create_info.flags = 0;
 
-    VkImageObj fdm_image(m_device);
-    fdm_image.init(&image_create_info);
-    ASSERT_TRUE(fdm_image.initialized());
+    vkt::Image fdm_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-
-    VkImageObj input_image(m_device);
-    input_image.init(&image_create_info);
-    ASSERT_TRUE(input_image.initialized());
+    vkt::Image input_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj color_image1(m_device);
-    color_image1.init(&image_create_info);
-    ASSERT_TRUE(color_image1.initialized());
-
-    VkImageObj color_image2(m_device);
-    color_image2.init(&image_create_info);
-    ASSERT_TRUE(color_image2.initialized());
+    vkt::Image color_image1(*m_device, image_create_info, vkt::set_layout);
+    vkt::Image color_image2(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.format = ds_format;
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-
-    VkImageObj depth_image(m_device);
-    depth_image.init(&image_create_info);
-    ASSERT_TRUE(depth_image.initialized());
+    vkt::Image depth_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-
-    VkImageObj resolve_image(m_device);
-    resolve_image.init(&image_create_info);
-    ASSERT_TRUE(resolve_image.initialized());
+    vkt::Image resolve_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
-    VkImageObj preserve_image(m_device);
-    preserve_image.init(&image_create_info);
-    ASSERT_TRUE(preserve_image.initialized());
+    vkt::Image preserve_image(*m_device, image_create_info, vkt::set_layout);
 
     // Create view attachment
     VkImageView iv[7];
@@ -2098,10 +2062,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
     CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-shadingRateImage-07727");
 
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-
-    // Should succeed.
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     // Test image view creation
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2183,9 +2144,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
     }
 
     // Create an image without the SRI bit
-    VkImageObj nonSRIimage(m_device);
-    nonSRIimage.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(nonSRIimage.initialized());
+    vkt::Image nonSRIimage(*m_device, 256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView nonSRIview = nonSRIimage.CreateView();
 
     // Test SRI layout on non-SRI image
@@ -2350,9 +2309,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNVViewportCount) {
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -2583,8 +2540,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
         image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
         image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
         image_ci.flags = 0;
-        VkImageObj image(m_device);
-        image.init(&image_ci);
+        vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
         vkt::ImageView view = image.CreateView(VK_FORMAT_D16_UNORM);
 
@@ -2624,9 +2580,8 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
 
     {
         // Create an image with 2 mip levels.
-        VkImageObj image(m_device);
-        image.Init(128, 128, 2, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, 128, 128, 2, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+        image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
         // Create a image view with two mip levels.
         VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2731,10 +2686,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
 
         {
             // Set small width
-            VkImageObj image2(m_device);
-            image2.Init(16, attachment_height, 1, attachment_format, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT,
-                        VK_IMAGE_TILING_LINEAR, 0);
-            ASSERT_TRUE(image2.initialized());
+            vkt::Image image2(*m_device, 16, attachment_height, 1, attachment_format, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT);
 
             ivci.image = image2.handle();
             vkt::ImageView view_fragment_density_map(*m_device, ivci);
@@ -2748,10 +2700,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
         }
         {
             // Set small height
-            VkImageObj image3(m_device);
-            image3.Init(attachment_width, 16, 1, attachment_format, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT,
-                        VK_IMAGE_TILING_LINEAR, 0);
-            ASSERT_TRUE(image3.initialized());
+            vkt::Image image3(*m_device, attachment_width, 16, 1, attachment_format, VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT);
 
             ivci.image = image3.handle();
             vkt::ImageView view_fragment_density_map(*m_device, ivci);
@@ -2766,9 +2715,8 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
 
     {
         // Create an image with one mip level.
-        VkImageObj image(m_device);
-        image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+        image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
         // Create view attachment with non-identity swizzle
         VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2827,9 +2775,8 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
             vkt::RenderPass rp_mv(*m_device, rpci_mv);
 
             // Create an image with 1 layer
-            VkImageObj image(m_device);
-            image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-            ASSERT_TRUE(image.initialized());
+            vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+            image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
             VkImageViewCreateInfo ivci = vku::InitStructHelper();
             ivci.image = image.handle();

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -50,9 +50,8 @@ TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
         GTEST_SKIP() << "Image options not supported";
     }
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
     imageMemoryBarrier.srcAccessMask = VK_ACCESS_NONE;
@@ -92,9 +91,7 @@ TEST_F(PositiveFragmentShadingRate, Attachments) {
     rp.AddFragmentShadingRateAttachment(0, fsr_properties.minFragmentShadingRateAttachmentTexelSize);
     rp.SetViewMask(0x2);
     rp.CreateRenderPass();
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+    vkt::Image image(*m_device, 1, 1, 1, VK_FORMAT_R8_UINT, VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     vkt::ImageView imageView = image.CreateView();
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle(),

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -380,7 +380,7 @@ TEST_F(NegativeGpuAV, DISABLED_InvalidAtomicStorageOperation) {
     VkImageUsageFlags usage = VK_IMAGE_USAGE_STORAGE_BIT;
     VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;  // The format doesn't support VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT to
                                                        // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
-    auto image_ci = VkImageObj::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
 
     if (ImageFormatIsSupported(instance(), gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
@@ -398,8 +398,7 @@ TEST_F(NegativeGpuAV, DISABLED_InvalidAtomicStorageOperation) {
     VkPhysicalDeviceFeatures device_features = {};
     GetPhysicalDeviceFeatures(&device_features);
 
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -547,14 +546,12 @@ TEST_F(NegativeGpuAV, DISABLED_UnnormalizedCoordinatesInBoundsAccess) {
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView view_pass = image.CreateView();
 
-    VkImageObj image_3d(m_device);
     image_ci.imageType = VK_IMAGE_TYPE_3D;
-    image_3d.Init(image_ci);
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
@@ -653,14 +650,12 @@ TEST_F(NegativeGpuAV, DISABLED_UnnormalizedCoordinatesCopyObject) {
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView view_pass = image.CreateView();
 
-    VkImageObj image_3d(m_device);
     image_ci.imageType = VK_IMAGE_TYPE_3D;
-    image_3d.Init(image_ci);
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
     sampler_ci.unnormalizedCoordinates = VK_TRUE;
@@ -725,14 +720,12 @@ TEST_F(NegativeGpuAV, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
 
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
-    VkImageObj image_3d(m_device);
     image_ci.imageType = VK_IMAGE_TYPE_3D;
-    image_3d.Init(image_ci);
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view_3d = image_3d.CreateView(VK_IMAGE_VIEW_TYPE_3D);
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
@@ -846,11 +839,10 @@ TEST_F(NegativeGpuAV, ShareOpSampledImage) {
     g_pipe.gp_ci_.layout = pipeline_layout.handle();
     g_pipe.CreateGraphicsPipeline();
 
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(
+    auto image_ci = vkt::Image::ImageCreateInfo2D(
         128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
@@ -906,8 +898,7 @@ TEST_F(NegativeGpuAV, DISABLED_YcbcrDrawFetchIndexed) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
-    VkImageObj image(m_device);
-    image.Init(ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     vkt::SamplerYcbcrConversion conversion(*m_device, format);
     auto conversion_info = conversion.ConversionInfo();
@@ -1000,9 +991,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();
@@ -1068,9 +1057,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32Vk13) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();
@@ -1140,9 +1127,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();
@@ -1205,9 +1190,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8Vk13) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -167,8 +167,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
                                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -277,8 +277,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
                                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT_EXT);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -405,8 +405,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
                                                 0, &layout_createinfo_binding_flags, 0, &variable_count);
     const vkt::PipelineLayout pipeline_layout_variable(*m_device, {&descriptor_set_variable.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -536,8 +536,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
                                        0, &layout_createinfo_binding_flags, 0, &variable_count);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1001,8 +1001,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
                                        0, &layout_createinfo_binding_flags, 0, &variable_count);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1123,8 +1123,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
                                        0, &layout_createinfo_binding_flags, 0, &variable_count);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1248,9 +1248,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ImageArrayDynamicIndexing) {
                                        0, &layout_createinfo_binding_flags, 0, &variable_count);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT,
-               VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -1481,8 +1479,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBindImageViewTypeMismatch) {
     VkShaderObj vs(this, kVertexDrawPassthroughGlsl, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1541,8 +1539,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
                                                  });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1662,8 +1660,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
                                                  });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1779,8 +1777,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     std::vector<VkPushConstantRange> push_constant_ranges = {{VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t)}};
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_}, push_constant_ranges);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1847,8 +1845,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
                                        });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -56,8 +56,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
                                        });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -119,8 +119,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
                                                  });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -240,8 +240,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
                                                  });
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -376,8 +376,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
                                        VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
 
     descriptor_set.WriteDescriptorBufferInfo(0, buffer0.handle(), 0, sizeof(uint32_t));
@@ -471,8 +471,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
                                        VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT);
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView image_view = image.CreateView();
 
     descriptor_set.WriteDescriptorBufferInfo(0, buffer0.handle(), 0, sizeof(uint32_t));

--- a/tests/unit/gpu_av_oob_positive.cpp
+++ b/tests/unit/gpu_av_oob_positive.cpp
@@ -167,8 +167,7 @@ TEST_F(PositiveGpuAVOOB, AtomicImageLoadStore) {
     RETURN_IF_SKIP(InitState());
 
     // Not sure if anyone actually support buffer texel on atomic
-    VkFormatProperties format_props = m_device->format_properties(VK_FORMAT_R32_SFLOAT);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(VK_FORMAT_R32_SFLOAT) & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT) == 0) {
         GTEST_SKIP() << "No atomic texel buffer support";
     }
 

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -529,8 +529,8 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
     )glsl";
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -661,9 +661,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();
@@ -726,9 +724,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
     image_ci.arrayLayers = 1;
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj copy_dst_image(m_device);
-    copy_dst_image.Init(image_ci);
-
+    vkt::Image copy_dst_image(*m_device, image_ci, vkt::set_layout);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     m_commandBuffer->begin();
@@ -757,13 +753,11 @@ TEST_F(PositiveGpuAV, CopyBufferToImageTwoSubmit) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 
-    vkt::CommandBuffer cb_0(m_device, m_commandPool);
-    vkt::CommandBuffer cb_1(m_device, m_commandPool);
+    vkt::CommandBuffer cb_0(*m_device, m_commandPool);
+    vkt::CommandBuffer cb_1(*m_device, m_commandPool);
 
-    auto image_ci = VkImageObj::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    VkImageObj image(m_device);
-    image.init(&image_ci);
-
+    auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::Buffer buffer(*m_device, 4096, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
     VkBufferImageCopy region = {};

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -23,6 +23,7 @@
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462
 TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
     TEST_DESCRIPTION("Require injection in the Loop Header block that contains a Phi");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -174,6 +174,7 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
 
 TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
     TEST_DESCRIPTION("Require injection in the Loop Header block that contains a Phi");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
 

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -892,7 +892,8 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -966,7 +967,8 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -1071,7 +1073,8 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -1179,7 +1182,8 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
- * Copyright (c) 2023 Google, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -71,7 +71,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     uint32_t width = 32;
     uint32_t height = 32;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto image_ci = VkImageObj::ImageCreateInfo2D(
+    auto image_ci = vkt::Image::ImageCreateInfo2D(
         width, height, 1, 1, format,
         VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
     RETURN_IF_SKIP(InitHostImageCopyTest(image_ci));
@@ -84,8 +84,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     }
 
     VkImageLayout layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
 
     std::vector<uint8_t> pixels(width * height * 4);
@@ -136,8 +135,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     ASSERT_EQ(pixels, welcome_back);
 
     // Copy from one image to another
-    VkImageObj image2(m_device);
-    image2.Init(image_ci);
+    vkt::Image image2(*m_device, image_ci, vkt::set_layout);
     image2.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
 
     VkImageCopy2 image_copy_2 = vku::InitStructHelper();
@@ -172,8 +170,8 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     transition_info.image = image2;
     result = vk::TransitionImageLayoutEXT(*m_device, 1, &transition_info);
     ASSERT_EQ(VK_SUCCESS, result);
-    VkImageSubresource image_sub = VkImageObj::subresource(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0);
-    VkImageSubresourceRange image_sub_range = VkImageObj::subresource_range(image_sub);
+    VkImageSubresource image_sub = vkt::Image::subresource(VK_IMAGE_ASPECT_COLOR_BIT, 0, 0);
+    VkImageSubresourceRange image_sub_range = vkt::Image::subresource_range(image_sub);
     VkImageMemoryBarrier image_barrier =
         image2.image_memory_barrier(0, 0, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL, image_sub_range);
 
@@ -210,14 +208,13 @@ TEST_F(PositiveHostImageCopy, CopyImageToMemoryMipLevel) {
     constexpr uint32_t width = 32;
     constexpr uint32_t height = 32;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto image_ci = VkImageObj::ImageCreateInfo2D(
+    auto image_ci = vkt::Image::ImageCreateInfo2D(
         width, height, 4, 1, format,
         VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
     RETURN_IF_SKIP(InitHostImageCopyTest(image_ci));
 
     VkImageLayout layout = VK_IMAGE_LAYOUT_GENERAL;
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
 
     const uint32_t bufferSize = width * height * 4u;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -29,10 +29,9 @@ TEST_F(NegativeImage, UsageBits) {
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 
     auto format = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj image(m_device);
     // Initialize image with transfer source usage
-    image.Init(128, 128, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
@@ -103,8 +102,6 @@ TEST_F(NegativeImage, CopyBufferToCompressedImage) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
-    VkImageObj width_image(m_device);
-    VkImageObj height_image(m_device);
     vkt::Buffer buffer(*m_device, 8 * 4 * 2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     VkBufferImageCopy region = {};
     region.bufferRowLength = 0;
@@ -115,8 +112,8 @@ TEST_F(NegativeImage, CopyBufferToCompressedImage) {
     region.imageExtent.height = 4;
     region.imageExtent.depth = 1;
 
-    width_image.Init(5, 4, 1, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    height_image.Init(8, 3, 1, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image width_image(*m_device, 5, 4, 1, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image height_image(*m_device, 8, 3, 1, VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     if (!width_image.initialized() || (!height_image.initialized())) {
         GTEST_SKIP() << "Unable to initialize surfaces";
     }
@@ -224,13 +221,11 @@ TEST_F(NegativeImage, SampleCounts) {
     {
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        VkImageObj src_image(m_device);
-        src_image.init(&image_create_info);
+        vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
         src_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
         image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        VkImageObj dst_image(m_device);
-        dst_image.init(&image_create_info);
+        vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBlitImage-srcImage-00233");
@@ -245,13 +240,11 @@ TEST_F(NegativeImage, SampleCounts) {
     {
         image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        VkImageObj src_image(m_device);
-        src_image.init(&image_create_info);
+        vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
         src_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        VkImageObj dst_image(m_device);
-        dst_image.init(&image_create_info);
+        vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBlitImage-dstImage-00234");
@@ -276,8 +269,7 @@ TEST_F(NegativeImage, SampleCounts) {
         vkt::Buffer src_buffer(*m_device, 128 * 128 * 4, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-        VkImageObj dst_image(m_device);
-        dst_image.init(&image_create_info);
+        vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(
@@ -294,8 +286,7 @@ TEST_F(NegativeImage, SampleCounts) {
         vkt::Buffer dst_buffer(*m_device, 128 * 128 * 4, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-        vkt::Image src_image;
-        src_image.init(*m_device, (const VkImageCreateInfo &)image_create_info, 0);
+        vkt::Image src_image(*m_device, (const VkImageCreateInfo &)image_create_info, 0);
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredFailureMsg(
             kErrorBit, "was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT");
@@ -337,29 +328,19 @@ TEST_F(NegativeImage, BlitFormatTypes) {
     bool d1dst = !FormatFeaturesAreSupported(gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
     bool d2src = !FormatFeaturesAreSupported(gpu(), f_depth2, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
 
-    VkImageObj unsigned_image(m_device);
-    unsigned_image.Init(64, 64, 1, f_unsigned, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(unsigned_image.initialized());
+    vkt::Image unsigned_image(*m_device, 64, 64, 1, f_unsigned, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     unsigned_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-    VkImageObj signed_image(m_device);
-    signed_image.Init(64, 64, 1, f_signed, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(signed_image.initialized());
+    vkt::Image signed_image(*m_device, 64, 64, 1, f_signed, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     signed_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-    VkImageObj float_image(m_device);
-    float_image.Init(64, 64, 1, f_float, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(float_image.initialized());
+    vkt::Image float_image(*m_device, 64, 64, 1, f_float, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     float_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-    VkImageObj depth_image(m_device);
-    depth_image.Init(64, 64, 1, f_depth, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(depth_image.initialized());
+    vkt::Image depth_image(*m_device, 64, 64, 1, f_depth, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     depth_image.SetLayout(VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-    VkImageObj depth_image2(m_device);
-    depth_image2.Init(64, 64, 1, f_depth2, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(depth_image2.initialized());
+    vkt::Image depth_image2(*m_device, 64, 64, 1, f_depth2, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     depth_image2.SetLayout(VK_IMAGE_ASPECT_DEPTH_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageBlit blitRegion = {};
@@ -496,14 +477,10 @@ TEST_F(NegativeImage, BlitFormatTypes) {
         bool ycbcrsrc = !FormatFeaturesAreSupported(gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
         bool ycbcrdst = !FormatFeaturesAreSupported(gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
 
-        VkImageObj ycbcr_image(m_device);
-        ycbcr_image.Init(64, 64, 1, f_ycbcr, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-        ASSERT_TRUE(ycbcr_image.initialized());
+        vkt::Image ycbcr_image(*m_device, 64, 64, 1, f_ycbcr, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
         ycbcr_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
-        VkImageObj ycbcr_image_2(m_device);
-        ycbcr_image_2.Init(64, 64, 1, f_ycbcr, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-        ASSERT_TRUE(ycbcr_image_2.initialized());
+        vkt::Image ycbcr_image_2(*m_device, 64, 64, 1, f_ycbcr, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
         ycbcr_image_2.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
         // Src, dst is ycbcr format
@@ -542,12 +519,8 @@ TEST_F(NegativeImage, BlitFilters) {
     }
 
     // Create 2D images
-    VkImageObj src2D(m_device);
-    VkImageObj dst2D(m_device);
-    src2D.Init(64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
-    dst2D.Init(64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    ASSERT_TRUE(src2D.initialized());
-    ASSERT_TRUE(dst2D.initialized());
+    vkt::Image src2D(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image dst2D(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     src2D.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     dst2D.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
@@ -562,10 +535,7 @@ TEST_F(NegativeImage, BlitFilters) {
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj src3D(m_device);
-    src3D.init(&ci);
-    ASSERT_TRUE(src3D.initialized());
+    vkt::Image src3D(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blitRegion = {};
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -616,22 +586,11 @@ TEST_F(NegativeImage, BlitLayout) {
 
     VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
 
-    // Create images
-    VkImageObj img_src_transfer(m_device);
-    VkImageObj img_dst_transfer(m_device);
-    VkImageObj img_general(m_device);
-    VkImageObj img_color(m_device);
-
-    img_src_transfer.InitNoLayout(64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    img_dst_transfer.InitNoLayout(64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    img_general.InitNoLayout(64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    img_color.InitNoLayout(64, 64, 1, fmt,
-                           VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-
-    ASSERT_TRUE(img_src_transfer.initialized());
-    ASSERT_TRUE(img_dst_transfer.initialized());
-    ASSERT_TRUE(img_general.initialized());
-    ASSERT_TRUE(img_color.initialized());
+    vkt::Image img_src_transfer(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img_dst_transfer(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img_general(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img_color(*m_device, 64, 64, 1, fmt,
+                         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     img_src_transfer.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     img_dst_transfer.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -774,22 +733,15 @@ TEST_F(NegativeImage, BlitOffsets) {
     ci.queueFamilyIndexCount = 0;
     ci.pQueueFamilyIndices = NULL;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    VkImageObj image_1D(m_device);
-    image_1D.init(&ci);
-    ASSERT_TRUE(image_1D.initialized());
+    vkt::Image image_1D(*m_device, ci, vkt::set_layout);
 
     ci.imageType = VK_IMAGE_TYPE_2D;
     ci.extent = {64, 64, 1};
-    VkImageObj image_2D(m_device);
-    image_2D.init(&ci);
-    ASSERT_TRUE(image_2D.initialized());
+    vkt::Image image_2D(*m_device, ci, vkt::set_layout);
 
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.extent = {64, 64, 64};
-    VkImageObj image_3D(m_device);
-    image_3D.init(&ci);
-    ASSERT_TRUE(image_3D.initialized());
+    vkt::Image image_3D(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blit_region = {};
     blit_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -917,10 +869,7 @@ TEST_F(NegativeImage, BlitOverlap) {
     ci.queueFamilyIndexCount = 0;
     ci.pQueueFamilyIndices = nullptr;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-
-    VkImageObj image_2D(m_device);
-    image_2D.init(&ci);
-    ASSERT_TRUE(image_2D.initialized());
+    vkt::Image image_2D(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blit_region = {};
     blit_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -972,23 +921,17 @@ TEST_F(NegativeImage, MiscBlitTests) {
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // 2D color image
-    VkImageObj color_img(m_device);
-    color_img.init(&ci);
-    ASSERT_TRUE(color_img.initialized());
+    vkt::Image color_img(*m_device, ci, vkt::set_layout);
 
     // 2D multi-sample image
     ci.samples = VK_SAMPLE_COUNT_4_BIT;
-    VkImageObj ms_img(m_device);
-    ms_img.init(&ci);
-    ASSERT_TRUE(ms_img.initialized());
+    vkt::Image ms_img(*m_device, ci, vkt::set_layout);
 
     // 3D color image
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.extent = {64, 64, 8};
-    VkImageObj color_3D_img(m_device);
-    color_3D_img.init(&ci);
-    ASSERT_TRUE(color_3D_img.initialized());
+    vkt::Image color_3D_img(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blitRegion = {};
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1125,9 +1068,7 @@ TEST_F(NegativeImage, BlitRemainingArrayLayers) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-
-    VkImageObj image(m_device);
-    image.init(&ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blitRegion = {};
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1177,9 +1118,7 @@ TEST_F(NegativeImage, BlitToDepth) {
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     // 2D depth image
-    VkImageObj depth_img(m_device);
-    depth_img.init(&ci);
-    ASSERT_TRUE(depth_img.initialized());
+    vkt::Image depth_img(*m_device, ci, vkt::set_layout);
 
     VkImageBlit blitRegion = {};
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1230,10 +1169,6 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
     VkExtent3D granularity = queue_family_properties[queue_family_index].minImageTransferGranularity;
     vkt::CommandPool command_pool(*m_device, queue_family_index, 0);
 
-    // Create two images of different types and try to copy between them
-    VkImage srcImage;
-    VkImage dstImage;
-
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_3D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -1246,21 +1181,12 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj src_image_obj(m_device);
-    src_image_obj.init(&image_create_info);
-    ASSERT_TRUE(src_image_obj.initialized());
-    srcImage = src_image_obj.handle();
+    vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
+    vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
 
-    VkImageObj dst_image_obj(m_device);
-    dst_image_obj.init(&image_create_info);
-    ASSERT_TRUE(dst_image_obj.initialized());
-    dstImage = dst_image_obj.handle();
-
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
-    ASSERT_TRUE(command_buffer.initialized());
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
 
     VkImageCopy copyRegion;
@@ -1286,7 +1212,8 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
     copyRegion.srcOffset.y = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImage-srcOffset-01783");  // srcOffset image transfer granularity
-    vk::CmdCopyImage(command_buffer.handle(), srcImage, VK_IMAGE_LAYOUT_GENERAL, dstImage, VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
+    vk::CmdCopyImage(command_buffer.handle(), src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1,
+                     &copyRegion);
     m_errorMonitor->VerifyFound();
 
     // Introduce failure by setting extent to a granularity value that is bad
@@ -1297,7 +1224,8 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
                                          "VUID-vkCmdCopyImage-srcOffset-01783");  // src extent image transfer granularity
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImage-dstOffset-01784");  // dst extent image transfer granularity
-    vk::CmdCopyImage(command_buffer.handle(), srcImage, VK_IMAGE_LAYOUT_GENERAL, dstImage, VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
+    vk::CmdCopyImage(command_buffer.handle(), src_image, VK_IMAGE_LAYOUT_GENERAL, dst_image, VK_IMAGE_LAYOUT_GENERAL, 1,
+                     &copyRegion);
     m_errorMonitor->VerifyFound();
 
     // Now do some buffer/image copies
@@ -1320,7 +1248,7 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
     region.imageExtent.width = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyImageToBuffer-imageOffset-07747");  // image transfer granularity
-    vk::CmdCopyImageToBuffer(command_buffer.handle(), srcImage, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer.handle(), 1, &region);
+    vk::CmdCopyImageToBuffer(command_buffer.handle(), src_image, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, buffer.handle(), 1, &region);
     m_errorMonitor->VerifyFound();
     region.imageExtent.width = granularity.width;
 
@@ -1328,7 +1256,7 @@ TEST_F(NegativeImage, MinImageTransferGranularity) {
     region.imageOffset.z = 3;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-vkCmdCopyBufferToImage-imageOffset-07738");  // image transfer granularity
-    vk::CmdCopyBufferToImage(command_buffer.handle(), buffer.handle(), dstImage, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
+    vk::CmdCopyBufferToImage(command_buffer.handle(), buffer.handle(), dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
     m_errorMonitor->VerifyFound();
 
     command_buffer.end();
@@ -1400,10 +1328,6 @@ TEST_F(NegativeImage, ImageLayout) {
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    // Create src & dst images to use for copy operations
-    VkImageObj src_image(m_device);
-    VkImageObj dst_image(m_device);
-    VkImageObj depth_image(m_device);
 
     const VkFormat tex_format = VK_FORMAT_B8G8R8A8_UNORM;
     const int32_t tex_width = 32;
@@ -1422,15 +1346,14 @@ TEST_F(NegativeImage, ImageLayout) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.flags = 0;
-
-    src_image.init(&image_create_info);
+    vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    dst_image.init(&image_create_info);
+    vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.format = VK_FORMAT_D16_UNORM;
     image_create_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-    depth_image.init(&image_create_info);
+    vkt::Image depth_image(*m_device, image_create_info, vkt::set_layout);
 
     m_commandBuffer->begin();
     VkImageCopy copy_region;
@@ -1615,7 +1538,6 @@ TEST_F(NegativeImage, ImageLayout) {
 TEST_F(NegativeImage, SameImageCopy) {
     TEST_DESCRIPTION("use wrong layout copying to the same image.");
     RETURN_IF_SKIP(Init());
-    VkImageObj src_image(m_device);
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -1630,8 +1552,7 @@ TEST_F(NegativeImage, SameImageCopy) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.flags = 0;
-
-    src_image.init(&image_create_info);
+    vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
 
     m_commandBuffer->begin();
     VkImageCopy copy_region;
@@ -1665,9 +1586,7 @@ TEST_F(NegativeImage, CopyImageRemainingArrayLayers) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
     ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-
-    VkImageObj image(m_device);
-    image.init(&ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageCopy copy_region = {};
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1695,14 +1614,7 @@ TEST_F(NegativeImage, StorageImageLayout) {
     RETURN_IF_SKIP(Init());
 
     const VkFormat tex_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageTiling tiling;
-    VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), tex_format, &format_properties);
-    if (format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) {
-        tiling = VK_IMAGE_TILING_LINEAR;
-    } else if (format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) {
-        tiling = VK_IMAGE_TILING_OPTIMAL;
-    } else {
+    if ((m_device->FormatFeaturesOptimal(tex_format) & VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT) == 0) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT; skipped.";
     }
 
@@ -1711,9 +1623,7 @@ TEST_F(NegativeImage, StorageImageLayout) {
                                            {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                        });
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, tex_format, VK_IMAGE_USAGE_STORAGE_BIT, tiling, 0);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 32, 32, 1, tex_format, VK_IMAGE_USAGE_STORAGE_BIT);
     vkt::ImageView view = image.CreateView();
 
     descriptor_set.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE);
@@ -1741,10 +1651,8 @@ TEST_F(NegativeImage, CopyImageMemory) {
     image_info.mipLevels = 1;
 
     // Create a small image with a dedicated allocation
-    VkImageObj image_no_mem(m_device);
-    image_no_mem.init_no_mem(*m_device, image_info);
-    VkImageObj image(m_device);
-    image.init(&image_info);
+    vkt::Image image_no_mem(*m_device, image_info, vkt::no_mem);
+    vkt::Image image(*m_device, image_info);
 
     VkImageCopy copy_region;
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1826,9 +1734,7 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
                                  0,
                                  nullptr,
                                  VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image1D(m_device);
-    image1D.init(&imgInfo);
-    ASSERT_TRUE(image1D.initialized());
+    vkt::Image image1D(*m_device, imgInfo, vkt::set_layout);
 
     // Initialize VkImageViewCreateInfo with mismatched viewType
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -1860,9 +1766,7 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
                0,
                nullptr,
                VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image2D(m_device);
-    image2D.init(&imgInfo);
-    ASSERT_TRUE(image2D.initialized());
+    vkt::Image image2D(*m_device, imgInfo, vkt::set_layout);
 
     // Initialize VkImageViewCreateInfo with mismatched viewType
     ivci = vku::InitStructHelper();
@@ -1901,9 +1805,7 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
                0,
                nullptr,
                VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image3D(m_device);
-    image3D.init(&imgInfo);
-    ASSERT_TRUE(image3D.initialized());
+    vkt::Image image3D(*m_device, imgInfo, vkt::set_layout);
 
     // Initialize VkImageViewCreateInfo with mismatched viewType
     ivci = vku::InitStructHelper();
@@ -2055,9 +1957,7 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
                                      0,
                                      nullptr,
                                      VK_IMAGE_LAYOUT_UNDEFINED};
-        VkImageObj image(m_device);
-        image.init(&imgInfo);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, imgInfo, vkt::set_layout);
 
         // Initialize VkImageViewCreateInfo with modified format
         VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2110,9 +2010,7 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
                                  0,
                                  nullptr,
                                  VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image(m_device);
-    image.init(&imgInfo);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, imgInfo, vkt::set_layout);
 
     // Initialize VkImageViewCreateInfo with modified format
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -2168,9 +2066,7 @@ TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
                                  0,
                                  nullptr,
                                  VK_IMAGE_LAYOUT_UNDEFINED};
-    VkImageObj image(m_device);
-    image.init(&imgInfo);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, imgInfo, vkt::set_layout);
 
     // Force the imageview format to exclude storage feature, include color attachment
     memset(&formatProps, 0, sizeof(formatProps));
@@ -2250,9 +2146,7 @@ TEST_F(NegativeImage, ImageViewNoSeparateStencilUsage) {
 
     image_view_create_info.pNext = &image_view_usage_create_info;
 
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     image_view_create_info.image = image.handle();
     image_view_usage_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;  // Extra flag
 
@@ -2301,9 +2195,7 @@ TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
 
     image_view_create_info.pNext = &image_view_usage_create_info;
 
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     image_view_create_info.image = image.handle();
 
     image_view_usage_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;  // Extra flag
@@ -2320,9 +2212,7 @@ TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
     image_view_create_info.subresourceRange.aspectMask =
         VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;  // Flag other than VK_IMAGE_ASPECT_STENCIL_BIT
 
-    VkImageObj image2(m_device);
-    image2.init(&image_create_info);
-    ASSERT_TRUE(image2.initialized());
+    vkt::Image image2(*m_device, image_create_info, vkt::set_layout);
     image_view_create_info.image = image2.handle();
 
     // VkImageViewUsageCreateInfo::usage must not include any bits that were not set in
@@ -2382,9 +2272,7 @@ TEST_F(NegativeImage, ImageViewAspect) {
     RETURN_IF_SKIP(Init());
 
     const VkFormat tex_format = VK_FORMAT_B8G8R8A8_UNORM;
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, tex_format, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR, 0);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 32, 32, 1, tex_format, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image.handle();
@@ -2407,10 +2295,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
 
     // VU 00732: image must have been created with tiling equal to VK_IMAGE_TILING_LINEAR
     {
-        const VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;  // ERROR: violates VU 00732
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, tiling);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_OPTIMAL);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2424,9 +2311,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
 
     // VU 00733: The aspectMask member of pSubresource must only have a single bit set
     {
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_LINEAR);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_METADATA_BIT;  // ERROR: triggers VU 00733
@@ -2441,9 +2328,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
 
     // 00739 mipLevel must be less than the mipLevels specified in VkImageCreateInfo when the image was created
     {
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_LINEAR);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2457,9 +2344,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
 
     // 00740 arrayLayer must be less than the arrayLayers specified in VkImageCreateInfo when the image was created
     {
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_LINEAR);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2482,8 +2369,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
                                                        VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
         if ((result == VK_SUCCESS) &&
             FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
-            VkImageObj img(m_device);
-            img.InitNoLayout(32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
+            auto image_ci =
+                vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
+            vkt::Image img(*m_device, image_ci);
 
             VkImageSubresource subres = {};
             subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;  // ERROR: triggers VU 04462
@@ -2505,8 +2393,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
                                                        VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
         if ((result == VK_SUCCESS) &&
             FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
-            VkImageObj img(m_device);
-            img.InitNoLayout(32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
+            auto image_ci =
+                vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
+            vkt::Image img(*m_device, image_ci);
 
             VkImageSubresource subres = {};
             subres.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;  // ERROR: triggers VU 04463
@@ -2520,9 +2409,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
     // 04464 If format does not contain stencil or depth component the aspectMask member of pResource must not contain
     // VK_IMAGE_ASPECT_DEPTH_BIT or VK_IMAGE_ASPECT_STENCIL_BIT
     {
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_LINEAR);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;  // ERROR: triggers VU 00997 and 04464
@@ -2533,9 +2422,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
         m_errorMonitor->VerifyFound();
     }
     {
-        VkImageObj img(m_device);
-        img.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-        ASSERT_TRUE(img.initialized());
+        auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT,
+                                                      VK_IMAGE_TILING_LINEAR);
+        vkt::Image img(*m_device, image_ci);
 
         VkImageSubresource subres = {};
         subres.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;  // ERROR: triggers VU 00997 and 04464
@@ -2652,9 +2541,7 @@ TEST_F(NegativeImage, ImageViewFormatMismatchUnrelated) {
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), depth_format, formatProps);
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.image = image.handle();
@@ -2680,9 +2567,7 @@ TEST_F(NegativeImage, ImageViewNoMutableFormatBit) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     VkFormatProperties formatProps;
 
@@ -2709,7 +2594,7 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
 
     RETURN_IF_SKIP(Init());
 
-    if (!(m_device->format_properties(VK_FORMAT_R8_UINT).optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
+    if (!(m_device->FormatFeaturesOptimal(VK_FORMAT_R8_UINT) & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
         GTEST_SKIP() << "Device does not support R8_UINT as color attachment";
     }
 
@@ -2730,9 +2615,7 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
                                    VK_IMAGE_LAYOUT_UNDEFINED};
 
     imageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-    VkImageObj mutImage(m_device);
-    mutImage.init(&imageInfo);
-    ASSERT_TRUE(mutImage.initialized());
+    vkt::Image mutImage(*m_device, imageInfo, vkt::set_layout);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -2751,9 +2634,7 @@ TEST_F(NegativeImage, ImageViewDifferentClass) {
         VkImageCreateInfo cubeImageInfo = imageInfo;
         cubeImageInfo.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
         cubeImageInfo.arrayLayers = 6;
-        VkImageObj cubeImage(m_device);
-        cubeImage.init(&cubeImageInfo);
-        ASSERT_TRUE(cubeImage.initialized());
+        vkt::Image cubeImage(*m_device, cubeImageInfo);
 
         VkImageViewCreateInfo cubeImgViewInfo = imgViewInfo;
         cubeImgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_CUBE_ARRAY;
@@ -2772,10 +2653,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
     VkPhysicalDeviceFeatures device_features = {};
     GetPhysicalDeviceFeatures(&device_features);
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.create_info().arrayLayers == 1);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     VkImageViewCreateInfo img_view_info_template = vku::InitStructHelper();
     img_view_info_template.image = image.handle();
@@ -2855,7 +2733,6 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
     }
 
     {
-        VkImageObj cubeArrayImg(m_device);
         auto image_ci = vkt::Image::create_info();
         image_ci.arrayLayers = 18;
         image_ci.flags = VK_IMAGE_CREATE_CUBE_COMPATIBLE_BIT;
@@ -2864,7 +2741,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
         image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-        cubeArrayImg.init(&image_ci);
+        vkt::Image cubeArrayImg(*m_device, image_ci, vkt::set_layout);
 
         VkImageViewCreateInfo cube_img_view_info_template = vku::InitStructHelper();
         cube_img_view_info_template.image = cubeArrayImg.handle();
@@ -2942,7 +2819,6 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
     VkPhysicalDeviceFeatures device_features = {};
     GetPhysicalDeviceFeatures(&device_features);
 
-    VkImageObj volumeImage(m_device);
     auto image_ci = vkt::Image::create_info();
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR;
     image_ci.imageType = VK_IMAGE_TYPE_3D;
@@ -2952,7 +2828,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    volumeImage.init(&image_ci);
+    vkt::Image volumeImage(*m_device, image_ci, vkt::set_layout);
 
     VkImageViewCreateInfo volume_img_view_info_template = vku::InitStructHelper();
     volume_img_view_info_template.image = volumeImage.handle();
@@ -3110,10 +2986,9 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
 
     // using VK_IMAGE_CREATE_SPARSE_BINDING_BIT
     if (device_features.sparseBinding) {
-        VkImageObj sparse_image(m_device);
         image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
-        sparse_image.Init(image_ci, 0, false);
+        vkt::Image sparse_image(*m_device, image_ci, vkt::no_mem);
         sparse_image_view_ci.image = sparse_image.handle();
 
         sparse_image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -3125,11 +3000,10 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
     }
     // using VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT
     if (device_features.sparseResidencyImage3D) {
-        VkImageObj sparse_image(m_device);
         image_ci.flags =
             VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
-        sparse_image.Init(image_ci, 0, false);
+        vkt::Image sparse_image(*m_device, image_ci, vkt::no_mem);
         sparse_image_view_ci.image = sparse_image.handle();
 
         sparse_image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -3141,11 +3015,10 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
     }
     // using VK_IMAGE_CREATE_SPARSE_ALIASED_BIT
     if (device_features.sparseResidencyAliased) {
-        VkImageObj sparse_image(m_device);
         image_ci.flags =
             VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_ALIASED_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-flags-09403");
-        sparse_image.Init(image_ci, 0, false);
+        vkt::Image sparse_image(*m_device, image_ci, vkt::no_mem);
         sparse_image_view_ci.image = sparse_image.handle();
 
         sparse_image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -3176,41 +3049,29 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     image_ci.imageType = VK_IMAGE_TYPE_1D;
-    VkImageObj image_1d(m_device);
-    image_1d.init(&image_ci);
-    ASSERT_TRUE(image_1d.initialized());
+    vkt::Image image_1d(*m_device, image_ci, vkt::set_layout);
 
     image_ci.imageType = VK_IMAGE_TYPE_2D;
-    VkImageObj image_2d(m_device);
-    image_2d.init(&image_ci);
-    ASSERT_TRUE(image_2d.initialized());
+    vkt::Image image_2d(*m_device, image_ci, vkt::set_layout);
 
     image_ci.imageType = VK_IMAGE_TYPE_3D;
-    VkImageObj image_3d(m_device);
-    image_3d.init(&image_ci);
-    ASSERT_TRUE(image_3d.initialized());
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
     image_ci.arrayLayers = 2;
 
     image_ci.imageType = VK_IMAGE_TYPE_1D;
-    VkImageObj image_1d_array(m_device);
-    image_1d_array.init(&image_ci);
-    ASSERT_TRUE(image_1d_array.initialized());
+    vkt::Image image_1d_array(*m_device, image_ci, vkt::set_layout);
 
     image_ci.imageType = VK_IMAGE_TYPE_2D;
-    VkImageObj image_2d_array(m_device);
-    image_2d_array.init(&image_ci);
-    ASSERT_TRUE(image_2d_array.initialized());
+    vkt::Image image_2d_array(*m_device, image_ci, vkt::set_layout);
 
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     VkImageFormatProperties img_limits;
     ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
-    std::optional<VkImageObj> image_3d_array;
+    vkt::Image image_3d_array;
     image_ci.arrayLayers = 1;  // arrayLayers must be 1 for 3D images
     if (img_limits.maxArrayLayers >= image_ci.arrayLayers) {
-        image_3d_array.emplace(m_device);
-        image_3d_array->init(&image_ci);
-        ASSERT_TRUE(image_3d_array->initialized());
+        image_3d_array.init(*m_device, image_ci, 0);
     }
 
     // base for each test that never changes
@@ -3231,9 +3092,9 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         image_view_ci.image = image_2d_array.image();
         CreateImageViewTest(*this, &image_view_ci);
-        if (image_3d_array) {
+        if (image_3d_array.handle() != VK_NULL_HANDLE) {
             image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-            image_view_ci.image = image_3d_array->image();
+            image_view_ci.image = image_3d_array.image();
             CreateImageViewTest(*this, &image_view_ci);
         }
 
@@ -3246,10 +3107,10 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
         image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
         image_view_ci.image = image_2d_array.image();
         CreateImageViewTest(*this, &image_view_ci);
-        if (image_3d_array) {
+        if (image_3d_array.handle() != VK_NULL_HANDLE) {
             image_view_ci.subresourceRange.baseArrayLayer = 0;
             image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-            image_view_ci.image = image_3d_array->image();
+            image_view_ci.image = image_3d_array.image();
             CreateImageViewTest(*this, &image_view_ci);
         }
 
@@ -3280,9 +3141,9 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
         image_view_ci.image = image_2d_array.image();
         CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
 
-        if (image_3d_array) {
+        if (image_3d_array.handle() != VK_NULL_HANDLE) {
             image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_3D;
-            image_view_ci.image = image_3d_array->image();
+            image_view_ci.image = image_3d_array.image();
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageViewCreateInfo-subresourceRange-06725");
             CreateImageViewTest(*this, &image_view_ci, "VUID-VkImageViewCreateInfo-imageViewType-04973");
         }
@@ -3634,8 +3495,6 @@ TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     RETURN_IF_SKIP(Init());
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
 
-    VkImageObj image_bad(m_device);
-    VkImageObj image_good(m_device);
     // One bad format and one good format for Color attachment
     const VkFormat tex_format_bad = depth_format;
     const VkFormat tex_format_good = VK_FORMAT_B8G8R8A8_UNORM;
@@ -3654,12 +3513,11 @@ TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    image_bad.init(&image_create_info);
+    vkt::Image image_bad(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.format = tex_format_good;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image_good.init(&image_create_info);
+    vkt::Image image_good(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo image_view_create_info = vku::InitStructHelper();
     image_view_create_info.image = image_bad.handle();
@@ -3867,12 +3725,8 @@ TEST_F(NegativeImage, AstcDecodeMode) {
     const VkFormat rgba_format = VK_FORMAT_R8G8B8A8_UNORM;
     const VkFormat ldr_format = VK_FORMAT_ASTC_4x4_UNORM_BLOCK;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, rgba_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
-    VkImageObj astc_image(m_device);
-    astc_image.Init(128, 128, 1, ldr_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(astc_image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, rgba_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image astc_image(*m_device, 128, 128, 1, ldr_format, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkImageViewASTCDecodeModeEXT astc_decode_mode = vku::InitStructHelper();
     astc_decode_mode.decodeMode = VK_FORMAT_R16G16B16A16_SFLOAT;
@@ -3927,9 +3781,7 @@ TEST_F(NegativeImage, ImageViewIncompatibleFormat) {
                                    VK_IMAGE_LAYOUT_UNDEFINED};
 
     imageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-    VkImageObj mutImage(m_device);
-    mutImage.init(&imageInfo);
-    ASSERT_TRUE(mutImage.initialized());
+    vkt::Image mutImage(*m_device, imageInfo, vkt::set_layout);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -3948,9 +3800,7 @@ TEST_F(NegativeImage, ImageViewIncompatibleFormat) {
     imgViewInfo.format = imageInfo.format;
     CreateImageViewTest(*this, &imgViewInfo, {});
 
-    VkImageObj mut_compat_image(m_device);
-    mut_compat_image.init(&imageInfo);
-    ASSERT_TRUE(mut_compat_image.initialized());
+    vkt::Image mut_compat_image(*m_device, imageInfo);
 
     imgViewInfo.image = mut_compat_image.handle();
     imgViewInfo.format = VK_FORMAT_R8_SINT;  // different, but size compatible
@@ -3983,10 +3833,7 @@ TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
                                    0,
                                    nullptr,
                                    VK_IMAGE_LAYOUT_UNDEFINED};
-
-    VkImageObj mutImage(m_device);
-    mutImage.init(&imageInfo);
-    ASSERT_TRUE(mutImage.initialized());
+    vkt::Image mutImage(*m_device, imageInfo, vkt::set_layout);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -4015,9 +3862,7 @@ TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
     }
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkImageViewCreateInfo view_info = vku::InitStructHelper();
     view_info.flags = 0;
@@ -4061,23 +3906,18 @@ TEST_F(NegativeImage, ImageFormatList) {
                                    nullptr,
                                    VK_IMAGE_LAYOUT_UNDEFINED};
 
-    VkImageObj mutableImage(m_device);
-    VkImageObj mutableImageZero(m_device);
-    VkImageObj normalImage(m_device);
-
     // Not all 4 formats are compatible
     CreateImageTest(*this, &imageInfo, "VUID-VkImageCreateInfo-pNext-06722");
 
     // Should work with only first 3 in array
     formatList.viewFormatCount = 3;
-    mutableImage.init(&imageInfo);
-    ASSERT_TRUE(mutableImage.initialized());
+    vkt::Image mutableImage(*m_device, imageInfo);
 
     // Make sure no error if 0 format
     formatList.viewFormatCount = 0;
     formatList.pViewFormats = &formats[3];  // non-compatible format
-    mutableImageZero.init(&imageInfo);
-    ASSERT_TRUE(mutableImageZero.initialized());
+    vkt::Image mutableImageZero(*m_device, imageInfo);
+
     // reset
     formatList.viewFormatCount = 3;
     formatList.pViewFormats = formats;
@@ -4088,8 +3928,7 @@ TEST_F(NegativeImage, ImageFormatList) {
 
     // Make sure no error if 1 format
     formatList.viewFormatCount = 1;
-    normalImage.init(&imageInfo);
-    ASSERT_TRUE(normalImage.initialized());
+    vkt::Image normalImage(*m_device, imageInfo);
 
     VkImageViewCreateInfo imageViewInfo = vku::InitStructHelper(nullptr);
     imageViewInfo.flags = 0;
@@ -4177,8 +4016,7 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
                                    VK_IMAGE_LAYOUT_UNDEFINED};
 
     // The first image in the list should be size-compatible (128-bit)
-    VkImageObj good_image(m_device);
-    good_image.init(&imageInfo);
+    vkt::Image good_image(*m_device, imageInfo);
 
     // The second image in the list should NOT be size-compatible (64-bit)
     formatList.viewFormatCount = 2;
@@ -4278,9 +4116,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCount) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     vkt::DeviceMemory image_mem;
     VkMemoryRequirements mem_reqs;
@@ -4367,9 +4203,7 @@ TEST_F(NegativeImage, ImageSplitInstanceBindRegionCountWithDeviceGroup) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetImageMemoryRequirements(m_device->device(), image.handle(), &mem_reqs);
@@ -4424,13 +4258,12 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    VkImageObj image(m_device);
     VkFormatProperties image_fmt;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
-    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
+    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
-    image.Init(image_create_info, 0);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -4477,13 +4310,12 @@ TEST_F(NegativeImage, BlockTexelViewCompatibleMultipleLayers) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkImageObj image(m_device);
     VkFormatProperties image_fmt;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
-    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
+    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
-    image.Init(image_create_info, 0);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -4544,9 +4376,7 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements mem_reqs;
     vk::GetImageMemoryRequirements(m_device->device(), image.handle(), &mem_reqs);
@@ -4610,13 +4440,12 @@ TEST_F(NegativeImage, BlockTexelViewType) {
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    VkImageObj image(m_device);
     VkFormatProperties image_fmt;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
-    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
+    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
-    image.Init(image_create_info, 0);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -4654,13 +4483,12 @@ TEST_F(NegativeImage, BlockTexelViewFormat) {
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
 
-    VkImageObj image(m_device);
     VkFormatProperties image_fmt;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
-    if (!image.IsCompatible(image_create_info.usage, image_fmt.optimalTilingFeatures)) {
+    if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
-    image.Init(image_create_info, 0);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -4717,10 +4545,7 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = vku::InitStructHelper();
     ycbcr_create_info.format = mp_format;
@@ -4842,8 +4667,7 @@ TEST_F(NegativeImage, MultiSampleImageView) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits for image format are not supported; skipping";
     }
 
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
@@ -4889,10 +4713,8 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_ci.flags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
-    VkImageObj image_3d(m_device);
-    image_3d.init(&image_ci);
-    ASSERT_TRUE(image_3d.initialized());
     VkImageViewCreateInfo view_ci = vku::InitStructHelper();
     view_ci.image = image_3d.handle();
     view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
@@ -4919,8 +4741,7 @@ TEST_F(NegativeImage, Image2DViewOf3D) {
     descriptor_set.Clear();
 
     image_ci.flags = 0;
-    VkImageObj image_3d_no_flag(m_device);
-    image_3d_no_flag.init(&image_ci);
+    vkt::Image image_3d_no_flag(*m_device, image_ci, vkt::set_layout);
     view_ci.image = image_3d_no_flag.handle();
     CreateImageViewTest(*this, &view_ci, "VUID-VkImageViewCreateInfo-image-06728");
 
@@ -4959,10 +4780,8 @@ TEST_F(NegativeImage, Image2DViewOf3DFeature) {
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_STORAGE_BIT;
     image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_ci.flags = VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
-    VkImageObj image_3d(m_device);
-    image_3d.init(&image_ci);
-    ASSERT_TRUE(image_3d.initialized());
     VkImageViewCreateInfo view_ci = vku::InitStructHelper();
     view_ci.image = image_3d.handle();
     view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -5011,10 +4830,7 @@ TEST_F(NegativeImage, ImageViewMinLod) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image2D(m_device);
-    image2D.init(&image_create_info);
-    ASSERT_TRUE(image2D.initialized());
+    vkt::Image image2D(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image2D.handle();
@@ -5048,9 +4864,8 @@ TEST_F(NegativeImage, ImageViewMinLodFeature) {
     TEST_DESCRIPTION("Checks for image view minimum level of detail feature enabled.");
     AddRequiredExtensions(VK_EXT_IMAGE_VIEW_MIN_LOD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    VkImageObj image(m_device);
     // Initialize image with transfer source usage
-    image.Init(128, 128, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 128, 128, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
     ivci.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -5075,8 +4890,7 @@ TEST_F(NegativeImage, ColorWthDepthAspect) {
 
     auto format = FindSupportedDepthStencilFormat(gpu());
 
-    VkImageObj color_image(m_device);
-    color_image.Init(64, 64, 1, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image color_image(*m_device, 64, 64, 1, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     VkImageViewCreateInfo civ_ci = vku::InitStructHelper();
     civ_ci.image = color_image.handle();
@@ -5115,22 +4929,18 @@ TEST_F(NegativeImage, ImageCopyMissingUsage) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    VkImageObj sampled_image(m_device);
-    sampled_image.Init(image_ci);
+    vkt::Image sampled_image(*m_device, image_ci, vkt::set_layout);
 
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    VkImageObj transfer_image(m_device);
-    transfer_image.Init(image_ci);
+    vkt::Image transfer_image(*m_device, image_ci, vkt::set_layout);
 
     image_ci.pNext = &stencil_usage_ci;
     image_ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj separate_stencil_sampled_image(m_device);
-    separate_stencil_sampled_image.Init(image_ci);
+    vkt::Image separate_stencil_sampled_image(*m_device, image_ci, vkt::set_layout);
 
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     stencil_usage_ci.stencilUsage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    VkImageObj separate_stencil_transfer_image(m_device);
-    separate_stencil_transfer_image.Init(image_ci);
+    vkt::Image separate_stencil_transfer_image(*m_device, image_ci, vkt::set_layout);
 
     VkImageCopy region;
     region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -5193,7 +5003,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT | VK_IMAGE_COMPRESSION_DISABLED_EXT;
 
-        auto image_create_info = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+        auto image_create_info = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                                                VK_IMAGE_USAGE_TRANSFER_DST_BIT, VK_IMAGE_TILING_LINEAR);
         image_create_info.pNext = &compression_control;
 
@@ -5206,7 +5016,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_EXPLICIT_EXT;
         compression_control.pFixedRateFlags = nullptr;
 
-        auto image_create_info = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+        auto image_create_info = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
         image_create_info.pNext = &compression_control;
 
@@ -5214,18 +5024,18 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     }
 
     // Image creation lambda
-    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, VkImageObj &image) -> bool {
+    const auto create_compressed_image = [&](VkFormat format, VkImageTiling imageTiling, vkt::Image &image) -> bool {
         VkImageCompressionControlEXT compression_control = vku::InitStructHelper();  // specify the desired compression settings
         compression_control.flags = VK_IMAGE_COMPRESSION_FIXED_RATE_DEFAULT_EXT;
 
         auto image_create_info =
-            VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, imageTiling);
+            vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, imageTiling);
         image_create_info.pNext = &compression_control;
 
         bool supported = ImageFormatIsSupported(instance(), gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
 
         if (supported) {
-            image.init(&image_create_info);
+            image.init(*m_device, image_create_info, 0);
         }
 
         return supported;
@@ -5233,7 +5043,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Exceed MipmapLevel
     {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-mipLevel-01716");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5249,7 +5059,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Exceed ArrayLayers
     {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-arrayLayer-01717");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5265,7 +5075,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Color format aspect
     {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-format-08886");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5282,7 +5092,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // Depth format, Stencil aspect
     {
         const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(depth_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-format-04462");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5298,7 +5108,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // Stencil format, Depth aspect
     const VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
     if (stencil_format != VK_FORMAT_UNDEFINED) {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(stencil_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-format-04463");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5315,7 +5125,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // AspectMask should be a bitset
     {
         const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(depth_stencil_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-aspectMask-00997");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5331,7 +5141,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Depth/Stencil format aspect
     {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(VK_FORMAT_R8G8B8A8_SNORM, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-format-08886");
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-format-04464");
@@ -5349,7 +5159,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // 2 plane format
     const VkFormat two_plane_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR;
     if (multi_plane_extensions) {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(two_plane_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-tiling-08717");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5366,7 +5176,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
     // 3 plane format
     const VkFormat three_plane_format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
     if (multi_plane_extensions) {
-        VkImageObj image(m_device);
+        vkt::Image image;
         if (create_compressed_image(three_plane_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-tiling-08717");
             VkImageSubresource2EXT subresource = vku::InitStructHelper();
@@ -5391,10 +5201,9 @@ TEST_F(NegativeImage, GetImageSubresourceLayout2Maintenance5) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkImageObj image(m_device);
-    auto image_create_info = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
+    auto image_create_info = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_R8G8B8A8_UNORM,
                                                            VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     // Exceed MipmapLevel
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageSubresourceLayout2KHR-mipLevel-01716");
@@ -5425,8 +5234,7 @@ TEST_F(NegativeImage, TransitionNonSparseImageLayoutWithoutBoundMemory) {
     VkImageCreateInfo info = vkt::Image::create_info();
     info.format = VK_FORMAT_B8G8R8A8_UNORM;
     info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, info);
+    vkt::Image image(*m_device, info, vkt::no_mem);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier-image-01932");
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
@@ -5444,8 +5252,7 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     info.format = VK_FORMAT_B8G8R8A8_UNORM;
     info.usage =
         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
-    VkImageObj image{m_device};
-    image.init(&info);
+    vkt::Image image(*m_device, info, vkt::set_layout);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageMemoryBarrier-attachmentFeedbackLoopLayout-07313");
     image.SetLayout(VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT);
     m_errorMonitor->VerifyFound();
@@ -5539,7 +5346,6 @@ TEST_F(NegativeImage, SlicedDeviceFeature) {
     // NOTE: We are NOT enabling the VkPhysicalDeviceImageSlicedViewOf3DFeaturesEXT::imageSlicedViewOf3D feature!
     InitState();
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -5551,8 +5357,7 @@ TEST_F(NegativeImage, SlicedDeviceFeature) {
     ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    image.init(&ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
@@ -5580,7 +5385,6 @@ TEST_F(NegativeImage, SlicedImageType) {
     AddRequiredFeature(vkt::Feature::imageSlicedViewOf3D);
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_2D;  // imageType should be VK_IMAGE_TYPE_3D
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -5592,8 +5396,7 @@ TEST_F(NegativeImage, SlicedImageType) {
     ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    image.init(&ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
@@ -5622,7 +5425,6 @@ TEST_F(NegativeImage, SlicedMipLevel) {
     AddRequiredFeature(vkt::Feature::imageSlicedViewOf3D);
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -5634,8 +5436,7 @@ TEST_F(NegativeImage, SlicedMipLevel) {
     ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    image.init(&ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
     sliced_info.sliceCount = VK_REMAINING_3D_SLICES_EXT;
@@ -5699,7 +5500,6 @@ TEST_F(NegativeImage, SlicedUsage) {
     AddRequiredFeature(vkt::Feature::imageSlicedViewOf3D);
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
     VkImageCreateInfo ci = vku::InitStructHelper();
     ci.imageType = VK_IMAGE_TYPE_3D;
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -5711,8 +5511,7 @@ TEST_F(NegativeImage, SlicedUsage) {
     ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    image.init(&ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     VkImageViewSlicedCreateInfoEXT sliced_info = vku::InitStructHelper();
 
@@ -5855,10 +5654,7 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj sampled_image2D(m_device);
-    sampled_image2D.init(&image_create_info);
-    ASSERT_TRUE(sampled_image2D.initialized());
+    vkt::Image sampled_image2D(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.arrayLayers = 1;
     image_create_info.format = VK_FORMAT_R8_UNORM;
@@ -5866,10 +5662,7 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     image_create_info.extent.height = 64;
     image_create_info.arrayLayers = 64;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLE_WEIGHT_BIT_QCOM;
-
-    VkImageObj weight_image2D(m_device);
-    weight_image2D.init(&image_create_info);
-    ASSERT_TRUE(weight_image2D.initialized());
+    vkt::Image weight_image2D(*m_device, image_create_info, vkt::set_layout);
 
     const VkComponentMapping identity = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                                          VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
@@ -6008,9 +5801,8 @@ TEST_F(NegativeImage, ComputeImageLayout) {
     pipe.CreateComputePipeline();
 
     const VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    image.Init(64, 64, 1, fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     vkt::ImageView view = image.CreateView();
 
@@ -6020,7 +5812,7 @@ TEST_F(NegativeImage, ComputeImageLayout) {
     pipe.descriptor_set_->UpdateDescriptorSets();
 
     {  // Verify invalid image layout with CmdDispatch
-        vkt::CommandBuffer cmd(m_device, m_commandPool);
+        vkt::CommandBuffer cmd(*m_device, m_commandPool);
         cmd.begin();
         vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                                   &pipe.descriptor_set_->set_, 0, nullptr);
@@ -6034,7 +5826,7 @@ TEST_F(NegativeImage, ComputeImageLayout) {
     }
 
     {  // Verify invalid image layout with CmdDispatchBaseKHR
-        vkt::CommandBuffer cmd(m_device, m_commandPool);
+        vkt::CommandBuffer cmd(*m_device, m_commandPool);
         cmd.begin();
         vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                                   &pipe.descriptor_set_->set_, 0, nullptr);
@@ -6069,9 +5861,8 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     pipe.CreateComputePipeline();
 
     const VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    image.Init(64, 64, 1, fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 64, 64, 1, fmt, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     vkt::ImageView view = image.CreateView();
 
@@ -6104,9 +5895,8 @@ TEST_F(NegativeImage, GetPhysicalDeviceImageFormatProperties) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
-    VkImageObj image(m_device);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
-    image.Init(128, 128, 1, VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_USAGE_STORAGE_BIT);
     m_errorMonitor->VerifyFound();
 }
 
@@ -6115,7 +5905,6 @@ TEST_F(NegativeImage, OverlappingImageCopy) {
 
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -6128,7 +5917,7 @@ TEST_F(NegativeImage, OverlappingImageCopy) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage =
         VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     m_commandBuffer->begin();
@@ -6151,12 +5940,10 @@ TEST_F(NegativeImage, BlitColorToDepth) {
     TEST_DESCRIPTION("Blit a color image to a depth image");
     RETURN_IF_SKIP(Init());
 
-    VkImageObj color_image(m_device);
-    color_image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
+    vkt::Image color_image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
     auto depth_format = FindSupportedDepthStencilFormat(gpu());
-    VkImageObj depth_image(m_device);
-    depth_image.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image depth_image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     VkFormatProperties format_properties;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), depth_format, &format_properties);
@@ -6212,11 +5999,9 @@ TEST_F(NegativeImage, ResolveDepthImage) {
         GTEST_SKIP() << "Required formats samples not supported";
     }
 
-    VkImageObj image1(m_device);
-    image1.init(&image_ci);
-
-    VkImageObj image2(m_device);
-    image2.Init(32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image1(*m_device, image_ci, vkt::set_layout);
+    vkt::Image image2(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    image2.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageResolve region;
     region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 0u, 1u};

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -182,8 +182,7 @@ TEST_F(NegativeImageDrm, GetImageSubresourceLayoutPlane) {
         }
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
     if (image.initialized() == false) {
         GTEST_SKIP() << "Failed to create image.";
     }
@@ -238,8 +237,7 @@ TEST_F(NegativeImageDrm, ImageSubresourceRangeAspectMask) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, mp_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, mp_format, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     vkt::SamplerYcbcrConversion conversion(*m_device, mp_format);
     auto conversion_info = conversion.ConversionInfo();
@@ -462,8 +460,7 @@ TEST_F(NegativeImageDrm, MultiPlanarGetImageMemoryRequirements) {
         }
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
     if (image.initialized() == false) {
         GTEST_SKIP() << "Failed to create image.";
     }
@@ -522,8 +519,7 @@ TEST_F(NegativeImageDrm, MultiPlanarBindMemory) {
         }
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
     if (image.initialized() == false) {
         GTEST_SKIP() << "Failed to create image.";
     }

--- a/tests/unit/image_drm_positive.cpp
+++ b/tests/unit/image_drm_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -240,8 +240,7 @@ TEST_F(PositiveImageDrm, GetImageSubresourceLayoutPlane) {
         }
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
     if (image.initialized() == false) {
         GTEST_SKIP() << "Failed to create image.";
     }

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -73,10 +73,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     imageCreateInfo.imageType = VK_IMAGE_TYPE_2D;
     imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
     imageCreateInfo.format = attachmentFormats[0];
-
-    VkImageObj imageObject(m_device);
-    imageObject.init(&imageCreateInfo);
-    VkImage image = imageObject.image();
+    vkt::Image image(*m_device, imageCreateInfo, vkt::set_layout);
 
     // Only use the subset without the TRANSFER bit
     VkImageViewUsageCreateInfo image_view_usage_create_info = vku::InitStructHelper();
@@ -92,11 +89,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
 
     // Has subset of usage flags
     vkt::ImageView imageViewSubset(*m_device, imageViewCreateInfo);
-    ASSERT_TRUE(imageViewSubset.initialized());
 
     imageViewCreateInfo.pNext = nullptr;
     vkt::ImageView imageView(*m_device, imageViewCreateInfo);
-    ASSERT_TRUE(imageView.initialized());
 
     VkImageView image_views[2] = {imageView.handle(), imageView.handle()};
     VkRenderPassAttachmentBeginInfoKHR renderPassAttachmentBeginInfo = vku::InitStructHelper();
@@ -115,7 +110,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferCreateInfo.pAttachments = nullptr;
         framebufferCreateInfo.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         m_commandBuffer->begin(&cmd_begin_info);
         m_commandBuffer->BeginRenderPass(renderPassBeginInfo);
@@ -127,7 +121,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferCreateInfo.pAttachments = &imageView.handle();
         framebufferCreateInfo.flags = 0;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03207", "VUID-VkRenderPassBeginInfo-framebuffer-03207");
@@ -136,7 +129,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferCreateInfo.pAttachments = nullptr;
         framebufferCreateInfo.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassAttachmentBeginInfo.attachmentCount = 2;
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
@@ -147,7 +139,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     // Mismatched number of attachments
     {
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassAttachmentBeginInfo.attachmentCount = 2;
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
@@ -159,7 +150,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.flags = 0;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03209", "VUID-VkRenderPassBeginInfo-framebuffer-03209");
@@ -170,7 +160,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
@@ -181,7 +170,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         renderPassAttachmentBeginInfo.pAttachments = &imageViewSubset.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-04627", "VUID-VkRenderPassBeginInfo-framebuffer-04627");
@@ -192,7 +180,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.width += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03211", "VUID-VkRenderPassBeginInfo-framebuffer-03211");
@@ -203,7 +190,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.height += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03212", "VUID-VkRenderPassBeginInfo-framebuffer-03212");
@@ -214,7 +200,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.layerCount += 1;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03213", "VUID-VkRenderPassBeginInfo-framebuffer-03213");
@@ -225,7 +210,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentImageInfo.viewFormatCount = 3;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03214", "VUID-VkRenderPassBeginInfo-framebuffer-03214");
@@ -236,7 +220,6 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         framebufferAttachmentFormats[1] = VK_FORMAT_B8G8R8A8_SRGB;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03215", "VUID-VkRenderPassBeginInfo-framebuffer-03215");
@@ -247,10 +230,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         imageViewCreateInfo.format = attachmentFormats[1];
         vkt::ImageView imageView2(*m_device, imageViewCreateInfo);
-        ASSERT_TRUE(imageView2.initialized());
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-03216", "VUID-VkRenderPassBeginInfo-framebuffer-03216");
@@ -262,19 +243,16 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         imageCreateInfo.samples = VK_SAMPLE_COUNT_4_BIT;
         imageCreateInfo.mipLevels = 1;
-        VkImageObj imageObject2(m_device);
-        imageObject2.init(&imageCreateInfo);
+        vkt::Image imageObject2(*m_device, imageCreateInfo, vkt::set_layout);
         imageViewCreateInfo.image = imageObject2.image();
         vkt::ImageView imageView2(*m_device, imageViewCreateInfo);
-        ASSERT_TRUE(imageView2.initialized());
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassBeginInfo-framebuffer-09047", "VUID-VkRenderPassBeginInfo-framebuffer-09047");
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
-        imageViewCreateInfo.image = imageObject.image();
+        imageViewCreateInfo.image = image.image();
         imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
         imageCreateInfo.mipLevels = 10;
     }
@@ -283,10 +261,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         imageViewCreateInfo.subresourceRange.levelCount = 2;
         vkt::ImageView imageView2(*m_device, imageViewCreateInfo);
-        ASSERT_TRUE(imageView2.initialized());
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03218",
@@ -299,10 +275,8 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         imageViewCreateInfo.components.r = VK_COMPONENT_SWIZZLE_A;
         vkt::ImageView imageView2(*m_device, imageViewCreateInfo);
-        ASSERT_TRUE(imageView2.initialized());
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         TestRenderPassBegin(m_errorMonitor, m_device->device(), m_commandBuffer->handle(), &renderPassBeginInfo, rp2Supported,
                             "VUID-VkRenderPassAttachmentBeginInfo-pAttachments-03219",
@@ -314,14 +288,12 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     {
         imageViewCreateInfo.subresourceRange.baseMipLevel = 1;
         vkt::ImageView imageView2(*m_device, imageViewCreateInfo);
-        ASSERT_TRUE(imageView2.initialized());
         renderPassAttachmentBeginInfo.pAttachments = &imageView2.handle();
         framebufferAttachmentImageInfo.height = framebufferAttachmentImageInfo.height / 2;
         framebufferAttachmentImageInfo.width = framebufferAttachmentImageInfo.width / 2;
         framebufferCreateInfo.height = framebufferCreateInfo.height / 2;
         framebufferCreateInfo.width = framebufferCreateInfo.width / 2;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
-        ASSERT_TRUE(framebuffer.initialized());
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         renderPassBeginInfo.renderArea.extent.height = renderPassBeginInfo.renderArea.extent.height / 2;
         renderPassBeginInfo.renderArea.extent.width = renderPassBeginInfo.renderArea.extent.width / 2;
@@ -965,9 +937,7 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageView3D) {
     imageCreateInfo.imageType = VK_IMAGE_TYPE_3D;
     imageCreateInfo.samples = VK_SAMPLE_COUNT_1_BIT;
     imageCreateInfo.format = attachmentFormats[0];
-
-    VkImageObj image3D(m_device);
-    image3D.init(&imageCreateInfo);
+    vkt::Image image3D(*m_device, imageCreateInfo, vkt::set_layout);
 
     VkImageViewCreateInfo imageViewCreateInfo = vku::InitStructHelper();
     imageViewCreateInfo.image = image3D;
@@ -1037,9 +1007,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImagePNext) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkImageObj image(m_device);
-    image.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM,
-               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, 256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::ImageView imageView = image.CreateView();
 
     // random invalid struct for a framebuffer pNext change
@@ -1099,9 +1068,8 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageFormat) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkImageObj image(m_device);
-    image.Init(256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM,
-               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, 256, 256, 1, VK_FORMAT_B8G8R8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::ImageView imageView = image.CreateView();
 
     VkFormat attachment_format = VK_FORMAT_UNDEFINED;

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,8 +89,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, 4);
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info = vku::InitStructHelper();

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -95,8 +95,7 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
     // Use extension to get image memory requirements
     VkImageMemoryRequirementsInfo2KHR image_info = {VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2_KHR, nullptr,
@@ -156,8 +155,7 @@ TEST_F(PositiveMemory, BindMemory2) {
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
     // Allocate image memory
     vkt::DeviceMemory image_memory;
@@ -426,10 +424,7 @@ TEST_F(PositiveMemory, DeviceImageMemoryRequirements) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_create_info);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkDeviceImageMemoryRequirements info = vku::InitStructHelper();
     info.pCreateInfo = &image_create_info;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020-2022 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2021 ARM, Inc. All rights reserved.
  *
@@ -89,9 +89,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
@@ -216,9 +214,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info);
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 
@@ -645,9 +641,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     auto image_view_ci = image.BasicViewCreatInfo();
     image_view_ci.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
     const vkt::ImageView imageView(*m_device, image_view_ci);
@@ -913,9 +907,8 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     }
 
     // Create image view
-    VkImageObj image(m_device);
-    auto ici2d = image.ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    image.Init(ici2d);
+    auto ici2d = vkt::Image::ImageCreateInfo2D(128, 128, 1, 2, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, ici2d);
     ASSERT_TRUE(image.initialized());
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -1237,8 +1230,7 @@ TEST_F(NegativeMultiview, DynamicRenderingMaxMultiviewInstanceIndex) {
     pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
-    VkImageObj img(m_device);
-    img.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image img(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView view = img.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -272,7 +272,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
 
     for (vkt::Queue *queue : queues) {
         vkt::CommandPool compute_pool(*m_device, queue->get_family_index());
-        vkt::CommandBuffer cmd_buffer(m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+        vkt::CommandBuffer cmd_buffer(*m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
 
         cmd_buffer.begin();
 
@@ -612,11 +612,10 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
     pipeline_rendering_info.stencilAttachmentFormat = depth_format;
 
-    VkImageObj image(m_device);
     // 3 array layers
-    image.Init(image.ImageCreateInfo2D(32, 32, 1, 3, depth_format,
-                                       VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT));
-    ASSERT_TRUE(image.initialized());
+    auto image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 3, depth_format,
+                                                  VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci);
 
     VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
     image_view_ci.image = image.handle();
@@ -983,9 +982,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
         m_errorMonitor->SetAllowedFailureMsg("BestPractices-DrawState-ClearCmdBeforeDraw");
     };
 
-    VkImageObj image(m_device);
-    image.Init(m_width, m_height, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, m_width, m_height, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
     image_view_ci.image = image.handle();

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -39,7 +39,7 @@ TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    vkt::CommandBuffer cmd_buf(m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buf(*m_device, m_commandPool);
     cmd_buf.begin();
     // Set Negative height, should give error if Maintenance 1 is not enabled
     VkViewport viewport = {0, 0, 16, -16, 0, 1};

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -509,7 +509,7 @@ TEST_F(VkLayerTest, SpecLinks) {
     bool maintenance2_support =
         (IsExtensionsEnabled(VK_KHR_MAINTENANCE_2_EXTENSION_NAME) || (DeviceValidationVersion() >= VK_API_VERSION_1_1));
 
-    if (!((m_device->format_properties(VK_FORMAT_R8_UINT).optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) &&
+    if (!((m_device->FormatFeaturesOptimal(VK_FORMAT_R8_UINT) & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) &&
           (ycbcr_support ^ maintenance2_support))) {
         GTEST_SKIP() << "Device does not support format and extensions required";
     }
@@ -530,9 +530,7 @@ TEST_F(VkLayerTest, SpecLinks) {
                                    nullptr,
                                    VK_IMAGE_LAYOUT_UNDEFINED};
     imageInfo.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-    VkImageObj mutImage(m_device);
-    mutImage.init(&imageInfo);
-    ASSERT_TRUE(mutImage.initialized());
+    vkt::Image mutImage(*m_device, imageInfo, vkt::set_layout);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.viewType = VK_IMAGE_VIEW_TYPE_2D;
@@ -1131,7 +1129,7 @@ TEST_F(VkLayerTest, ExecuteUnrecordedCB) {
     m_errorMonitor->VerifyFound();
 
     // Testing an "unfinished secondary CB" crashes on some HW/drivers (notably Pixel 3 and RADV)
-    // vkt::CommandBuffer cb(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    // vkt::CommandBuffer cb(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     // m_commandBuffer->begin();
     // vk::CmdExecuteCommands(m_commandBuffer->handle(), 1u, &cb.handle());
     // m_commandBuffer->end();
@@ -1258,7 +1256,7 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
     vk::WaitForFences(device(), 0, &fence.handle(), true, 1);
     m_errorMonitor->VerifyFound();
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
     command_buffer.begin();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindDescriptorSets-descriptorSetCount-arraylength");

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -107,9 +107,8 @@ TEST_F(NegativeParent, DISABLED_BindImage) {
     auto features = m_device->phy().features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     VkMemoryRequirements mem_reqs;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetImageMemoryRequirements-image-parent");
@@ -139,9 +138,8 @@ TEST_F(NegativeParent, ImageView) {
     auto features = m_device->phy().features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     VkImageView image_view;
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -231,9 +229,8 @@ TEST_F(NegativeParent, RenderPassImagelessFramebuffer) {
     fb_info.layers = 1;
     vkt::Framebuffer fb(*m_device, fb_info);
 
-    VkImageObj image(m_second_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_second_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     VkRenderPassAttachmentBeginInfo render_pass_attachment_bi = vku::InitStructHelper();
@@ -259,7 +256,7 @@ TEST_F(NegativeParent, RenderPassCommandBuffer) {
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::CommandPool command_pool(*m_second_device, m_device->graphics_queue_node_index_, 0);
-    vkt::CommandBuffer command_buffer(m_second_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_second_device, &command_pool);
 
     command_buffer.begin();
     // one for each the framebuffer and renderpass being different from the CommandBuffer
@@ -664,8 +661,7 @@ TEST_F(NegativeParent, UpdateDescriptorSetsImage) {
     auto features = m_device->phy().features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
-    VkImageObj image(m_second_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_second_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView image_view = image.CreateView();
 
     OneOffDescriptorSet ds(m_device, {

--- a/tests/unit/parent_positive.cpp
+++ b/tests/unit/parent_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,9 +30,8 @@ TEST_F(PositiveParent, ImagelessFramebuffer) {
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
-    VkImageObj image(m_second_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView image_view = image.CreateView();
 
     VkFramebufferAttachmentImageInfo framebuffer_attachment_image_info = vku::InitStructHelper();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -145,9 +145,9 @@ TEST_F(NegativePipeline, BlendingOnFormatWithoutBlendingSupport) {
 
     VkFormat non_blending_format = VK_FORMAT_UNDEFINED;
     for (uint32_t i = 1; i <= VK_FORMAT_ASTC_12x12_SRGB_BLOCK; i++) {
-        VkFormatProperties format_props = m_device->format_properties(static_cast<VkFormat>(i));
-        if ((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) &&
-            !(format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)) {
+        VkFormatFeatureFlags2 format_features = m_device->FormatFeaturesOptimal(static_cast<VkFormat>(i));
+        if ((format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) &&
+            !(format_features & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)) {
             non_blending_format = static_cast<VkFormat>(i);
             break;
         }
@@ -614,7 +614,8 @@ TEST_F(NegativePipeline, RasterizerDiscardWithFragmentShader) {
     RETURN_IF_SKIP(Init());
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -683,7 +684,8 @@ TEST_F(NegativePipeline, CreateGraphicsPipelineWithBadBasePointer) {
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
 
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -1839,9 +1841,8 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT);
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), sampled_format, formatProps);
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, sampled_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, sampled_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
 
     // maps to VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER
@@ -2391,12 +2392,10 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     rpci.pAttachments = &attach_desc;
     rpci.dependencyCount = 1;
     rpci.pDependencies = &subpass_dependency;
-
     vkt::RenderPass render_pass(*m_device, rpci);
-    ASSERT_TRUE(render_pass.initialized());
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle());
@@ -3132,7 +3131,6 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
     AddRequiredFeature(vkt::Feature::multisampledRenderToSingleSampled);
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT;
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -3152,7 +3150,7 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
         GTEST_SKIP() << "Required format not supported";
     }
 
-    image.init(&image_ci);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     vkt::ImageView image_view = image.CreateView();
 
@@ -3239,12 +3237,10 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
 
-    VkImageObj color_image(m_device);
-    color_image.Init(32, 32, 1, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image color_image(*m_device, 32, 32, 1, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView color_image_view = color_image.CreateView();
 
-    VkImageObj ds_image(m_device);
-    ds_image.Init(32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    vkt::Image ds_image(*m_device, 32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView ds_image_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -198,7 +198,8 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
     RETURN_IF_SKIP(Init());
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -785,8 +786,8 @@ TEST_F(PositivePipeline, SamplerDataForCombinedImageSampler) {
     pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -831,8 +832,8 @@ TEST_F(PositivePipeline, ConditionalRendering) {
                             VK_ACCESS_SHADER_WRITE_BIT, VK_ACCESS_CONDITIONAL_RENDERING_READ_BIT_EXT, 0);
     rp.CreateRenderPass();
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
 
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
@@ -1123,8 +1124,7 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_STORAGE_BIT;
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -484,7 +484,7 @@ TEST_F(PositivePipelineTopology, LineTopologyClasses) {
 
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
-    vkt::CommandBuffer cb(m_device, m_commandPool);
+    vkt::CommandBuffer cb(*m_device, m_commandPool);
     cb.begin();
     cb.BeginRenderPass(m_renderPassBeginInfo);
 

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -133,8 +133,7 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatSwizzle) {
     imageCI.queueFamilyIndexCount = 0;
     imageCI.pQueueFamilyIndices = nullptr;
     imageCI.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    VkImageObj image(m_device);
-    image.init(&imageCI);
+    vkt::Image image(*m_device, imageCI, vkt::set_layout);
 
     VkImageViewCreateInfo ci = vku::InitStructHelper();
     ci.flags = 0;
@@ -181,8 +180,7 @@ TEST_F(NegativePortabilitySubset, ImageViewFormatReinterpretationComponentCount)
     imageCI.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     imageCI.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     imageCI.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
-    VkImageObj image(m_device);
-    image.init(&imageCI);
+    vkt::Image image(*m_device, imageCI, vkt::set_layout);
 
     VkImageViewCreateInfo ci = vku::InitStructHelper();
     ci.flags = 0;
@@ -230,7 +228,8 @@ TEST_F(NegativePortabilitySubset, TriangleFans) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -263,7 +262,8 @@ TEST_F(NegativePortabilitySubset, VertexInputStride) {
     auto vertex_stride = portability_properties.minVertexInputBindingStrideAlignment - 1;
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -297,7 +297,8 @@ TEST_F(NegativePortabilitySubset, VertexAttributes) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -380,7 +381,8 @@ TEST_F(NegativePortabilitySubset, DepthStencilState) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
-    m_depthStencil->Init(m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
@@ -464,8 +466,7 @@ TEST_F(VkPortabilitySubsetTest, UpdateDescriptorSets) {
     vkt::Sampler sampler(*m_device, sampler_info);
 
     constexpr VkFormat img_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, img_format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, img_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     image.Layout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     OneOffDescriptorSet descriptor_set(m_device,
                                        {

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -198,13 +198,10 @@ TEST_F(NegativeProtectedMemory, Memory) {
     }
 
     // Create actual protected and unprotected images
-    VkImageObj image_protected(m_device);
-    VkImageObj image_unprotected(m_device);
-
     image_create_info.flags = VK_IMAGE_CREATE_PROTECTED_BIT;
-    image_protected.init_no_mem(*m_device, image_create_info);
+    vkt::Image image_protected(*m_device, image_create_info, vkt::no_mem);
     image_create_info.flags = 0;
-    image_unprotected.init_no_mem(*m_device, image_create_info);
+    vkt::Image image_unprotected(*m_device, image_create_info, vkt::no_mem);
 
     // Create protected and unproteced memory
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
@@ -513,7 +510,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     protected_pipe.CreateGraphicsPipeline();
 
     vkt::CommandPool command_pool(*m_device, m_device->graphics_queue_node_index_);
-    vkt::CommandBuffer unprotected_cmdbuf(m_device, &command_pool);
+    vkt::CommandBuffer unprotected_cmdbuf(*m_device, &command_pool);
     unprotected_cmdbuf.begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-pipelineProtectedAccess-07409");
     vk::CmdBindPipeline(unprotected_cmdbuf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, protected_pipe.Handle());
@@ -720,7 +717,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     vkt::CommandPool protectedCommandPool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_PROTECTED_BIT);
-    vkt::CommandBuffer protectedCommandBuffer(m_device, &protectedCommandPool);
+    vkt::CommandBuffer protectedCommandBuffer(*m_device, &protectedCommandPool);
 
     // Create actual protected and unprotected buffers
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
@@ -738,10 +735,6 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
 
     // Create actual protected and unprotected images
     const VkFormat image_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image_protected(m_device);
-    VkImageObj image_unprotected(m_device);
-    VkImageObj image_protected_descriptor(m_device);
-    VkImageObj image_unprotected_descriptor(m_device);
     VkImageView image_views[2];
     VkImageView image_views_descriptor[2];
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
@@ -755,12 +748,12 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     image_create_info.arrayLayers = 1;
     image_create_info.mipLevels = 1;
     image_create_info.flags = VK_IMAGE_CREATE_PROTECTED_BIT;
-    image_protected.init_no_mem(*m_device, image_create_info);
-    image_protected_descriptor.init_no_mem(*m_device, image_create_info);
 
+    vkt::Image image_protected(*m_device, image_create_info, vkt::no_mem);
+    vkt::Image image_protected_descriptor(*m_device, image_create_info, vkt::no_mem);
     image_create_info.flags = 0;
-    image_unprotected.init_no_mem(*m_device, image_create_info);
-    image_unprotected_descriptor.init_no_mem(*m_device, image_create_info);
+    vkt::Image image_unprotected(*m_device, image_create_info, vkt::no_mem);
+    vkt::Image image_unprotected_descriptor(*m_device, image_create_info, vkt::no_mem);
 
     // Create protected and unproteced memory
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -281,9 +281,8 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
-               VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM,
+                     VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
 
@@ -652,7 +651,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
 
         vkt::CommandPool command_pool(*m_device, err_qfi);
         ASSERT_TRUE(command_pool.initialized());
-        vkt::CommandBuffer command_buffer(m_device, &command_pool);
+        vkt::CommandBuffer command_buffer(*m_device, &command_pool);
         ASSERT_TRUE(command_buffer.initialized());
         command_buffer.begin();
 
@@ -672,7 +671,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
             // Need to test the neither compute/gfx supported case separately.
             vkt::CommandPool tran_command_pool(*m_device, transfer_only_qfi.value());
             ASSERT_TRUE(tran_command_pool.initialized());
-            vkt::CommandBuffer tran_command_buffer(m_device, &tran_command_pool);
+            vkt::CommandBuffer tran_command_buffer(*m_device, &tran_command_pool);
             ASSERT_TRUE(tran_command_buffer.initialized());
             tran_command_buffer.begin();
 
@@ -784,7 +783,7 @@ TEST_F(NegativePushDescriptor, UnsupportedDescriptorTemplateBindPoint) {
     }
 
     vkt::CommandPool command_pool(*m_device, no_gfx_qfi.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 32;

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -290,8 +290,7 @@ TEST_F(PositivePushDescriptor, ImmutableSampler) {
     vkt::Sampler sampler(*m_device, sampler_ci);
     VkSampler sampler_handle = sampler.handle();
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
 
     std::vector<VkDescriptorSetLayoutBinding> ds_bindings = {

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1675,7 +1675,6 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     vkt::RenderPass render_pass(*m_device, rp_ci);
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -1687,8 +1686,7 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image.init(&image_ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     VkImageViewCreateInfo iv_ci = vku::InitStructHelper();
     iv_ci.image = image.handle();
@@ -1732,7 +1730,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
     if (graphics_queue_family_index) {
         vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
 
-        vkt::CommandBuffer command_buffer(m_device, &command_pool);
+        vkt::CommandBuffer command_buffer(*m_device, &command_pool);
         command_buffer.begin();
 
         VkQueryPoolCreateInfo qpci = vkt::QueryPool::create_info(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1);
@@ -1749,7 +1747,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
     if (compute_queue_family_index) {
         vkt::CommandPool command_pool(*m_device, compute_queue_family_index.value());
 
-        vkt::CommandBuffer command_buffer(m_device, &command_pool);
+        vkt::CommandBuffer command_buffer(*m_device, &command_pool);
         command_buffer.begin();
 
         VkQueryPoolCreateInfo qpci = vkt::QueryPool::create_info(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1);
@@ -1805,7 +1803,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
     }
     vkt::CommandPool command_pool(*m_device, compute_queue_family_index.value());
 
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
@@ -1968,7 +1966,7 @@ TEST_F(NegativeQuery, CommandBufferMissingOcclusion) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
@@ -1999,7 +1997,7 @@ TEST_F(NegativeQuery, CommandBufferInheritanceFlags) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
@@ -2087,7 +2085,6 @@ TEST_F(NegativeQuery, DISABLED_MultiviewEndQuery) {
 
     vkt::RenderPass render_pass(*m_device, rp_ci);
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
     image_ci.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2099,8 +2096,7 @@ TEST_F(NegativeQuery, DISABLED_MultiviewEndQuery) {
     image_ci.samples = VK_SAMPLE_COUNT_1_BIT;
     image_ci.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    image.init(&image_ci);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
 
     VkImageViewCreateInfo iv_ci = vku::InitStructHelper();
     iv_ci.image = image.handle();
@@ -2366,7 +2362,7 @@ TEST_F(NegativeQuery, CmdExecuteCommandsActiveQueries) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
 
@@ -2404,7 +2400,7 @@ TEST_F(NegativeQuery, CmdExecuteBeginActiveQuery) {
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
 
-    vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     secondary.begin(&cbbi);
     vk::CmdBeginQuery(secondary.handle(), query_pool.handle(), 1u, 0u);
     vk::CmdEndQuery(secondary.handle(), query_pool.handle(), 1u);
@@ -2482,7 +2478,7 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
         m_device->wait();
     }
 
-    vkt::CommandBuffer command_buffer(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer command_buffer(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     command_buffer.begin();
     vk::CmdBeginQuery(command_buffer.handle(), query_pool, 0u, 0u);
     vk::CmdEndQuery(command_buffer.handle(), query_pool, 0u);
@@ -2590,7 +2586,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQueryWithSecondaryCmdBuffer) {
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
 
-    vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     secondary.begin(&cbbi);
     secondary.end();
 
@@ -2776,7 +2772,7 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     vkt::CommandPool command_pool(*m_device, pool_create_info);
 
     vkt::Queue *queue = m_device->queue_family_queues(1)[0].get();
-    vkt::CommandBuffer cb(m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+    vkt::CommandBuffer cb(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
     acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -246,8 +246,8 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
     vkt::CommandPool command_pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer primary_buffer(m_device, &command_pool);
-    vkt::CommandBuffer secondary_buffer(m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer primary_buffer(*m_device, &command_pool);
+    vkt::CommandBuffer secondary_buffer(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkQueue queue = VK_NULL_HANDLE;
     vk::GetDeviceQueue(m_device->device(), m_device->graphics_queue_node_index_, 1, &queue);
@@ -406,7 +406,7 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    vkt::CommandBuffer secondary(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
@@ -493,7 +493,7 @@ TEST_F(PositiveQuery, PerformanceQueries) {
         m_device->wait();
     }
 
-    vkt::CommandBuffer cmd_buffer(m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer(*m_device, m_commandPool);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
     acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -85,9 +85,8 @@ TEST_F(NegativeRayTracing, BarrierSync2AccessAccelerationStructureRayQueryDisabl
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = 32;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
@@ -150,9 +149,9 @@ TEST_F(NegativeRayTracing, BarrierSync1AccessAccelerationStructureRayQueryDisabl
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = VK_WHOLE_SIZE;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -200,9 +199,9 @@ TEST_F(NegativeRayTracing, EventSync1AccessAccelerationStructureRayQueryDisabled
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = VK_WHOLE_SIZE;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 28, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
+
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
     image_barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     image_barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;

--- a/tests/unit/ray_tracing_gpu_nv.cpp
+++ b/tests/unit/ray_tracing_gpu_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2022 The Khronos Group Inc.
- * Copyright (c) 2020-2023 Valve Corporation
- * Copyright (c) 2020-2023 LunarG, Inc.
- * Copyright (c) 2020-2022 Google, Inc.
+ * Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
+ * Copyright (c) 2020-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -81,7 +81,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationInvalidHan
 
     const vkt::Buffer top_level_as_scratch = top_level_as.create_scratch_buffer(*m_device);
 
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
     vk::CmdBuildAccelerationStructureNV(command_buffer.handle(), &top_level_as_create_info.info, instance_buffer.handle(), 0,
                                         VK_FALSE, top_level_as.handle(), VK_NULL_HANDLE, top_level_as_scratch.handle(), 0);
@@ -166,7 +166,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationBottomLeve
 
     const vkt::Buffer top_level_as_scratch = top_level_as.create_scratch_buffer(*m_device);
 
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
     vk::CmdBuildAccelerationStructureNV(command_buffer.handle(), &top_level_as_create_info.info, instance_buffer.handle(), 0,
                                         VK_FALSE, top_level_as.handle(), VK_NULL_HANDLE, top_level_as_scratch.handle(), 0);
@@ -230,7 +230,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationBottomLeve
 
         const vkt::Buffer bot_level_as_scratch = destroyed_bot_level_as.create_scratch_buffer(*m_device);
 
-        vkt::CommandBuffer command_buffer(m_device, &command_pool);
+        vkt::CommandBuffer command_buffer(*m_device, &command_pool);
         command_buffer.begin();
         vk::CmdBuildAccelerationStructureNV(command_buffer.handle(), &bot_level_as_create_info.info, VK_NULL_HANDLE, 0, VK_FALSE,
                                             destroyed_bot_level_as.handle(), VK_NULL_HANDLE, bot_level_as_scratch.handle(), 0);
@@ -268,7 +268,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationBottomLeve
 
     const vkt::Buffer top_level_as_scratch = top_level_as.create_scratch_buffer(*m_device);
 
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
     vk::CmdBuildAccelerationStructureNV(command_buffer.handle(), &top_level_as_create_info.info, instance_buffer.handle(), 0,
                                         VK_FALSE, top_level_as.handle(), VK_NULL_HANDLE, top_level_as_scratch.handle(), 0);
@@ -452,7 +452,7 @@ TEST_F(NegativeGpuAVRayTracingNV, BuildAccelerationStructureValidationRestoresSt
     push_descriptor_set_write.dstBinding = 0;
     push_descriptor_set_write.pBufferInfo = &push_descriptor_buffer_info;
 
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
     vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, compute_pipeline);
     vk::CmdPushConstants(command_buffer.handle(), compute_pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, 4,

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -91,7 +91,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
 
     vkt::CommandPool ray_tracing_command_pool(*m_device, ray_tracing_queue_family_index,
                                               VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer ray_tracing_command_buffer(m_device, &ray_tracing_command_pool);
+    vkt::CommandBuffer ray_tracing_command_buffer(*m_device, &ray_tracing_command_pool);
 
     constexpr std::array<VkAabbPositionsKHR, 1> aabbs = {{{-1.0f, -1.0f, -1.0f, +1.0f, +1.0f, +1.0f}}};
 
@@ -202,8 +202,8 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     ray_tracing_queue->submit(ray_tracing_command_buffer);
     ray_tracing_queue->wait();
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -263,9 +263,8 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = 32;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
@@ -329,9 +328,8 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     buffer_barrier.buffer = buffer.handle();
     buffer_barrier.size = 32;
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
@@ -518,9 +516,9 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
     alloc_info.allocationSize = 1u << 18;
     vkt::DeviceMemory common_scratch_memory(*m_device, alloc_info);
 
-    vkt::CommandBuffer cmd_buffer_frame_0(m_device, m_commandPool);
-    vkt::CommandBuffer cmd_buffer_frame_1(m_device, m_commandPool);
-    vkt::CommandBuffer cmd_buffer_frame_2(m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_0(*m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_1(*m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_2(*m_device, m_commandPool);
 
     std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec_frame_0;
     std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec_frame_1;
@@ -668,9 +666,9 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    vkt::CommandBuffer cmd_buffer_frame_0(m_device, m_commandPool);
-    vkt::CommandBuffer cmd_buffer_frame_1(m_device, m_commandPool);
-    vkt::CommandBuffer cmd_buffer_frame_2(m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_0(*m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_1(*m_device, m_commandPool);
+    vkt::CommandBuffer cmd_buffer_frame_2(*m_device, m_commandPool);
 
     std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec_frame_0;
     std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec_frame_1;
@@ -851,9 +849,9 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     const char* miss = R"glsl(
     #version 460
     #extension GL_EXT_ray_tracing : require
-   
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
-    
+
     void main() {
         hit = vec3(0.1, 0.2, 0.3);
     }
@@ -863,10 +861,10 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     const char* closest_hit = R"glsl(
     #version 460
     #extension GL_EXT_ray_tracing : require
-    
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
     hitAttributeEXT vec2 baryCoord;
-    
+
     void main() {
       const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
       hit = barycentricCoords;
@@ -932,9 +930,9 @@ TEST_F(PositiveRayTracing, BasicTraceRaysMultipleStages) {
     #extension GL_EXT_ray_tracing : require
 
     layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-   
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
-    
+
     void main() {
         hit = vec3(0.1, 0.2, 0.3);
         traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
@@ -947,10 +945,10 @@ TEST_F(PositiveRayTracing, BasicTraceRaysMultipleStages) {
     #extension GL_EXT_ray_tracing : require
 
     layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-    
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
     hitAttributeEXT vec2 baryCoord;
-    
+
     void main() {
       const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
       hit = barycentricCoords;
@@ -1025,9 +1023,9 @@ TEST_F(PositiveRayTracing, DynamicTminTmax) {
       float t_min;
       float t_max;
     } trace_rays_params;
-   
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
-    
+
     void main() {
         hit = vec3(0.1, 0.2, 0.3);
         traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), trace_rays_params.t_min, vec3(0,0,1), trace_rays_params.t_max, 0);
@@ -1044,10 +1042,10 @@ TEST_F(PositiveRayTracing, DynamicTminTmax) {
       float t_min;
       float t_max;
     } trace_rays_params;
-    
+
     layout(location = 0) rayPayloadInEXT vec3 hit;
     hitAttributeEXT vec2 baryCoord;
-    
+
     void main() {
       const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
       hit = barycentricCoords;
@@ -1133,7 +1131,7 @@ TEST_F(PositiveRayTracing, BasicTraceRaysDynamicRayFlags) {
     } trace_rays_params;
 
     layout(location = 0) rayPayloadInEXT vec3 hit;
-    
+
     void main() {
         hit = vec3(0.1, 0.2, 0.3);
         traceRayEXT(tlas, trace_rays_params.ray_flags, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1.0, 0);
@@ -1152,7 +1150,7 @@ TEST_F(PositiveRayTracing, BasicTraceRaysDynamicRayFlags) {
 
     layout(location = 0) rayPayloadInEXT vec3 hit;
     hitAttributeEXT vec2 baryCoord;
-    
+
     void main() {
       const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
       hit = barycentricCoords;
@@ -1239,7 +1237,7 @@ TEST_F(PositiveRayTracing, DynamicRayFlagsSkipTriangle) {
     } trace_rays_params;
 
     layout(location = 0) rayPayloadInEXT vec3 hit;
-    
+
     void main() {
         hit = vec3(0.1, 0.2, 0.3);
         traceRayEXT(tlas, trace_rays_params.ray_flags, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1.0, 0);
@@ -1259,7 +1257,7 @@ TEST_F(PositiveRayTracing, DynamicRayFlagsSkipTriangle) {
 
     layout(location = 0) rayPayloadInEXT vec3 hit;
     hitAttributeEXT vec2 baryCoord;
-    
+
     void main() {
       const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
       hit = barycentricCoords;

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1107,10 +1107,8 @@ TEST_F(NegativeRenderPass, BeginIncompatibleFramebuffer) {
     RETURN_IF_SKIP(Init());
 
     // Create a depth stencil image view
-    VkImageObj image(m_device);
-
-    image.Init(128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
@@ -1175,10 +1173,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     }
 
     // Create an input attachment view
-    VkImageObj iai(m_device);
-
-    iai.InitNoLayout(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
-    ASSERT_TRUE(iai.initialized());
+    vkt::Image iai(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
     VkImageViewCreateInfo iavci = vku::InitStructHelper();
     iavci.image = iai.handle();
@@ -1191,19 +1186,12 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     vkt::ImageView iav(*m_device, iavci);
 
     // Create an input depth attachment view
-    VkImageObj iadi(m_device);
-
     VkFormat dformat = FindSupportedDepthStencilFormat(gpu());
-    iadi.InitNoLayout(128, 128, 1, dformat, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
-    ASSERT_TRUE(iadi.initialized());
-
+    vkt::Image iadi(*m_device, 128, 128, 1, dformat, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView iadv = iadi.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
     // Create a color attachment view
-    VkImageObj cai(m_device);
-
-    cai.InitNoLayout(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(cai.initialized());
+    vkt::Image cai(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
     VkImageViewCreateInfo cavci = vku::InitStructHelper();
     cavci.image = cai.handle();
@@ -1298,10 +1286,9 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     }
 
     if (feedback_loop_layout) {
-        VkImageObj no_fb_loop_attachment(m_device);
         // No VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT
-        no_fb_loop_attachment.InitNoLayout(
-            128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM,
+        vkt::Image no_fb_loop_attachment(
+            *m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM,
             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
         vkt::ImageView image_view_no_fb_loop;
         auto image_view_ci = no_fb_loop_attachment.BasicViewCreatInfo();
@@ -1315,10 +1302,9 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
         descriptions[0].format = dformat;
         ;
         views[0] = iadv;
-        VkImageObj no_usage_sampled_attachment(m_device);
         // No VK_IMAGE_USAGE_SAMPLED_BIT_EXT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT
-        no_usage_sampled_attachment.InitNoLayout(
-            128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM,
+        vkt::Image no_usage_sampled_attachment(
+            *m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM,
             VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT);
         image_view_ci.image = no_usage_sampled_attachment.handle();
         vkt::ImageView image_view_no_usage_sampled;
@@ -1343,11 +1329,8 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     auto test = [this](VkImageLayout depth_initial_layout, VkImageLayout stencil_initial_layout, const char *rp1_vuid,
                        const char *rp2_vuid) {
         // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
-        VkImageObj input_image(m_device);
-
         VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-        input_image.InitNoLayout(128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
-        ASSERT_TRUE(input_image.initialized());
+        vkt::Image input_image(*m_device, 128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
         vkt::ImageView input_view = input_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -1404,10 +1387,7 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
             return;
         }
         // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
-        VkImageObj depth_stencil_image(m_device);
-
-        depth_stencil_image.InitNoLayout(128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-        ASSERT_TRUE(depth_stencil_image.initialized());
+        vkt::Image depth_stencil_image(*m_device, 128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
         // Create the render pass attachment...
         VkAttachmentDescription2 depth_stencil_attachment_desc = vku::InitStructHelper();
@@ -1499,10 +1479,8 @@ TEST_F(NegativeRenderPass, BeginSampleLocationsIndicesEXT) {
     }
 
     // Create a depth stencil image view
-    VkImageObj image(m_device);
-
-    image.Init(128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewCreateInfo dsvci = vku::InitStructHelper();
     dsvci.image = image.handle();
@@ -1623,16 +1601,12 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     image_create_info.flags = 0;
-    VkImageObj ds_image(m_device);
-    ds_image.init(&image_create_info);
-    ASSERT_TRUE(ds_image.initialized());
+    vkt::Image ds_image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
-    VkImageObj ds_resolve_image(m_device);
-    ds_resolve_image.init(&image_create_info);
-    ASSERT_TRUE(ds_resolve_image.initialized());
+    vkt::Image ds_resolve_image(*m_device, image_create_info, vkt::set_layout);
 
     vkt::ImageView depth_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     vkt::ImageView resolve_view = ds_resolve_image.CreateView();
@@ -1660,9 +1634,8 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     rp.CreateRenderPass();
 
     // A compatible framebuffer.
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     vkt::ImageView view = image.CreateView();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1u, &view.handle());
@@ -1891,9 +1864,8 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     ASSERT_TRUE(rp2.initialized());
 
     // Create image views
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     vkt::ImageView iv = image.CreateView();
 
@@ -2491,9 +2463,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = 0;
-
-    VkImageObj image(m_device);
-    image.init(&image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -2578,8 +2548,9 @@ TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
                                        {
                                            {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                        });
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
     VkImageViewUsageCreateInfo image_view_usage = vku::InitStructHelper();
     image_view_usage.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
@@ -2988,8 +2959,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = nullptr;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj two_count_image(m_device);
-    two_count_image.init(&image_create_info);
+    vkt::Image two_count_image(*m_device, image_create_info, vkt::set_layout);
 
     auto image_view_ci = two_count_image.BasicViewCreatInfo();
     vkt::ImageView two_count_image_view(*m_device, image_view_ci);
@@ -3003,8 +2973,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     m_errorMonitor->VerifyFound();
 
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-    VkImageObj one_count_image(m_device);
-    one_count_image.init(&image_create_info);
+    vkt::Image one_count_image(*m_device, image_create_info, vkt::set_layout);
     auto one_count_image_view_ci = one_count_image.BasicViewCreatInfo();
     vkt::ImageView one_count_image_view(*m_device, one_count_image_view_ci);
     color_attachment.imageView = one_count_image_view.handle();
@@ -3015,9 +2984,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     m_errorMonitor->VerifyFound();
 
     color_attachment.resolveMode = VK_RESOLVE_MODE_AVERAGE_BIT;
-    VkImageObj good_one_count_image(m_device);
     image_create_info.flags = VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT;
-    good_one_count_image.init(&image_create_info);
+    vkt::Image good_one_count_image(*m_device, image_create_info, vkt::set_layout);
     auto good_one_count_image_view_ci = good_one_count_image.BasicViewCreatInfo();
     vkt::ImageView good_one_count_image_view(*m_device, good_one_count_image_view_ci);
     color_attachment.imageView = good_one_count_image_view.handle();
@@ -3106,8 +3074,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
         image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_create_info.flags =
             VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT | VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT;
-        VkImageObj unsampleable_image(m_device);
-        unsampleable_image.init(&image_create_info);
+        vkt::Image unsampleable_image(*m_device, image_create_info, vkt::set_layout);
         auto unsampleable_image_view_ci = unsampleable_image.BasicViewCreatInfo();
         vkt::ImageView unsampleable_image_view(*m_device, unsampleable_image_view_ci);
         begin_rendering_info.pNext = &ms_render_to_ss;
@@ -3281,9 +3248,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     dependency.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
     dependency.srcStageMask = VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT;
     vkt::RenderPass render_pass3(*m_device, rpci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass1.handle(), 1, &imageView.handle(), width, height);
 
@@ -3370,8 +3335,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     correlated_view_mask = 0x2;
     vkt::RenderPass render_pass3(*m_device, rpci);
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, width, height, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass1.handle(), 1, &imageView.handle(), width, height);
 
@@ -3441,9 +3405,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPassSubpassFlags) {
     vkt::RenderPass render_pass1(*m_device, rpci);
     subpass.flags = VK_SUBPASS_DESCRIPTION_ENABLE_LEGACY_DITHERING_BIT_EXT;
     vkt::RenderPass render_pass2(*m_device, rpci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass1.handle(), 1, &imageView.handle());
 
@@ -3895,7 +3857,7 @@ TEST_F(NegativeRenderPass, IncompatibleFramebuffer) {
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmd_buffer_begin_info.pInheritanceInfo = &inheritance_info;
 
-    vkt::CommandBuffer secondary_cmd_buffer(m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary_cmd_buffer(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkCommandBufferBeginInfo-flags-00055");
     vk::BeginCommandBuffer(secondary_cmd_buffer.handle(), &cmd_buffer_begin_info);
@@ -3995,8 +3957,8 @@ TEST_F(NegativeRenderPass, InvalidFramebufferAttachmentImageUsage) {
 
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
-    image.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     VkAttachmentDescription description = {0,
@@ -4085,8 +4047,8 @@ TEST_F(NegativeRenderPass, AttachmentLayout) {
     TEST_DESCRIPTION("Test attachment descriptions with layouts other than undefined");
     RETURN_IF_SKIP(Init());
 
-    VkImageObj image(m_device);
-    image.Init(32u, 32u, 1u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32u, 32u, 1u, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     RenderPassSingleSubpass rp(*this);

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 LunarG, Inc.
- * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -68,8 +68,8 @@ TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     )";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -123,8 +123,8 @@ TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -185,9 +185,8 @@ TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView view_pass = image.CreateView();
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();
@@ -227,8 +226,8 @@ TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -285,9 +284,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-
-    VkImageObj image(m_device);
-    image.Init(image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::set_layout);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -342,14 +339,10 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, formatProps);
 
-    VkImageObj bad_image(m_device);
-    bad_image.Init(128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(bad_image.initialized());
+    vkt::Image bad_image(*m_device, 128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView bad_view = bad_image.CreateView();
 
-    VkImageObj good_image(m_device);
-    good_image.Init(128, 128, 1, good_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(good_image.initialized());
+    vkt::Image good_image(*m_device, 128, 128, 1, good_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView good_view = good_image.CreateView();
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 LunarG, Inc.
- * Copyright (c) 2023 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -406,8 +406,8 @@ TEST_F(PositiveShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    VkImageObj image(m_device);
-    image.Init(16, 16, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_SAMPLED_BIT, VK_IMAGE_TILING_LINEAR);
+    vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView imageView = image.CreateView();
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -462,14 +462,10 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
     fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, formatProps);
 
-    VkImageObj bad_image(m_device);
-    bad_image.Init(128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(bad_image.initialized());
+    vkt::Image bad_image(*m_device, 128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView bad_view = bad_image.CreateView();
 
-    VkImageObj good_image(m_device);
-    good_image.Init(128, 128, 1, good_format, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(good_image.initialized());
+    vkt::Image good_image(*m_device, 128, 128, 1, good_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView good_view = good_image.CreateView();
 
     VkSamplerCreateInfo sampler_ci = SafeSaneSamplerCreateInfo();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -619,7 +619,7 @@ TEST_F(NegativeShaderObject, ComputeShaderNotSupportedByCommandPool) {
     VkShaderEXT shaderHandle = shader.handle();
 
     vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &createInfo.stage, &shaderHandle);
@@ -654,7 +654,7 @@ TEST_F(NegativeShaderObject, GraphicsShadersNotSupportedByCommandPool) {
     VkShaderEXT shaderHandle = shader.handle();
 
     vkt::CommandPool command_pool(*m_device, non_graphics_queue_family_index.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &createInfo.stage, &shaderHandle);
@@ -689,7 +689,7 @@ TEST_F(NegativeShaderObject, GraphicsMeshShadersNotSupportedByCommandPool) {
     VkShaderEXT shaderHandle = shader.handle();
 
     vkt::CommandPool command_pool(*m_device, non_graphics_queue_family_index.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool);
     command_buffer.begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &createInfo.stage, &shaderHandle);
@@ -1383,8 +1383,8 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
@@ -1818,12 +1818,10 @@ TEST_F(NegativeShaderObject, ColorWriteEnableAttachmentCount) {
     AddRequiredFeature(vkt::Feature::colorWriteEnable);
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    VkImageObj img1(m_device);
-    img1.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    VkImageObj img2(m_device);
-    img2.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img1(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img2(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::ImageView view1 = img1.CreateView();
     vkt::ImageView view2 = img2.CreateView();
@@ -5828,8 +5826,8 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
         GTEST_SKIP() << "image format not supported as color attachment.";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
@@ -6414,8 +6412,8 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src),
                                  &descriptor_set.layout_.handle());
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView image_view = image.CreateView();
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
@@ -6457,8 +6455,7 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    VkImageObj img(m_device);
-    img.Init(m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image img(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView view = img.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -6517,12 +6514,10 @@ TEST_F(NegativeShaderObject, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendE
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fsSource.str().c_str()));
 
-    VkImageObj img1(m_device);
-    img1.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    VkImageObj img2(m_device);
-    img2.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img1(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img2(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::ImageView view1 = img1.CreateView();
     vkt::ImageView view2 = img2.CreateView();

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -389,8 +389,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     imageInfo.queueFamilyIndexCount = 0u;
     imageInfo.pQueueFamilyIndices = nullptr;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj image(m_device);
-    image.init(&imageInfo);
+    vkt::Image image(*m_device, imageInfo, vkt::set_layout);
     vkt::ImageView view = image.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -582,8 +581,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     imageInfo.queueFamilyIndexCount = 0u;
     imageInfo.pQueueFamilyIndices = nullptr;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj image(m_device);
-    image.init(&imageInfo);
+    vkt::Image image(*m_device, imageInfo, vkt::set_layout);
     vkt::ImageView view = image.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -778,8 +776,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     imageInfo.queueFamilyIndexCount = 0u;
     imageInfo.pQueueFamilyIndices = nullptr;
     imageInfo.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
-    VkImageObj image(m_device);
-    image.init(&imageInfo);
+    vkt::Image image(*m_device, imageInfo, vkt::set_layout);
     vkt::ImageView view = image.CreateView();
 
     VkRenderingAttachmentInfo color_attachment = vku::InitStructHelper();
@@ -1117,9 +1114,8 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     vert_descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 32, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     vert_descriptor_set.UpdateDescriptorSets();
 
-    auto image_ci = VkImageObj::ImageCreateInfo2D(64, 64, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    VkImageObj image(m_device);
-    image.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 2, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
+    vkt::Image image(*m_device, image_ci, vkt::set_layout);
     vkt::ImageView view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 1, 1);
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
@@ -1576,7 +1572,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffers) {
     const std::optional<uint32_t> graphics_queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT, 0u);
 
     vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     command_buffer.begin();
     command_buffer.BeginRenderingColor(GetDynamicRenderTarget());
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -1615,12 +1611,10 @@ TEST_F(PositiveShaderObject, OutputToMultipleAttachments) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src));
 
-    VkImageObj img1(m_device);
-    img1.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    VkImageObj img2(m_device);
-    img2.Init(m_width, m_height, 1, m_render_target_fmt,
-              VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img1(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+    vkt::Image img2(*m_device, m_width, m_height, 1, m_render_target_fmt,
+                    VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     vkt::ImageView view1 = img1.CreateView();
     vkt::ImageView view2 = img2.CreateView();
@@ -1698,7 +1692,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
     const std::optional<uint32_t> graphics_queue_family_index = m_device->QueueFamilyMatching(VK_QUEUE_GRAPHICS_BIT, 0u);
 
     vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
-    vkt::CommandBuffer command_buffer(m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer command_buffer(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     VkCommandBufferInheritanceRenderingInfo rendering_info = vku::InitStructHelper();
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachmentFormats = &m_render_target_fmt;

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -805,11 +805,9 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    auto image_ci = VkImageObj::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, usage);
     image_ci.imageType = VK_IMAGE_TYPE_3D;
-    VkImageObj image_3d(m_device);
-    image_3d.Init(image_ci);
-    ASSERT_TRUE(image_3d.initialized());
+    vkt::Image image_3d(*m_device, image_ci, vkt::set_layout);
 
     // If the sampler is unnormalizedCoordinates, the imageview type shouldn't be 3D, CUBE, 1D_ARRAY, 2D_ARRAY, CUBE_ARRAY.
     // This causes DesiredFailure.

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -272,8 +272,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
     for (int t = 0; t < n_tests; t++) {
         VkFormat format = tests[t].format;
 
-        VkImageObj image(m_device);
-        image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+        vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+        image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
         vkt::ImageView view = image.CreateView();
 
         VkDescriptorImageInfo image_info = {};
@@ -426,8 +426,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
     for (int t = 0; t < n_tests; t++) {
         VkFormat format = tests[t].format;
 
-        VkImageObj image(m_device);
-        image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+        vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+        image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
         vkt::ImageView view = image.CreateView();
 
         VkDescriptorImageInfo image_info = {};
@@ -842,8 +842,8 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};
@@ -924,8 +924,8 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,8 +65,8 @@ TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};
@@ -156,8 +156,8 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};
@@ -239,8 +239,8 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};
@@ -367,8 +367,8 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
-    VkImageObj image(m_device);
-    image.Init(32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
+    image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView view = image.CreateView();
 
     VkDescriptorImageInfo image_info = {};

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -184,9 +184,7 @@ TEST_F(NegativeSparseImage, ResidencyFlag) {
     image_create_info.queueFamilyIndexCount = 0;
     image_create_info.pQueueFamilyIndices = NULL;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkSparseImageMemoryBind image_memory_bind = {};
     image_memory_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -285,8 +283,7 @@ TEST_F(NegativeSparseImage, MemoryBindOffset) {
         (buffer_mem_alloc.allocationSize + buffer_mem_reqs.alignment - 1) & ~(buffer_mem_reqs.alignment - 1);
     vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(device(), image, &image_mem_reqs);
     VkMemoryAllocateInfo image_mem_alloc =
@@ -411,8 +408,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     /// Create image whose memory has an incompatible type
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -560,9 +556,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType2) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
-
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements buffer_mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &buffer_mem_reqs);
@@ -691,8 +685,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     const auto image_exportable_types =
         FindSupportedExternalMemoryHandleTypes(gpu(), image_create_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
@@ -892,8 +885,7 @@ TEST_F(NegativeSparseImage, DISABLED_QueueBindSparseMemoryType4) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkImportMemoryFdInfoKHR image_import_memory_fd_info = vku::InitStructHelper();
     image_import_memory_fd_info.handleType = handle_type;
@@ -996,9 +988,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBind) {
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
     create_info.arrayLayers = 1;
-
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(m_device->handle(), image.handle(), &image_mem_reqs);
@@ -1119,9 +1109,7 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidExtent) {
     create_info.extent.height = 1024;
     create_info.extent.depth = 1;
     create_info.arrayLayers = 1;
-
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, create_info);
+    vkt::Image image(*m_device, create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(m_device->handle(), image.handle(), &image_mem_reqs);

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -26,7 +26,6 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -39,7 +38,7 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements memory_reqs;
     vk::GetImageMemoryRequirements(m_device->device(), image, &memory_reqs);
@@ -99,7 +98,6 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -112,7 +110,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements memory_reqs;
 
@@ -189,7 +187,6 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     }
 
     // Create a sparse image
-    VkImageObj image(m_device);
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
     image_create_info.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -202,7 +199,7 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     // Query image memory requirements
     VkMemoryRequirements memory_reqs;
@@ -280,8 +277,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT | VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     vkt::ImageView image_view = image.CreateView();
 
@@ -351,8 +347,7 @@ TEST_F(PositiveSparseImage, BindImage) {
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
-    VkImageObj image(m_device);
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkSparseImageMemoryBind image_memory_bind = {};
     image_memory_bind.subresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -441,9 +441,7 @@ TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
                                VK_DEPENDENCY_BY_REGION_BIT};
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 1u, attach, 2u, subpasses, 1u, &dep);
     vkt::RenderPass rp(*m_device, rpci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer fb(*m_device, rp.handle(), 1u, &imageView.handle());
 
@@ -506,11 +504,9 @@ TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
     auto rpci = vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, 2u, attach, 1u, subpasses, 1u, &dep);
     vkt::RenderPass rp(*m_device, rpci);
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
-    VkImageObj image2(m_device);
-    image2.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image2(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView2 = image2.CreateView();
     // re-use imageView from start of test
     VkImageView iv_array[2] = {imageView, imageView2};
@@ -547,9 +543,8 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
     VkImageUsageFlags usage_input =
         VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image_input(m_device);
-    auto image_ci = VkImageObj::ImageCreateInfo2D(64, 64, 1, 1, format, usage_input);
-    image_input.Init(image_ci);
+    auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, format, usage_input);
+    vkt::Image image_input(*m_device, image_ci, vkt::set_layout);
     image_input.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     vkt::ImageView view_input = image_input.CreateView();
 
@@ -744,9 +739,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     render_pass_ci.pAttachments = &attach_desc;
 
     vkt::RenderPass render_pass(*m_device, render_pass_ci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &imageView.handle());
 

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -51,10 +51,8 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     rpci.dependencyCount = 1;
     rpci.pDependencies = &dependency;
     vkt::RenderPass render_pass(*m_device, rpci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
-                       VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 
@@ -131,10 +129,8 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     rpci.dependencyCount = 1;
     rpci.pDependencies = &dependency;
     vkt::RenderPass render_pass(*m_device, rpci);
-
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
-                       VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM,
+                     VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView image_view = image.CreateView();
     vkt::Framebuffer framebuffer(*m_device, render_pass, 1, &image_view.handle());
 

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2022 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020-2021 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -30,7 +30,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
     }
 
     // Calls AllocateCommandBuffers
-    vkt::CommandBuffer commandBuffer(m_device, m_commandPool);
+    vkt::CommandBuffer commandBuffer(*m_device, m_commandPool);
 
     commandBuffer.begin();
 

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -450,7 +450,7 @@ TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
 
     // A pool we can reset in.
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
     VkCommandBufferInheritanceInfo hinfo = vku::InitStructHelper();
@@ -589,7 +589,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
     device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     vkt::Device test_device(gpu(), device_extension_names);
     vkt::CommandPool commandPool(test_device, 0);
-    vkt::CommandBuffer commandBuffer(&test_device, &commandPool);
+    vkt::CommandBuffer commandBuffer(test_device, &commandPool);
     vkt::Buffer counter_buffer2;
     counter_buffer2.init(test_device, buffer_create_info);
 
@@ -1099,8 +1099,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
 
     vkt::RenderPass rp(*m_device, rpci);
 
-    VkImageObj image(m_device);
-    image.InitNoLayout(32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
 

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -29,8 +29,7 @@ TEST_F(NegativeVertexInput, AttributeFormat) {
 
     // Pick a really bad format for this purpose and make sure it should fail
     input_attribs.format = VK_FORMAT_BC2_UNORM_BLOCK;
-    VkFormatProperties format_props = m_device->format_properties(input_attribs.format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) != 0) {
+    if ((m_device->FormatFeaturesBuffer(VK_FORMAT_BC2_UNORM_BLOCK) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) != 0) {
         GTEST_SKIP() << "Format unsuitable for test";
     }
 
@@ -1148,8 +1147,7 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
     InitRenderTarget();
 
     const VkFormat format = VK_FORMAT_R64_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(format) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
@@ -1184,8 +1182,7 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
     InitRenderTarget();
 
     const VkFormat format = VK_FORMAT_R32_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(format) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
@@ -1221,8 +1218,7 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
     InitRenderTarget();
 
     const VkFormat format = VK_FORMAT_R64_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(format) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -440,8 +440,7 @@ TEST_F(PositiveVertexInput, VertexAttribute64bit) {
     InitRenderTarget();
 
     const VkFormat format = VK_FORMAT_R64_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(format) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 
@@ -538,8 +537,7 @@ TEST_F(PositiveVertexInput, Attribute64bitMissingComponent) {
     InitRenderTarget();
 
     const VkFormat format = VK_FORMAT_R64G64B64A64_SFLOAT;
-    VkFormatProperties format_props = m_device->format_properties(format);
-    if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
+    if ((m_device->FormatFeaturesBuffer(format) & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "Format not supported for Vertex Buffer";
     }
 

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -3053,7 +3053,7 @@ TEST_F(NegativeVideo, BeginCodingUnsupportedCodecOp) {
     context.CreateAndBindSessionMemory();
 
     vkt::CommandPool pool(*m_device, queue_family_index);
-    vkt::CommandBuffer cb(m_device, &pool);
+    vkt::CommandBuffer cb(*m_device, &pool);
 
     cb.begin();
 
@@ -9836,7 +9836,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryIncompatibleQueueFamily) {
     context.CreateStatusQueryPool();
 
     vkt::CommandPool cmd_pool(*m_device, queue_family_index, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(m_device, &cmd_pool);
+    vkt::CommandBuffer cb(*m_device, &cmd_pool);
 
     cb.begin();
 
@@ -10101,7 +10101,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryIncompatibleQueueFamily) {
     context.CreateStatusQueryPool();
 
     vkt::CommandPool cmd_pool(*m_device, queue_family_index, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(m_device, &cmd_pool);
+    vkt::CommandBuffer cb(*m_device, &cmd_pool);
 
     cb.begin();
 
@@ -11910,8 +11910,7 @@ TEST_F(NegativeVideo, CreateImageViewInvalidViewType) {
         image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-        vkt::Image image;
-        image.init(*m_device, image_ci);
+        vkt::Image image(*m_device, image_ci);
 
         VkImageViewCreateInfo image_view_ci = vku::InitStructHelper();
         image_view_ci.image = image.handle();
@@ -11993,8 +11992,7 @@ TEST_F(NegativeVideo, CreateImageViewProfileIndependent) {
         image_ci.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
         image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-        vkt::Image image;
-        image.init(*m_device, image_ci);
+        vkt::Image image(*m_device, image_ci);
 
         auto image_usage_ci = vku::InitStruct<VkImageViewUsageCreateInfoKHR>();
         image_usage_ci.usage = test_case.usage;
@@ -12104,7 +12102,7 @@ TEST_F(NegativeVideo, BeginQueryIncompatibleQueueFamily) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR, 1);
 
     vkt::CommandPool cmd_pool(*m_device, queue_family_index, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(m_device, &cmd_pool);
+    vkt::CommandBuffer cb(*m_device, &cmd_pool);
 
     cb.begin();
 

--- a/tests/unit/video_positive.cpp
+++ b/tests/unit/video_positive.cpp
@@ -51,8 +51,8 @@ TEST_F(PositiveVideo, MultipleCmdBufs) {
     context.CreateResources();
 
     vkt::CommandPool cmd_pool(*m_device, config.QueueFamilyIndex(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb1(m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
-    vkt::CommandBuffer cb2(m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
+    vkt::CommandBuffer cb1(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
+    vkt::CommandBuffer cb2(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
 
     cb1.begin();
     cb1.BeginVideoCoding(context.Begin());

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -26,7 +26,7 @@ class ViewportInheritanceTestData {
     VkRenderPass m_renderPass{};
 
     // Framebuffer data.
-    VkImageObj m_colorImageObj;
+    vkt::Image m_colorImageObj;
     VkImageView m_colorImageView{};
     VkFramebuffer m_framebuffer{};
 
@@ -102,9 +102,9 @@ class ViewportInheritanceTestData {
         if (result != VK_SUCCESS) m_failureReason = "Could not create render pass.";
     }
 
-    void CreateColorImageObj() noexcept {
+    void CreateColorImageObj(vkt::Device& device_obj) noexcept {
         assert(m_colorFormat != VK_FORMAT_UNDEFINED);
-        m_colorImageObj.Init(128, 128, 1, m_colorFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+        m_colorImageObj.Init(device_obj, 128, 128, 1, m_colorFormat, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
         if (!m_colorImageObj.initialized()) {
             m_failureReason = "Image not initialized";
         }
@@ -246,15 +246,14 @@ class ViewportInheritanceTestData {
         return true;
     }
 
-    ViewportInheritanceTestData(vkt::Device* p_device_obj, VkPhysicalDevice physical_device) noexcept
-        : m_colorImageObj(p_device_obj) {
+    ViewportInheritanceTestData(vkt::Device* p_device_obj, VkPhysicalDevice physical_device) noexcept {
         m_device = p_device_obj->handle();
 
         PickColorFormat(physical_device);
         if (m_failureReason) return;
         CreateRenderPass();
         if (m_failureReason) return;
-        CreateColorImageObj();
+        CreateColorImageObj(*p_device_obj);
         if (m_failureReason) return;
         CreateColorView();
         if (m_failureReason) return;
@@ -947,7 +946,7 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
     InitRenderTarget();
 
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer secondary(m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
+    vkt::CommandBuffer secondary(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
     ViewportInheritanceTestData test_data(m_device, gpu());
     if (test_data.FailureReason()) {

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -298,9 +298,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     image_create_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
-
-    VkImageObj src_Image(m_device);
-    src_Image.init(&image_create_info);
+    vkt::Image src_Image(*m_device, image_create_info, vkt::set_layout);
 
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
@@ -2385,7 +2383,8 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
     uint32_t image_index = 0;
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore.handle(), VK_NULL_HANDLE, &image_index);
 
-    const VkImageMemoryBarrier present_transition = vkt::Image::transition_to_present(swapchain_images[image_index]);
+    const VkImageMemoryBarrier present_transition =
+        TransitionToPresent(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, 0);
     m_commandBuffer->begin();
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                            0, nullptr, 0, nullptr, 1, &present_transition);

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -256,9 +256,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
     sycci.components = identity;
     vkt::SamplerYcbcrConversion conversion(*m_device, sycci);
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkSamplerYcbcrConversionInfo conversion_info = vku::InitStructHelper();
     conversion_info.conversion = conversion.handle();
@@ -440,15 +438,11 @@ TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
 
     // Create images
     ci.extent = {64, 64, 1};
-    VkImageObj image_422(m_device);
-    image_422.init(&ci);
-    ASSERT_TRUE(image_422.initialized());
+    vkt::Image image_422(*m_device, ci, vkt::set_layout);
 
     ci.extent = {64, 64, 1};
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkImageObj image_ucmp(m_device);
-    image_ucmp.init(&ci);
-    ASSERT_TRUE(image_ucmp.initialized());
+    vkt::Image image_ucmp(*m_device, ci, vkt::set_layout);
 
     m_commandBuffer->begin();
 
@@ -533,19 +527,13 @@ TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
     }
 
     // Create images
-    VkImageObj mp3_image(m_device);
-    mp3_image.init(&ci);
-    ASSERT_TRUE(mp3_image.initialized());
+    vkt::Image mp3_image(*m_device, ci, vkt::set_layout);
 
     ci.format = mp2_format;
-    VkImageObj mp2_image(m_device);
-    mp2_image.init(&ci);
-    ASSERT_TRUE(mp2_image.initialized());
+    vkt::Image mp2_image(*m_device, ci, vkt::set_layout);
 
     ci.format = VK_FORMAT_D24_UNORM_S8_UINT;
-    VkImageObj sp_image(m_device);
-    sp_image.init(&ci);
-    ASSERT_TRUE(sp_image.initialized());
+    vkt::Image sp_image(*m_device, ci, vkt::set_layout);
 
     m_commandBuffer->begin();
 
@@ -640,7 +628,6 @@ TEST_F(NegativeYcbcr, ClearColorImageFormat) {
     RETURN_IF_SKIP(InitBasicYcbcr());
     InitRenderTarget();
 
-    VkImageObj mp_image(m_device);
     VkFormat mp_format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
@@ -660,7 +647,7 @@ TEST_F(NegativeYcbcr, ClearColorImageFormat) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
-    mp_image.init(&image_create_info);
+    vkt::Image mp_image(*m_device, image_create_info, vkt::set_layout);
     m_commandBuffer->begin();
 
     VkClearColorValue color_clear_value = {};
@@ -699,13 +686,11 @@ TEST_F(NegativeYcbcr, WriteDescriptorSet) {
                                                      {0, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                  });
 
-    VkImageObj image_obj(m_device);
     auto image_ci = vku::InitStruct<VkImageCreateInfo>(
         nullptr, VkImageCreateFlags{VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT},  // need for multi-planar
         VK_IMAGE_TYPE_2D, mp_format, VkExtent3D{64, 64u, 1u}, 1u, 1u, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_TILING_OPTIMAL,
         VkImageUsageFlags{VK_IMAGE_USAGE_SAMPLED_BIT}, VK_SHARING_MODE_EXCLUSIVE, 0u, nullptr, VK_IMAGE_LAYOUT_UNDEFINED);
-    image_obj.init(&image_ci);
-    ASSERT_TRUE(image_obj.initialized());
+    vkt::Image image_obj(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionInfo ycbcr_info = vku::InitStructHelper();
     ycbcr_info.conversion = conversion.handle();
@@ -953,9 +938,7 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     }
 
     // Try to bind memory to an object with an invalid memoryOffset
-
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs = {};
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -1155,9 +1138,7 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
     }
 
     // Try to bind memory to an object with an invalid memoryOffset
-
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkMemoryRequirements image_mem_reqs = {};
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
@@ -1295,9 +1276,7 @@ TEST_F(NegativeYcbcr, MismatchedImageViewAndSamplerFormat) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitBasicYcbcr());
 
-    VkImageObj image(m_device);
-    image.Init(128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
-    ASSERT_TRUE(image.initialized());
+    vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     VkSamplerYcbcrConversionCreateInfo sampler_conversion_ci = vku::InitStructHelper();
     sampler_conversion_ci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
@@ -1375,9 +1354,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     if (!supported) {
         printf("Multiplane image format not supported.  Skipping test.\n");
     } else {
-        VkImageObj image_obj(m_device);
-        image_obj.init(&ci);
-        ASSERT_TRUE(image_obj.initialized());
+        vkt::Image image_obj(*m_device, ci, vkt::set_layout);
 
         VkImageViewCreateInfo ivci = vku::InitStructHelper();
         ivci.image = image_obj.image();
@@ -1415,9 +1392,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     if (!supported) {
         printf("Multiplane image format not supported.  Skipping test.\n");
     } else {
-        VkImageObj image_obj(m_device);
-        image_obj.init(&ci);
-        ASSERT_TRUE(image_obj.initialized());
+        vkt::Image image_obj(*m_device, ci, vkt::set_layout);
 
         VkImageViewCreateInfo ivci = vku::InitStructHelper();
         ivci.image = image_obj.image();
@@ -1480,9 +1455,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
     // Different formats between VkImage and VkImageView
     {
         ci.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
-        VkImageObj image(m_device);
-        image.init(&ci);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, ci, vkt::set_layout);
 
         ivci.image = image.image();
         ivci.format = VK_FORMAT_R8_UNORM;
@@ -1494,9 +1467,7 @@ TEST_F(NegativeYcbcr, MultiplaneImageViewAspectMasks) {
     // Without Mutable format
     {
         ci.flags = 0;
-        VkImageObj image(m_device);
-        image.init(&ci);
-        ASSERT_TRUE(image.initialized());
+        vkt::Image image(*m_device, ci, vkt::set_layout);
 
         VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = vku::InitStructHelper();
         ycbcr_create_info.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
@@ -1532,10 +1503,9 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
     }
 
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;  // commonly supported multi-planar format
-    VkImageObj image_obj(m_device);
     VkFormatProperties format_props;
     vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &format_props);
-    if (!image_obj.IsCompatible(VK_IMAGE_USAGE_SAMPLED_BIT, format_props.optimalTilingFeatures)) {
+    if (!vkt::Image::IsCompatible(*m_device, VK_IMAGE_USAGE_SAMPLED_BIT, format_props.optimalTilingFeatures)) {
         GTEST_SKIP() << "multi-planar format cannot be sampled for optimalTiling.";
     }
 
@@ -1543,8 +1513,7 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
         nullptr, VkImageCreateFlags{VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT},  // need for multi-planar
         VK_IMAGE_TYPE_2D, mp_format, VkExtent3D{64, 64, 1}, 1u, 1u, VK_SAMPLE_COUNT_1_BIT, VK_IMAGE_TILING_OPTIMAL,
         VkImageUsageFlags{VK_IMAGE_USAGE_SAMPLED_BIT}, VK_SHARING_MODE_EXCLUSIVE, 0u, nullptr, VK_IMAGE_LAYOUT_UNDEFINED);
-    image_obj.init(&image_ci);
-    ASSERT_TRUE(image_obj.initialized());
+    vkt::Image image_obj(*m_device, image_ci, vkt::set_layout);
 
     VkSamplerYcbcrConversionCreateInfo ycbcr_create_info = vku::InitStructHelper();
     ycbcr_create_info.format = mp_format;
@@ -1640,9 +1609,7 @@ TEST_F(NegativeYcbcr, DisjointImageWithDrmFormatModifier) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-
-    vkt::Image image;
-    image.init_no_mem(*m_device, image_create_info);
+    vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     VkImageMemoryRequirementsInfo2 mem_req_info2 = vku::InitStructHelper();
     mem_req_info2.image = image;
@@ -1674,9 +1641,7 @@ TEST_F(NegativeYcbcr, DrawFetch) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image(m_device);
-    image.Init(ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     vkt::SamplerYcbcrConversion conversion(*m_device, format);
     auto conversion_info = conversion.ConversionInfo();
@@ -1751,9 +1716,7 @@ TEST_F(NegativeYcbcr, DrawConstOffset) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image(m_device);
-    image.Init(ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     vkt::SamplerYcbcrConversion conversion(*m_device, format);
     auto conversion_info = conversion.ConversionInfo();

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -77,9 +77,7 @@ TEST_F(PositiveYcbcr, MultiplaneGetImageSubresourceLayout) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, ci);
+    vkt::Image image(*m_device, ci, vkt::no_mem);
 
     // Query layout of 3rd plane
     VkImageSubresource subres = {};
@@ -114,9 +112,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image(m_device);
-    image.init(&ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     m_commandBuffer->reset();
     m_commandBuffer->begin();
@@ -174,9 +170,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, ci);
-
+    vkt::Image image(*m_device, ci, vkt::no_mem);
     vkt::DeviceMemory mem_obj;
     mem_obj.init(*m_device, vkt::DeviceMemory::get_resource_alloc_info(*m_device, image.memory_requirements(), 0));
 
@@ -240,8 +234,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
-    VkImageObj image{m_device};
-    image.init_no_mem(*m_device, ci);
+    vkt::Image image(*m_device, ci, vkt::no_mem);
 
     // Allocate & bind memory
     auto image_plane_req = vku::InitStruct<VkImagePlaneMemoryRequirementsInfo>();
@@ -328,10 +321,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image(m_device);
-    image.Init(ci);
-
+    vkt::Image image(*m_device, ci, vkt::set_layout);
     vkt::Buffer buffer(*m_device, 128 * 128 * 3, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
 
     VkBufferImageCopy copy_region = {};
@@ -430,9 +420,7 @@ TEST_F(PositiveYcbcr, DrawCombinedImageSampler) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-
-    VkImageObj image(m_device);
-    image.Init(ci);
+    vkt::Image image(*m_device, ci, vkt::set_layout);
 
     vkt::SamplerYcbcrConversion conversion(*m_device, format);
     auto conversion_info = conversion.ConversionInfo();


### PR DESCRIPTION
There are many misc fixes that went along my journey to this, but the main thing is `VkImageObj` is now fully gone for `vkt::Image`