### PR TITLE
sync: Filter accesses in async hazard detection

### DIFF
--- a/layers/sync/sync_access_state.h
+++ b/layers/sync/sync_access_state.h
@@ -339,9 +339,9 @@ class ResourceAccessState : public SyncStageAccess {
     HazardResult DetectHazard(const SyncStageAccessInfoType &usage_info, const OrderingBarrier &ordering, QueueId queue_id) const;
     HazardResult DetectHazard(const ResourceAccessState &recorded_use, QueueId queue_id, const ResourceUsageRange &tag_range) const;
 
-    HazardResult DetectAsyncHazard(const SyncStageAccessInfoType &usage_info, ResourceUsageTag start_tag) const;
+    HazardResult DetectAsyncHazard(const SyncStageAccessInfoType &usage_info, ResourceUsageTag start_tag, QueueId queue_id) const;
     HazardResult DetectAsyncHazard(const ResourceAccessState &recorded_use, const ResourceUsageRange &tag_range,
-                                   ResourceUsageTag start_tag) const;
+                                   ResourceUsageTag start_tag, QueueId queue_id) const;
 
     HazardResult DetectBarrierHazard(const SyncStageAccessInfoType &usage_info, QueueId queue_id,
                                      VkPipelineStageFlags2KHR source_exec_scope,

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -562,7 +562,7 @@ void QueueBatchContext::CommonSetupAccessContext(const std::shared_ptr<const Que
         }
 
         // The start of the asynchronous access range for a given queue is one more than the highest tagged reference
-        access_context_.AddAsyncContext(async_batch->GetCurrentAccessContext(), sync_tag);
+        access_context_.AddAsyncContext(async_batch->GetCurrentAccessContext(), sync_tag, async_batch->GetQueueId());
         // We need to snapshot the async log information for async hazard reporting
         batch_log_.Import(async_batch->batch_log_);
     }


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7386, https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7455.

Only the accesses from the async queue participate in async hazard detection.
The resolved accesses from the other contexts might belong to different queues
and do not create async hazards.

The positive test is a regression test from:
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7386.

The `QSWriteRacingWrite`/`QSWriteRacingWrite2` negative tests were added to
increase `WRITE-RACING-WRITE` coverage, but they do not reproduce the
issue that was fixed.

The `QSWriteRacingRead` test is a regression test for the initial
incorrect attempt to fix the issue (using scalar async tag tracking
instead of per-queue), which nevertheless did not cause any failures.
