### PR TITLE
gpuav: Fix VUID from pipeline vs shaderObject

### DIFF
--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -414,9 +414,11 @@ bool gpuav::Validator::GenerateValidationMessage(const uint32_t *debug_record, c
                          << " access out of bounds. Descriptor size is " << size << " and highest byte accessed was " << offset;
                     if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER ||
                         binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC) {
-                        out_vuid_msg = vuid.uniform_access_oob;
+                        out_vuid_msg =
+                            cmd_resources.uses_shader_object ? vuid.uniform_access_oob_08612 : vuid.uniform_access_oob_06935;
                     } else {
-                        out_vuid_msg = vuid.storage_access_oob;
+                        out_vuid_msg =
+                            cmd_resources.uses_shader_object ? vuid.storage_access_oob_08613 : vuid.storage_access_oob_06936;
                     }
                     error_found = true;
                     break;
@@ -425,9 +427,11 @@ bool gpuav::Validator::GenerateValidationMessage(const uint32_t *debug_record, c
                          << " access out of bounds. Descriptor size is " << size << " texels and highest texel accessed was "
                          << offset;
                     if (binding_state->type == VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER) {
-                        out_vuid_msg = vuid.uniform_access_oob;
+                        out_vuid_msg =
+                            cmd_resources.uses_shader_object ? vuid.uniform_access_oob_08612 : vuid.uniform_access_oob_06935;
                     } else {
-                        out_vuid_msg = vuid.storage_access_oob;
+                        out_vuid_msg =
+                            cmd_resources.uses_shader_object ? vuid.storage_access_oob_08613 : vuid.storage_access_oob_06936;
                     }
                     error_found = true;
                     break;

--- a/layers/gpu_validation/gpu_resources.h
+++ b/layers/gpu_validation/gpu_resources.h
@@ -64,6 +64,7 @@ class CommandResources {
     VkDescriptorPool output_buffer_desc_pool = VK_NULL_HANDLE;
     VkPipelineBindPoint pipeline_bind_point = VK_PIPELINE_BIND_POINT_MAX_ENUM;
     bool uses_robustness = false;  // Only used in AnalyseAndeGenerateMessages, to output using LogWarning instead of LogError. It needs to be removed
+    bool uses_shader_object = false;       // Some VU are dependent if used with pipeline or shader object
     vvl::Func command = vvl::Func::Empty;  // Should probably use Location instead
     uint32_t desc_binding_index = vvl::kU32Max;// desc_binding is only used to help generate an error message
     std::vector<DescBindingInfo> *desc_binding_list = nullptr;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -566,6 +566,7 @@ gpuav::CommandResources gpuav::Validator::AllocateActionCommandResources(const V
     cmd_resources.output_buffer_desc_pool = output_buffer_desc_pool;
     cmd_resources.pipeline_bind_point = bind_point;
     cmd_resources.uses_robustness = uses_robustness;
+    cmd_resources.uses_shader_object = pipeline_state == nullptr;
     cmd_resources.command = loc.function;
     cmd_resources.desc_binding_index = di_buf_index;
     cmd_resources.desc_binding_list = &cb_node->di_input_buffer_list;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -45,8 +45,10 @@ struct CmdIndirectState;
 struct AccelerationStructureBuildValidationInfo;
 
 struct GpuVuid {
-    const char* uniform_access_oob = kVUIDUndefined;
-    const char* storage_access_oob = kVUIDUndefined;
+    const char* uniform_access_oob_06935 = kVUIDUndefined;
+    const char* storage_access_oob_06936 = kVUIDUndefined;
+    const char* uniform_access_oob_08612 = kVUIDUndefined;
+    const char* storage_access_oob_08613 = kVUIDUndefined;
     const char* invalid_descriptor = kVUIDUndefined;
     const char* count_exceeds_bufsize_1 = kVUIDUndefined;
     const char* count_exceeds_bufsize = kVUIDUndefined;

--- a/layers/gpu_validation/gpu_vuids.cpp
+++ b/layers/gpu_validation/gpu_vuids.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2021-2023 The Khronos Group Inc.
- * Copyright (c) 2021-2023 Valve Corporation
- * Copyright (c) 2021-2023 LunarG, Inc.
+/* Copyright (c) 2021-2024 The Khronos Group Inc.
+ * Copyright (c) 2021-2024 Valve Corporation
+ * Copyright (c) 2021-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,40 +19,50 @@
 // clang-format off
 struct GpuVuidsCmdDraw : gpuav::GpuVuid {
     GpuVuidsCmdDraw() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDraw-None-08612";
-        storage_access_oob = "VUID-vkCmdDraw-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDraw-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDraw-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDraw-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDraw-None-08613";
         invalid_descriptor = "VUID-vkCmdDraw-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawMultiEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMultiEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMultiEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMultiEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMultiEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMultiEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMultiEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMultiEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMultiEXT-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawIndexed : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexed() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndexed-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndexed-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndexed-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndexed-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndexed-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndexed-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndexed-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawMultiIndexedEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMultiIndexedEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMultiIndexedEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMultiIndexedEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMultiIndexedEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMultiIndexedEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMultiIndexedEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMultiIndexedEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMultiIndexedEXT-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirect() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndirect-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndirect-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndirect-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndirect-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndirect-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndirect-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndirectCommand-firstInstance-00501";
     }
@@ -60,8 +70,10 @@ struct GpuVuidsCmdDrawIndirect : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawIndexedIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexedIndirect() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndexedIndirect-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndexedIndirect-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndexedIndirect-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndexedIndirect-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirect-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndexedIndirect-None-08114";
         first_instance_not_zero = "VUID-VkDrawIndexedIndirectCommand-firstInstance-00554";
     }
@@ -69,16 +81,20 @@ struct GpuVuidsCmdDrawIndexedIndirect : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDispatch : gpuav::GpuVuid {
     GpuVuidsCmdDispatch() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDispatch-None-08612";
-        storage_access_oob = "VUID-vkCmdDispatch-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDispatch-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDispatch-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDispatch-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDispatch-None-08613";
         invalid_descriptor = "VUID-vkCmdDispatch-None-08114";
     }
 };
 
 struct GpuVuidsCmdDispatchIndirect : gpuav::GpuVuid {
     GpuVuidsCmdDispatchIndirect() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDispatchIndirect-None-08612";
-        storage_access_oob = "VUID-vkCmdDispatchIndirect-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDispatchIndirect-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDispatchIndirect-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDispatchIndirect-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDispatchIndirect-None-08613";
         invalid_descriptor = "VUID-vkCmdDispatchIndirect-None-08114";
         group_exceeds_device_limit_x = "VUID-VkDispatchIndirectCommand-x-00417";
         group_exceeds_device_limit_y = "VUID-VkDispatchIndirectCommand-y-00418";
@@ -89,8 +105,10 @@ struct GpuVuidsCmdDispatchIndirect : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawIndirectCount : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirectCount() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndirectCount-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndirectCount-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndirectCount-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndirectCount-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectCount-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndirectCount-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndirectCount-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndirectCount-countBuffer-03121";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndirectCount-countBuffer-03122";
@@ -100,8 +118,10 @@ struct GpuVuidsCmdDrawIndirectCount : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawIndexedIndirectCount : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndexedIndirectCount() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndexedIndirectCount-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndexedIndirectCount-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndexedIndirectCount-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndexedIndirectCount-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndexedIndirectCount-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndexedIndirectCount-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndexedIndirectCount-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153";
         count_exceeds_bufsize = "VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154";
@@ -111,24 +131,30 @@ struct GpuVuidsCmdDrawIndexedIndirectCount : gpuav::GpuVuid {
 
 struct GpuVuidsCmdTraceRaysNV : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysNV() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdTraceRaysNV-None-08612";
-        storage_access_oob = "VUID-vkCmdTraceRaysNV-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdTraceRaysNV-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdTraceRaysNV-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdTraceRaysNV-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdTraceRaysNV-None-08613";
         invalid_descriptor = "VUID-vkCmdTraceRaysNV-None-08114";
     }
 };
 
 struct GpuVuidsCmdTraceRaysKHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysKHR() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdTraceRaysKHR-None-08612";
-        storage_access_oob = "VUID-vkCmdTraceRaysKHR-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdTraceRaysKHR-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdTraceRaysKHR-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdTraceRaysKHR-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdTraceRaysKHR-None-08613";
         invalid_descriptor = "VUID-vkCmdTraceRaysKHR-None-08114";
     }
 };
 
 struct GpuVuidsCmdTraceRaysIndirectKHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysIndirectKHR() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdTraceRaysIndirectKHR-None-08612";
-        storage_access_oob = "VUID-vkCmdTraceRaysIndirectKHR-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdTraceRaysIndirectKHR-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdTraceRaysIndirectKHR-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirectKHR-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirectKHR-None-08613";
         invalid_descriptor = "VUID-vkCmdTraceRaysIndirectKHR-None-08114";
         trace_rays_width_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-width-03638";
         trace_rays_height_exceeds_device_limit = "VUID-VkTraceRaysIndirectCommandKHR-height-03639";
@@ -138,24 +164,30 @@ struct GpuVuidsCmdTraceRaysIndirectKHR : gpuav::GpuVuid {
 
 struct GpuVuidsCmdTraceRaysIndirect2KHR : gpuav::GpuVuid {
     GpuVuidsCmdTraceRaysIndirect2KHR() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdTraceRaysIndirect2KHR-None-08612";
-        storage_access_oob = "VUID-vkCmdTraceRaysIndirect2KHR-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdTraceRaysIndirect2KHR-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdTraceRaysIndirect2KHR-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdTraceRaysIndirect2KHR-None-08613";
         invalid_descriptor = "VUID-vkCmdTraceRaysIndirect2KHR-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawMeshTasksNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksNV() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksNV-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksNV-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksNV-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksNV-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksNV-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksNV-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksNV-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawMeshTasksIndirectNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectNV() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksIndirectNV-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectNV-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08114";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
@@ -170,8 +202,10 @@ struct GpuVuidsCmdDrawMeshTasksIndirectNV : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectCountNV() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02191";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountNV-countBuffer-02192";
@@ -189,16 +223,20 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountNV : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawMeshTasksEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksEXT-None-08114";
     }
 };
 
 struct GpuVuidsCmdDrawMeshTasksIndirectEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksIndirectEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08114";
         task_group_count_exceeds_max_x = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322";
         task_group_count_exceeds_max_y = "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323";
@@ -213,8 +251,10 @@ struct GpuVuidsCmdDrawMeshTasksIndirectEXT : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawMeshTasksIndirectCountEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawMeshTasksIndirectCountEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08114";
         count_exceeds_bufsize_1 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098";
         count_exceeds_bufsize = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099";
@@ -232,16 +272,20 @@ struct GpuVuidsCmdDrawMeshTasksIndirectCountEXT : gpuav::GpuVuid {
 
 struct GpuVuidsCmdDrawIndirectByteCountEXT : gpuav::GpuVuid {
     GpuVuidsCmdDrawIndirectByteCountEXT() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDrawIndirectByteCountEXT-None-08612";
-        storage_access_oob = "VUID-vkCmdDrawIndirectByteCountEXT-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDrawIndirectByteCountEXT-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDrawIndirectByteCountEXT-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDrawIndirectByteCountEXT-None-08613";
         invalid_descriptor = "VUID-vkCmdDrawIndirectByteCountEXT-None-08114";
     }
 };
 
 struct GpuVuidsCmdDispatchBase : gpuav::GpuVuid {
     GpuVuidsCmdDispatchBase() : GpuVuid() {
-        uniform_access_oob = "VUID-vkCmdDispatchBase-None-08612";
-        storage_access_oob = "VUID-vkCmdDispatchBase-None-08613";
+        uniform_access_oob_06935 = "VUID-vkCmdDispatchBase-uniformBuffers-06935";
+        storage_access_oob_06936 = "VUID-vkCmdDispatchBase-storageBuffers-06936";
+        uniform_access_oob_08612 = "VUID-vkCmdDispatchBase-None-08612";
+        storage_access_oob_08613 = "VUID-vkCmdDispatchBase-None-08613";
         invalid_descriptor = "VUID-vkCmdDispatchBase-None-08114";
     }
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -99,6 +99,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/gpu_av_oob.cpp
     unit/gpu_av_oob_positive.cpp
     unit/gpu_av_positive.cpp
+    unit/gpu_av_shader_object_positive.cpp
     unit/gpu_av_spirv.cpp
     unit/gpu_av_spirv_positive.cpp
     unit/gpu_av_ray_query.cpp

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -554,6 +554,8 @@ class ShaderObjectTest : public virtual VkLayerTest {
 class NegativeShaderObject : public ShaderObjectTest {};
 class PositiveShaderObject : public ShaderObjectTest {};
 
+class PositiveGpuAVShaderObject : public PositiveShaderObject, public PositiveGpuAV {};
+
 class ShaderInterfaceTest : public VkLayerTest {};
 class NegativeShaderInterface : public ShaderInterfaceTest {};
 class PositiveShaderInterface : public ShaderInterfaceTest {};

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -165,7 +165,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     m_commandBuffer->end();
     // Should get a warning since shader was instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-storageBuffers-06936");
     m_commandBuffer->QueueCommandBuffer();
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -404,7 +404,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ArrayOfStruct) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-None-08612");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-uniformBuffers-06935");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -80,7 +80,7 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     uint32_t *data = (uint32_t *)uniform_buffer.memory().map();
     *data = 0;
     uniform_buffer.memory().unmap();
-    // normally VUID-vkCmdDraw-None-08612
+    // normally VUID-vkCmdDraw-uniformBuffers-06935
     m_errorMonitor->SetDesiredFailureMsg(
         kWarningBit, "Descriptor index 0 access out of bounds. Descriptor size is 4 and highest byte accessed was 19");
     m_commandBuffer->QueueCommandBuffer();
@@ -88,7 +88,7 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     data = (uint32_t *)uniform_buffer.memory().map();
     *data = 1;
     uniform_buffer.memory().unmap();
-    // normally VUID-vkCmdDraw-None-08613
+    // normally VUID-vkCmdDraw-storageBuffers-06936
     m_errorMonitor->SetDesiredFailureMsg(
         kWarningBit, "Descriptor index 0 access out of bounds. Descriptor size is 16 and highest byte accessed was 35");
     m_commandBuffer->QueueCommandBuffer();
@@ -144,7 +144,7 @@ TEST_F(NegativeGpuAVOOB, Basic) {
     *data = 8;
     offset_buffer.memory().unmap();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -279,7 +279,7 @@ TEST_F(NegativeGpuAVOOB, UniformBufferTooSmall) {
     ShaderBufferSizeTest(4,  // buffer size
                          0,  // binding offset
                          4,  // binding range
-                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-None-08612");
+                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-uniformBuffers-06935");
 }
 
 TEST_F(NegativeGpuAVOOB, StorageBufferTooSmall) {
@@ -298,7 +298,7 @@ TEST_F(NegativeGpuAVOOB, StorageBufferTooSmall) {
     ShaderBufferSizeTest(4,  // buffer size
                          0,  // binding offset
                          4,  // binding range
-                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, fsSource, "VUID-vkCmdDraw-None-08613");
+                         VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, fsSource, "VUID-vkCmdDraw-storageBuffers-06936");
 }
 
 TEST_F(NegativeGpuAVOOB, UniformBufferTooSmallArray) {
@@ -322,7 +322,7 @@ TEST_F(NegativeGpuAVOOB, UniformBufferTooSmallArray) {
     ShaderBufferSizeTest(64,  // buffer size
                          0,   // binding offset
                          64,  // binding range
-                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-None-08612");
+                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-uniformBuffers-06935");
 }
 
 // Is failing to create a pipeline on new Windows NVIDIA NDA driver
@@ -348,7 +348,7 @@ TEST_F(NegativeGpuAVOOB, DISABLED_UniformBufferTooSmallNestedStruct) {
     ShaderBufferSizeTest(8,  // buffer size
                          0,  // binding offset
                          8,  // binding range
-                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-None-08612");
+                         VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, fsSource, "VUID-vkCmdDraw-uniformBuffers-06935");
 }
 
 TEST_F(NegativeGpuAVOOB, ObjectUniformBufferTooSmall) {
@@ -486,13 +486,13 @@ TEST_F(NegativeGpuAVOOB, GPL) {
         char const *expected_error;
     };
     std::vector<TestCase> tests;
-    tests.push_back({"read", 8, "VUID-vkCmdDraw-None-08613"});
+    tests.push_back({"read", 8, "VUID-vkCmdDraw-storageBuffers-06936"});
     // Uniform buffer stride rounded up to the alignment of a vec4 (16 bytes)
     // so u_index.index[4] accesses bytes 64, 65, 66, and 67
-    tests.push_back({"write", 0, "VUID-vkCmdDraw-None-08612"});
-    tests.push_back({"texel fetch", 2, "VUID-vkCmdDraw-None-08612"});
-    tests.push_back({"image load", 3, "VUID-vkCmdDraw-None-08613"});
-    tests.push_back({"image store", 4, "VUID-vkCmdDraw-None-08613"});
+    tests.push_back({"write", 0, "VUID-vkCmdDraw-uniformBuffers-06935"});
+    tests.push_back({"texel fetch", 2, "VUID-vkCmdDraw-uniformBuffers-06935"});
+    tests.push_back({"image load", 3, "VUID-vkCmdDraw-storageBuffers-06936"});
+    tests.push_back({"image store", 4, "VUID-vkCmdDraw-storageBuffers-06936"});
 
     for (const auto &test : tests) {
         SCOPED_TRACE(test.name);
@@ -639,13 +639,13 @@ TEST_F(NegativeGpuAVOOB, GPLIndependentSets) {
         char const *expected_error;
     };
     std::vector<TestCase> tests;
-    tests.push_back({"read", 8, "VUID-vkCmdDraw-None-08613"});
+    tests.push_back({"read", 8, "VUID-vkCmdDraw-storageBuffers-06936"});
     // Uniform buffer stride rounded up to the alignment of a vec4 (16 bytes)
     // so u_index.index[4] accesses bytes 64, 65, 66, and 67
-    tests.push_back({"write", 0, "VUID-vkCmdDraw-None-08612"});
-    tests.push_back({"texel fetch", 2, "VUID-vkCmdDraw-None-08612"});
-    tests.push_back({"image load", 3, "VUID-vkCmdDraw-None-08613"});
-    tests.push_back({"image store", 4, "VUID-vkCmdDraw-None-08613"});
+    tests.push_back({"write", 0, "VUID-vkCmdDraw-uniformBuffers-06935"});
+    tests.push_back({"texel fetch", 2, "VUID-vkCmdDraw-uniformBuffers-06935"});
+    tests.push_back({"image load", 3, "VUID-vkCmdDraw-storageBuffers-06936"});
+    tests.push_back({"image store", 4, "VUID-vkCmdDraw-storageBuffers-06936"});
 
     for (const auto &test : tests) {
         SCOPED_TRACE(test.name);
@@ -727,7 +727,7 @@ TEST_F(NegativeGpuAVOOB, StorageBuffer) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -781,7 +781,7 @@ TEST_F(NegativeGpuAVOOB, Vector) {
             in_buffer.b.y = 0.0;
         }
     )glsl";
-    ComputeStorageBufferTest("VUID-vkCmdDispatch-None-08613", shader_source, 20);
+    ComputeStorageBufferTest("VUID-vkCmdDispatch-storageBuffers-06936", shader_source, 20);
 }
 
 TEST_F(NegativeGpuAVOOB, Matrix) {
@@ -800,7 +800,7 @@ TEST_F(NegativeGpuAVOOB, Matrix) {
             in_buffer.b[2][1] = 0.0;
         }
     )glsl";
-    ComputeStorageBufferTest("VUID-vkCmdDispatch-None-08613", shader_source, 30);
+    ComputeStorageBufferTest("VUID-vkCmdDispatch-storageBuffers-06936", shader_source, 30);
 }
 
 TEST_F(NegativeGpuAVOOB, TexelFetch) {
@@ -853,7 +853,7 @@ TEST_F(NegativeGpuAVOOB, TexelFetch) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-None-08612");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-uniformBuffers-06935");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -908,7 +908,7 @@ TEST_F(NegativeGpuAVOOB, ImageLoad) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -956,7 +956,7 @@ TEST_F(NegativeGpuAVOOB, ImageStore) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDispatch-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -1010,7 +1010,7 @@ TEST_F(NegativeGpuAVOOB, Geometry) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -1071,7 +1071,7 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationControl) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
@@ -1130,7 +1130,7 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationEvaluation) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-None-08613");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->submit(*m_commandBuffer, false);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2023-2024 Nintendo
+ * Copyright (c) 2023-2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "../framework/descriptor_helper.h"
+#include "../framework/gpu_av_helper.h"
+
+TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
+    TEST_DESCRIPTION("GPU validation: Validate selection of which shaders get instrumented for GPU-AV");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
+    const VkBool32 value = true;
+    const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                       &value};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
+                                                               &setting};
+    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
+    validation_features.pNext = &layer_settings_create_info;
+    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework(&validation_features));
+    if (!CanEnableGpuAV(*this)) {
+        GTEST_SKIP() << "Requirements for GPU-AV are not met";
+    }
+
+    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
+    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
+    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&shader_object_features);
+    GetPhysicalDeviceFeatures2(features2);
+    if (!features2.features.robustBufferAccess) {
+        GTEST_SKIP() << "Not safe to write outside of buffer memory";
+    }
+    // Robust buffer access will be on by default
+    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
+    InitState(nullptr, &features2, pool_flags);
+    InitDynamicRenderTarget();
+
+    OneOffDescriptorSet vert_descriptor_set(m_device,
+                                            {
+                                                {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
+                                            });
+    vkt::PipelineLayout pipeline_layout(*m_device, {&vert_descriptor_set.layout_});
+
+    static const char vert_src[] = R"glsl(
+        #version 460
+        layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
+        void main() {
+            Data.data[4] = 0xdeadca71;
+        }
+    )glsl";
+
+    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
+    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
+
+    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle()};
+
+    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
+    vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
+    vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+    vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
+    vert_create_info.pCode = vert_spv.data();
+    vert_create_info.pName = "main";
+    vert_create_info.setLayoutCount = 1;
+    vert_create_info.pSetLayouts = descriptor_set_layouts;
+
+    VkValidationFeatureEnableEXT enabled[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
+    VkValidationFeaturesEXT features = vku::InitStructHelper();
+    features.enabledValidationFeatureCount = 1;
+    features.pEnabledValidationFeatures = enabled;
+    vert_create_info.pNext = &features;
+
+    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
+    frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
+    frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
+    frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
+    frag_create_info.pCode = frag_spv.data();
+    frag_create_info.pName = "main";
+    frag_create_info.setLayoutCount = 1;
+    frag_create_info.pSetLayouts = descriptor_set_layouts;
+
+    // TODO - Once the spec is changed to allow this, the SetUnexpectedError call can be removed
+    m_errorMonitor->SetUnexpectedError("VUID-VkShaderCreateInfoEXT-pNext-pNext");
+    const vkt::Shader vertShader(*m_device, vert_create_info);
+    const vkt::Shader fragShader(*m_device, frag_create_info);
+
+    vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vert_descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    vert_descriptor_set.UpdateDescriptorSets();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());
+    SetDefaultDynamicStates();
+    BindVertFragShader(vertShader, fragShader);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
+                              &vert_descriptor_set.set_, 0u, nullptr);
+    vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
+    m_commandBuffer->EndRendering();
+    m_commandBuffer->end();
+
+    // Should get a warning since shader was instrumented
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
+    m_commandBuffer->QueueCommandBuffer();
+    m_default_queue->wait();
+    m_errorMonitor->VerifyFound();
+
+    vert_create_info.pNext = nullptr;
+    const vkt::Shader vertShader2(*m_device, vert_create_info);
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());
+    SetDefaultDynamicStates();
+    BindVertFragShader(vertShader2, fragShader);
+    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
+                              &vert_descriptor_set.set_, 0u, nullptr);
+    vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
+    m_commandBuffer->EndRendering();
+    m_commandBuffer->end();
+
+    // Should not get a warning since shader was not instrumented
+    m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
+    m_commandBuffer->QueueCommandBuffer();
+    m_default_queue->wait();
+}

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -11,7 +11,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 void ShaderObjectTest::InitBasicShaderObject() {
     SetTargetApiVersion(VK_API_VERSION_1_1);
@@ -1186,124 +1185,6 @@ TEST_F(PositiveShaderObject, DescriptorBuffer) {
     vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
     m_commandBuffer->EndRendering();
     m_commandBuffer->end();
-}
-
-class PositiveGpuAVShaderObject : public PositiveShaderObject, public PositiveGpuAV {};
-
-TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
-    TEST_DESCRIPTION("GPU validation: Validate selection of which shaders get instrumented for GPU-AV");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_LAYER_SETTINGS_EXTENSION_NAME);
-    const VkBool32 value = true;
-    const VkLayerSettingEXT setting = {OBJECT_LAYER_NAME, "select_instrumented_shaders", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                       &value};
-    VkLayerSettingsCreateInfoEXT layer_settings_create_info = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, 1,
-                                                               &setting};
-    VkValidationFeaturesEXT validation_features = GetGpuAvValidationFeatures();
-    validation_features.pNext = &layer_settings_create_info;
-    AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework(&validation_features));
-    if (!CanEnableGpuAV(*this)) {
-        GTEST_SKIP() << "Requirements for GPU-AV are not met";
-    }
-
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_rendering_features = vku::InitStructHelper();
-    VkPhysicalDeviceShaderObjectFeaturesEXT shader_object_features = vku::InitStructHelper(&dynamic_rendering_features);
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&shader_object_features);
-    GetPhysicalDeviceFeatures2(features2);
-    if (!features2.features.robustBufferAccess) {
-        GTEST_SKIP() << "Not safe to write outside of buffer memory";
-    }
-    // Robust buffer access will be on by default
-    VkCommandPoolCreateFlags pool_flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
-    InitState(nullptr, &features2, pool_flags);
-    InitDynamicRenderTarget();
-
-    OneOffDescriptorSet vert_descriptor_set(m_device,
-                                            {
-                                                {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
-                                            });
-    vkt::PipelineLayout pipeline_layout(*m_device, {&vert_descriptor_set.layout_});
-
-    static const char vert_src[] = R"glsl(
-        #version 460
-        layout(set = 0, binding = 0) buffer StorageBuffer { uint data[]; } Data;
-        void main() {
-            Data.data[4] = 0xdeadca71;
-        }
-    )glsl";
-
-    const auto vert_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vert_src);
-    const auto frag_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
-
-    VkDescriptorSetLayout descriptor_set_layouts[] = {vert_descriptor_set.layout_.handle()};
-
-    VkShaderCreateInfoEXT vert_create_info = vku::InitStructHelper();
-    vert_create_info.stage = VK_SHADER_STAGE_VERTEX_BIT;
-    vert_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
-    vert_create_info.codeSize = vert_spv.size() * sizeof(vert_spv[0]);
-    vert_create_info.pCode = vert_spv.data();
-    vert_create_info.pName = "main";
-    vert_create_info.setLayoutCount = 1;
-    vert_create_info.pSetLayouts = descriptor_set_layouts;
-
-    VkValidationFeatureEnableEXT enabled[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
-    VkValidationFeaturesEXT features = vku::InitStructHelper();
-    features.enabledValidationFeatureCount = 1;
-    features.pEnabledValidationFeatures = enabled;
-    vert_create_info.pNext = &features;
-
-    VkShaderCreateInfoEXT frag_create_info = vku::InitStructHelper();
-    frag_create_info.stage = VK_SHADER_STAGE_FRAGMENT_BIT;
-    frag_create_info.codeType = VK_SHADER_CODE_TYPE_SPIRV_EXT;
-    frag_create_info.codeSize = frag_spv.size() * sizeof(frag_spv[0]);
-    frag_create_info.pCode = frag_spv.data();
-    frag_create_info.pName = "main";
-    frag_create_info.setLayoutCount = 1;
-    frag_create_info.pSetLayouts = descriptor_set_layouts;
-
-    // TODO - Once the spec is changed to allow this, the SetUnexpectedError call can be removed
-    m_errorMonitor->SetUnexpectedError("VUID-VkShaderCreateInfoEXT-pNext-pNext");
-    const vkt::Shader vertShader(*m_device, vert_create_info);
-    const vkt::Shader fragShader(*m_device, frag_create_info);
-
-    vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    vert_descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    vert_descriptor_set.UpdateDescriptorSets();
-
-    m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());
-    SetDefaultDynamicStates();
-    BindVertFragShader(vertShader, fragShader);
-    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
-                              &vert_descriptor_set.set_, 0u, nullptr);
-    vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
-    m_commandBuffer->EndRendering();
-    m_commandBuffer->end();
-
-    // Should get a warning since shader was instrumented
-    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
-    m_commandBuffer->QueueCommandBuffer();
-    m_default_queue->wait();
-    m_errorMonitor->VerifyFound();
-
-    vert_create_info.pNext = nullptr;
-    const vkt::Shader vertShader2(*m_device, vert_create_info);
-    m_commandBuffer->begin();
-    m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget());
-    SetDefaultDynamicStates();
-    BindVertFragShader(vertShader2, fragShader);
-    vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
-                              &vert_descriptor_set.set_, 0u, nullptr);
-    vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
-    m_commandBuffer->EndRendering();
-    m_commandBuffer->end();
-
-    // Should not get a warning since shader was not instrumented
-    m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_commandBuffer->QueueCommandBuffer();
-    m_default_queue->wait();
 }
 
 TEST_F(PositiveShaderObject, MultiplePushConstants) {


### PR DESCRIPTION
These 2 VUs were split into 4 because and adjusted the VUID logic to represent that

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/bef8c889-9916-4392-87c4-a1279a86e28d)

(also moved our GPU-AV Shader Object test to a dedicated file)