### PR TITLE
tests: Revert SetTargetApiVersion behavior and add SetRequiredApiVersion

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -117,6 +117,14 @@ if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
 }
 ```
 
+Alternatively, to require the device to support the target Vulkan version, the test writer can call:
+
+```cpp
+SetRequiredApiVersion(VK_API_VERSION_1_1);
+// Will skip if the supported instance version or device supported version is not high enough
+RETURN_IF_SKIP(InitFramework());
+```
+
 ### Promoted extensions
 
 The test framework now automatically handles extensions promoted to core versions by not enabling the extensions if the target instance Vulkan version (set through `SetTargetApiVersion`) or the Vulkan version supported by the device (queriable using `DeviceValidationVersion`) already includes the instance or device extension's functionality, respectively.

--- a/tests/device_profiles/max_core.json
+++ b/tests/device_profiles/max_core.json
@@ -649,6 +649,28 @@
                     "uniformTexelBufferOffsetSingleTexelAlignment": true,
                     "maxBufferSize": 4294967000
                 },
+                "VkPhysicalDeviceSubgroupProperties": {
+                    "subgroupSize": 32,
+                    "supportedStages": [
+                        "VK_SHADER_STAGE_VERTEX_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT",
+                        "VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT",
+                        "VK_SHADER_STAGE_GEOMETRY_BIT",
+                        "VK_SHADER_STAGE_FRAGMENT_BIT",
+                        "VK_SHADER_STAGE_COMPUTE_BIT"
+                    ],
+                    "supportedOperations": [
+                        "VK_SUBGROUP_FEATURE_BASIC_BIT",
+                        "VK_SUBGROUP_FEATURE_VOTE_BIT",
+                        "VK_SUBGROUP_FEATURE_ARITHMETIC_BIT",
+                        "VK_SUBGROUP_FEATURE_BALLOT_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_BIT",
+                        "VK_SUBGROUP_FEATURE_SHUFFLE_RELATIVE_BIT",
+                        "VK_SUBGROUP_FEATURE_CLUSTERED_BIT",
+                        "VK_SUBGROUP_FEATURE_QUAD_BIT"
+                    ],
+                    "quadOperationsInAllStages": true
+                },
                 "VkPhysicalDevicePointClippingProperties": {},
                 "VkPhysicalDeviceMultiviewProperties": {
                     "maxMultiviewViewCount": 16,

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -423,6 +423,12 @@ void VkLayerTest::SetTargetApiVersion(APIVersion target_api_version) {
     app_info_.apiVersion = m_target_api_version.Value();
 }
 
+void VkLayerTest::SetRequiredApiVersion(APIVersion required_api_version) {
+    // Implicitly means that the target API version is at least as high
+    SetTargetApiVersion(required_api_version);
+    m_required_api_version = required_api_version;
+}
+
 APIVersion VkLayerTest::DeviceValidationVersion() const {
     // The validation layers assume the version we are validating to is the apiVersion unless the device apiVersion is lower
     return std::min(m_target_api_version, APIVersion(physDevProps().apiVersion));

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -203,7 +203,16 @@ class VkLayerTest : public VkLayerTestBase {
     APIVersion DeviceValidationVersion() const;
 
   protected:
+    // Enables target API version (at instance creation) but does NOT require the target API version
+    // to be supported by the physical device itself in order to enable functionalities that may be
+    // either available as extension form or as promoted core features.
+    // In order to actually require physical device version, check the physical device supported API version
+    // with DeviceValidationVersion() or use SetRequiredApiVersion().
     void SetTargetApiVersion(APIVersion target_api_version);
+    // Enables required API version and ALSO requires it to be supported by the physical device itself.
+    // Should only be used when the API version is a hard requirement that would otherwise necessitate
+    // the use of DeviceValidationVersion() to verify physical device supported API version.
+    void SetRequiredApiVersion(APIVersion required_api_version);
     bool LoadDeviceProfileLayer(
         PFN_vkSetPhysicalDeviceFormatPropertiesEXT &fpvkSetPhysicalDeviceFormatPropertiesEXT,
         PFN_vkGetOriginalPhysicalDeviceFormatPropertiesEXT &fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT);

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -329,8 +329,8 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
     }
 
     APIVersion used_version = std::min(m_instance_api_version, APIVersion(physDevProps_.apiVersion));
-    if (used_version < m_target_api_version) {
-        GTEST_SKIP() << "At least Vulkan version 1." << m_target_api_version.Minor() << " is required";
+    if (used_version < m_required_api_version) {
+        GTEST_SKIP() << "At least Vulkan version 1." << m_required_api_version.Minor() << " is required";
     }
 
     for (const auto &ext : m_required_extensions) {

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -168,6 +168,7 @@ class VkRenderFramework : public VkTestFramework {
     APIVersion m_instance_api_version = 0;
     APIVersion m_target_api_version = 0;
     APIVersion m_attempted_api_version = 0;
+    APIVersion m_required_api_version = 0;
 
     VkRenderFramework();
     virtual ~VkRenderFramework() = 0;

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -522,7 +522,9 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
 
 TEST_F(NegativeAtomic, Float) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float.");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+
+    // Requires Vulkan 1.1 as we use SPIR-V 1.3 shaders
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
 
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     // Create device without VK_EXT_shader_atomic_float extension or features enabled
@@ -805,6 +807,9 @@ TEST_F(NegativeAtomic, Float) {
 TEST_F(NegativeAtomic, Float2) {
     TEST_DESCRIPTION("Test VK_EXT_shader_atomic_float2.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+
+    // Requires Vulkan 1.1 as we use SPIR-V 1.3 shaders
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
 
     // Create device without VK_EXT_shader_atomic_float2 extension or features enabled
     RETURN_IF_SKIP(InitFramework());

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -668,6 +668,7 @@ TEST_F(PositiveAtomic, Float2) {
 TEST_F(PositiveAtomic, PhysicalPointer) {
     TEST_DESCRIPTION("Make sure atomic validation handles if from a OpConvertUToPtr (physical pointer)");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderInt64);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1455,6 +1455,7 @@ TEST_F(VkBestPracticesLayerTest, OverAllocateFromDescriptorPool) {
     TEST_DESCRIPTION("Attempt to allocate more sets and descriptors than descriptor pool has available.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -53,7 +53,7 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
 TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
     TEST_DESCRIPTION("texelBufferAlignment is enabled by default in 1.3.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
 
     const VkDeviceSize minTexelBufferOffsetAlignment = m_device->phy().limits_.minTexelBufferOffsetAlignment;

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -5075,7 +5075,7 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
 TEST_F(NegativeCommand, DrawIndirectCountFeature) {
     TEST_DESCRIPTION("Test covered valid usage for the 1.2 drawIndirectCount feature");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -5947,7 +5947,7 @@ TEST_F(NegativeCommand, IncompatibleRenderPassesInExecuteCommands) {
 TEST_F(NegativeCommand, CopyCommands2V13) {
     TEST_DESCRIPTION("Ensure copy_commands2 promotions are validated");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -7053,6 +7053,7 @@ TEST_F(NegativeCommand, CopyDifferentFormatTexelBlockExtent) {
     TEST_DESCRIPTION("Copy bewteen compress images with different texel block extent.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_TEXTURE_COMPRESSION_ASTC_HDR_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     VkFormat src_format = VK_FORMAT_BC7_UNORM_BLOCK;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -393,7 +393,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
 TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
     TEST_DESCRIPTION("Use VK_KHR_draw_indirect_count in 1.2 with feature bit enabled");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -5043,6 +5043,7 @@ TEST_F(NegativeDescriptors, MaxInlineUniformTotalSize) {
     TEST_DESCRIPTION("Test the maxInlineUniformTotalSize limit");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::inlineUniformBlock);
     AddRequiredFeature(vkt::Feature::geometryShader);
     AddRequiredFeature(vkt::Feature::tessellationShader);
@@ -5099,7 +5100,8 @@ TEST_F(NegativeDescriptors, MaxInlineUniformTotalSize) {
 
 TEST_F(NegativeDescriptors, DescriptorTypeNotInPool) {
     TEST_DESCRIPTION("With maintenance1, allocate descriptor with type not in pool");
-    SetTargetApiVersion(VK_API_VERSION_1_1);  // Need VK_KHR_maintenance1
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -1669,6 +1669,7 @@ TEST_F(NegativeDynamicRendering, BufferBeginInfoLegacy) {
 TEST_F(NegativeDynamicRendering, SecondaryCommandBuffer) {
     TEST_DESCRIPTION("VkCommandBufferBeginInfo Dynamic Rendering Tests.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     vkt::CommandBuffer cb(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -4021,6 +4021,7 @@ TEST_F(NegativeDynamicState, ScissorWithCount) {
     TEST_DESCRIPTION("Validate creating graphics pipeline with dynamic state scissor with count.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -4723,6 +4724,7 @@ TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
 
 TEST_F(NegativeDynamicState, CmdBindVertexBuffers2NullOffset) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     m_commandBuffer->begin();
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -22,6 +22,7 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating buffer with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -62,6 +63,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating image with incompatible external memory handle types");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -163,6 +165,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
 TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -216,6 +219,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
 TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind buffer memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -264,6 +268,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind buffer memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -303,6 +308,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
 TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Bind image memory with unsupported external memory handle type.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -350,6 +356,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Bind image memory with incompatible external memory handle types.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -403,6 +410,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
 TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     TEST_DESCRIPTION("Test exporting memory with mismatching handleTypes.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -462,6 +470,7 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
     const char *no_tempory_tl_vuid = "VUID-VkImportSemaphoreFdInfoKHR-flags-03323";
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
@@ -517,6 +526,7 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
 TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
 
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
@@ -764,6 +774,7 @@ TEST_F(NegativeExternalMemorySync, TemporaryFence) {
     const auto extension_name = VK_KHR_EXTERNAL_FENCE_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
@@ -832,6 +843,7 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     const char *other_export_type_vuid = "VUID-VkFenceGetFdInfoKHR-handleType-01453";
     const char *bad_import_type_vuid = "VUID-VkImportFenceFdInfoKHR-handleType-01464";
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
@@ -905,6 +917,7 @@ TEST_F(NegativeExternalMemorySync, Fence) {
 TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT_KHR;
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
@@ -961,6 +974,7 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
     const auto extension_name = VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
@@ -1052,6 +1066,7 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
     const char *other_export_type_vuid = "VUID-VkSemaphoreGetFdInfoKHR-handleType-01132";
     const char *bad_import_type_vuid = "VUID-VkImportSemaphoreFdInfoKHR-handleType-01143";
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(extension_name);
@@ -1113,6 +1128,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     const auto ext_mem_extension_name = VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(ext_mem_extension_name);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
@@ -1324,6 +1340,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create fence with unsupported external handle type in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -1349,6 +1366,7 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create fence with incompatible external handle types in VkExportFenceCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -1376,6 +1394,7 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
 TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
     TEST_DESCRIPTION("Create semaphore with unsupported external handle type in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -1401,6 +1420,7 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
 TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
     TEST_DESCRIPTION("Create semaphore with incompatible external handle types in VkExportSemaphoreCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -1428,6 +1448,7 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
 TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
     TEST_DESCRIPTION("Test for both external memory and external memory NV in image create pNext chain.");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
@@ -1461,6 +1482,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     TEST_DESCRIPTION("Validate layout of image with external memory");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     AddOptionalExtensions(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
@@ -1497,6 +1519,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 TEST_F(NegativeExternalMemorySync, D3D12FenceSubmitInfo) {
     TEST_DESCRIPTION("Test invalid D3D12FenceSubmitInfo");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
@@ -1952,6 +1975,7 @@ TEST_F(NegativeExternalMemorySync, Win32ExportFromImportedFence) {
 TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
     TEST_DESCRIPTION("Bind external buffer that requires dedicated allocation to non-dedicated memory.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -1977,6 +2001,7 @@ TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
 TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
     TEST_DESCRIPTION("Bind external image that requires dedicated allocation to non-dedicated memory.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -2015,6 +2040,7 @@ TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 TEST_F(NegativeExternalMemorySync, Win32MemoryHandleProperties) {
     TEST_DESCRIPTION("Call vkGetMemoryWin32HandlePropertiesKHR with invalid Win32 handle or with opaque handle type");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_WIN32_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
@@ -2219,6 +2245,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferSupport) {
 
 TEST_F(NegativeExternalMemorySync, FdMemoryHandleProperties) {
     TEST_DESCRIPTION("Call vkGetMemoryFdPropertiesKHR with invalid fd handle or with opaque handle type");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
@@ -2606,6 +2633,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHostMemoryIndex) {
 TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     TEST_DESCRIPTION("Test VK_EXT_metal_objects VUIDs");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -139,7 +139,7 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
     const auto ext_mem_extension_name = VK_KHR_EXTERNAL_MEMORY_FD_EXTENSION_NAME;
     const auto handle_type = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR;
 #endif
-
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
@@ -253,6 +253,8 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
 TEST_F(PositiveExternalMemorySync, BufferDedicatedAllocation) {
     TEST_DESCRIPTION("Create external buffer that requires dedicated allocation.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
@@ -330,6 +332,7 @@ TEST_F(PositiveExternalMemorySync, SyncFdSemaphore) {
 TEST_F(PositiveExternalMemorySync, ExportMetalObjects) {
     TEST_DESCRIPTION("Test vkExportMetalObjectsEXT");
 
+    SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_METAL_OBJECTS_EXTENSION_NAME);
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -3850,17 +3850,10 @@ TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
 TEST_F(NegativeImage, ImageViewMissingYcbcrConversion) {
     TEST_DESCRIPTION("Do not use VkSamplerYcbcrConversionInfo when required for an image view.");
 
-    // Use 1.1 to get VK_KHR_sampler_ycbcr_conversion easier
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(features11);
-    if (features11.samplerYcbcrConversion != VK_TRUE) {
-        printf("samplerYcbcrConversion not supported, skipping test\n");
-        return;
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::samplerYcbcrConversion);
+    RETURN_IF_SKIP(Init());
 
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
@@ -4085,6 +4078,7 @@ TEST_F(NegativeImage, SparseResidencyLinear) {
 TEST_F(NegativeImage, DisjointWithoutAlias) {
     TEST_DESCRIPTION("use VK_IMAGE_CREATE_DISJOINT_BIT without VK_IMAGE_CREATE_ALIAS_BIT.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkImageCreateInfo image_ci = DefaultImageInfo();
     image_ci.flags = VK_IMAGE_CREATE_DISJOINT_BIT;
@@ -5843,7 +5837,7 @@ TEST_F(NegativeImage, ComputeImageLayout) {
 TEST_F(NegativeImage, ComputeImageLayout11) {
     TEST_DESCRIPTION("Attempt to use an image with an invalid layout in a compute shader using vkCmdDispatchBase");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
     const char *cs = R"glsl(#version 450

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -1062,6 +1062,7 @@ TEST_F(PositiveImage, DescriptorSubresourceLayout) {
 TEST_F(PositiveImage, Descriptor3D2DSubresourceLayout) {
     TEST_DESCRIPTION("Verify renderpass layout transitions for a 2d ImageView created from a 3d Image.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -15,6 +15,7 @@
 TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     TEST_DESCRIPTION("Create an imageless framebuffer");
 
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
     RETURN_IF_SKIP(Init());
@@ -62,6 +63,7 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     TEST_DESCRIPTION("Create imageless framebuffer with image view from 3D image.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -1794,9 +1794,11 @@ TEST_F(NegativeMemory, DeviceCoherentMemoryDisabledAMD) {
 TEST_F(NegativeMemory, DedicatedAllocation) {
     TEST_DESCRIPTION("Create invalid requests to dedicated allocation of memory");
 
-    // Both VK_KHR_dedicated_allocation and VK_KHR_sampler_ycbcr_conversion supported in 1.1
-    // Quicke to set 1.1 then check all extensions in 1.0
+    // Required Vulkan 1.1 or VK_KHR_dedicated_allocation + VK_KHR_sampler_ycbcr_conversion
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEDICATED_ALLOCATION_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
+
     RETURN_IF_SKIP(Init());
 
     const VkFormat disjoint_format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -380,6 +380,7 @@ TEST_F(PositiveMemory, DeviceBufferMemoryRequirements) {
     TEST_DESCRIPTION("Test vkGetDeviceBufferMemoryRequirements");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
 
     RETURN_IF_SKIP(Init());
 
@@ -409,6 +410,7 @@ TEST_F(PositiveMemory, DeviceImageMemoryRequirements) {
     TEST_DESCRIPTION("Test vkGetDeviceImageMemoryRequirements");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
 
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -1114,6 +1114,8 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
     TEST_DESCRIPTION("Create graphics pipeline using multiview features which are not enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::multiview);
     AddRequiredFeature(vkt::Feature::tessellationShader);
     AddRequiredFeature(vkt::Feature::geometryShader);

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -582,16 +582,12 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
 TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
 {
     SetTargetApiVersion(VK_API_VERSION_1_3);
-
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-
-    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
-    VkPhysicalDeviceSynchronization2Features synchronization2_features = vku::InitStructHelper(&dynamic_rendering_features);
-    VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(synchronization2_features);
-    if (!dynamic_rendering_features.dynamicRendering) {
-        GTEST_SKIP() << "This test requires dynamicRendering";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    RETURN_IF_SKIP(InitState());
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
     VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
@@ -951,16 +947,10 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
 TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
 {
     SetTargetApiVersion(VK_API_VERSION_1_3);
-
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-
-    VkPhysicalDeviceDynamicRenderingFeaturesKHR dynamic_rendering_features = vku::InitStructHelper();
-    VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(dynamic_rendering_features);
-    if (!dynamic_rendering_features.dynamicRendering) {
-        GTEST_SKIP() << "This test requires dynamicRendering";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    RETURN_IF_SKIP(InitState());
 
     auto set_desired = [this] {
         m_errorMonitor->Finish();

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -233,7 +233,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrNullPtr) {
 
 TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr with and without extension enabled");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
     auto vkTrimCommandPool = vk::GetDeviceProcAddr(m_device->device(), "vkTrimCommandPool");
     auto vkTrimCommandPoolKHR = vk::GetDeviceProcAddr(m_device->device(), "vkTrimCommandPoolKHR");
@@ -264,7 +264,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
 
 TEST_F(VkPositiveLayerTest, Vulkan12FeaturesBufferDeviceAddress) {
     TEST_DESCRIPTION("Enable bufferDeviceAddress feature via Vulkan12features struct");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceBufferDeviceAddressFeatures bda_features = vku::InitStructHelper();
     VkPhysicalDeviceFeatures2 features2 = GetPhysicalDeviceFeatures2(bda_features);

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -954,8 +954,7 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
 TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
     TEST_DESCRIPTION("Checks that features are enabled if extension is passed in for promoted extensions with requirement.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
 
     const bool test_1_2 = (DeviceValidationVersion() >= VK_API_VERSION_1_2);
@@ -1373,6 +1372,7 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
 TEST_F(VkLayerTest, InvalidImageCreateFlagWithPhysicalDeviceCount) {
     TEST_DESCRIPTION("Test for invalid imageCreate flags bit with physicalDeviceCount.");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
 
     RETURN_IF_SKIP(InitFramework());
 
@@ -1499,7 +1499,7 @@ TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
     TEST_DESCRIPTION("Create a pNext chain containing valid structures, but with a duplicate structure type");
 
     // VK_KHR_get_physical_device_properties2 promoted to 1.1
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPhysicalDeviceProperties2-sType-unique");

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -198,6 +198,7 @@ TEST_F(NegativeParent, RenderPassFramebuffer) {
 TEST_F(NegativeParent, RenderPassImagelessFramebuffer) {
     TEST_DESCRIPTION("Test RenderPass and Imageless Framebuffer");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceImagelessFramebufferFeatures imageless_framebuffer = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_framebuffer);
@@ -250,6 +251,7 @@ TEST_F(NegativeParent, RenderPassImagelessFramebuffer) {
 TEST_F(NegativeParent, RenderPassCommandBuffer) {
     TEST_DESCRIPTION("Test RenderPass and Framebuffer");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();  // Renderpass created on first device
     auto features = m_device->phy().features();

--- a/tests/unit/parent_positive.cpp
+++ b/tests/unit/parent_positive.cpp
@@ -21,6 +21,7 @@ ParentTest::~ParentTest() {
 TEST_F(PositiveParent, ImagelessFramebuffer) {
     TEST_DESCRIPTION("pAttachments is ignored even for common parent");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceImagelessFramebufferFeatures imageless_framebuffer = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(imageless_framebuffer);

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -217,7 +217,8 @@ TEST_F(NegativePipeline, CmdBufferPipelineDestroyed) {
 }
 
 TEST_F(NegativePipeline, BadPipelineObject) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
+
     constexpr uint64_t fake_pipeline_handle = 0xbaad6001;
     VkPipeline bad_pipeline = CastFromUint64<VkPipeline>(fake_pipeline_handle);
 
@@ -2060,7 +2061,7 @@ TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled10) {
 TEST_F(NegativePipeline, ShaderDrawParametersNotEnabled11) {
     TEST_DESCRIPTION("Validation using DrawParameters for Vulkan 1.1 without the shaderDrawParameters feature enabled.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1296,16 +1296,8 @@ TEST_F(PositivePipeline, DualBlendShader) {
     TEST_DESCRIPTION("Test drawing with dual source blending with too many fragment output attachments.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(features2);
-
-    if (features2.features.dualSrcBlend == VK_FALSE) {
-        GTEST_SKIP() << "dualSrcBlend feature is not available";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredFeature(vkt::Feature::dualSrcBlend);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     char const *fsSource = R"glsl(

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -19,9 +19,8 @@
 
 TEST_F(NegativeProtectedMemory, Queue) {
     TEST_DESCRIPTION("Try creating queue without VK_QUEUE_PROTECTED_BIT capability");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceProtectedMemoryFeatures protected_features = vku::InitStructHelper();
@@ -76,8 +75,7 @@ TEST_F(NegativeProtectedMemory, Queue) {
 TEST_F(NegativeProtectedMemory, Submit) {
     TEST_DESCRIPTION("Setting protectedSubmit with a queue not created with VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     // creates a queue without VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT
     RETURN_IF_SKIP(Init());
 
@@ -148,9 +146,7 @@ TEST_F(NegativeProtectedMemory, Submit) {
 TEST_F(NegativeProtectedMemory, Memory) {
     TEST_DESCRIPTION("Validate cases where protectedMemory feature is enabled and usages are invalid");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
@@ -271,9 +267,8 @@ TEST_F(NegativeProtectedMemory, Memory) {
 
 TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
     TEST_DESCRIPTION("Vulkan 1.1 unique queue detection where both are protected and same queue family");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     // Needed for both protected memory and vkGetDeviceQueue2
@@ -342,9 +337,8 @@ TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
 
 TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     TEST_DESCRIPTION("General testing of vkGetDeviceQueue and general Device creation cases");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     VkDeviceQueueInfo2 queue_info_2 = vku::InitStructHelper();
@@ -466,7 +460,7 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
 TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     TEST_DESCRIPTION("Test VUIDs from VK_EXT_pipeline_protected_access");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_PIPELINE_PROTECTED_ACCESS_EXTENSION_NAME);
     AddOptionalExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
@@ -630,10 +624,7 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
     TEST_DESCRIPTION("Test making commands in unprotected command buffers that can't be used");
 
     // protect memory added in VK 1.1
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
@@ -698,9 +689,7 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
 TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     TEST_DESCRIPTION("Test where there is mixing of protectedMemory backed resource in command buffers");
 
-    SetTargetApiVersion(VK_API_VERSION_1_1);
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceProtectedMemoryFeatures protected_memory_features = vku::InitStructHelper();
@@ -1072,6 +1061,7 @@ TEST_F(NegativeProtectedMemory, RayTracingPipeline) {
     TEST_DESCRIPTION("Bind ray tracing pipeline in a protected command buffer");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
@@ -1142,7 +1132,7 @@ TEST_F(NegativeProtectedMemory, RayTracingPipeline) {
 
 TEST_F(NegativeProtectedMemory, RayQuery) {
     TEST_DESCRIPTION("Bind ray tracing pipeline in a protected command buffer");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_RAY_QUERY_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::rayQuery);
     AddRequiredFeature(vkt::Feature::protectedMemory);

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -17,9 +17,8 @@
 
 TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
     TEST_DESCRIPTION("Test creating 2 queues, 1 protected, and getting both with vkGetDeviceQueue2");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
 
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitFramework());
 
     // Needed for both protected memory and vkGetDeviceQueue2

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -491,7 +491,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
 
     // Vulkan 1.1 is a dependency of VK_KHR_video_queue, but both the version and the extension
     // is optional from the point of view of this test case
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredFeature(vkt::Feature::hostQueryReset);
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
@@ -591,7 +591,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
         VkCommandBufferBeginInfo command_buffer_begin_info = vku::InitStructHelper();
         command_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
 
-        vk::ResetQueryPoolEXT(m_device->device(), query_pool.handle(), 0, 1);
+        vk::ResetQueryPool(m_device->device(), query_pool.handle(), 0, 1);
 
         m_commandBuffer->begin(&command_buffer_begin_info);
         vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
@@ -890,6 +890,7 @@ TEST_F(NegativeQuery, HostResetBadRange) {
     TEST_DESCRIPTION("Bad range in vkResetQueryPoolEXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::hostQueryReset);
     RETURN_IF_SKIP(Init());
 
@@ -904,6 +905,7 @@ TEST_F(NegativeQuery, HostResetQueryPool) {
     TEST_DESCRIPTION("Invalid queryPool in vkResetQueryPoolEXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::hostQueryReset);
     RETURN_IF_SKIP(Init());
 
@@ -922,6 +924,7 @@ TEST_F(NegativeQuery, HostResetDevice) {
     TEST_DESCRIPTION("Device not matching queryPool in vkResetQueryPoolEXT");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceHostQueryResetFeaturesEXT host_query_reset_features = vku::InitStructHelper();
@@ -1633,15 +1636,9 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
     TEST_DESCRIPTION("Test CmdBeginQuery in subpass with multiview");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan11Features features_1_1 = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(features_1_1);
-    if (!features_1_1.multiview) {
-        GTEST_SKIP() << "Test requires VkPhysicalDeviceVulkan11Features::multiview feature.";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(Init());
 
     VkAttachmentDescription attach = {};
     attach.format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -2285,6 +2282,7 @@ TEST_F(NegativeQuery, CmdResetQueryPoolWithoutQueryPool) {
 TEST_F(NegativeQuery, ResetQueryPoolWithoutQueryPool) {
     TEST_DESCRIPTION("call vkResetQueryPool with queryPool being invalid.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_HOST_QUERY_RESET_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkResetQueryPool-queryPool-parameter");

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -924,6 +924,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceSync2Layout) {
     TEST_DESCRIPTION("Attachment reference uses sync2 and ATTACHMENT_OPTIMAL_KHR or READ_ONLY_OPTIMAL_KHR layouts");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     // synchronization2 not enabled
     RETURN_IF_SKIP(Init());
 
@@ -1373,6 +1374,7 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
     TEST_DESCRIPTION("Test that separate stencil initial/final layouts match up with the usage bits in framebuffer attachment");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::separateDepthStencilLayouts);
     RETURN_IF_SKIP(Init());
 
@@ -2662,6 +2664,7 @@ TEST_F(NegativeRenderPass, AllViewMasksZero) {
     TEST_DESCRIPTION("Test VkRenderPassMultiviewCreateInfo with all view mask elements being 0.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkSubpassDescription subpass_description = {};
     subpass_description.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -3274,6 +3277,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     TEST_DESCRIPTION("Validate if attachments in render pass and descriptor set use the same image subresources");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceMultiviewFeatures multiview_features = vku::InitStructHelper();
@@ -4006,6 +4010,7 @@ TEST_F(NegativeRenderPass, ViewMaskWithoutFeature) {
     TEST_DESCRIPTION("Create render pass using view masks with multiview disabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     VkAttachmentReference attachment_reference = {};

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -738,15 +738,9 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     TEST_DESCRIPTION("Render pass using a dedicated stencil layout, different from depth layout");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan12Features vulkan_12_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(vulkan_12_features);
-    if (vulkan_12_features.separateDepthStencilLayouts == VK_FALSE) {
-        GTEST_SKIP() << "separateDepthStencilLayouts feature not supported, skipping test.";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &vulkan_12_features));
+    AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::separateDepthStencilLayouts);
+    RETURN_IF_SKIP(Init());
 
     // Create depth stencil image
     const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
@@ -797,15 +791,9 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     TEST_DESCRIPTION("Use queries in a render pass instance with multiview enabled.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceVulkan11Features vulkan_11_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(vulkan_11_features);
-
-    if (vulkan_11_features.multiview == VK_FALSE) {
-        GTEST_SKIP() << "multiview feature not supported, skipping test.";
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredExtensions(VK_KHR_MULTIVIEW_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::multiview);
+    RETURN_IF_SKIP(Init());
 
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -34,7 +34,7 @@ TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled) {
 TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled12) {
     TEST_DESCRIPTION("Validation using CLAMP_TO_EDGE for Vulkan 1.2 without the samplerMirrorClampToEdge feature enabled.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();
@@ -487,8 +487,9 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
     TEST_DESCRIPTION(
         "Create sampler with ycbcr conversion and use with an image created without ycrcb conversion or immutable sampler");
 
-    // Use 1.1 to get VK_KHR_sampler_ycbcr_conversion easier
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    // Require Vulkan 1.1 or VK_KHR_sampler_ycbcr_conversion
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan11Features features11 = vku::InitStructHelper();
@@ -1402,7 +1403,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
 TEST_F(NegativeSampler, ReductionModeFeature) {
     TEST_DESCRIPTION("Test using VkSamplerReductionModeCreateInfo without required feature.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     VkSamplerReductionModeCreateInfo sampler_reduction_mode_ci = vku::InitStructHelper();

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -49,19 +49,9 @@ TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithoutFeature12) {
 TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithFeature) {
     TEST_DESCRIPTION("Use VK_KHR_sampler_mirror_clamp_to_edge in 1.2 with feature bit enabled");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
-    features12.samplerMirrorClampToEdge = VK_TRUE;
-    auto features2 = GetPhysicalDeviceFeatures2(features12);
-    if (features12.samplerMirrorClampToEdge != VK_TRUE) {
-        printf("samplerMirrorClampToEdge not supported, skipping test\n");
-        return;
-    }
-
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::samplerMirrorClampToEdge);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     VkSamplerCreateInfo sampler_info = SafeSaneSamplerCreateInfo();

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -322,12 +322,9 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeSpecConstantDefault) {
 TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeId) {
     TEST_DESCRIPTION("Validate LocalSizeId also triggers maxComputeWorkGroupSize limit");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
 
@@ -363,12 +360,9 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeId) {
 TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantDefault) {
     TEST_DESCRIPTION("Validate LocalSizeId also triggers maxComputeWorkGroupSize limit with spec constants default");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
 
@@ -409,12 +403,9 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantDefault) {
 TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
     TEST_DESCRIPTION("Validate LocalSizeId also triggers maxComputeWorkGroupSize limit with spec constants");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
 
@@ -465,8 +456,9 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
 
 TEST_F(NegativeShaderCompute, WorkgroupMemoryExplicitLayout) {
     TEST_DESCRIPTION("Test VK_KHR_workgroup_memory_explicit_layout");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
 
+    // Vulkan 1.2 is required because we use SPIR-V 1.5 shaders
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceShaderFloat16Int8Features float16int8_features = vku::InitStructHelper();

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -112,12 +112,9 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeSpecConstantUnder) {
 TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeId) {
     TEST_DESCRIPTION("Validate LocalSizeId doesn't triggers maxComputeWorkGroupSize limit");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -148,12 +145,9 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeId) {
 TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeIdSpecConstant) {
     TEST_DESCRIPTION("Validate LocalSizeId doesn't triggers maxComputeWorkGroupSize limit with spec constants");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
 
@@ -206,12 +200,9 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSizeId) {
     // execution mode."
     TEST_DESCRIPTION("Make sure work WorkgroupSize decoration is used over LocalSizeId");
 
-    SetTargetApiVersion(VK_API_VERSION_1_3);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDeviceVulkan13Features features13 = vku::InitStructHelper();
-    features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
-    RETURN_IF_SKIP(InitState(nullptr, &features13));
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::maintenance4);
+    RETURN_IF_SKIP(Init());
 
     uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
 

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -547,7 +547,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentMissingNotRead) {
 TEST_F(PositiveShaderInterface, InputAttachmentArray) {
     TEST_DESCRIPTION("Input Attachment array where need to follow the index into the array");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);
@@ -678,7 +678,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentArray) {
 TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
     TEST_DESCRIPTION("Input Attachment sharing same variable, but different aspect");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
     GetPhysicalDeviceFeatures2(features12);

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -1208,13 +1208,11 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeZero) {
 TEST_F(NegativeShaderSpirv, SpecializationSizeMismatch) {
     TEST_DESCRIPTION("Make sure an error is logged when a specialization map entry's size is not correct with type");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
 
     bool int8_support = false;
     bool float64_support = false;
 
-    // require to make enable logic simpler
-    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
@@ -1834,14 +1832,10 @@ TEST_F(NegativeShaderSpirv, DeviceMemoryScope) {
     TEST_DESCRIPTION("Validate using Device memory scope in spirv.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(features12);
-    features12.vulkanMemoryModelDeviceScope = VK_FALSE;
-    if (features12.vulkanMemoryModel == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModel feature is not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredExtensions(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
+    AddDisabledFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
+    RETURN_IF_SKIP(Init());
 
     char const *csSource = R"glsl(
         #version 450
@@ -1861,14 +1855,10 @@ TEST_F(NegativeShaderSpirv, QueueFamilyMemoryScope) {
     TEST_DESCRIPTION("Validate using QueueFamily memory scope in spirv.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(features12);
-    features12.vulkanMemoryModel = VK_FALSE;
-    if (features12.vulkanMemoryModelDeviceScope == VK_FALSE) {
-        GTEST_SKIP() << "vulkanMemoryModelDeviceScope feature is not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
+    AddRequiredExtensions(VK_KHR_VULKAN_MEMORY_MODEL_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
+    AddDisabledFeature(vkt::Feature::vulkanMemoryModel);
+    RETURN_IF_SKIP(Init());
 
     char const *csSource = R"glsl(
         #version 450
@@ -2124,7 +2114,7 @@ TEST_F(NegativeShaderSpirv, DISABLED_DescriptorCountSpecConstant) {
 TEST_F(NegativeShaderSpirv, InvalidExtension) {
     TEST_DESCRIPTION("Use an invalid SPIR-V extension in OpExtension.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     InitRenderTarget();

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -282,7 +282,7 @@ TEST_F(PositiveShaderSpirv, ShaderDrawParametersWithFeature) {
     TEST_DESCRIPTION("Use VK_KHR_shader_draw_parameters in 1.2 with feature bit enabled");
 
     // use 1.2 to get the feature bit in VkPhysicalDeviceVulkan11Features
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
 
     RETURN_IF_SKIP(InitFramework());
 
@@ -382,7 +382,7 @@ TEST_F(PositiveShaderSpirv, Std430SpirvOptFlags12) {
     TEST_DESCRIPTION("Reproduces issue 3442 where spirv-opt fails to set layout flags options using Vulkan 1.2");
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3442
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
@@ -611,15 +611,15 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
 
 TEST_F(PositiveShaderSpirv, Spirv16Vulkan13) {
     TEST_DESCRIPTION("Create a shader using 1.3 spirv environment");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
 
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3);
 }
 
-TEST_F(PositiveShaderInterface, OpTypeArraySpecConstant) {
+TEST_F(PositiveShaderSpirv, OpTypeArraySpecConstant) {
     TEST_DESCRIPTION("Make sure spec constants for a OpTypeArray doesn't assert");
-    SetTargetApiVersion(VK_API_VERSION_1_1);
+    SetRequiredApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
     std::stringstream spv_source;
@@ -1700,7 +1700,7 @@ TEST_F(PositiveShaderSpirv, OpCopyObjectSampler) {
 
     // https://github.com/KhronosGroup/glslang/pull/1762 appears to be the change that introduces the OpCopyObject in this context.
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -19,7 +19,7 @@
 TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     TEST_DESCRIPTION("Create a shader reading a storage image without an image format");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu(), &features);
@@ -96,7 +96,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
 TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     TEST_DESCRIPTION("Create a shader writing a storage image without an image format");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu(), &features);
@@ -486,7 +486,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
     // because checks for read/write without format has to be done per format
     // rather than as a device feature. The code we test here only looks at
     // the shader.
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu(), &features);
@@ -557,7 +557,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
     // because checks for read/write without format has to be done per format
     // rather than as a device feature. The code we test here only looks at
     // the shader.
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu(), &features);
@@ -619,7 +619,7 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
 TEST_F(NegativeShaderStorageImage, WriteLessComponent) {
     TEST_DESCRIPTION("Test writing to image with less components.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     // not valid GLSL, but would look like:
@@ -669,7 +669,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponent) {
 TEST_F(NegativeShaderStorageImage, WriteLessComponentCopyObject) {
     TEST_DESCRIPTION("Test writing to image with less components, but use OpCopyObject.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     // not valid GLSL, but would look like:
@@ -723,7 +723,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponentCopyObject) {
 TEST_F(NegativeShaderStorageImage, WriteSpecConstantLessComponent) {
     TEST_DESCRIPTION("Test writing to image with less components with Texel being a spec constant.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     // not valid GLSL, but would look like:
@@ -789,7 +789,8 @@ TEST_F(NegativeShaderStorageImage, WriteSpecConstantLessComponent) {
 TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
     TEST_DESCRIPTION("Test writing to image unknown format with less components.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     // not valid GLSL, but would look like:
@@ -877,7 +878,7 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
 TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
     TEST_DESCRIPTION("Test writing to image unknown format with VK_FORMAT_A8_UNORM_KHR.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -285,6 +285,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
     TEST_DESCRIPTION("Test writing to image unknown format with less components, but in unused Entrypoint.");
 
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -19,7 +19,7 @@
 TEST_F(NegativeShaderStorageTexel, WriteLessComponent) {
     TEST_DESCRIPTION("Test writing to texel buffer with less components.");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
 
     // not valid GLSL, but would look like:

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -901,6 +901,7 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeature) {
     TEST_DESCRIPTION("Test using subgroupSizeControl feature when it's not enabled");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_SUBGROUP_SIZE_CONTROL_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceSubgroupSizeControlPropertiesEXT subgroup_properties = vku::InitStructHelper();

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -1122,7 +1122,7 @@ TEST_F(NegativeSubpass, InputAttachmentSharingVariable) {
 TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
     TEST_DESCRIPTION("Non-InputAttachment shader input with unknown image format");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
     vk::GetPhysicalDeviceFeatures(gpu(), &features);

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -21,6 +21,7 @@
 TEST_F(PositiveSubpass, SubpassImageBarrier) {
     TEST_DESCRIPTION("Subpass with image barrier (self-dependency)");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -99,6 +100,7 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
 TEST_F(PositiveSubpass, SubpassWithEventWait) {
     TEST_DESCRIPTION("Subpass waits for the event set outside of this subpass");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -1357,6 +1357,7 @@ TEST_F(NegativeSyncObject, BarrierQueueFamily) {
 TEST_F(NegativeSyncObject, BufferBarrierWithHostStage) {
     TEST_DESCRIPTION("Buffer barrier includes VK_PIPELINE_STAGE_2_HOST_BIT as srcStageMask or dstStageMask");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -1398,6 +1399,7 @@ TEST_F(NegativeSyncObject, BufferBarrierWithHostStage) {
 TEST_F(NegativeSyncObject, ImageBarrierWithHostStage) {
     TEST_DESCRIPTION("Image barrier includes VK_PIPELINE_STAGE_2_HOST_BIT as srcStageMask or dstStageMask");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -1713,6 +1715,7 @@ TEST_F(NegativeSyncObject, BarrierQueues) {
     TEST_DESCRIPTION("Test buffer memory with both src and dst queue VK_QUEUE_FAMILY_EXTERNAL.");
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
@@ -1975,6 +1978,7 @@ TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
 
 TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddDisabledFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -2194,7 +2198,7 @@ TEST_F(NegativeSyncObject, WaitEventsDifferentQueueFamilies) {
 TEST_F(NegativeSyncObject, SemaphoreTypeCreateInfoCore) {
     TEST_DESCRIPTION("Invalid usage of VkSemaphoreTypeCreateInfo with a 1.2 core version");
 
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     // Core 1.2 supports timelineSemaphore feature bit but not enabled
     RETURN_IF_SKIP(Init());
 
@@ -3367,6 +3371,7 @@ TEST_F(NegativeSyncObject, DetectInterQueueEventUsage) {
 TEST_F(NegativeSyncObject, DetectInterQueueEventUsage2) {
     TEST_DESCRIPTION("Sets event on one queue and tries to wait on a different queue (CmdSetEvent2/CmdWaitEvents2)");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -3539,6 +3544,7 @@ TEST_F(NegativeSyncObject, InvalidDeviceOnlyEvent) {
 
 TEST_F(NegativeSyncObject, SetEvent2DependencyFlags) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -3556,6 +3562,7 @@ TEST_F(NegativeSyncObject, SetEvent2DependencyFlags) {
 
 TEST_F(NegativeSyncObject, SetEvent2HostStage) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -1517,6 +1517,7 @@ TEST_F(PositiveSyncObject, BasicSetAndWaitEvent) {
 TEST_F(PositiveSyncObject, BasicSetAndWaitEvent2) {
     TEST_DESCRIPTION("Sets event and then wait for it using CmdSetEvent2/CmdWaitEvents2");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -2195,6 +2196,7 @@ TEST_F(PositiveSyncObject, SubpassBarrier) {
 TEST_F(PositiveSyncObject, SubpassBarrier2) {
     TEST_DESCRIPTION("The queue family indices for subpass barrier should be equal (but otherwise are not restricted");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
@@ -2285,6 +2287,7 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
 TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     TEST_DESCRIPTION("Barrier includes VK_PIPELINE_STAGE_2_HOST_BIT as srcStageMask or dstStageMask");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -1550,13 +1550,10 @@ TEST_F(NegativeSyncVal, AttachmentStoreHazard) {
 TEST_F(NegativeSyncVal, DynamicRenderingAttachmentLoadHazard) {
     TEST_DESCRIPTION("Copying to attachment creates hazard with attachment load operation");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
-    if (!dynamic_rendering_features.dynamicRendering) {
-        GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+    RETURN_IF_SKIP(InitState());
 
     InitRenderTarget();
     m_renderTargets[0]->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -1601,13 +1598,10 @@ TEST_F(NegativeSyncVal, DynamicRenderingAttachmentLoadHazard) {
 TEST_F(NegativeSyncVal, DynamicRenderingAttachmentStoreHazard) {
     TEST_DESCRIPTION("Copying to attachment creates hazard with attachment store operation");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(dynamic_rendering_features);
-    if (!dynamic_rendering_features.dynamicRendering) {
-        GTEST_SKIP() << "Test requires (unsupported) dynamicRendering";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+    RETURN_IF_SKIP(InitState());
 
     InitRenderTarget();
     m_renderTargets[0]->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -1651,7 +1645,7 @@ TEST_F(NegativeSyncVal, DynamicRenderingAttachmentStoreHazard) {
 }
 
 TEST_F(NegativeSyncVal, CmdDispatchDrawHazards) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
 
     // Enable VK_KHR_draw_indirect_count for KHR variants
     AddOptionalExtensions(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
@@ -4534,6 +4528,7 @@ TEST_F(NegativeSyncVal, QSBufferCopyHazards) {
 
 TEST_F(NegativeSyncVal, QSSubmit2) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
@@ -6127,13 +6122,13 @@ TEST_F(NegativeSyncVal, QSDebugRegion_Secondary) {
 TEST_F(NegativeSyncVal, QSDebugRegion_TimelineStability) {
     TEST_DESCRIPTION("Timeline semaphores are not supported yet but they should not crash the app");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceTimelineSemaphoreFeatures timeline_features = vku::InitStructHelper();
-    timeline_features.timelineSemaphore = VK_TRUE;
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper(&timeline_features);
-    sync2_features.synchronization2 = VK_TRUE;
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     vkt::Buffer buffer_a(*m_device, 256, buffer_usage);
@@ -6203,10 +6198,10 @@ TEST_F(NegativeSyncVal, QSDebugRegion_TimelineStability) {
 TEST_F(NegativeSyncVal, UseShaderReadAccessForUniformBuffer) {
     TEST_DESCRIPTION("SHADER_READ_BIT barrier cannot protect UNIFORM_READ_BIT accesses");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     constexpr VkDeviceSize size = 1024;
     const vkt::Buffer staging_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -6280,10 +6275,10 @@ TEST_F(NegativeSyncVal, FillBufferMissingBarrier) {
 TEST_F(NegativeSyncVal, FillBufferWrongBarrier) {
     TEST_DESCRIPTION("Insufficient synchronization with vkCmdFillBuffer TRANSFER_WRITE access");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     constexpr VkDeviceSize size = 1024;
     vkt::Buffer src_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -6338,10 +6333,10 @@ TEST_F(NegativeSyncVal, UpdateBufferMissingBarrier) {
 TEST_F(NegativeSyncVal, UpdateBufferWrongBarrier) {
     TEST_DESCRIPTION("Insufficient synchronization with vkCmdUpdateBuffer TRANSFER_WRITE access");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     constexpr VkDeviceSize size = 64;
     vkt::Buffer src_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -184,7 +184,7 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968
 TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
     TEST_DESCRIPTION("Signal semaphore on the host and wait on the host");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitSyncValFramework());
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
     RETURN_IF_SKIP(InitState());
@@ -238,7 +238,7 @@ TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOnHost) {
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4968
 TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
     TEST_DESCRIPTION("Singal semaphore on the host and regularly read semaphore payload value");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitSyncValFramework());
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
     RETURN_IF_SKIP(InitState());
@@ -283,7 +283,7 @@ TEST_F(PositiveSyncVal, SignalAndGetSemaphoreCounter) {
 
 TEST_F(PositiveSyncVal, GetSemaphoreCounterFromMultipleThreads) {
     TEST_DESCRIPTION("Read semaphore counter value from multiple threads");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
+    SetRequiredApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitSyncValFramework());
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
     RETURN_IF_SKIP(InitState());
@@ -618,13 +618,10 @@ TEST_F(PositiveSyncVal, LayoutTransitionWithAlreadyAvailableImage) {
 TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     TEST_DESCRIPTION("Access different elements of the image array using dynamic indexing. There should be no hazards");
     SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::runtimeDescriptorArray);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceVulkan12Features features12 = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(features12);
-    if (features12.runtimeDescriptorArray != VK_TRUE) {
-        GTEST_SKIP() << "runtimeDescriptorArray not supported and is required";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &features12));
+    RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
     constexpr VkDescriptorType descriptor_type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
@@ -701,12 +698,8 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
 TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the image array using constant indices. There should be no hazards");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::fragmentStoresAndAtomics);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(features2);
-    if (!features2.features.fragmentStoresAndAtomics) {
-        GTEST_SKIP() << "Test requires (unsupported) fragmentStoresAndAtomics";
-    }
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
@@ -772,12 +765,8 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
 TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     TEST_DESCRIPTION("Access different elements of the texel buffer array using constant indices. There should be no hazards");
     SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredFeature(vkt::Feature::fragmentStoresAndAtomics);
     RETURN_IF_SKIP(InitSyncValFramework());
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(features2);
-    if (!features2.features.fragmentStoresAndAtomics) {
-        GTEST_SKIP() << "Test requires (unsupported) fragmentStoresAndAtomics";
-    }
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
@@ -873,10 +862,10 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
         "with image read in the previous batch.");
 
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     vkt::Image image(*m_device, 64, 64, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -962,10 +951,10 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
 TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     TEST_DESCRIPTION("Transition and read image in different submits synchronized via ALL_COMMANDS semaphore");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     vkt::Image image(*m_device, 64, 64, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
     vkt::ImageView view = image.CreateView();
@@ -1048,12 +1037,12 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
 TEST_F(PositiveSyncVal, DynamicRenderingColorResolve) {
     TEST_DESCRIPTION("Test color resolve with dynamic rendering");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper(&sync2_features);
-    dynamic_rendering_features.dynamicRendering = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+    RETURN_IF_SKIP(InitState());
 
     const uint32_t width = 64;
     const uint32_t height = 64;
@@ -1096,12 +1085,12 @@ TEST_F(PositiveSyncVal, DynamicRenderingColorResolve) {
 TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
     TEST_DESCRIPTION("Test depth resolve with dynamic rendering");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper(&sync2_features);
-    dynamic_rendering_features.dynamicRendering = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+    RETURN_IF_SKIP(InitState());
 
     const uint32_t width = 64;
     const uint32_t height = 64;
@@ -1143,10 +1132,10 @@ TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
 TEST_F(PositiveSyncVal, FillBuffer) {
     TEST_DESCRIPTION("Synchronize with vkCmdFillBuffer assuming that its writes happen on the CLEAR stage");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     constexpr VkDeviceSize size = 1024;
     vkt::Buffer src_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -1177,10 +1166,10 @@ TEST_F(PositiveSyncVal, FillBuffer) {
 TEST_F(PositiveSyncVal, UpdateBuffer) {
     TEST_DESCRIPTION("Synchronize with vkCmdUpdateBuffer assuming that its writes happen on the CLEAR stage");
     SetTargetApiVersion(VK_API_VERSION_1_3);
-    VkPhysicalDeviceSynchronization2Features sync2_features = vku::InitStructHelper();
-    sync2_features.synchronization2 = VK_TRUE;
+    AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitSyncValFramework());
-    RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
+    RETURN_IF_SKIP(InitState());
 
     constexpr VkDeviceSize size = 64;
     vkt::Buffer src_buffer(*m_device, size, VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT);

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -38,6 +38,7 @@ TEST_F(NegativeTooling, PrivateDataFeature) {
 TEST_F(NegativeTooling, PrivateDataSetNonDevice) {
     TEST_DESCRIPTION("Use Private Data on a non-Device object type.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -60,6 +61,7 @@ TEST_F(NegativeTooling, PrivateDataSetNonDevice) {
 TEST_F(NegativeTooling, PrivateDataSetBadHandle) {
     TEST_DESCRIPTION("Use Private Data a non valid handle.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -79,6 +81,7 @@ TEST_F(NegativeTooling, PrivateDataSetBadHandle) {
 TEST_F(NegativeTooling, PrivateDataSetSecondDevice) {
     TEST_DESCRIPTION("Test private data can set VkDevice.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -104,6 +107,7 @@ TEST_F(NegativeTooling, PrivateDataSetSecondDevice) {
 
 TEST_F(NegativeTooling, PrivateDataGetNonDevice) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -130,6 +134,7 @@ TEST_F(NegativeTooling, PrivateDataGetNonDevice) {
 
 TEST_F(NegativeTooling, PrivateDataGetBadHandle) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -148,6 +153,7 @@ TEST_F(NegativeTooling, PrivateDataGetBadHandle) {
 
 TEST_F(NegativeTooling, PrivateDataGetDestroyedHandle) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -120,7 +120,7 @@ TEST_F(PositiveTooling, PrivateDataExt) {
 
 TEST_F(PositiveTooling, PrivateDataCore) {
     TEST_DESCRIPTION("Basic usage calling private data as core.");
-    SetTargetApiVersion(VK_API_VERSION_1_3);
+    SetRequiredApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
@@ -149,6 +149,7 @@ TEST_F(PositiveTooling, PrivateDataCore) {
 TEST_F(PositiveTooling, PrivateDataDevice) {
     TEST_DESCRIPTION("Test private data can set VkDevice.");
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -35,6 +35,8 @@ void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
 
 TEST_F(PositiveYcbcr, PlaneAspectNone) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
     VkImageCreateInfo image_createinfo = vku::InitStructHelper();


### PR DESCRIPTION
A possible resolution to issue #7547.

Please note that it is not necessarily the mechanism, or name I'm worried about.

It's just that it would be really great if applicable test cases could run if either the API version or extension is available, because that option seems to be eliminated since the behavior of `SetTargetApiVersion()` was changed.