### PR TITLE
gpu: Dont't run descriptor validation after an in-shader error

### DIFF
--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -526,8 +526,9 @@ bool gpuav::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer cmd_buffer, Vk
     return error_found;
 }
 
-void gpuav::CommandResources::LogErrorIfAny(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+bool gpuav::CommandResources::LogErrorIfAny(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                             const uint32_t operation_index) {
+    bool error_found = false;
     uint32_t *output_buffer = nullptr;
     VkResult result = vmaMapMemory(validator.vmaAllocator, output_mem_block.allocation, reinterpret_cast<void **>(&output_buffer));
     if (result == VK_SUCCESS) {
@@ -535,32 +536,35 @@ void gpuav::CommandResources::LogErrorIfAny(gpuav::Validator &validator, VkQueue
         // A zero here means that the shader instrumentation didn't write anything.
         if (total_words != 0) {
             const LogObjectList objlist(queue, cmd_buffer);
-            LogValidationMessage(validator, queue, cmd_buffer, output_buffer, operation_index, objlist);
+            error_found |= LogValidationMessage(validator, queue, cmd_buffer, output_buffer, operation_index, objlist);
         }
         output_buffer[spvtools::kDebugOutputSizeOffset] = 0;
         vmaUnmapMemory(validator.vmaAllocator, output_mem_block.allocation);
     }
+    return error_found;
 }
 
-void gpuav::CommandResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+bool gpuav::CommandResources::LogValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                                    uint32_t *output_buffer_begin, const uint32_t operation_index,
                                                    const LogObjectList &objlist) {
     const DescBindingInfo *di_info = desc_binding_index != vvl::kU32Max ? &(*desc_binding_list)[desc_binding_index] : nullptr;
     const Location loc(command);
-    const bool error_logged =
+    bool error_logged =
         validator.AnalyzeAndGenerateMessages(cmd_buffer, queue, *this, operation_index, output_buffer_begin,
                                              di_info ? di_info->descriptor_set_buffers : std::vector<DescSetState>(), loc);
 
     if (!error_logged) {
         uint32_t *debug_record = &output_buffer_begin[spvtools::kDebugOutputDataOffset];
-        LogCustomValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist);
+        error_logged = LogCustomValidationMessage(validator, queue, cmd_buffer, debug_record, operation_index, objlist);
     }
+    return error_logged;
 }
 
-void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                                          const uint32_t *debug_record, const uint32_t operation_index,
                                                          const LogObjectList &objlist) {
     using namespace glsl;
+    bool error_logged = false;
 
     const GpuVuid &vuids = GetGpuVuid(command);
     const Location loc(command);
@@ -590,6 +594,7 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                                        " (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand)) = %" PRIu32 ".",
                                        count, indirect_buffer_size, validator.FormatHandle(indirect_buffer).c_str(), stride, offset,
                                        draw_size);
+                    error_logged = true;
                     break;
                 }
                 case pre_draw_count_exceeds_limit_error: {
@@ -597,6 +602,7 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                     validator.LogError(vuids.count_exceeds_device_limit, objlist, loc,
                                        "Indirect draw count of %" PRIu32 " would exceed maxDrawIndirectCount limit of %" PRIu32 ".",
                                        count, validator.phys_dev_props.limits.maxDrawIndirectCount);
+                    error_logged = true;
                     break;
                 }
                 case pre_draw_first_instance_error: {
@@ -606,6 +612,7 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                         "The drawIndirectFirstInstance feature is not enabled, but the firstInstance member of the %s structure at "
                         "index %" PRIu32 " is not zero.",
                         command == vvl::Func::vkCmdDrawIndirect ? "VkDrawIndirectCommand" : "VkDrawIndexedIndirectCommand", index);
+                    error_logged = true;
                     break;
                 }
                 case pre_draw_group_count_exceeds_limit_x_error:
@@ -640,6 +647,7 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                         " which is greater than VkPhysicalDeviceMeshShaderPropertiesEXT::maxTaskWorkGroupCount[%" PRIu32
                         "] (%" PRIu32 ").",
                         draw_number, count_label, group_count, index, limit);
+                    error_logged = true;
                     break;
                 }
                 case pre_draw_group_count_exceeds_total_error: {
@@ -652,6 +660,7 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                         "In draw %" PRIu32 ", The product of groupCountX, groupCountY and groupCountZ (%" PRIu32
                         ") is greater than VkPhysicalDeviceMeshShaderPropertiesEXT::maxTaskWorkGroupTotalCount (%" PRIu32 ").",
                         draw_number, total_count, validator.phys_dev_ext_props.mesh_shader_props_ext.maxTaskWorkGroupTotalCount);
+                    error_logged = true;
                     break;
                 }
                 default:
@@ -661,15 +670,17 @@ void gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
         default:
             break;
     }
+    return error_logged;
 }
 
-void gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+bool gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                                              const uint32_t *debug_record, const uint32_t operation_index,
                                                              const LogObjectList &objlist) {
     using namespace glsl;
 
     const Location loc(command);
 
+    bool error_logged = false;
     switch (debug_record[kInstValidationOutError]) {
         case kInstErrorPreDispatchValidate: {
             if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_x_error) {
@@ -678,31 +689,36 @@ void gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &v
                                    "Indirect dispatch VkDispatchIndirectCommand::x of %" PRIu32
                                    " would exceed maxComputeWorkGroupCount[0] limit of %" PRIu32 ".",
                                    count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]);
+                error_logged = true;
             } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_y_error) {
                 uint32_t count = debug_record[kPreValidateSubError + 1];
                 validator.LogError("VUID-VkDispatchIndirectCommand-y-00418", objlist, loc,
                                    "Indirect dispatch VkDispatchIndirectCommand::y of %" PRIu32
                                    " would exceed maxComputeWorkGroupCount[1] limit of %" PRIu32 ".",
                                    count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[1]);
+                error_logged = true;
             } else if (debug_record[kPreValidateSubError] == pre_dispatch_count_exceeds_limit_z_error) {
                 uint32_t count = debug_record[kPreValidateSubError + 1];
                 validator.LogError("VUID-VkDispatchIndirectCommand-z-00419", objlist, loc,
                                    "Indirect dispatch VkDispatchIndirectCommand::z of %" PRIu32
                                    " would exceed maxComputeWorkGroupCount[2] limit of %" PRIu32 ".",
                                    count, validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]);
+                error_logged = true;
             }
         } break;
         default:
             break;
     }
+    return error_logged;
 }
 
-void gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue,
+bool gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue,
                                                               VkCommandBuffer cmd_buffer, const uint32_t *debug_record,
                                                               const uint32_t operation_index, const LogObjectList &objlist) {
     using namespace glsl;
 
     const Location loc(command);
+    bool error_logged = false;
 
     switch (debug_record[kInstValidationOutError]) {
         case kInstErrorPreTraceRaysKhrValidate: {
@@ -715,7 +731,7 @@ void gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
                                    width,
                                    static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[0]) *
                                        static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[0]));
-
+                error_logged = true;
             } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_height_limit) {
                 uint32_t height = debug_record[kPreValidateSubError + 1];
                 validator.LogError("VUID-VkTraceRaysIndirectCommandKHR-height-03639", objlist, loc,
@@ -725,6 +741,7 @@ void gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
                                    height,
                                    static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[1]) *
                                        static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[1]));
+                error_logged = true;
             } else if (debug_record[kPreValidateSubError] == pre_trace_rays_query_dimensions_exceeds_depth_limit) {
                 uint32_t depth = debug_record[kPreValidateSubError + 1];
                 validator.LogError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640", objlist, loc,
@@ -734,18 +751,22 @@ void gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
                                    depth,
                                    static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupCount[2]) *
                                        static_cast<uint64_t>(validator.phys_dev_props.limits.maxComputeWorkGroupSize[2]));
+                error_logged = true;
             }
         } break;
         default:
             break;
     }
+    return error_logged;
 }
 
-void gpuav::PreCopyBufferToImageResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue,
+bool gpuav::PreCopyBufferToImageResources::LogCustomValidationMessage(gpuav::Validator &validator, VkQueue queue,
                                                                       VkCommandBuffer cmd_buffer, const uint32_t *debug_record,
                                                                       const uint32_t operation_index,
                                                                       const LogObjectList &objlist) {
     using namespace glsl;
+    bool error_logged = false;
+
     switch (debug_record[kInstValidationOutError]) {
         case kInstErrorCopyBufferToImage: {
             if (debug_record[kPreValidateSubError] == pre_copy_buffer_to_image_out_of_range_value) {
@@ -758,9 +779,11 @@ void gpuav::PreCopyBufferToImageResources::LogCustomValidationMessage(gpuav::Val
                 validator.LogError(vuid, objlist_and_src_buffer, command,
                                    "Source buffer %s has a float value at offset %" PRIu32 " that is not in the range [0, 1].",
                                    validator.FormatHandle(this->src_buffer).c_str(), texel_offset);
+                error_logged = true;
             }
         } break;
         default:
             break;
     }
+    return error_logged;
 }

--- a/layers/gpu_validation/gpu_resources.h
+++ b/layers/gpu_validation/gpu_resources.h
@@ -51,12 +51,12 @@ class CommandResources {
     CommandResources(const CommandResources &) = default;
     CommandResources &operator=(const CommandResources &) = default;
 
-    void LogErrorIfAny(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer, const uint32_t operation_index);
-    void LogValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer, uint32_t *output_buffer_begin,
+    bool LogErrorIfAny(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer, const uint32_t operation_index);
+    bool LogValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer, uint32_t *output_buffer_begin,
                               const uint32_t operation_index, const LogObjectList &objlist);
-    virtual void LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+    virtual bool LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                             const uint32_t *debug_record, const uint32_t operation_index,
-                                            const LogObjectList &objlist) {}
+                                            const LogObjectList &objlist) { return false; }
 
     DeviceMemoryBlock output_mem_block{};
 
@@ -89,7 +89,7 @@ class PreDrawResources : public CommandResources {
     bool emit_task_error = false;  // Used to decide between mesh error and task error
 
     void Destroy(Validator &validator) final;
-    void LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+    bool LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                     const uint32_t *debug_record, const uint32_t operation_index,
                                     const LogObjectList &objlist) final;
 
@@ -115,7 +115,7 @@ class PreDispatchResources : public CommandResources {
     static constexpr uint32_t push_constant_words = 4;
 
     void Destroy(Validator &validator) final;
-    void LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+    bool LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                     const uint32_t *debug_record, const uint32_t operation_index,
                                     const LogObjectList &objlist) final;
 
@@ -139,7 +139,7 @@ class PreTraceRaysResources : public CommandResources {
     static constexpr uint32_t push_constant_words = 5;
 
     void Destroy(Validator &validator) final;
-    void LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+    bool LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                     const uint32_t *debug_record, const uint32_t operation_index,
                                     const LogObjectList &objlist) final;
 
@@ -170,7 +170,7 @@ class PreCopyBufferToImageResources : public CommandResources {
     VmaAllocation copy_src_regions_allocation = VK_NULL_HANDLE;
 
     void Destroy(Validator &validator) final;
-    void LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
+    bool LogCustomValidationMessage(Validator &validator, VkQueue queue, VkCommandBuffer cmd_buffer,
                                     const uint32_t *debug_record, const uint32_t operation_index,
                                     const LogObjectList &objlist) final;
 

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -158,6 +158,7 @@ void gpuav::CommandBuffer::Process(VkQueue queue, const Location &loc) {
     uint32_t draw_index = 0;
     uint32_t compute_index = 0;
     uint32_t ray_trace_index = 0;
+    bool error_found = false;
 
     for (auto &cmd_info : per_command_resources) {
         uint32_t operation_index = 0;
@@ -169,35 +170,39 @@ void gpuav::CommandBuffer::Process(VkQueue queue, const Location &loc) {
             operation_index = ray_trace_index++;
         }
 
-        cmd_info->LogErrorIfAny(*device_state, queue, VkHandle(), operation_index);
+        error_found |= cmd_info->LogErrorIfAny(*device_state, queue, VkHandle(), operation_index);
     }
 
-    // For each vkCmdBindDescriptorSets()...
-    // Some applications repeatedly call vkCmdBindDescriptorSets() with the same descriptor sets, avoid
-    // checking them multiple times.
-    vvl::unordered_set<VkDescriptorSet> validated_desc_sets;
-    for (auto &di_info : di_input_buffer_list) {
-        Location draw_loc(vvl::Func::vkCmdDraw);
-        // For each descriptor set ...
-        for (auto &set : di_info.descriptor_set_buffers) {
-            if (validated_desc_sets.count(set.state->VkHandle()) > 0) {
-                continue;
-            }
-            validated_desc_sets.emplace(set.state->VkHandle());
-            assert(set.output_state);
-
-            vvl::DescriptorValidator context(*device_state, *this, *set.state, VK_NULL_HANDLE /*framebuffer*/, draw_loc);
-            auto used_descs = set.output_state->UsedDescriptors(*set.state);
-            // For each used binding ...
-            for (const auto &u : used_descs) {
-                auto iter = set.binding_req.find(u.first);
-                vvl::DescriptorBindingInfo binding_info;
-                binding_info.first = u.first;
-                while (iter != set.binding_req.end() && iter->first == u.first) {
-                    binding_info.second.emplace_back(iter->second);
-                    ++iter;
+    // If instrumentation found an error, skip post processing. Errors detected by instrumentation are usually
+    // very serious, such as a prematurely destroyed resource and the state needed below is likely invalid.
+    if (!error_found) {
+        // For each vkCmdBindDescriptorSets()...
+        // Some applications repeatedly call vkCmdBindDescriptorSets() with the same descriptor sets, avoid
+        // checking them multiple times.
+        vvl::unordered_set<VkDescriptorSet> validated_desc_sets;
+        for (auto &di_info : di_input_buffer_list) {
+            Location draw_loc(vvl::Func::vkCmdDraw);
+            // For each descriptor set ...
+            for (auto &set : di_info.descriptor_set_buffers) {
+                if (validated_desc_sets.count(set.state->VkHandle()) > 0) {
+                    continue;
                 }
-                context.ValidateBinding(binding_info, u.second);
+                validated_desc_sets.emplace(set.state->VkHandle());
+                assert(set.output_state);
+
+                vvl::DescriptorValidator context(*device_state, *this, *set.state, VK_NULL_HANDLE /*framebuffer*/, draw_loc);
+                auto used_descs = set.output_state->UsedDescriptors(*set.state);
+                // For each used binding ...
+                for (const auto &u : used_descs) {
+                    auto iter = set.binding_req.find(u.first);
+                    vvl::DescriptorBindingInfo binding_info;
+                    binding_info.first = u.first;
+                    while (iter != set.binding_req.end() && iter->first == u.first) {
+                        binding_info.second.emplace_back(iter->second);
+                        ++iter;
+                    }
+                    context.ValidateBinding(binding_info, u.second);
+                }
             }
         }
     }


### PR DESCRIPTION
If instrumentation found an error, skip post processing. Errors detected by instrumentation are usually very serious, such as a prematurely destroyed resource and the state needed below is likely invalid.