### PR TITLE
layers: Fix dynamic state tracking now resetting

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -288,9 +288,11 @@ class CommandBuffer : public RefcountedStateObject {
             viewports.clear();
             discard_rectangles.reset();
             color_blend_enable_attachments.reset();
+            color_blend_enabled.reset();
             color_blend_equation_attachments.reset();
             color_write_mask_attachments.reset();
             color_blend_advanced_attachments.reset();
+            color_write_enabled.reset();
             color_blend_equations.clear();
             color_write_masks.clear();
             vertex_binding_descriptions.clear();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7521 (but plan to make another follow-up PR to improve the error messages)

The issue was more obvious once I showed (details in issue) this occured between 2 different usages

There is a message above `DynamicStateValue::reset()` the explains why some items need to be cleared/reset and not others... slightly worried this may happen again, but all the dynamic state that needs to be tracked is being tracked so it lowers my worry