### PR TITLE
layers: Give UNASSIGNED VUs unique name

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1958,7 +1958,8 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     }
 
     // Validate correct image aspect bits for desired formats and format consistency
-    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_format, aspect_mask, image_state.disjoint, error_obj.location);
+    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_format, aspect_mask, image_state.disjoint, error_obj.location,
+                                    "UNASSIGNED-vkCreateImageView-InvalidImageAspect");
 
     // Valdiate Image/ImageView type compatibility #resources-image-views-compatibility
     switch (image_type) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2406,8 +2406,9 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
         skip |= ValidateBarrierQueueFamilies(objects, barrier_loc, image_loc, mem_barrier, image_data->Handle(),
                                              image_data->createInfo.sharingMode);
 
-        skip |= ValidateImageAspectMask(image_data->VkHandle(), image_data->createInfo.format,
-                                        mem_barrier.subresourceRange.aspectMask, image_data->disjoint, image_loc);
+        skip |=
+            ValidateImageAspectMask(image_data->VkHandle(), image_data->createInfo.format, mem_barrier.subresourceRange.aspectMask,
+                                    image_data->disjoint, image_loc, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
 
         skip |= ValidateImageBarrierSubresourceRange(image_data->createInfo, mem_barrier.subresourceRange, objects,
                                                      barrier_loc.dot(Field::subresourceRange));

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -983,8 +983,7 @@ class CoreChecks : public ValidationStateTracker {
                                          const ErrorObject& error_obj) const override;
 
     bool ValidateImageAspectMask(VkImage image, VkFormat format, VkImageAspectFlags aspect_mask, bool is_image_disjoint,
-                                 const Location& loc,
-                                 const char* vuid = "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect") const;
+                                 const Location& loc, const char* vuid) const;
 
     bool ValidateCreateImageViewSubresourceRange(const vvl::Image& image_state, bool is_imageview_2d_type,
                                                  const VkImageSubresourceRange& subresourceRange, const Location& loc) const;

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -2284,7 +2284,7 @@ TEST_F(NegativeImage, ImageViewAspect) {
     // Cause an error by setting an invalid image aspect
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-vkCreateImageView-InvalidImageAspect");
 }
 
 TEST_F(NegativeImage, GetImageSubresourceLayout) {
@@ -3528,7 +3528,7 @@ TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     image_view_create_info.subresourceRange.layerCount = 1;
     image_view_create_info.subresourceRange.levelCount = 1;
     image_view_create_info.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    CreateImageViewTest(*this, &image_view_create_info, "UNASSIGNED-vkCreateImageView-InvalidImageAspect");
 }
 
 TEST_F(NegativeImage, CornerSampledImageNV) {
@@ -4901,7 +4901,7 @@ TEST_F(NegativeImage, ColorWthDepthAspect) {
     civ_ci.subresourceRange.levelCount = 1;
     civ_ci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-vkCreateImageView-InvalidImageAspect");
     vkt::ImageView color_image_view(*m_device, civ_ci);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -251,7 +251,7 @@ TEST_F(NegativeImageDrm, ImageSubresourceRangeAspectMask) {
     ivci.subresourceRange.baseArrayLayer = 0;
     ivci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT;
 
-    m_errorMonitor->SetUnexpectedError("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetUnexpectedError("UNASSIGNED-vkCreateImageView-InvalidImageAspect");
     CreateImageViewTest(*this, &ivci, "VUID-VkImageSubresourceRange-aspectMask-02278");
 }
 

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -386,7 +386,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     // Not having DEPTH or STENCIL set is an error
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier-image-03319");
 
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -402,7 +402,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     // Having anything other than DEPTH and STENCIL is an error
     conc_test.image_barrier_.subresourceRange.aspectMask =
         VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
-    conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    conc_test("UNASSIGNED-ImageBarrier-InvalidImageAspect");
 
     // Now test depth-only
     VkFormatProperties format_props;
@@ -416,11 +416,11 @@ TEST_F(NegativeSyncObject, Barriers) {
 
         // DEPTH bit must be set
         conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
-        conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+        conc_test("UNASSIGNED-ImageBarrier-InvalidImageAspect");
 
         // No bits other than DEPTH may be set
         conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
-        conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+        conc_test("UNASSIGNED-ImageBarrier-InvalidImageAspect");
     }
 
     // Now test stencil-only
@@ -435,7 +435,7 @@ TEST_F(NegativeSyncObject, Barriers) {
         // Use of COLOR aspect on depth image is error
         conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         // must have the VK_IMAGE_ASPECT_STENCIL_BIT set
-        conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+        conc_test("UNASSIGNED-ImageBarrier-InvalidImageAspect");
     }
 
     // Finally test color
@@ -446,12 +446,12 @@ TEST_F(NegativeSyncObject, Barriers) {
 
     // COLOR bit must be set
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier-image-09241");
 
     // No bits other than COLOR may be set
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier-image-09241");
 
     // Test multip-planar image
@@ -523,11 +523,11 @@ TEST_F(NegativeSyncObject, Barriers) {
             conc_test("", "", VK_QUEUE_FAMILY_IGNORED, VK_QUEUE_FAMILY_IGNORED, true);
 
             conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
             conc_test("VUID-VkImageMemoryBarrier-image-01672");
 
             conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_PLANE_2_BIT;
-            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+            m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
             conc_test("VUID-VkImageMemoryBarrier-image-01672");
 
             vk::FreeMemory(device(), plane_0_memory, NULL);
@@ -902,7 +902,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     // Not having DEPTH or STENCIL set is an error
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
 
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     {
         conc_test("VUID-VkImageMemoryBarrier2-image-03320");
 
@@ -914,7 +914,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     // Having anything other than DEPTH and STENCIL is an error
     conc_test.image_barrier_.subresourceRange.aspectMask =
         VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT | VK_IMAGE_ASPECT_COLOR_BIT;
-    conc_test("UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    conc_test("UNASSIGNED-ImageBarrier-InvalidImageAspect");
 
     // Now test depth-only
     VkFormatProperties format_props;
@@ -957,12 +957,12 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
 
     // COLOR bit must be set
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier2-image-09241");
 
     // No bits other than COLOR may be set
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT | VK_IMAGE_ASPECT_DEPTH_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier2-image-09241");
 
     // A barrier's new and old VkImageLayout must be compatible with an image's VkImageUsageFlags.
@@ -1192,7 +1192,7 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparate) {
 
     // Not having DEPTH or STENCIL set is an error
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier-image-03320");
 
     // Having only one of depth or stencil set for DS image is an error
@@ -1231,7 +1231,7 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparateSync2) {
 
     // Not having DEPTH or STENCIL set is an error
     conc_test.image_barrier_.subresourceRange.aspectMask = VK_IMAGE_ASPECT_METADATA_BIT;
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-CoreValidation-DrawState-InvalidImageAspect");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "UNASSIGNED-ImageBarrier-InvalidImageAspect");
     conc_test("VUID-VkImageMemoryBarrier2-image-03320");
 
     // Having only one of depth or stencil set for DS image is an error


### PR DESCRIPTION
This just splits up `UNASSIGNED-vkCreateImageView-InvalidImageAspect` into `UNASSIGNED-vkCreateImageView-InvalidImageAspect` and `UNASSIGNED-ImageBarrier-InvalidImageAspect`

I am working on getting these dedicated VUID, but will be easier to find later