### PR TITLE
layers: Rework DescriptorSet invalidation

### DIFF
--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -31,9 +31,9 @@ void gpuav::Buffer::Destroy() {
     vvl::Buffer::Destroy();
 }
 
-void gpuav::Buffer::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::Buffer::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::Buffer::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::Buffer::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
@@ -47,9 +47,9 @@ void gpuav::BufferView::Destroy() {
     vvl::BufferView::Destroy();
 }
 
-void gpuav::BufferView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::BufferView::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::BufferView::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::BufferView::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::ImageView::ImageView(const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
@@ -64,9 +64,9 @@ void gpuav::ImageView::Destroy() {
     vvl::ImageView::Destroy();
 }
 
-void gpuav::ImageView::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::ImageView::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::ImageView::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::ImageView::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::Sampler::Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_)
@@ -77,9 +77,9 @@ void gpuav::Sampler::Destroy() {
     vvl::Sampler::Destroy();
 }
 
-void gpuav::Sampler::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::Sampler::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::Sampler::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::Sampler::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::AccelerationStructureKHR::AccelerationStructureKHR(VkAccelerationStructureKHR as,
@@ -94,9 +94,9 @@ void gpuav::AccelerationStructureKHR::Destroy() {
     vvl::AccelerationStructureKHR::Destroy();
 }
 
-void gpuav::AccelerationStructureKHR::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::AccelerationStructureKHR::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::AccelerationStructureKHR::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::AccelerationStructureKHR::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::AccelerationStructureNV::AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as,
@@ -110,9 +110,9 @@ void gpuav::AccelerationStructureNV::Destroy() {
     vvl::AccelerationStructureNV::Destroy();
 }
 
-void gpuav::AccelerationStructureNV::NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) {
+void gpuav::AccelerationStructureNV::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
     desc_heap.DeleteId(id);
-    vvl::AccelerationStructureNV::NotifyInvalidate(invalid_nodes, unlink);
+    vvl::AccelerationStructureNV::NotifyInvalidate(invalid_objs);
 }
 
 gpuav::CommandBuffer::CommandBuffer(gpuav::Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -108,7 +108,7 @@ class Buffer : public vvl::Buffer {
     Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;
@@ -120,7 +120,7 @@ class BufferView : public vvl::BufferView {
                VkFormatFeatureFlags2KHR buf_ff, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;
@@ -133,7 +133,7 @@ class ImageView : public vvl::ImageView {
               DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;
@@ -144,7 +144,7 @@ class Sampler : public vvl::Sampler {
     Sampler(const VkSampler s, const VkSamplerCreateInfo *pci, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;
@@ -156,7 +156,7 @@ class AccelerationStructureKHR : public vvl::AccelerationStructureKHR {
                              std::shared_ptr<vvl::Buffer> &&buf_state, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;
@@ -168,7 +168,7 @@ class AccelerationStructureNV : public vvl::AccelerationStructureNV {
                             DescriptorHeap &desc_heap_);
 
     void Destroy() final;
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) final;
 
     DescriptorHeap &desc_heap;
     const DescriptorId id;

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -84,7 +84,7 @@ class BufferView : public StateObject {
     BufferView(const std::shared_ptr<Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
                VkFormatFeatureFlags2KHR buf_ff);
 
-    void LinkChildNodes() override {
+    void LinkChildObjects() override {
         // Connect child node(s), which cannot safely be done in the constructor.
         buffer_state->AddParent(this);
     }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -610,6 +610,8 @@ class CommandBuffer : public RefcountedStateObject {
     static std::string GetDebugRegionName(const std::vector<LabelCommand> &label_commands, uint32_t label_command_index,
                                           const std::vector<std::string> &initial_label_stack = {});
 
+    virtual void NotifyUpdateDescriptor(const vvl::DescriptorSet &set, const StateObjectList &invalid_node, bool is_bindless);
+
   private:
     void ResetCBState();
 
@@ -626,7 +628,7 @@ class CommandBuffer : public RefcountedStateObject {
     std::optional<VkSampleCountFlagBits> active_subpass_sample_count_;
 
   protected:
-    void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
+    void NotifyInvalidate(const StateObjectList &invalid_objs) override;
     void UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPassBegin);
     void EnqueueUpdateVideoInlineQueries(const VkVideoInlineQueryInfoKHR &query_info);
     void UnbindResources();

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -213,7 +213,10 @@ class Bindable : public StateObject {
   public:
     template <typename Handle>
     Bindable(Handle h, VulkanObjectType t, bool is_sparse, bool is_unprotected, VkExternalMemoryHandleTypeFlags handle_types)
-        : StateObject(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected),
+        : StateObject(h, t),
+          external_memory_handle_types(handle_types),
+          sparse(is_sparse),
+          unprotected(is_unprotected),
           memory_tracker_(nullptr) {}
 
     virtual ~Bindable() {
@@ -255,9 +258,9 @@ class Bindable : public StateObject {
         return mem_state && !mem_state->Destroyed();
     }
 
-    void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) override {
+    void NotifyInvalidate(const StateObjectList &invalid_objs) override {
         need_to_recache_invalid_memory_ = true;
-        StateObject::NotifyInvalidate(invalid_nodes, unlink);
+        StateObject::NotifyInvalidate(invalid_objs);
     }
 
     const BindableMemoryTracker::DeviceMemoryState &GetInvalidMemory() const {
@@ -288,9 +291,7 @@ class Bindable : public StateObject {
         return memory_tracker_->GetBoundMemoryRange(range);
     }
 
-    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const {
-        return memory_tracker_->GetBoundMemoryStates();
-    }
+    BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const { return memory_tracker_->GetBoundMemoryStates(); }
 
     // Kept for compatibility
     const MEM_BINDING *Binding() const { return memory_tracker_->Binding(); }
@@ -303,6 +304,7 @@ class Bindable : public StateObject {
     mutable BindableMemoryTracker::DeviceMemoryState cached_invalid_memory_;
 
     void SetMemoryTracker(BindableMemoryTracker *tracker) { memory_tracker_ = tracker; }
+
   public:
     // Tracks external memory types creating resource
     const VkExternalMemoryHandleTypeFlags external_memory_handle_types;

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -266,11 +266,9 @@ void Image::Destroy() {
     Bindable::Destroy();
 }
 
-void Image::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    Bindable::NotifyInvalidate(invalid_nodes, unlink);
-    if (unlink) {
-        bind_swapchain = nullptr;
-    }
+void Image::NotifyInvalidate(const StateObjectList &invalid_objs) {
+    Bindable::NotifyInvalidate(invalid_objs);
+    bind_swapchain = nullptr;
 }
 
 bool Image::IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const {
@@ -591,11 +589,9 @@ void Swapchain::Destroy() {
     StateObject::Destroy();
 }
 
-void Swapchain::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) {
-    StateObject::NotifyInvalidate(invalid_nodes, unlink);
-    if (unlink) {
-        surface = nullptr;
-    }
+void Swapchain::NotifyInvalidate(const StateObjectList &invalid_objs) {
+    StateObject::NotifyInvalidate(invalid_objs);
+    surface = nullptr;
 }
 
 SwapchainImage Swapchain::GetSwapChainImage(uint32_t index) const {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -220,10 +220,10 @@ class Image : public Bindable {
     void SetImageLayout(const VkImageSubresourceRange &range, VkImageLayout layout);
 
   protected:
-    void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
+    void NotifyInvalidate(const StateObjectList &invalid_objs) override;
 
     template <typename UnaryPredicate>
-    bool AnyAliasBindingOf(const StateObject::NodeMap &bindings, const UnaryPredicate &pred) const {
+    bool AnyAliasBindingOf(const StateObjectMap &bindings, const UnaryPredicate &pred) const {
         for (auto &entry : bindings) {
             if (entry.first.type == kVulkanObjectTypeImage) {
                 auto state_object = entry.second.lock();
@@ -251,11 +251,9 @@ class Image : public Bindable {
     }
 
   private:
-    std::variant<std::monostate,
-                 BindableNoMemoryTracker,
-                 BindableLinearMemoryTracker,
-                 BindableSparseMemoryTracker,
-                 BindableMultiplanarMemoryTracker> tracker_;
+    std::variant<std::monostate, BindableNoMemoryTracker, BindableLinearMemoryTracker, BindableSparseMemoryTracker,
+                 BindableMultiplanarMemoryTracker>
+        tracker_;
 };
 
 // State for VkImageView objects.
@@ -285,7 +283,7 @@ class ImageView : public StateObject {
     ImageView(const ImageView &rh_obj) = delete;
     VkImageView VkHandle() const { return handle_.Cast<VkImageView>(); }
 
-    void LinkChildNodes() override {
+    void LinkChildObjects() override {
         // Connect child node(s), which cannot safely be done in the constructor.
         image_state->AddParent(this);
     }
@@ -356,7 +354,7 @@ class Swapchain : public StateObject {
     std::shared_ptr<const vvl::Image> GetSwapChainImageShared(uint32_t index) const;
 
   protected:
-    void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
+    void NotifyInvalidate(const StateObjectList &invalid_objs) override;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -84,7 +84,7 @@ class AccelerationStructureKHR : public StateObject {
 
     VkAccelerationStructureKHR VkHandle() const { return handle_.Cast<VkAccelerationStructureKHR>(); }
 
-    void LinkChildNodes() override {
+    void LinkChildObjects() override {
         // Connect child node(s), which cannot safely be done in the constructor.
         buffer_state->AddParent(this);
     }

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -413,7 +413,7 @@ Framebuffer::Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreat
       rp_state(rpstate),
       attachments_view_state(std::move(attachments)) {}
 
-void Framebuffer::LinkChildNodes() {
+void Framebuffer::LinkChildObjects() {
     // Connect child node(s), which cannot safely be done in the constructor.
     for (auto &a : attachments_view_state) {
         a->AddParent(this);

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -132,7 +132,7 @@ class Framebuffer : public StateObject {
 
     Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
                 std::vector<std::shared_ptr<vvl::ImageView>> &&attachments);
-    void LinkChildNodes() override;
+    void LinkChildObjects() override;
 
     VkFramebuffer VkHandle() const { return handle_.Cast<VkFramebuffer>(); }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -279,7 +279,7 @@ class ValidationStateTracker : public ValidationObject {
         auto handle = state_object->Handle().template Cast<HandleType>();
         // Finish setting up the object node tree, which cannot be done from the state object contructors
         // due to use of shared_from_this()
-        state_object->LinkChildNodes();
+        state_object->LinkChildObjects();
         map.insert_or_assign(handle, std::move(state_object));
     }
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1202,8 +1202,8 @@ void syncval_state::CommandBuffer::Reset() {
     access_context.Reset();
 }
 
-void syncval_state::CommandBuffer::NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) {
-    for (auto &obj : invalid_nodes) {
+void syncval_state::CommandBuffer::NotifyInvalidate(const vvl::StateObjectList &invalid_objs) {
+    for (auto &obj : invalid_objs) {
         switch (obj->Type()) {
             case kVulkanObjectTypeEvent:
                 access_context.RecordDestroyEvent(static_cast<vvl::Event *>(obj.get()));
@@ -1211,6 +1211,6 @@ void syncval_state::CommandBuffer::NotifyInvalidate(const vvl::StateObject::Node
             default:
                 break;
         }
-        vvl::CommandBuffer::NotifyInvalidate(invalid_nodes, unlink);
     }
+    vvl::CommandBuffer::NotifyInvalidate(invalid_objs);
 }

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -423,7 +423,7 @@ class CommandBuffer : public vvl::CommandBuffer {
                   const vvl::CommandPool *pool);
     ~CommandBuffer() { Destroy(); }
 
-    void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
+    void NotifyInvalidate(const vvl::StateObjectList &invalid_objs) override;
 
     void Destroy() override;
     void Reset() override;


### PR DESCRIPTION
In StateObject::NotifyInvalidate(), the unlink parameter was only ever set to true when a descriptor in a DescriptorSet became invalid. But for bindless, no invalidation of state happened at all. This was because invalidating an unused descriptor is not an error in bindless.

However, a CommandBuffer might be tracking layout state for an Image descriptor inside its image_layout_map. When an Image is destroyed, this state needs to be cleaned up. Otherwise its possible to end up with destroyed memory in the map.

Instead add CommandBuffer::NotifyUpdateDescriptor() which can more flexibly be used to tell the command buffer what to do.

Fixes #7435