### PR TITLE
tests: Enable core validation for GPU-AV and SyncVal tests

### DIFF
--- a/scripts/tests.py
+++ b/scripts/tests.py
@@ -214,8 +214,8 @@ def RunVVLTests(args):
 
     common_ci.RunShellCmd(lvt_cmd, env=lvt_env)
 
-    print("Re-Running syncval tests with core validation enabled (--syncval-enable-core)")
-    common_ci.RunShellCmd(lvt_cmd + ' --gtest_filter=*SyncVal* --syncval-enable-core', env=lvt_env)
+    print("Re-Running syncval tests with core validation disabled (--syncval-disable-core)")
+    common_ci.RunShellCmd(lvt_cmd + ' --gtest_filter=*SyncVal* --syncval-disable-core', env=lvt_env)
 
     print("Re-Running multithreaded tests with VK_LAYER_FINE_GRAINED_LOCKING disabled")
     lvt_env['VK_LAYER_FINE_GRAINED_LOCKING'] = '0'

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  * Copyright (c) 2015-2023 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -92,6 +92,9 @@ bool ImageFormatIsSupported(const VkInstance inst, const VkPhysicalDevice phy, c
     VkResult err =
         vk::GetPhysicalDeviceImageFormatProperties(phy, info.format, info.imageType, info.tiling, info.usage, info.flags, &props);
     if (VK_SUCCESS != err) {
+        return false;
+    }
+    if (info.arrayLayers > props.maxArrayLayers) {
         return false;
     }
 

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -153,21 +153,10 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
     return info;
 }
 
-inline void CheckDisableCoreValidation(VkValidationFeaturesEXT &features) {
-    auto disable = GetEnvironment("VK_LAYER_TESTS_DISABLE_CORE_VALIDATION");
-    vvl::ToLower(disable);
-    if (disable == "false" || disable == "0" || disable == "FALSE") {       // default is to change nothing, unless flag is correctly specified
-        features.disabledValidationFeatureCount = 0;                        // remove all disables to get all validation messages
-    }
-}
-
 void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
     auto validation = GetEnvironment("VK_LAYER_TESTS_VALIDATION_FEATURES");
     vvl::ToLower(validation);
     VkValidationFeaturesEXT *features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(first_pnext);
-    if (features) {
-        CheckDisableCoreValidation(*features);
-    }
     if (validation == "all" || validation == "core" || validation == "none") {
         if (!features) {
             features = &m_validation_features;

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -1,7 +1,7 @@
 ﻿/*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -162,10 +162,10 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
             m_canonicalize_spv = true;
         } else if (current_argument == "--print-vu") {
             m_print_vu = true;
-        } else if (current_argument == "--syncval-enable-core") {
-            m_syncval_enable_core = true;
-        } else if (current_argument == "--gpuav-enable-core") {
-            m_gpuav_enable_core = true;
+        } else if (current_argument == "--syncval-disable-core") {
+            m_syncval_disable_core = true;
+        } else if (current_argument == "--gpuav-disable-core") {
+            m_gpuav_disable_core = true;
         } else if (current_argument == "--device-index" && ((i + 1) < *argc)) {
             m_phys_device_index = std::atoi(argv[++i]);
         } else if ((current_argument == "--help") || (current_argument == "-h")) {

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -52,8 +52,8 @@ class VkTestFramework : public ::testing::Test {
     static inline bool m_strip_spv = false;
     static inline bool m_do_everything_spv = false;
     static inline bool m_print_vu = false;
-    static inline bool m_syncval_enable_core = false;
-    static inline bool m_gpuav_enable_core = false;
+    static inline bool m_syncval_disable_core = false;
+    static inline bool m_gpuav_disable_core = false;
     static inline int m_phys_device_index = -1;
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -563,7 +563,7 @@ TEST_F(NegativeGpuAV, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
     // GPU-AV will thus not be able to validate this draw call.
     // Descriptor arrays are not validated in core validation
     // (See call to `descriptor_set.SkipBinding()` in `CoreChecks::ValidateDrawState()`)
-    if (m_gpuav_enable_core) {
+    if (!m_gpuav_disable_core) {
         m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdDraw-None-08609");
         m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdDraw-None-08610");
     }
@@ -676,7 +676,7 @@ TEST_F(NegativeGpuAV, ShareOpSampledImage) {
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
 
-    if (m_gpuav_enable_core) {
+    if (!m_gpuav_disable_core) {
         m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdDraw-None-08610");
     }
     vk::CmdDraw(m_commandBuffer->handle(), 3, 1, 0, 0);

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -33,7 +33,7 @@ VkValidationFeaturesEXT GpuAVTest::GetGpuAvValidationFeatures() {
     VkValidationFeaturesEXT features = vku::InitStructHelper();
     features.enabledValidationFeatureCount = size32(gpu_av_enables);
     features.pEnabledValidationFeatures = gpu_av_enables.data();
-    if (!m_gpuav_enable_core) {
+    if (m_gpuav_disable_core) {
         features.disabledValidationFeatureCount = size32(gpu_av_disables);
         features.pDisabledValidationFeatures = gpu_av_disables.data();
     }

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -24,7 +24,7 @@ void VkSyncValTest::InitSyncValFramework(bool disable_queue_submit_validation) {
     features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1u, enables_, 4, disables_};
 
     // Optionally enable core validation (by disabling nothing)
-    if (m_syncval_enable_core) {
+    if (!m_syncval_disable_core) {
         features_.disabledValidationFeatureCount = 0;
     }
 
@@ -1169,6 +1169,12 @@ TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
     dynamic_rendering_features.dynamicRendering = VK_TRUE;
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState(nullptr, &dynamic_rendering_features));
+
+    VkPhysicalDeviceDepthStencilResolveProperties resolve_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(resolve_properties);
+    if ((resolve_properties.supportedDepthResolveModes & VK_RESOLVE_MODE_MIN_BIT) == 0) {
+        GTEST_SKIP() << "VK_RESOLVE_MODE_MIN_BIT not supported";
+    }
 
     const uint32_t width = 64;
     const uint32_t height = 64;


### PR DESCRIPTION
Switch --gpuav-enable-core to --gpuav-disable-core. Switch --syncval-enable-core to --syncval-disable-core.

Remove the env var VK_LAYER_TESTS_DISABLE_CORE_VALIDATION because it is a subset of VK_LAYER_TESTS_VALIDATION_FEATURES.