### PR TITLE
Fix external_memory_sync_positive.cpp on metal platforms

### DIFF
--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -350,7 +350,7 @@ TEST_F(PositiveExternalMemorySync, ExportMetalObjects) {
         RETURN_IF_SKIP(InitState(nullptr, &features2));
     }
 
-    const VkDevice device = device();
+    const VkDevice device = this->device();
 
     // Get Metal Device and Metal Command Queue in 1 call
     {


### PR DESCRIPTION
Building on Mac does not succeed:
```c++
error: called object type 'VkDevice' (aka 'VkDevice_T *') is not a function or function pointer
    const VkDevice device = device();
```
Simple change on line 353 of external_memory_sync_positive.cpp from `const VkDevice device = device();` to `const VkDevice device = this->device();` to avoid name clashing error.