### PR TITLE
 tests: Reenable DISABLED GPU-AV tests

### DIFF
--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -77,8 +77,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     m_errorMonitor->VerifyFound();
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7132
-TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ReadAfterPointerPushConstant) {
+TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     TEST_DESCRIPTION("Read after the valid pointer - use Push Constants to set the value");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();
@@ -206,8 +205,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     m_errorMonitor->VerifyFound();
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7132
-TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ReadAfterPointerDescriptor) {
+TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     TEST_DESCRIPTION("Read after the valid pointer - use Descriptor to set the value");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());
     InitRenderTarget();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -325,8 +325,7 @@ TEST_F(NegativeGpuAVOOB, UniformBufferTooSmallArray) {
                          VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-uniformBuffers-06935");
 }
 
-// Is failing to create a pipeline on new Windows NVIDIA NDA driver
-TEST_F(NegativeGpuAVOOB, DISABLED_UniformBufferTooSmallNestedStruct) {
+TEST_F(NegativeGpuAVOOB, UniformBufferTooSmallNestedStruct) {
     TEST_DESCRIPTION(
         "Test that an error is produced when trying to access uniform buffer outside the bound region. Uses nested struct in block "
         "definition.");


### PR DESCRIPTION
Reenable the following tests:
- NegativeGpuAVBufferDeviceAddress.ReadAfterPointerPushConstant
- NegativeGpuAVBufferDeviceAddress.ReadAfterPointerDescriptor
- NegativeGpuAVOOB.UniformBufferTooSmallNestedStruct