### PR TITLE
sync: Do not expand stages during sync1->sync2 conversion

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -788,9 +788,7 @@ VkSemaphoreSubmitInfo SubmitInfoConverter::BatchStore::SignalSemaphore(const VkS
                                                                        VkQueueFlags queue_flags) {
     VkSemaphoreSubmitInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.semaphore = info.pSignalSemaphores[index];
-    // Can't just use BOTTOM, because of how access expansion is done
-    semaphore_info.stageMask =
-        sync_utils::ExpandPipelineStages(VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, queue_flags, VK_PIPELINE_STAGE_2_HOST_BIT);
+    semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     return semaphore_info;
 }
 


### PR DESCRIPTION
Do not expand stages associated with a signal semaphore during sync1->sync2 conversion. The stages get expanded later, down the pipeline. By expanding them early we lose information about operations that can't be covered by the standard Vulkan stages (e.g. layout transition).

This also ensures that `QueueSubmit` and `QueueSubmit2` behave the same way from syncval perspective with regard to signal semaphores.

The regression test implements false-positive scenario discovered by this project:
https://github.com/kennyalive/vulkan-ray-tracing

> SYNC-HAZARD-PRESENT-AFTER-WRITE(ERROR / SPEC): msgNum: -512052050 - Validation Error: [ SYNC-HAZARD-PRESENT-AFTER-WRITE ] Object 0: handle = 0x1a527fb5960, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0xe17ab4ae | vkQueuePresentKHR():  Hazard PRESENT_AFTER_WRITE for present pSwapchains[0] , swapchain VkSwapchainKHR 0xec4bec000000000b[], image index 0 VkImage 0xe88693000000000c[], Access info (usage: SYNC_PRESENT_ENGINE_SYNCVAL_PRESENT_PRESENTED_SYNCVAL, prior_usage: SYNC_IMAGE_LAYOUT_TRANSITION, write_barriers: 0, queue: VkQueue 0x1a527fb5960[], submit: 9, batch: 0, batch_tag: 57, command: vkCmdPipelineBarrier, command_buffer: VkCommandBuffer 0x1a527fad170[], seq_no: 9, VkImage 0xe88693000000000c[], reset_no: 2).

