### PR TITLE
Validation layer build as framework when built for iOS

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -116,7 +116,11 @@ endif()
 
 add_subdirectory(gpu_validation/spirv)
 
-add_library(vvl MODULE)
+if(IOS)
+    add_library(vvl SHARED)
+else()
+    add_library(vvl MODULE)
+endif()
 
 target_sources(vvl PRIVATE
     best_practices/best_practices_error_enums.h
@@ -334,7 +338,16 @@ elseif(MINGW)
     target_compile_options(vvl PRIVATE -Wa,-mbig-obj)
     set_target_properties(vvl PROPERTIES PREFIX "") # remove the prefix "lib" so the manifest json "library_path" matches
 elseif(APPLE)
+
+if(IOS)
+    set_target_properties(vvl PROPERTIES
+		FRAMEWORK			TRUE
+		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.validation
+    )
+else()
     set_target_properties(vvl PROPERTIES SUFFIX ".dylib")
+endif()
+
     target_link_options(vvl PRIVATE -exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.exp)
 elseif(ANDROID)
     target_link_options(vvl PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}-android.map)


### PR DESCRIPTION
This change builds the Khronos validation layer as a Framework when built for iOS. This is required for Apple App store compatibility. Although it is unlikely that this validation layer would be shipped with an iOS application, for consistency, all frameworks for iOS are being packaged as Frameworks to align with Apples policy.