### PR TITLE
layers: Build frameworks instead of dylib for ios

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -1,5 +1,5 @@
-# Copyright (c) 2021-2023 Valve Corporation
-# Copyright (c) 2021-2023 LunarG, Inc.
+# Copyright (c) 2021-2024 Valve Corporation
+# Copyright (c) 2021-2024 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -220,10 +220,10 @@ jobs:
       - run: cmake --build build
       - run: cmake --install build --prefix /tmp
       # Helps verify install location and prints the exported symbols.
-      - run: nm -gU /tmp/lib/libVkLayer_khronos_validation.dylib
+      - run: nm -gU /tmp/lib/VkLayer_khronos_validation.framework/VkLayer_khronos_validation
       # Helps verify useful details about the dylib (platform, minos, sdk)
-      - run: vtool -show-build /tmp/lib/libVkLayer_khronos_validation.dylib
-
+      - run: vtool -show-build /tmp/lib/VkLayer_khronos_validation.framework/VkLayer_khronos_validation
+ 
   mingw:
     runs-on: windows-latest
     defaults:

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -116,7 +116,11 @@ endif()
 
 add_subdirectory(gpu_validation/spirv)
 
-add_library(vvl MODULE)
+if(IOS)
+    add_library(vvl SHARED)
+else()
+    add_library(vvl MODULE)
+endif()
 
 target_sources(vvl PRIVATE
     best_practices/best_practices_error_enums.h
@@ -333,7 +337,16 @@ elseif(MINGW)
     target_compile_options(vvl PRIVATE -Wa,-mbig-obj)
     set_target_properties(vvl PROPERTIES PREFIX "") # remove the prefix "lib" so the manifest json "library_path" matches
 elseif(APPLE)
+
+if(IOS)
+    set_target_properties(vvl PROPERTIES
+		FRAMEWORK			TRUE
+		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.validation
+    )
+else()
     set_target_properties(vvl PROPERTIES SUFFIX ".dylib")
+endif()
+
     target_link_options(vvl PRIVATE -exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}.exp)
 elseif(ANDROID)
     target_link_options(vvl PRIVATE LINKER:--version-script=${CMAKE_CURRENT_SOURCE_DIR}/${LAYER_NAME}-android.map)


### PR DESCRIPTION
Apples App store rules require dynamic libraries be packaged as Frameworks for iOS. This requirement is not applied for macOS, so all iOS libraries should be packaged as Frameworks moving forward to comply with Apples policy. Although this validation layer in particular is not likely to be shipped in an application bundle, it is being made a Framework as well to be consistent with all the other layers.