### PR TITLE
tests: Fix building on Metal

### DIFF
--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -350,7 +350,7 @@ TEST_F(PositiveExternalMemorySync, ExportMetalObjects) {
         RETURN_IF_SKIP(InitState(nullptr, &features2));
     }
 
-    const VkDevice device = device();
+    const VkDevice device = this->device();
 
     // Get Metal Device and Metal Command Queue in 1 call
     {


### PR DESCRIPTION
This is a duplicate pull request because I'm a git novice.

Simple change to external_memory_sync_positive.cpp:353 
Build succeeds with with change of `device()` to `this->device()`