### PR TITLE
Rename gpu_error_constants.h -> gpu_error_header.h

### DIFF
--- a/layers/gpu_shaders/gpu_pre_action.h
+++ b/layers/gpu_shaders/gpu_pre_action.h
@@ -14,7 +14,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "gpu_error_constants.h"
+#include "gpu_error_header.h"
 #include "gpu_shaders_constants.h"
 
 #define ERROR_RECORD_WORDS_COUNT kHeaderErrorGroupOffset + 4

--- a/layers/gpu_shaders/inst_bindless_descriptor.comp
+++ b/layers/gpu_shaders/inst_bindless_descriptor.comp
@@ -26,7 +26,7 @@
 #error No extension available for 64-bit integers.
 #endif
 
-#include "gpu_error_constants.h"
+#include "gpu_error_header.h"
 #include "gpu_shaders_constants.h"
 
 layout(buffer_reference) buffer DescriptorSetData;

--- a/layers/gpu_shaders/inst_buffer_device_address.comp
+++ b/layers/gpu_shaders/inst_buffer_device_address.comp
@@ -26,7 +26,7 @@
 #error No extension available for 64-bit integers.
 #endif
 
-#include "gpu_error_constants.h"
+#include "gpu_error_header.h"
 #include "gpu_shaders_constants.h"
 
 layout(set = kDefaultDescriptorSet, binding = 0, std430) buffer inst_OutputBuffer {

--- a/layers/gpu_shaders/inst_ray_query.comp
+++ b/layers/gpu_shaders/inst_ray_query.comp
@@ -26,7 +26,7 @@
 #error No extension available for 64-bit integers.
 #endif
 
-#include "gpu_error_constants.h"
+#include "gpu_error_header.h"
 #include "gpu_shaders_constants.h"
 
 layout(set = kDefaultDescriptorSet, binding = 0, std430) buffer inst_OutputBuffer {


### PR DESCRIPTION
The header was renamed in #7631 but not all shaders were updated.