### PR TITLE
gpu: Renamings in gpu_error_constants.h

### DIFF
--- a/layers/gpu_shaders/gpu_error_codes.h
+++ b/layers/gpu_shaders/gpu_error_codes.h
@@ -1,0 +1,99 @@
+// Copyright (c) 2021-2024 The Khronos Group Inc.
+// Copyright (c) 2021-2024 Valve Corporation
+// Copyright (c) 2021-2024 LunarG, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// Values used between the GLSL shaders and the GPU-AV logic
+
+// NOTE: This header is included by the instrumentation shaders and glslang doesn't support #pragma once
+#ifndef GPU_ERROR_CODES_H
+#define GPU_ERROR_CODES_H
+
+#ifdef __cplusplus
+namespace gpuav {
+namespace glsl {
+#endif
+
+// Error Groups
+//
+// These will match one-for-one with the file found in gpu_shader folder
+const int kErrorGroupInstBindlessDescriptor = 1;
+const int kErrorGroupInstBufferDeviceAddress = 2;
+const int kErrorGroupInstRayQuery = 3;
+const int kErrorGroupGpuPreDraw = 4;
+const int kErrorGroupGpuPreDispatch = 5;
+const int kErrorGroupGpuPreTraceRays = 6;
+const int kErrorGroupGpuCopyBufferToImage = 7;
+
+// Bindless Descriptor
+//
+const int kErrorSubCodeBindlessDescriptorBounds = 1;
+const int kErrorSubCodeBindlessDescriptorUninit = 2;
+const int kErrorSubCodeBindlessDescriptorOOB = 3;
+const int kErrorSubCodeBindlessDescriptorDestroyed = 4;
+
+// Buffer Device Address
+//
+const int kErrorSubCodeBufferDeviceAddressUnallocRef = 1;
+
+// Ray Query
+//
+const int kErrorSubCodeRayQueryNegativeMin = 1;
+const int kErrorSubCodeRayQueryNegativeMax = 2;
+const int kErrorSubCodeRayQueryBothSkip = 3;
+const int kErrorSubCodeRayQuerySkipCull = 4;
+const int kErrorSubCodeRayQueryOpaque = 5;
+const int kErrorSubCodeRayQueryMinMax = 6;
+const int kErrorSubCodeRayQueryMinNaN = 7;
+const int kErrorSubCodeRayQueryMaxNaN = 8;
+const int kErrorSubCodeRayQueryOriginNaN = 9;
+const int kErrorSubCodeRayQueryDirectionNaN = 10;
+const int kErrorSubCodeRayQueryOriginFinite = 11;
+const int kErrorSubCodeRayQueryDirectionFinite = 12;
+
+// Pre Draw
+//
+const int kErrorSubCodePreDrawBufferSize = 1;
+const int kErrorSubCodePreDrawCountLimit = 2;
+const int kErrorSubCodePreDrawFirstInstance = 3;
+const int kErrorSubCodePreDrawGroupCountX = 4;
+const int kErrorSubCodePreDrawGroupCountY = 5;
+const int kErrorSubCodePreDrawGroupCountZ = 6;
+const int kErrorSubCodePreDrawGroupCountTotal = 7;
+
+const int kPreDrawSelectCountBuffer = 1;
+const int kPreDrawSelectDrawBuffer = 2;
+const int kPreDrawSelectMeshCountBuffer = 3;
+const int kPreDrawSelectMeshNoCount = 4;
+
+// Pre Dispatch
+//
+const int kErrorSubCodePreDispatchCountLimitX = 1;
+const int kErrorSubCodePreDispatchCountLimitY = 2;
+const int kErrorSubCodePreDispatchCountLimitZ = 3;
+
+// Pre Tracy Rays
+//
+const int kErrorSubCodePreTraceRaysLimitWidth = 1;
+const int kErrorSubCodePreTraceRaysLimitHeight = 2;
+const int kErrorSubCodePreTraceRaysLimitDepth = 3;
+
+// Pre Copy Buffer To Image
+//
+const int kErrorSubCodePreCopyBufferToImageBufferTexel = 1;
+
+#ifdef __cplusplus
+}  // namespace glsl
+}  // namespace gpuav
+#endif
+#endif

--- a/layers/gpu_shaders/gpu_error_constants.h
+++ b/layers/gpu_shaders/gpu_error_constants.h
@@ -19,200 +19,150 @@
 #ifndef GPU_ERROR_CONSTANTS_H
 #define GPU_ERROR_CONSTANTS_H
 
+#include "gpu_error_codes.h"
+
 #ifdef __cplusplus
 namespace gpuav {
 namespace glsl {
 #endif
 
-// Common Stream Record Offsets
+// GPU-AV Error record structure:
+// ------------------------------
+
+// /---------------------------------
+// | Error header
+// | 	- Record size
+// |	- Shader Id
+// |	- Instruction Id
+// |	- Shader stage Id
+// |	- Shader stage info (3 integers)
+// | 	- Error group (Id unique to the shader/instrumentation code that wrote the error)
+// |	- subcode (maps to VUIDs)
+// | --------------------------------
+// | Error specific parameters
+// \---------------------------------
 //
-// The following are offsets to fields which are common to all records written
-// to the output stream.
-//
+// The size of these parts depends on the validation being done.
+
+// Error Header offsets:
+// ---------------------
+// The following are offsets to fields common to all records
+
 // Each record first contains the size of the record in 32-bit words, including
 // the size word.
-const int kInstCommonOutSize = 0;
+const int kHeaderErrorRecordSizeOffset = 0;
 
 // This is the shader id passed by the layer when the instrumentation pass is
 // created.
-const int kInstCommonOutShaderId = 1;
+const int kHeaderShaderIdOffset = 1;
 
 // This is the ordinal position of the instruction within the SPIR-V shader
 // which generated the validation error.
-const int kInstCommonOutInstructionIdx = 2;
+const int kHeaderInstructionIdOffset = 2;
 
 // This is the stage which generated the validation error. This word is used
 // to determine the contents of the next two words in the record.
-// 0:Vert, 1:TessCtrl, 2:TessEval, 3:Geom, 4:Frag, 5:Compute
-const int kInstCommonOutStageIdx = 3;
-const int kInstCommonOutCnt = 4;
+const int kHeaderStageIdOffset = 3;  // Values come from SpvExecutionModel (See spirv.h):
+const int kHeaderStageInfoOffset_0 = 4;
+const int kHeaderStageInfoOffset_1 = 5;
+const int kHeaderStageInfoOffset_2 = 6;
 
-// Size of Common and Stage-specific Members
-const int kInstStageOutCnt = kInstCommonOutCnt + 3;
-
-// This identifies the validation error
-// We use groups to more easily mangage the many int values not conflicting
-const int kErrorGroup = kInstStageOutCnt;
-const int kErrorSubCode = kErrorGroup + 1;
-
-// Maximum Output Record Member Count
-const int kInstMaxOutCnt = kErrorSubCode + 6;
-
-// Stage-specific Stream Record Offsets
-//
+// Stage-specific Error record offsets
+// ---
 // Each stage will contain different values in the next set of words of the
 // record used to identify which instantiation of the shader generated the
 // validation error.
 //
 // Vertex Shader Output Record Offsets
-const int kInstVertOutVertexIndex = kInstCommonOutCnt;
-const int kInstVertOutInstanceIndex = kInstCommonOutCnt + 1;
-const int kInstVertOutUnused = kInstCommonOutCnt + 2;
+const int kHeaderVertexIndexOffset = kHeaderStageInfoOffset_0;
+const int kHeaderVertInstanceIndexOffset = kHeaderStageInfoOffset_1;
 
 // Frag Shader Output Record Offsets
-const int kInstFragOutFragCoordX = kInstCommonOutCnt;
-const int kInstFragOutFragCoordY = kInstCommonOutCnt + 1;
-const int kInstFragOutUnused = kInstCommonOutCnt + 2;
+const int kHeaderFragCoordXOffset = kHeaderStageInfoOffset_0;
+const int kHeaderFragCoordYOffset = kHeaderStageInfoOffset_1;
 
 // Compute Shader Output Record Offsets
-const int kInstCompOutGlobalInvocationIdX = kInstCommonOutCnt;
-const int kInstCompOutGlobalInvocationIdY = kInstCommonOutCnt + 1;
-const int kInstCompOutGlobalInvocationIdZ = kInstCommonOutCnt + 2;
+const int kHeaderInvocationIdXOffset = kHeaderStageInfoOffset_0;
+const int kHeaderInvocationIdYOffset = kHeaderStageInfoOffset_1;
+const int kHeaderInvocationIdZOffset = kHeaderStageInfoOffset_2;
 
 // Tessellation Control Shader Output Record Offsets
-const int kInstTessCtlOutInvocationId = kInstCommonOutCnt;
-const int kInstTessCtlOutPrimitiveId = kInstCommonOutCnt + 1;
-const int kInstTessCtlOutUnused = kInstCommonOutCnt + 2;
+const int kHeaderTessCltInvocationIdOffset = kHeaderStageInfoOffset_0;
+const int kHeaderTessCtlPrimitiveIdOffset = kHeaderStageInfoOffset_1;
 
 // Tessellation Eval Shader Output Record Offsets
-const int kInstTessEvalOutPrimitiveId = kInstCommonOutCnt;
-const int kInstTessEvalOutTessCoordU = kInstCommonOutCnt + 1;
-const int kInstTessEvalOutTessCoordV = kInstCommonOutCnt + 2;
+const int kHeaderTessEvalPrimitiveIdOffset = kHeaderStageInfoOffset_0;
+const int kHeaderTessEvalCoordUOffset = kHeaderStageInfoOffset_1;
+const int kHeaderTessEvalCoordVOffset = kHeaderStageInfoOffset_2;
 
 // Geometry Shader Output Record Offsets
-const int kInstGeomOutPrimitiveId = kInstCommonOutCnt;
-const int kInstGeomOutInvocationId = kInstCommonOutCnt + 1;
-const int kInstGeomOutUnused = kInstCommonOutCnt + 2;
+const int kHeaderGeomPrimitiveIdOffset = kHeaderStageInfoOffset_0;
+const int kHeaderGeomInvocationIdOffset = kHeaderStageInfoOffset_1;
 
 // Ray Tracing Shader Output Record Offsets
-const int kInstRayTracingOutLaunchIdX = kInstCommonOutCnt;
-const int kInstRayTracingOutLaunchIdY = kInstCommonOutCnt + 1;
-const int kInstRayTracingOutLaunchIdZ = kInstCommonOutCnt + 2;
+const int kHeaderRayTracingLaunchIdXOffset = kHeaderStageInfoOffset_0;
+const int kHeaderRayTracingLaunchIdYOffset = kHeaderStageInfoOffset_1;
+const int kHeaderRayTracingLaunchIdZOffset = kHeaderStageInfoOffset_2;
 
 // Mesh Shader Output Record Offsets
-const int kInstMeshOutGlobalInvocationIdX = kInstCommonOutCnt;
-const int kInstMeshOutGlobalInvocationIdY = kInstCommonOutCnt + 1;
-const int kInstMeshOutGlobalInvocationIdZ = kInstCommonOutCnt + 2;
+const int kHeaderMeshGlobalInvocationIdXOffset = kHeaderStageInfoOffset_0;
+const int kHeaderMeshGlobalInvocationIdYOffset = kHeaderStageInfoOffset_1;
+const int kHeaderMeshGlobalInvocationIdZOffset = kHeaderStageInfoOffset_2;
 
 // Task Shader Output Record Offsets
-const int kInstTaskOutGlobalInvocationIdX = kInstCommonOutCnt;
-const int kInstTaskOutGlobalInvocationIdY = kInstCommonOutCnt + 1;
-const int kInstTaskOutGlobalInvocationIdZ = kInstCommonOutCnt + 2;
+const int kHeaderTaskGlobalInvocationIdXOffset = kHeaderStageInfoOffset_0;
+const int kHeaderTaskGlobalInvocationIdYOffset = kHeaderStageInfoOffset_1;
+const int kHeaderTaskGlobalInvocationIdZOffset = kHeaderStageInfoOffset_2;
 
-// Error Group
-//
-// These will match one-for-one with the file found in gpu_shader folder
-const int kErrorGroupInstBindlessDescriptor = 1;
-const int kErrorGroupInstBufferDeviceAddress = 2;
-const int kErrorGroupInstRayQuery = 3;
-const int kErrorGroupGpuPreDraw = 4;
-const int kErrorGroupGpuPreDispatch = 5;
-const int kErrorGroupGpuPreTraceRays = 6;
-const int kErrorGroupGpuCopyBufferToImage = 7;
+// This identifies the validation error
+// We use groups to more easily mangage the many int values not conflicting
+const int kHeaderErrorGroupOffset = 7;
+const int kHeaderErrorSubCodeOffset = 8;
 
-// Bindless Descriptor
-//
-const int kErrorSubCodeBindlessDescriptorBounds = 1;
-const int kErrorSubCodeBindlessDescriptorUninit = 2;
-const int kErrorSubCodeBindlessDescriptorOOB = 3;
-const int kErrorSubCodeBindlessDescriptorDestroyed = 4;
+const int kHeaderSize = 9;
+
+// Error specific parameters offsets:
+// ----------------------------------
 
 // A bindless bounds error will output the index and the bound.
-const int kInstBindlessBoundsOutDescSet = kErrorSubCode + 1;
-const int kInstBindlessBoundsOutDescBinding = kErrorSubCode + 2;
-const int kInstBindlessBoundsOutDescIndex = kErrorSubCode + 3;
-const int kInstBindlessBoundsOutDescBound = kErrorSubCode + 4;
-const int kInstBindlessBoundsOutUnused = kErrorSubCode + 5;
-const int kInstBindlessBoundsOutCnt = kErrorSubCode + 6;
+const int kInstBindlessBoundsDescSetOffset = kHeaderSize;
+const int kInstBindlessBoundsDescBindingOffset = kHeaderSize + 1;
+const int kInstBindlessBoundsDescIndexOffset = kHeaderSize + 2;
+const int kInstBindlessBoundsDescBoundOffset = kHeaderSize + 3;
+const int kInstBindlessBoundsUnusedOffset = kHeaderSize + 4;
+const int kInstBindlessBoundsCntOffset = kHeaderSize + 5;
 
 // A descriptor uninitialized error will output the index.
-const int kInstBindlessUninitOutDescSet = kErrorSubCode + 1;
-const int kInstBindlessUninitOutBinding = kErrorSubCode + 2;
-const int kInstBindlessUninitOutDescIndex = kErrorSubCode + 3;
-const int kInstBindlessUninitOutUnused = kErrorSubCode + 4;
-const int kInstBindlessUninitOutUnused2 = kErrorSubCode + 5;
-const int kInstBindlessUninitOutCnt = kErrorSubCode + 6;
+const int kInstBindlessUninitDescSetOffset = kHeaderSize;
+const int kInstBindlessUninitBindingOffset = kHeaderSize + 1;
+const int kInstBindlessUninitDescIndexOffset = kHeaderSize + 2;
+const int kInstBindlessUninitUnusedOffset = kHeaderSize + 3;
+const int kInstBindlessUninitOutUnused2 = kHeaderSize + 4;
+const int kInstBindlessUninitCntOffset = kHeaderSize + 5;
 
 // A buffer out-of-bounds error will output the descriptor
 // index, the buffer offset and the buffer size
-const int kInstBindlessBuffOOBOutDescSet = kErrorSubCode + 1;
-const int kInstBindlessBuffOOBOutDescBinding = kErrorSubCode + 2;
-const int kInstBindlessBuffOOBOutDescIndex = kErrorSubCode + 3;
-const int kInstBindlessBuffOOBOutBuffOff = kErrorSubCode + 4;
-const int kInstBindlessBuffOOBOutBuffSize = kErrorSubCode + 5;
-const int kInstBindlessBuffOOBOutCnt = kErrorSubCode + 6;
-
-// Buffer Device Address
-//
-const int kErrorSubCodeBufferDeviceAddressUnallocRef = 1;
+const int kInstBindlessBuffOOBDescSetOffset = kHeaderSize;
+const int kInstBindlessBuffOOBDescBindingOffset = kHeaderSize + 1;
+const int kInstBindlessBuffOOBDescIndexOffset = kHeaderSize + 2;
+const int kInstBindlessBuffOOBBuffOffOffset = kHeaderSize + 3;
+const int kInstBindlessBuffOOBBuffSizeOffset = kHeaderSize + 4;
+const int kInstBindlessBuffOOBCntOffset = kHeaderSize + 5;
 
 // A buffer address unalloc error will output the 64-bit pointer in
 // two 32-bit pieces, lower bits first.
-const int kInstBuffAddrUnallocOutDescPtrLo = kErrorSubCode + 1;
-const int kInstBuffAddrUnallocOutDescPtrHi = kErrorSubCode + 2;
-const int kInstBuffAddrUnallocOutCnt = kErrorSubCode + 3;
+const int kInstBuffAddrUnallocDescPtrLoOffset = kHeaderSize;
+const int kInstBuffAddrUnallocDescPtrHiOffset = kHeaderSize + 1;
+const int kInstBuffAddrUnallocCntOffset = kHeaderSize + 2;
 
-// Ray Query
-//
-const int kErrorSubCodeRayQueryNegativeMin = 1;
-const int kErrorSubCodeRayQueryNegativeMax = 2;
-const int kErrorSubCodeRayQueryBothSkip = 3;
-const int kErrorSubCodeRayQuerySkipCull = 4;
-const int kErrorSubCodeRayQueryOpaque = 5;
-const int kErrorSubCodeRayQueryMinMax = 6;
-const int kErrorSubCodeRayQueryMinNaN = 7;
-const int kErrorSubCodeRayQueryMaxNaN = 8;
-const int kErrorSubCodeRayQueryOriginNaN = 9;
-const int kErrorSubCodeRayQueryDirectionNaN = 10;
-const int kErrorSubCodeRayQueryOriginFinite = 11;
-const int kErrorSubCodeRayQueryDirectionFinite = 12;
-
-const int kInstRayQueryOutParam0 = kErrorSubCode + 1;
+const int kInstRayQueryParamOffset_0 = kHeaderSize;
 
 // Used by all "Pre" shaders
-const int kPreActionOutParam0 = kErrorSubCode + 1;
-const int kPreActionOutParam1 = kErrorSubCode + 2;
+const int kPreActionParamOffset_0 = kHeaderSize;
+const int kPreActionParamOffset_1 = kHeaderSize + 1;
 
-// Pre Draw
-//
-const int kErrorSubCodePreDrawBufferSize = 1;
-const int kErrorSubCodePreDrawCountLimit = 2;
-const int kErrorSubCodePreDrawFirstInstance = 3;
-const int kErrorSubCodePreDrawGroupCountX = 4;
-const int kErrorSubCodePreDrawGroupCountY = 5;
-const int kErrorSubCodePreDrawGroupCountZ = 6;
-const int kErrorSubCodePreDrawGroupCountTotal = 7;
-
-const int kPreDrawSelectCountBuffer = 1;
-const int kPreDrawSelectDrawBuffer = 2;
-const int kPreDrawSelectMeshCountBuffer = 3;
-const int kPreDrawSelectMeshNoCount = 4;
-
-// Pre Dispatch
-//
-const int kErrorSubCodePreDispatchCountLimitX = 1;
-const int kErrorSubCodePreDispatchCountLimitY = 2;
-const int kErrorSubCodePreDispatchCountLimitZ = 3;
-
-// Pre Tracy Rays
-//
-const int kErrorSubCodePreTraceRaysLimitWidth = 1;
-const int kErrorSubCodePreTraceRaysLimitHeight = 2;
-const int kErrorSubCodePreTraceRaysLimitDepth = 3;
-
-// Pre Copy Buffer To Image
-//
-const int kErrorSubCodePreCopyBufferToImageBufferTexel = 1;
+// Maximum record size
+const int kMaxErrorRecordSize = kHeaderSize + 7;
 
 #ifdef __cplusplus
 }  // namespace glsl

--- a/layers/gpu_shaders/gpu_pre_action.h
+++ b/layers/gpu_shaders/gpu_pre_action.h
@@ -17,7 +17,7 @@
 #include "gpu_error_constants.h"
 #include "gpu_shaders_constants.h"
 
-#define ERROR_RECORD_WORDS_COUNT kErrorGroup + 4
+#define ERROR_RECORD_WORDS_COUNT kHeaderErrorGroupOffset + 4
 
 layout(set = 0, binding = 0) buffer OutputBuffer {
     uint flags;
@@ -29,8 +29,8 @@ void gpuavLogError(uint error_group, uint error_sub_code, uint param_0, uint par
     uint vo_idx = atomicAdd(output_buffer_count, ERROR_RECORD_WORDS_COUNT);
     if (vo_idx + ERROR_RECORD_WORDS_COUNT > output_buffer.length()) return;
 
-    output_buffer[vo_idx + kErrorGroup] = error_group;
-    output_buffer[vo_idx + kErrorSubCode] = error_sub_code;
-    output_buffer[vo_idx + kPreActionOutParam0] = param_0;
-    output_buffer[vo_idx + kPreActionOutParam1] = param_1;
+    output_buffer[vo_idx + kHeaderErrorGroupOffset] = error_group;
+    output_buffer[vo_idx + kHeaderErrorSubCodeOffset] = error_sub_code;
+    output_buffer[vo_idx + kPreActionParamOffset_0] = param_0;
+    output_buffer[vo_idx + kPreActionParamOffset_1] = param_1;
 }

--- a/layers/gpu_shaders/inst_bindless_descriptor.comp
+++ b/layers/gpu_shaders/inst_bindless_descriptor.comp
@@ -172,8 +172,10 @@ bool inst_bindless_descriptor(const uint inst_num, const uvec4 stage_info, const
             inst_output_buffer.data[write_pos + 4u] = stage_info.y;
             inst_output_buffer.data[write_pos + 5u] = stage_info.z;
             inst_output_buffer.data[write_pos + 6u] = stage_info.w;
+
             inst_output_buffer.data[write_pos + 7u] = kErrorGroupInstBindlessDescriptor;
             inst_output_buffer.data[write_pos + 8u] = error;
+            
             inst_output_buffer.data[write_pos + 9u] = desc_set;
             inst_output_buffer.data[write_pos + 10u] = binding;
             inst_output_buffer.data[write_pos + 11u] = desc_index;

--- a/layers/gpu_shaders/inst_ray_query.comp
+++ b/layers/gpu_shaders/inst_ray_query.comp
@@ -120,8 +120,10 @@ bool inst_ray_query_comp(const uint inst_num, const uvec4 stage_info, const uint
             inst_output_buffer.data[write_pos + 4u] = stage_info.y;
             inst_output_buffer.data[write_pos + 5u] = stage_info.z;
             inst_output_buffer.data[write_pos + 6u] = stage_info.w;
+
             inst_output_buffer.data[write_pos + 7u] = kErrorGroupInstRayQuery;
             inst_output_buffer.data[write_pos + 8u] = error;
+            
             inst_output_buffer.data[write_pos + 9u] = param_0;
         }
         return false;

--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -30,67 +30,75 @@
 static void GenerateStageMessage(const uint32_t *debug_record, std::string &msg) {
     using namespace gpuav::glsl;
     std::ostringstream strm;
-    switch (debug_record[kInstCommonOutStageIdx]) {
+    switch (debug_record[kHeaderStageIdOffset]) {
         case spv::ExecutionModelVertex: {
-            strm << "Stage = Vertex. Vertex Index = " << debug_record[kInstVertOutVertexIndex]
-                 << " Instance Index = " << debug_record[kInstVertOutInstanceIndex] << ". ";
+            strm << "Stage = Vertex. Vertex Index = " << debug_record[kHeaderVertexIndexOffset]
+                 << " Instance Index = " << debug_record[kHeaderVertInstanceIndexOffset] << ". ";
         } break;
         case spv::ExecutionModelTessellationControl: {
-            strm << "Stage = Tessellation Control.  Invocation ID = " << debug_record[kInstTessCtlOutInvocationId]
-                 << ", Primitive ID = " << debug_record[kInstTessCtlOutPrimitiveId];
+            strm << "Stage = Tessellation Control.  Invocation ID = " << debug_record[kHeaderTessCltInvocationIdOffset]
+                 << ", Primitive ID = " << debug_record[kHeaderTessCtlPrimitiveIdOffset];
         } break;
         case spv::ExecutionModelTessellationEvaluation: {
-            strm << "Stage = Tessellation Eval.  Primitive ID = " << debug_record[kInstTessEvalOutPrimitiveId]
-                 << ", TessCoord (u, v) = (" << debug_record[kInstTessEvalOutTessCoordU] << ", "
-                 << debug_record[kInstTessEvalOutTessCoordV] << "). ";
+            strm << "Stage = Tessellation Eval.  Primitive ID = " << debug_record[kHeaderTessEvalPrimitiveIdOffset]
+                 << ", TessCoord (u, v) = (" << debug_record[kHeaderTessEvalCoordUOffset] << ", "
+                 << debug_record[kHeaderTessEvalCoordVOffset] << "). ";
         } break;
         case spv::ExecutionModelGeometry: {
-            strm << "Stage = Geometry.  Primitive ID = " << debug_record[kInstGeomOutPrimitiveId]
-                 << " Invocation ID = " << debug_record[kInstGeomOutInvocationId] << ". ";
+            strm << "Stage = Geometry.  Primitive ID = " << debug_record[kHeaderGeomPrimitiveIdOffset]
+                 << " Invocation ID = " << debug_record[kHeaderGeomInvocationIdOffset] << ". ";
         } break;
         case spv::ExecutionModelFragment: {
             strm << "Stage = Fragment.  Fragment coord (x,y) = ("
-                 << *reinterpret_cast<const float *>(&debug_record[kInstFragOutFragCoordX]) << ", "
-                 << *reinterpret_cast<const float *>(&debug_record[kInstFragOutFragCoordY]) << "). ";
+                 << *reinterpret_cast<const float *>(&debug_record[kHeaderFragCoordXOffset]) << ", "
+                 << *reinterpret_cast<const float *>(&debug_record[kHeaderFragCoordYOffset]) << "). ";
         } break;
         case spv::ExecutionModelGLCompute: {
-            strm << "Stage = Compute.  Global invocation ID (x, y, z) = (" << debug_record[kInstCompOutGlobalInvocationIdX] << ", "
-                 << debug_record[kInstCompOutGlobalInvocationIdY] << ", " << debug_record[kInstCompOutGlobalInvocationIdZ] << " )";
+            strm << "Stage = Compute.  Global invocation ID (x, y, z) = (" << debug_record[kHeaderInvocationIdXOffset] << ", "
+                 << debug_record[kHeaderInvocationIdYOffset] << ", " << debug_record[kHeaderInvocationIdZOffset] << " )";
         } break;
         case spv::ExecutionModelRayGenerationNV: {
-            strm << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset]
+                 << ", " << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelIntersectionNV: {
-            strm << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset] << ", "
+                 << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelAnyHitNV: {
-            strm << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset] << ", "
+                 << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelClosestHitNV: {
-            strm << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset] << ", "
+                 << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelMissNV: {
-            strm << "Stage = Miss.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Miss.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset] << ", "
+                 << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelCallableNV: {
-            strm << "Stage = Callable.  Global Launch ID (x,y,z) = (" << debug_record[kInstRayTracingOutLaunchIdX] << ", "
-                 << debug_record[kInstRayTracingOutLaunchIdY] << ", " << debug_record[kInstRayTracingOutLaunchIdZ] << "). ";
+            strm << "Stage = Callable.  Global Launch ID (x,y,z) = (" << debug_record[kHeaderRayTracingLaunchIdXOffset] << ", "
+                 << debug_record[kHeaderRayTracingLaunchIdYOffset] << ", " << debug_record[kHeaderRayTracingLaunchIdZOffset]
+                 << "). ";
         } break;
         case spv::ExecutionModelTaskNV: {
-            strm << "Stage = Task. Global invocation ID (x, y, z) = (" << debug_record[kInstTaskOutGlobalInvocationIdX] << ", "
-                 << debug_record[kInstTaskOutGlobalInvocationIdY] << ", " << debug_record[kInstTaskOutGlobalInvocationIdZ] << " )";
+            strm << "Stage = Task. Global invocation ID (x, y, z) = (" << debug_record[kHeaderTaskGlobalInvocationIdXOffset] << ", "
+                 << debug_record[kHeaderTaskGlobalInvocationIdYOffset] << ", " << debug_record[kHeaderTaskGlobalInvocationIdZOffset]
+                 << " )";
         } break;
         case spv::ExecutionModelMeshNV: {
-            strm << "Stage = Mesh.Global invocation ID (x, y, z) = (" << debug_record[kInstMeshOutGlobalInvocationIdX] << ", "
-                 << debug_record[kInstMeshOutGlobalInvocationIdY] << ", " << debug_record[kInstMeshOutGlobalInvocationIdZ] << " )";
+            strm << "Stage = Mesh.Global invocation ID (x, y, z) = (" << debug_record[kHeaderMeshGlobalInvocationIdXOffset] << ", "
+                 << debug_record[kHeaderMeshGlobalInvocationIdYOffset] << ", " << debug_record[kHeaderMeshGlobalInvocationIdZOffset]
+                 << " )";
         } break;
         default: {
-            strm << "Internal Error (unexpected stage = " << debug_record[kInstCommonOutStageIdx] << "). ";
+            strm << "Internal Error (unexpected stage = " << debug_record[kHeaderStageIdOffset] << "). ";
             assert(false);
         } break;
     }
@@ -149,7 +157,7 @@ void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCom
         }
     }
     strm << std::dec << std::noshowbase;
-    strm << "Shader Instruction Index = " << debug_record[kInstCommonOutInstructionIdx] << ". ";
+    strm << "Shader Instruction Index = " << debug_record[gpuav::glsl::kHeaderInstructionIdOffset] << ". ";
     msg = strm.str();
 }
 
@@ -250,7 +258,7 @@ void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *d
             reported_line_number = insn.Word(2);
             reported_column_number = insn.Word(3);
         }
-        if (instruction_index == debug_record[kInstCommonOutInstructionIdx]) {
+        if (instruction_index == debug_record[gpuav::glsl::kHeaderInstructionIdOffset]) {
             break;
         }
         instruction_index++;
@@ -357,35 +365,35 @@ bool gpuav::Validator::LogMessageInstBindlessDescriptor(const uint32_t *debug_re
     std::ostringstream strm;
     const GpuVuid vuid = GetGpuVuid(cmd_resources.command);
 
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodeBindlessDescriptorBounds: {
-            strm << "(set = " << debug_record[kInstBindlessBoundsOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessBoundsOutDescBinding] << ") Index of "
-                 << debug_record[kInstBindlessBoundsOutDescIndex] << " used to index descriptor array of length "
-                 << debug_record[kInstBindlessBoundsOutDescBound] << ".";
+            strm << "(set = " << debug_record[kInstBindlessBoundsDescSetOffset]
+                 << ", binding = " << debug_record[kInstBindlessBoundsDescBindingOffset] << ") Index of "
+                 << debug_record[kInstBindlessBoundsDescIndexOffset] << " used to index descriptor array of length "
+                 << debug_record[kInstBindlessBoundsDescBoundOffset] << ".";
             out_vuid_msg = "UNASSIGNED-Descriptor index out of bounds";
             error_found = true;
         } break;
         case kErrorSubCodeBindlessDescriptorUninit: {
-            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
-                 << debug_record[kInstBindlessUninitOutDescIndex] << " is uninitialized.";
+            strm << "(set = " << debug_record[kInstBindlessUninitDescSetOffset]
+                 << ", binding = " << debug_record[kInstBindlessUninitBindingOffset] << ") Descriptor index "
+                 << debug_record[kInstBindlessUninitDescIndexOffset] << " is uninitialized.";
             out_vuid_msg = vuid.invalid_descriptor;
             error_found = true;
         } break;
         case kErrorSubCodeBindlessDescriptorDestroyed: {
-            strm << "(set = " << debug_record[kInstBindlessUninitOutDescSet]
-                 << ", binding = " << debug_record[kInstBindlessUninitOutBinding] << ") Descriptor index "
-                 << debug_record[kInstBindlessUninitOutDescIndex] << " references a resource that was destroyed.";
+            strm << "(set = " << debug_record[kInstBindlessUninitDescSetOffset]
+                 << ", binding = " << debug_record[kInstBindlessUninitBindingOffset] << ") Descriptor index "
+                 << debug_record[kInstBindlessUninitDescIndexOffset] << " references a resource that was destroyed.";
             out_vuid_msg = "UNASSIGNED-Descriptor destroyed";
             error_found = true;
         } break;
         case kErrorSubCodeBindlessDescriptorOOB: {
-            const uint32_t set_num = debug_record[kInstBindlessBuffOOBOutDescSet];
-            const uint32_t binding_num = debug_record[kInstBindlessBuffOOBOutDescBinding];
-            const uint32_t desc_index = debug_record[kInstBindlessBuffOOBOutDescIndex];
-            const uint32_t size = debug_record[kInstBindlessBuffOOBOutBuffSize];
-            const uint32_t offset = debug_record[kInstBindlessBuffOOBOutBuffOff];
+            const uint32_t set_num = debug_record[kInstBindlessBuffOOBDescSetOffset];
+            const uint32_t binding_num = debug_record[kInstBindlessBuffOOBDescBindingOffset];
+            const uint32_t desc_index = debug_record[kInstBindlessBuffOOBDescIndexOffset];
+            const uint32_t size = debug_record[kInstBindlessBuffOOBBuffSizeOffset];
+            const uint32_t offset = debug_record[kInstBindlessBuffOOBBuffOffOffset];
             const auto *binding_state = descriptor_sets[set_num].state->GetBinding(binding_num);
             assert(binding_state);
             if (size == 0) {
@@ -443,10 +451,10 @@ bool gpuav::Validator::LogMessageInstBufferDeviceAddress(const uint32_t *debug_r
     using namespace glsl;
     bool error_found = true;
     std::ostringstream strm;
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodeBufferDeviceAddressUnallocRef: {
             out_oob_access = true;
-            uint64_t *ptr = (uint64_t *)&debug_record[kInstBuffAddrUnallocOutDescPtrLo];
+            uint64_t *ptr = (uint64_t *)&debug_record[kInstBuffAddrUnallocDescPtrLoOffset];
             strm << "Device address 0x" << std::hex << *ptr << " access out of bounds. ";
             out_vuid_msg = "UNASSIGNED-Device address out of bounds";
         } break;
@@ -463,7 +471,7 @@ bool gpuav::Validator::LogMessageInstRayQuery(const uint32_t *debug_record, std:
     using namespace glsl;
     bool error_found = true;
     std::ostringstream strm;
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodeRayQueryNegativeMin: {
             // TODO - Figure a way to properly use GLSL floatBitsToUint and print the float values
             strm << "OpRayQueryInitializeKHR operand Ray Tmin value is negative. ";
@@ -502,17 +510,17 @@ bool gpuav::Validator::LogMessageInstRayQuery(const uint32_t *debug_record, std:
             out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348";
         } break;
         case kErrorSubCodeRayQueryBothSkip: {
-            const uint32_t value = debug_record[kInstRayQueryOutParam0];
+            const uint32_t value = debug_record[kInstRayQueryParamOffset_0];
             strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
             out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889";
         } break;
         case kErrorSubCodeRayQuerySkipCull: {
-            const uint32_t value = debug_record[kInstRayQueryOutParam0];
+            const uint32_t value = debug_record[kInstRayQueryParamOffset_0];
             strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
             out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06890";
         } break;
         case kErrorSubCodeRayQueryOpaque: {
-            const uint32_t value = debug_record[kInstRayQueryOutParam0];
+            const uint32_t value = debug_record[kInstRayQueryParamOffset_0];
             strm << "OpRayQueryInitializeKHR operand Ray Flags is 0x" << std::hex << value << ". ";
             out_vuid_msg = "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891";
         } break;
@@ -558,7 +566,7 @@ bool gpuav::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer cmd_buffer, Vk
     const uint32_t *debug_record = &debug_output_buffer[spvtools::kDebugOutputDataOffset];
     // Lookup the VkShaderModule handle and SPIR-V code used to create the shader, using the unique shader ID value returned
     // by the instrumented shader.
-    auto it = shader_map.find(debug_record[glsl::kInstCommonOutShaderId]);
+    auto it = shader_map.find(debug_record[glsl::kHeaderShaderIdOffset]);
     if (it != shader_map.end()) {
         shader_module_handle = it->second.shader_module;
         pipeline_handle = it->second.pipeline;
@@ -570,7 +578,7 @@ bool gpuav::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer cmd_buffer, Vk
     std::string vuid_msg;
     bool oob_access = false;
     bool error_found = false;
-    switch (debug_record[glsl::kErrorGroup]) {
+    switch (debug_record[glsl::kHeaderErrorGroupOffset]) {
         case glsl::kErrorGroupInstBindlessDescriptor:
             error_found =
                 LogMessageInstBindlessDescriptor(debug_record, error_msg, vuid_msg, cmd_resources, descriptor_sets, oob_access);
@@ -655,17 +663,17 @@ bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
                                                          const LogObjectList &objlist) {
     using namespace glsl;
     bool error_logged = false;
-    if (debug_record[kErrorGroup] != kErrorGroupGpuPreDraw) {
+    if (debug_record[kHeaderErrorGroupOffset] != kErrorGroupGpuPreDraw) {
         return error_logged;
     }
 
     const GpuVuid &vuids = GetGpuVuid(command);
     const Location loc(command);
 
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodePreDrawBufferSize: {
             // Buffer size must be >= (stride * (drawCount - 1) + offset + sizeof(VkDrawIndexedIndirectCommand))
-            const uint32_t count = debug_record[kPreActionOutParam0];
+            const uint32_t count = debug_record[kPreActionParamOffset_0];
             const uint32_t stride = indirect_buffer_stride;
             const uint32_t offset =
                 static_cast<uint32_t>(indirect_buffer_offset);  // TODO: why cast to uin32_t? If it is changed, think about
@@ -689,7 +697,7 @@ bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
             break;
         }
         case kErrorSubCodePreDrawCountLimit: {
-            const uint32_t count = debug_record[kPreActionOutParam0];
+            const uint32_t count = debug_record[kPreActionParamOffset_0];
             validator.LogError(vuids.count_exceeds_device_limit, objlist, loc,
                                "Indirect draw count of %" PRIu32 " would exceed maxDrawIndirectCount limit of %" PRIu32 ".", count,
                                validator.phys_dev_props.limits.maxDrawIndirectCount);
@@ -697,7 +705,7 @@ bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
             break;
         }
         case kErrorSubCodePreDrawFirstInstance: {
-            const uint32_t index = debug_record[kPreActionOutParam0];
+            const uint32_t index = debug_record[kPreActionParamOffset_0];
             validator.LogError(
                 vuids.first_instance_not_zero, objlist, loc,
                 "The drawIndirectFirstInstance feature is not enabled, but the firstInstance member of the %s structure at "
@@ -709,24 +717,24 @@ bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
         case kErrorSubCodePreDrawGroupCountX:
         case kErrorSubCodePreDrawGroupCountY:
         case kErrorSubCodePreDrawGroupCountZ: {
-            const uint32_t group_count = debug_record[kPreActionOutParam0];
-            const uint32_t draw_number = debug_record[kPreActionOutParam1];
+            const uint32_t group_count = debug_record[kPreActionParamOffset_0];
+            const uint32_t draw_number = debug_record[kPreActionParamOffset_1];
             const char *count_label;
             uint32_t index;
             uint32_t limit;
             const char *vuid;
-            if (debug_record[kErrorSubCode] == kErrorSubCodePreDrawGroupCountX) {
+            if (debug_record[kHeaderErrorSubCodeOffset] == kErrorSubCodePreDrawGroupCountX) {
                 count_label = "groupCountX";
                 index = 0;
                 vuid = emit_task_error ? vuids.task_group_count_exceeds_max_x : vuids.mesh_group_count_exceeds_max_x;
                 limit = validator.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupCount[0];
-            } else if (debug_record[kErrorSubCode] == kErrorSubCodePreDrawGroupCountY) {
+            } else if (debug_record[kHeaderErrorSubCodeOffset] == kErrorSubCodePreDrawGroupCountY) {
                 count_label = "groupCountY";
                 index = 1;
                 vuid = emit_task_error ? vuids.task_group_count_exceeds_max_y : vuids.mesh_group_count_exceeds_max_y;
                 limit = validator.phys_dev_ext_props.mesh_shader_props_ext.maxMeshWorkGroupCount[1];
             } else {
-                assert(debug_record[kErrorSubCode] == kErrorSubCodePreDrawGroupCountZ);
+                assert(debug_record[kHeaderErrorSubCodeOffset] == kErrorSubCodePreDrawGroupCountZ);
                 count_label = "groupCountZ";
                 index = 2;
                 vuid = emit_task_error ? vuids.task_group_count_exceeds_max_z : vuids.mesh_group_count_exceeds_max_z;
@@ -741,8 +749,8 @@ bool gpuav::PreDrawResources::LogCustomValidationMessage(gpuav::Validator &valid
             break;
         }
         case kErrorSubCodePreDrawGroupCountTotal: {
-            const uint32_t total_count = debug_record[kPreActionOutParam0];
-            const uint32_t draw_number = debug_record[kPreActionOutParam1];
+            const uint32_t total_count = debug_record[kPreActionParamOffset_0];
+            const uint32_t draw_number = debug_record[kPreActionParamOffset_1];
             auto vuid = emit_task_error ? vuids.task_group_count_exceeds_max_total : vuids.mesh_group_count_exceeds_max_total;
             validator.LogError(
                 vuid, objlist, loc,
@@ -763,14 +771,14 @@ bool gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &v
                                                              const LogObjectList &objlist) {
     using namespace glsl;
     bool error_logged = false;
-    if (debug_record[kErrorGroup] != kErrorGroupGpuPreDispatch) {
+    if (debug_record[kHeaderErrorGroupOffset] != kErrorGroupGpuPreDispatch) {
         return error_logged;
     }
 
     const Location loc(command);
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodePreDispatchCountLimitX: {
-            uint32_t count = debug_record[kPreActionOutParam0];
+            uint32_t count = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkDispatchIndirectCommand-x-00417", objlist, loc,
                                "Indirect dispatch VkDispatchIndirectCommand::x of %" PRIu32
                                " would exceed maxComputeWorkGroupCount[0] limit of %" PRIu32 ".",
@@ -779,7 +787,7 @@ bool gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &v
             break;
         }
         case kErrorSubCodePreDispatchCountLimitY: {
-            uint32_t count = debug_record[kPreActionOutParam0];
+            uint32_t count = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkDispatchIndirectCommand-y-00418", objlist, loc,
                                "Indirect dispatch VkDispatchIndirectCommand::y of %" PRIu32
                                " would exceed maxComputeWorkGroupCount[1] limit of %" PRIu32 ".",
@@ -788,7 +796,7 @@ bool gpuav::PreDispatchResources::LogCustomValidationMessage(gpuav::Validator &v
             break;
         }
         case kErrorSubCodePreDispatchCountLimitZ: {
-            uint32_t count = debug_record[kPreActionOutParam0];
+            uint32_t count = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkDispatchIndirectCommand-z-00419", objlist, loc,
                                "Indirect dispatch VkDispatchIndirectCommand::z of %" PRIu32
                                " would exceed maxComputeWorkGroupCount[2] limit of %" PRIu32 ".",
@@ -809,13 +817,13 @@ bool gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
 
     const Location loc(command);
     bool error_logged = false;
-    if (debug_record[kErrorGroup] != kErrorGroupGpuPreTraceRays) {
+    if (debug_record[kHeaderErrorGroupOffset] != kErrorGroupGpuPreTraceRays) {
         return error_logged;
     }
 
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodePreTraceRaysLimitWidth: {
-            const uint32_t width = debug_record[kPreActionOutParam0];
+            const uint32_t width = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkTraceRaysIndirectCommandKHR-width-03638", objlist, loc,
                                "Indirect trace rays of VkTraceRaysIndirectCommandKHR::width of %" PRIu32
                                " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[0] * "
@@ -827,7 +835,7 @@ bool gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
             break;
         }
         case kErrorSubCodePreTraceRaysLimitHeight: {
-            uint32_t height = debug_record[kPreActionOutParam0];
+            uint32_t height = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkTraceRaysIndirectCommandKHR-height-03639", objlist, loc,
                                "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[1] * "
@@ -839,7 +847,7 @@ bool gpuav::PreTraceRaysResources::LogCustomValidationMessage(gpuav::Validator &
             break;
         }
         case kErrorSubCodePreTraceRaysLimitDepth: {
-            uint32_t depth = debug_record[kPreActionOutParam0];
+            uint32_t depth = debug_record[kPreActionParamOffset_0];
             validator.LogError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640", objlist, loc,
                                "Indirect trace rays of VkTraceRaysIndirectCommandKHR::height of %" PRIu32
                                " would exceed VkPhysicalDeviceLimits::maxComputeWorkGroupCount[2] * "
@@ -862,13 +870,13 @@ bool gpuav::PreCopyBufferToImageResources::LogCustomValidationMessage(gpuav::Val
                                                                       const LogObjectList &objlist) {
     using namespace glsl;
     bool error_logged = false;
-    if (debug_record[kErrorGroup] != kErrorGroupGpuCopyBufferToImage) {
+    if (debug_record[kHeaderErrorGroupOffset] != kErrorGroupGpuCopyBufferToImage) {
         return error_logged;
     }
 
-    switch (debug_record[kErrorSubCode]) {
+    switch (debug_record[kHeaderErrorSubCodeOffset]) {
         case kErrorSubCodePreCopyBufferToImageBufferTexel: {
-            uint32_t texel_offset = debug_record[kPreActionOutParam0];
+            uint32_t texel_offset = debug_record[kPreActionParamOffset_0];
             LogObjectList objlist_and_src_buffer = objlist;
             objlist_and_src_buffer.add(this->src_buffer);
             const char *vuid = this->command == vvl::Func::vkCmdCopyBufferToImage ? "VUID-vkCmdCopyBufferToImage-pRegions-07931"

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -162,7 +162,7 @@ void gpuav::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const
                    "Use of descriptor buffers will result in no descriptor checking");
     }
 
-    output_buffer_size = sizeof(uint32_t) * (glsl::kInstMaxOutCnt + spvtools::kDebugOutputDataOffset);
+    output_buffer_size = sizeof(uint32_t) * (glsl::kMaxErrorRecordSize + spvtools::kDebugOutputDataOffset);
 
     if (gpuav_settings.validate_descriptors && !force_buffer_device_address) {
         gpuav_settings.validate_descriptors = false;

--- a/layers/vulkan/generated/gpu_inst_shader_hash.h
+++ b/layers/vulkan/generated/gpu_inst_shader_hash.h
@@ -24,4 +24,4 @@
 
 #pragma once
 
-#define INST_SHADER_GIT_HASH "cc590782907ff9c6c9730ab88e72001b514a0fae"
+#define INST_SHADER_GIT_HASH "af50035a9884f4cd3b1d773f608cdfd5643e2d51"


### PR DESCRIPTION
Renamed constants, to clarify intents. Added `Offset` suffix to values representing offsets.
gpu_error_constants now includes `gpu_error_codes.h`, a file holding constant values used to retrieve VUIDs