### PR TITLE
tests: Cleanup pipeline class

### DIFF
--- a/tests/framework/ray_tracing_helper_nv.cpp
+++ b/tests/framework/ray_tracing_helper_nv.cpp
@@ -162,15 +162,6 @@ void RayTracingPipelineHelper::InitInfo() {
     InitPipelineCacheInfo();
 }
 
-void RayTracingPipelineHelper::InitState() {
-    descriptor_set_.reset(new OneOffDescriptorSet(layer_test_.DeviceObj(), dsl_bindings_));
-    ASSERT_TRUE(descriptor_set_->Initialized());
-
-    pipeline_layout_ = vkt::PipelineLayout(*layer_test_.DeviceObj(), {&descriptor_set_->layout_});
-
-    InitPipelineCache();
-}
-
 void RayTracingPipelineHelper::InitPipelineCache() {
     if (pipeline_cache_ != VK_NULL_HANDLE) {
         vk::DestroyPipelineCache(layer_test_.device(), pipeline_cache_, nullptr);
@@ -181,6 +172,11 @@ void RayTracingPipelineHelper::InitPipelineCache() {
 
 void RayTracingPipelineHelper::LateBindPipelineInfo(bool isKHR) {
     // By value or dynamically located items must be late bound
+    descriptor_set_.reset(new OneOffDescriptorSet(layer_test_.DeviceObj(), dsl_bindings_));
+    ASSERT_TRUE(descriptor_set_->Initialized());
+
+    pipeline_layout_ = vkt::PipelineLayout(*layer_test_.DeviceObj(), {&descriptor_set_->layout_});
+
     if (isKHR) {
         rp_ci_KHR_.layout = pipeline_layout_.handle();
         rp_ci_KHR_.stageCount = shader_stages_.size();
@@ -193,6 +189,7 @@ void RayTracingPipelineHelper::LateBindPipelineInfo(bool isKHR) {
 }
 
 VkResult RayTracingPipelineHelper::CreateNVRayTracingPipeline(bool do_late_bind) {
+    InitPipelineCache();
     if (do_late_bind) {
         LateBindPipelineInfo();
     }

--- a/tests/framework/ray_tracing_helper_nv.h
+++ b/tests/framework/ray_tracing_helper_nv.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ class RayTracingPipelineHelper {
     void AddLibrary(const RayTracingPipelineHelper& library);
     void InitPipelineCacheInfo();
     void InitInfo();
-    void InitState();
     void InitPipelineCache();
     void LateBindPipelineInfo(bool isKHR = false);
     VkResult CreateNVRayTracingPipeline(bool do_late_bind = true);
@@ -69,7 +68,6 @@ class RayTracingPipelineHelper {
                             const VkFlags flags = kErrorBit) {
         RayTracingPipelineHelper helper(test);
         info_override(helper);
-        helper.InitState();
 
         for (const auto& error : errors) test.Monitor().SetDesiredFailureMsg(flags, error);
         helper.CreateNVRayTracingPipeline();
@@ -85,7 +83,6 @@ class RayTracingPipelineHelper {
     static void OneshotPositiveTest(Test& test, const OverrideFunc& info_override, const VkFlags message_flag_mask = kErrorBit) {
         RayTracingPipelineHelper helper(test);
         info_override(helper);
-        helper.InitState();
 
         ASSERT_EQ(VK_SUCCESS, helper.CreateNVRayTracingPipeline());
     }

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -41,7 +41,6 @@ TEST_F(VkAmdBestPracticesLayerTest, TooManyPipelines) {
                                                  "BestPractices-vkCreatePipelines-multiple-pipelines-caches");
         }
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
         pipeline_Array[i] = pipe.pipeline_;
         if (i == 1) {
@@ -223,7 +222,6 @@ TEST_F(VkAmdBestPracticesLayerTest, PrimitiveRestart) {
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-CreatePipelines-AvoidPrimitiveRestart");
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.ia_ci_.primitiveRestartEnable = true;
     pipe.CreateGraphicsPipeline();
 
@@ -251,7 +249,6 @@ TEST_F(VkAmdBestPracticesLayerTest, NumDynamicStates) {
     dynamic_state_info.pDynamicStates = dynamic_states_array;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.dyn_state_ci_ = dynamic_state_info;
     pipe.CreateGraphicsPipeline();
 
@@ -690,8 +687,7 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
     vkt::Buffer vertex_buffer(*m_device, 64, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.pipe_ms_state_ci_ = pipe_ms_state_ci;
-    pipe.InitState();
+    pipe.ms_ci_ = pipe_ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);
@@ -743,16 +739,6 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableAMDValidation));
     RETURN_IF_SKIP(InitState());
 
-    CreateComputePipelineHelper pipe(*this);
-
-    auto make_pipeline_with_shader = [=](CreateComputePipelineHelper& pipe, const VkPipelineShaderStageCreateInfo& stage) {
-        pipe.InitState();
-        pipe.cp_ci_.stage = stage;
-        pipe.dsl_bindings_ = {};
-        pipe.cp_ci_.layout = pipe.pipeline_layout_.handle();
-        pipe.CreateComputePipeline(false);
-    };
-
     // workgroup size = 4
     {
         VkShaderObj compute_4_1_1(this,
@@ -762,7 +748,9 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
                                   "void main() {}\n",
                                   VK_SHADER_STAGE_COMPUTE_BIT);
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-LocalWorkgroup-Multiple64");
-        make_pipeline_with_shader(pipe, compute_4_1_1.GetStageCreateInfo());
+        CreateComputePipelineHelper pipe(*this);
+        pipe.cp_ci_.stage = compute_4_1_1.GetStageCreateInfo();
+        pipe.CreateComputePipeline();
         m_errorMonitor->VerifyFound();
     }
 
@@ -774,7 +762,9 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
                                   "layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;\n\n"
                                   "void main() {}\n",
                                   VK_SHADER_STAGE_COMPUTE_BIT);
-        make_pipeline_with_shader(pipe, compute_8_8_1.GetStageCreateInfo());
+        CreateComputePipelineHelper pipe(*this);
+        pipe.cp_ci_.stage = compute_8_8_1.GetStageCreateInfo();
+        pipe.CreateComputePipeline();
     }
 
     // workgroup size = 128
@@ -785,6 +775,8 @@ TEST_F(VkAmdBestPracticesLayerTest, ComputeWorkgroupSize) {
                                    "layout(local_size_x = 16, local_size_y = 8, local_size_z = 1) in;\n\n"
                                    "void main() {}\n",
                                    VK_SHADER_STAGE_COMPUTE_BIT);
-        make_pipeline_with_shader(pipe, compute_16_8_1.GetStageCreateInfo());
+        CreateComputePipelineHelper pipe(*this);
+        pipe.cp_ci_.stage = compute_16_8_1.GetStageCreateInfo();
+        pipe.CreateComputePipeline();
     }
 }

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -796,10 +796,8 @@ TEST_F(NegativeAndroidExternalResolve, PipelineRasterizationSamples) {
     rp.AddResolveAttachment(1);
     rp.CreateRenderPass();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &external_format;
-    pipe.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
+    CreatePipelineHelper pipe(*this, &external_format);
+    pipe.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
     pipe.gp_ci_.renderPass = rp.Handle();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-externalFormatResolve-09313");
@@ -831,10 +829,8 @@ TEST_F(NegativeAndroidExternalResolve, PipelineRasterizationSamplesDynamicRender
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
-    pipe.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-externalFormatResolve-09304");
     pipe.CreateGraphicsPipeline();
@@ -1077,10 +1073,8 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -1164,7 +1158,6 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
@@ -1271,9 +1264,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &external_format;
+    CreatePipelineHelper pipe(*this, &external_format);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -35,7 +35,6 @@ TEST_F(PositiveAndroidExternalResolve, NoResolve) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -110,9 +109,7 @@ TEST_F(PositiveAndroidExternalResolve, RenderPassAndFramebuffer) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &external_format;
+    CreatePipelineHelper pipe(*this, &external_format);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 }
@@ -382,9 +379,7 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 2, attachments);
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &external_format;
+    CreatePipelineHelper pipe(*this, &external_format);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -305,7 +305,6 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R32_UINT, VK_IMAGE_USAGE_STORAGE_BIT);
@@ -355,7 +354,6 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     // "64-bit integer atomic support is guaranteed for optimally tiled images with the VK_FORMAT_R64_UINT"
@@ -414,7 +412,6 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
@@ -496,7 +493,6 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
     // Ensure pVertexInputState and pInputAssembly state are null, as these should be ignored.
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // "64-bit integer atomic support is guaranteed for optimally tiled images with the VK_FORMAT_R64_UINT"
@@ -1287,8 +1283,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
                             {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(3, image_view, sampler.handle(), VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
                                                      VK_IMAGE_LAYOUT_GENERAL);

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -106,7 +106,6 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
@@ -860,7 +859,6 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -419,8 +419,7 @@ TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
     pipe_ms_state_ci.pSampleMask = NULL;
 
     CreatePipelineHelper pipe(*this);
-    pipe.pipe_ms_state_ci_ = pipe_ms_state_ci;
-    pipe.InitState();
+    pipe.ms_ci_ = pipe_ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -717,7 +716,6 @@ TEST_F(VkBestPracticesLayerTest, TooManyInstancedVertexBuffers) {
 
     CreatePipelineHelper pipe(*this);
     pipe.vi_ci_ = vi_state_ci;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->VerifyFound();
@@ -792,15 +790,13 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
 
     CreatePipelineHelper pipe_masked(*this);
-    pipe_masked.InitState();
     pipe_masked.gp_ci_.renderPass = rp.Handle();
-    pipe_masked.cb_attachments_[0].colorWriteMask = 0;
+    pipe_masked.cb_attachments_.colorWriteMask = 0;
     pipe_masked.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_writes(*this);
-    pipe_writes.InitState();
     pipe_writes.gp_ci_.renderPass = rp.Handle();
-    pipe_writes.cb_attachments_[0].colorWriteMask = 0xf;
+    pipe_writes.cb_attachments_.colorWriteMask = 0xf;
     pipe_writes.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1141,7 +1137,6 @@ TEST_F(VkBestPracticesLayerTest, DepthBiasNoAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_.depthBiasConstantFactor = 1.0f;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1234,7 +1229,6 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineWithoutRenderPass) {
     VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }
@@ -1889,7 +1883,6 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.dsl_bindings_[0].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
     pipe.dsl_bindings_[0].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT;
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -2150,7 +2143,6 @@ TEST_F(VkBestPracticesLayerTest, PipelineWithoutRenderPassOrRenderingInfo) {
     RETURN_IF_SKIP(InitState());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -2261,7 +2253,6 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(data)};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
@@ -2316,7 +2307,6 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     VkPushConstantRange push_constant_range = {VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(uint8_t) * 3};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
@@ -2383,7 +2373,6 @@ TEST_F(VkBestPracticesLayerTest, CreatePipelineInputAttachmentTypeMismatch) {
     vkt::RenderPass render_pass(*m_device, rpci);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.renderPass = render_pass.handle();
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-Shader-MissingInputAttachment");

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -113,7 +113,6 @@ TEST_F(VkPositiveBestPracticesLayerTest, DrawingWithUnboundUnusedSet) {
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     OneOffDescriptorSet empty_ds(m_device, {});
@@ -167,7 +166,6 @@ TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
     CreatePipelineHelper pipe(*this);
     pipe.cb_ci_.pAttachments = nullptr;
     pipe.gp_ci_.pDynamicState = &dynamic_create_info;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
@@ -212,7 +210,6 @@ TEST_F(VkPositiveBestPracticesLayerTest, PipelineLibraryNoRendering) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     pre_raster_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     pre_raster_lib.CreateGraphicsPipeline();
@@ -250,7 +247,6 @@ TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
                                                              {VK_SHADER_STAGE_FRAGMENT_BIT, 16, 4}};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, push_constant_ranges);
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -193,7 +193,6 @@ TEST_F(PositiveBuffer, IndexBufferNull) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -114,7 +114,6 @@ TEST_F(NegativeCommand, IndexBufferNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -134,7 +133,6 @@ TEST_F(NegativeCommand, IndexBufferDestroyed) {
     vkt::Buffer index_buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -155,7 +153,6 @@ TEST_F(NegativeCommand, IndexBufferSizeOffset) {
     vkt::Buffer index_buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -193,7 +190,6 @@ TEST_F(NegativeCommand, MissingClearAttachment) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -874,7 +870,6 @@ TEST_F(NegativeCommand, DrawOutsideRenderPass) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -894,7 +889,6 @@ TEST_F(NegativeCommand, MultiDrawDrawOutsideRenderPass) {
     multi_draws[0].vertexCount = multi_draws[1].vertexCount = multi_draws[2].vertexCount = 3;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4575,7 +4569,6 @@ TEST_F(NegativeCommand, MultiDraw) {
     multi_draw_indices[0].indexCount = multi_draw_indices[1].indexCount = multi_draw_indices[2].indexCount = 1;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -4653,7 +4646,6 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -4693,7 +4685,6 @@ TEST_F(NegativeCommand, MultiDrawWholeSizeMaintenance5) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -4727,7 +4718,6 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5Mixed) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -4765,7 +4755,6 @@ TEST_F(NegativeCommand, MultiDrawFeatures) {
     multi_draw_indices[0].indexCount = multi_draw_indices[1].indexCount = multi_draw_indices[2].indexCount = 1;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4789,7 +4778,6 @@ TEST_F(NegativeCommand, IndirectDraw) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4846,7 +4834,6 @@ TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawIndirectCommand) * 3, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
@@ -4880,7 +4867,6 @@ TEST_F(NegativeCommand, StrideMultiDrawIndirect) {
                        VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT | VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4938,7 +4924,6 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -5013,7 +4998,6 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -5110,7 +5094,6 @@ TEST_F(NegativeCommand, DrawIndirectCountFeature) {
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands but without the drawIndirectCount feature set
@@ -5343,13 +5326,11 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
 
     vpsi.viewportCount = vp_count;
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.vp_state_ci_ = vpci;
     pipe.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_dynamic(*this);
-    pipe_dynamic.InitState();
     pipe_dynamic.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe_dynamic.vp_state_ci_ = vpci;
     pipe_dynamic.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV);
@@ -5431,8 +5412,7 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler_reduction.handle());
     g_pipe.descriptor_set_->UpdateDescriptorSets();
@@ -5516,8 +5496,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler.handle());
     g_pipe.descriptor_set_->UpdateDescriptorSets();
@@ -5708,8 +5687,7 @@ TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.cb_attachments_[0].blendEnable = VK_TRUE;
+    pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -6394,21 +6372,18 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     stencil_disabled_state_info.back.writeMask = 0;
 
     CreatePipelineHelper depth_pipe(*this);
-    depth_pipe.InitState();
     depth_pipe.LateBindPipelineInfo();
     depth_pipe.gp_ci_.renderPass = rp.Handle();
     depth_pipe.gp_ci_.pDepthStencilState = &depth_state_info;
     depth_pipe.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper stencil_pipe(*this);
-    stencil_pipe.InitState();
     stencil_pipe.LateBindPipelineInfo();
     stencil_pipe.gp_ci_.renderPass = rp.Handle();
     stencil_pipe.gp_ci_.pDepthStencilState = &stencil_state_info;
     stencil_pipe.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper stencil_disabled_pipe(*this);
-    stencil_disabled_pipe.InitState();
     stencil_disabled_pipe.LateBindPipelineInfo();
     stencil_disabled_pipe.gp_ci_.renderPass = rp.Handle();
     stencil_disabled_pipe.gp_ci_.pDepthStencilState = &stencil_disabled_state_info;
@@ -6416,7 +6391,6 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
 
     CreatePipelineHelper stencil_dynamic_pipe(*this);
     stencil_dynamic_pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK);
-    stencil_dynamic_pipe.InitState();
     stencil_dynamic_pipe.LateBindPipelineInfo();
     stencil_dynamic_pipe.gp_ci_.renderPass = rp.Handle();
     stencil_dynamic_pipe.gp_ci_.pDepthStencilState = &stencil_state_info;

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -336,7 +336,6 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
@@ -374,7 +373,6 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
@@ -418,7 +416,6 @@ TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
@@ -908,7 +905,6 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -950,7 +946,6 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5Mixed) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
@@ -1053,7 +1048,6 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchWithZeroExtend) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM));
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkFormat format = VK_FORMAT_R32G32B32A32_SINT;
@@ -1123,7 +1117,6 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM));
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkFormat format = VK_FORMAT_R32G32B32A32_UINT;
@@ -1188,7 +1181,6 @@ TEST_F(PositiveCommand, DISABLED_ClearAttachmentBasicUsage) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2023 The Khronos Group Inc.
- * Copyright (c) 2020-2023 Valve Corporation
- * Copyright (c) 2020-2023 LunarG, Inc.
- * Copyright (c) 2020-2023 Google, Inc.
+ * Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
+ * Copyright (c) 2020-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,7 +56,6 @@ TEST_F(NegativeDebugPrintf, BasicCompute) {
         )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
@@ -164,7 +163,6 @@ TEST_F(NegativeDebugPrintf, BasicUsage) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo()};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.gp_ci_.layout = pipeline_layout.handle();
@@ -274,7 +272,6 @@ TEST_F(NegativeDebugPrintf, BasicUsage) {
         VkShaderObj vs_int64(this, shader_source_int64, VK_SHADER_STAGE_VERTEX_BIT);
 
         CreatePipelineHelper pipe2(*this);
-        pipe2.InitState();
         pipe2.shader_stages_ = {vs_int64.GetStageCreateInfo()};
         pipe2.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
         pipe2.gp_ci_.layout = pipeline_layout.handle();
@@ -367,7 +364,6 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
     VkShaderObj ms(this, meshShaderText, VK_SHADER_STAGE_MESH_BIT_NV);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {ts.GetStageCreateInfo(), ms.GetStageCreateInfo()};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
@@ -470,7 +466,6 @@ TEST_F(NegativeDebugPrintf, GPL) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, shader_source);
@@ -479,7 +474,6 @@ TEST_F(NegativeDebugPrintf, GPL) {
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
     pre_raster.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pre_raster.InitState();
     pre_raster.gp_ci_.layout = pipeline_layout.handle();
     pre_raster.CreateGraphicsPipeline(false);
 
@@ -737,7 +731,6 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     static const char vertshader[] = R"glsl(
@@ -764,7 +757,6 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     VkRect2D scissor = {{0, 0}, {1, 1}};
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
-    pre_raster.InitState();
     pre_raster.vp_state_ci_.pViewports = &viewport;
     pre_raster.vp_state_ci_.pScissors = &scissor;
     pre_raster.gp_ci_.layout = vs_layout;
@@ -877,7 +869,6 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     static const char vertshader[] = R"glsl(
@@ -904,7 +895,6 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     VkRect2D scissor = {{0, 0}, {1, 1}};
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
-    pre_raster.InitState();
     pre_raster.vp_state_ci_.pViewports = &viewport;
     pre_raster.vp_state_ci_.pScissors = &scissor;
     pre_raster.gp_ci_.layout = vs_layout;

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -843,7 +843,6 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     ASSERT_EQ(VK_SUCCESS, pipe.CreateComputePipeline());
 
     m_commandBuffer->begin();
@@ -901,7 +900,6 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-    pipe.InitState();
     ASSERT_EQ(VK_SUCCESS, pipe.CreateComputePipeline());
 
     m_commandBuffer->begin();

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -74,7 +74,6 @@ TEST_F(PositiveDescriptorBuffer, BindBufferAndSetOffset) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&set_layout});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -107,7 +107,6 @@ TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -24,7 +24,6 @@ void DescriptorIndexingTest::ComputePipelineShaderTest(const char *shader, std::
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -98,7 +97,6 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -195,7 +193,6 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
@@ -306,7 +303,6 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -440,7 +440,6 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        pipe.InitState();
         pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
         pipe.CreateGraphicsPipeline();
 
@@ -484,7 +483,6 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
         )glsl";
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
         pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Correctly update descriptor to avoid "NOT_UPDATED" error
@@ -533,7 +531,6 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
         )glsl";
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
         pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Correctly update descriptor to avoid "NOT_UPDATED" error
@@ -680,7 +677,6 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -888,7 +884,6 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -951,7 +946,6 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentSamplerGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1079,7 +1073,6 @@ TEST_F(NegativeDescriptors, DescriptorPoolInUseResetSignaled) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentSamplerGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1197,7 +1190,6 @@ TEST_F(NegativeDescriptors, DynamicOffsetCases) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1503,7 +1495,6 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
@@ -1659,7 +1650,6 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipe_layout_fs_only.handle();
     pipe.CreateGraphicsPipeline();
@@ -2987,7 +2977,6 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -3082,8 +3071,7 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenAttachmentsAndDescript
 
     g_pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
     g_pipe.gp_ci_.renderPass = rp.Handle();
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_input, sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
     // input attachment and combined image sampler use the same view to cause DesiredFailure.
@@ -3745,7 +3733,6 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout});
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -3849,7 +3836,6 @@ TEST_F(NegativeDescriptors, DescriptorReadFromWriteAttachment) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout, &descriptor_set_layout});
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -3961,7 +3947,6 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout1, &descriptor_set_layout2});
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -4577,7 +4562,6 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
 
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&combined_image_set.layout_, &storage_image_set.layout_});
     cs_pipeline.CreateComputePipeline();
 
@@ -4677,7 +4661,6 @@ TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
     g_pipe.CreateGraphicsPipeline();
 
     vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -357,7 +357,6 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
@@ -631,7 +630,6 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout, &descriptor_set_layout2});
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -819,7 +817,6 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_, &ds_layout_unused});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -896,7 +893,6 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
         vkt::PipelineLayout pipeline_layout(*m_device, pipeline_layout_ci);
 
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.shader_stages_[1] = fs.GetStageCreateInfo();
         pipe.gp_ci_.layout = pipeline_layout.handle();
         pipe.CreateGraphicsPipeline();
@@ -1060,7 +1056,6 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     VkShaderObj fs(this, frag_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_COLOR_ATTACHMENT_FEEDBACK_LOOP_BIT_EXT;
     pipe.gp_ci_.renderPass = rp.Handle();

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -323,10 +323,8 @@ TEST_F(NegativeDeviceQueue, BindPipeline) {
     vkt::CommandBuffer commandBuffer(*m_device, &commandPool);
 
     CreatePipelineHelper g_pipe(*this);
-    g_pipe.InitState();
     g_pipe.CreateGraphicsPipeline();
     CreateComputePipelineHelper c_pipe(*this);
-    c_pipe.InitState();
     c_pipe.CreateComputePipeline();
 
     // Get implicit VU because using Transfer only instead of a Graphics-only or Compute-only queue

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -77,9 +77,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdDrawColorLocation) {
     cbi.attachmentCount = 2;
     cbi.pAttachments = color_blend_attachments.data();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.gp_ci_.pColorBlendState = &cbi;
     pipe.CreateGraphicsPipeline();
@@ -134,9 +132,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdDrawColorIndex) {
     cbi.attachmentCount = 2u;
     cbi.pAttachments = color_blend_attachments.data();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.gp_ci_.pColorBlendState = &cbi;
     pipe.CreateGraphicsPipeline();
@@ -181,9 +177,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdClearAttachments) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -721,9 +715,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, RemappingAtCreatePipeline) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-09531");
@@ -750,9 +742,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexColorAttachmentCou
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
 
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-renderPass-09531");
@@ -771,9 +761,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ColorAttachmentCountInPipelineRenderin
     pipeline_rendering_info.colorAttachmentCount = color_attachments.size();
     pipeline_rendering_info.pColorAttachmentFormats = color_attachments.data();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRenderingCreateInfo-colorAttachmentCount-09533");
@@ -790,9 +778,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentIndicesColorAttachment
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -827,7 +813,6 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentIndices) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -856,9 +841,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexSetToUnused) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -904,9 +887,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexUnique) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -949,9 +930,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentLocationsColorAttachme
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -993,9 +972,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, NewFunctionsReportErrorExtensionDisabl
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -1032,7 +1009,6 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetRenderingAttachmentLocations) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1062,9 +1038,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLocationsValidity) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -1105,9 +1079,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLocationsMax) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -39,8 +39,8 @@ TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
                       VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT |
                           VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
-    CreatePipelineHelper pipe1(*this, 2);
-    CreatePipelineHelper pipe2(*this, 2);
+    CreatePipelineHelper pipe1(*this);
+    CreatePipelineHelper pipe2(*this);
     for (uint32_t i = 0; i < 2; i++)
     {
         CreatePipelineHelper* pipe = (i == 0) ? &pipe1 : &pipe2;
@@ -62,9 +62,12 @@ TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
         pipeline_rendering_info.colorAttachmentCount = 2;
         pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
-        pipe->InitState();
+        VkPipelineColorBlendAttachmentState cb_attachments[2];
+        memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
         pipe->ds_ci_ = vku::InitStructHelper();
         pipe->gp_ci_.pNext = &pipeline_rendering_info;
+        pipe->cb_ci_.attachmentCount = 2;
+        pipe->cb_ci_.pAttachments = cb_attachments;
         pipe->CreateGraphicsPipeline();
     }
 

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -51,9 +51,7 @@ TEST_F(PositiveDynamicRendering, Draw) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -85,16 +83,12 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.ds_ci_ = vku::InitStructHelper();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
-    CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
-    pipe2.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe2(*this, &pipeline_rendering_info);
     pipe2.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -157,9 +151,7 @@ TEST_F(PositiveDynamicRendering, PipeWithDiscard) {
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;  // D16_UNORM has guaranteed support
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.ds_ci_ = ds_ci;
     pipe.CreateGraphicsPipeline();
 }
@@ -271,10 +263,8 @@ TEST_F(PositiveDynamicRendering, SuspendResumeDraw) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.ds_ci_ = vku::InitStructHelper();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -349,12 +339,10 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipeline) {
     rp.AddInputAttachment(0);
     rp.CreateRenderPass();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &rendering_info);
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.gp_ci_.pNext = &rendering_info;
     pipe.CreateGraphicsPipeline();
 }
 
@@ -383,7 +371,6 @@ TEST_F(PositiveDynamicRendering, CreateGraphicsPipelineNoInfo) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -418,15 +405,13 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
     ms_ci.minSampleShading = 1.0;
     ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
 
-    CreatePipelineHelper pipe(*this);
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs->GetStageCreateInfo()};
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.gp_ci_.pMultisampleState = &ms_ci;
     pipe.gp_ci_.pDepthStencilState = &ds_state;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::Image depth_image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
@@ -504,10 +489,8 @@ TEST_F(PositiveDynamicRendering, DualSourceBlending) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
-    pipe.cb_attachments_[0] = cb_attachments;
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.cb_attachments_ = cb_attachments;
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -583,9 +566,7 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -632,9 +613,7 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -745,29 +724,25 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
-    CreatePipelineHelper pipeline_color(*this);
-    pipeline_color.InitState();
-    pipeline_color.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipeline_color(*this, &pipeline_rendering_info);
     pipeline_color.CreateGraphicsPipeline();
 
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
 
-    CreatePipelineHelper pipeline_depth(*this, 0);
-    pipeline_depth.InitState();
+    CreatePipelineHelper pipeline_depth(*this, &pipeline_rendering_info);
     pipeline_depth.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-    pipeline_depth.gp_ci_.pNext = &pipeline_rendering_info;
+    pipeline_depth.cb_ci_.attachmentCount = 0;
     pipeline_depth.CreateGraphicsPipeline();
 
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     pipeline_rendering_info.stencilAttachmentFormat = VK_FORMAT_UNDEFINED;
 
-    CreatePipelineHelper pipeline_stencil(*this, 0);
-    pipeline_stencil.InitState();
+    CreatePipelineHelper pipeline_stencil(*this, &pipeline_rendering_info);
     pipeline_stencil.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-    pipeline_stencil.gp_ci_.pNext = &pipeline_rendering_info;
+    pipeline_stencil.cb_ci_.attachmentCount = 0;
     pipeline_stencil.CreateGraphicsPipeline();
 
     vkt::Image colorImage(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -837,9 +812,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = color_formats;
 
-    CreatePipelineHelper pipeline_color(*this);
-    pipeline_color.InitState();
-    pipeline_color.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipeline_color(*this, &pipeline_rendering_info);
     pipeline_color.CreateGraphicsPipeline();
 
     VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
@@ -848,20 +821,18 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = depthStencilFormat;
 
-    CreatePipelineHelper pipeline_depth(*this, 0);
-    pipeline_depth.InitState();
+    CreatePipelineHelper pipeline_depth(*this, &pipeline_rendering_info);
     pipeline_depth.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-    pipeline_depth.gp_ci_.pNext = &pipeline_rendering_info;
+    pipeline_depth.cb_ci_.attachmentCount = 0;
     pipeline_depth.CreateGraphicsPipeline();
 
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     pipeline_rendering_info.stencilAttachmentFormat = depthStencilFormat;
 
-    CreatePipelineHelper pipeline_stencil(*this, 0);
-    pipeline_stencil.InitState();
+    CreatePipelineHelper pipeline_stencil(*this, &pipeline_rendering_info);
     pipeline_stencil.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-    pipeline_stencil.gp_ci_.pNext = &pipeline_rendering_info;
+    pipeline_stencil.cb_ci_.attachmentCount = 0;
     pipeline_stencil.CreateGraphicsPipeline();
 
     vkt::Image colorImage(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -1004,10 +975,8 @@ TEST_F(PositiveDynamicRendering, ColorAttachmentMismatch) {
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 0;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
@@ -1034,9 +1003,7 @@ TEST_F(PositiveDynamicRendering, PipelineUnusedAttachments) {
     cbi.attachmentCount = 2u;
     cbi.pAttachments = color_blend_attachments.data();
 
-    CreatePipelineHelper pipeline(*this);
-    pipeline.InitState();
-    pipeline.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipeline(*this, &pipeline_rendering_info);
     pipeline.gp_ci_.pColorBlendState = &cbi;
     pipeline.CreateGraphicsPipeline();
 
@@ -1075,11 +1042,9 @@ TEST_F(PositiveDynamicRendering, DynamicColorBlendEnable) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
 
-    CreatePipelineHelper pipe(*this);
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
     pipe.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -1116,10 +1081,9 @@ TEST_F(PositiveDynamicRendering, UnusedAttachmentsMismatchedFormats) {
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D16_UNORM;
 
-    CreatePipelineHelper pipeline_depth(*this, 0);
-    pipeline_depth.InitState();
+    CreatePipelineHelper pipeline_depth(*this, &pipeline_rendering_info);
     pipeline_depth.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
-    pipeline_depth.gp_ci_.pNext = &pipeline_rendering_info;
+    pipeline_depth.cb_ci_.attachmentCount = 0;
     pipeline_depth.CreateGraphicsPipeline();
 
     VkCommandBufferInheritanceRenderingInfoKHR inheritance_rendering_info = vku::InitStructHelper();

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -24,7 +24,6 @@ TEST_F(NegativeDynamicState, DepthBiasNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     pipe.rs_state_ci_.lineWidth = 1.0f;
     pipe.rs_state_ci_.depthBiasEnable = VK_TRUE;
@@ -46,7 +45,6 @@ TEST_F(NegativeDynamicState, LineWidthNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     pipe.CreateGraphicsPipeline();
@@ -77,7 +75,6 @@ TEST_F(NegativeDynamicState, LineStippleNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     VkPipelineRasterizationLineStateCreateInfoKHR line_state = vku::InitStructHelper();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_KHR);
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
@@ -105,7 +102,6 @@ TEST_F(NegativeDynamicState, ViewportNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
     pipe.CreateGraphicsPipeline();
 
@@ -124,7 +120,6 @@ TEST_F(NegativeDynamicState, ScissorNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
     pipe.CreateGraphicsPipeline();
 
@@ -144,10 +139,9 @@ TEST_F(NegativeDynamicState, BlendConstantsNotBound) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_BLEND_CONSTANTS);
-    pipe.cb_attachments_[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[0].blendEnable = VK_TRUE;
+    pipe.cb_attachments_.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -173,7 +167,6 @@ TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     InitRenderTarget(1, &depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
@@ -200,7 +193,6 @@ TEST_F(NegativeDynamicState, StencilReadNotBound) {
     InitRenderTarget(1, &depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK);
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
@@ -227,7 +219,6 @@ TEST_F(NegativeDynamicState, StencilWriteNotBound) {
     InitRenderTarget(1, &depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_WRITE_MASK);
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
@@ -254,7 +245,6 @@ TEST_F(NegativeDynamicState, StencilRefNotBound) {
     InitRenderTarget(1, &depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_STENCIL_REFERENCE);
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthWriteEnable = VK_TRUE;
@@ -409,7 +399,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     pipe.dyn_state_ci_ = dyn_state_ci;
     pipe.vp_state_ci_.viewportCount = 0;
     pipe.vp_state_ci_.scissorCount = 0;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03378");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -472,7 +461,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorPipeline) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03379");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03380");
         pipe.CreateGraphicsPipeline();
@@ -484,7 +472,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorPipeline) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
-        pipe.InitState();
         pipe.vp_state_ci_.viewportCount = 0;
         pipe.vp_state_ci_.scissorCount = 1;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04132");
@@ -496,7 +483,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorPipeline) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
-        pipe.InitState();
         pipe.vp_state_ci_.viewportCount = 1;
         pipe.vp_state_ci_.scissorCount = 0;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04133");
@@ -533,7 +519,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDuplicate) {
         if (dyn_states[i] == VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT) {
             pipe.vp_state_ci_.scissorCount = 0;
         }
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -561,7 +546,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     VkVertexInputAttributeDescription attribute = {0, 0, VK_FORMAT_R32_SFLOAT, 0};
     pipe.vi_ci_.pVertexAttributeDescriptions = &attribute;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
@@ -643,7 +627,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
         pipe.vp_state_ci_.viewportCount = 0;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -660,7 +643,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
         pipe.vp_state_ci_.scissorCount = 0;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -679,7 +661,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
         pipe.vp_state_ci_.viewportCount = 0;
         pipe.vp_state_ci_.scissorCount = 0;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
@@ -726,7 +707,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     VkVertexInputAttributeDescription attribute = {0, 0, VK_FORMAT_R32_SFLOAT, 0};
     pipe.vi_ci_.pVertexAttributeDescriptions = &attribute;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -861,7 +841,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04868");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -904,7 +883,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04870");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -939,7 +917,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04869");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -978,7 +955,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
             CreatePipelineHelper pipe(*this);
             pipe.AddDynamicState(dyn_states[i]);
             pipe.AddDynamicState(dyn_states[i]);
-            pipe.InitState();
             m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
             pipe.CreateGraphicsPipeline();
             m_errorMonitor->VerifyFound();
@@ -988,7 +964,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
         {
             CreatePipelineHelper pipe(*this);
             pipe.AddDynamicState(dyn_states[i]);
-            pipe.InitState();
             pipe.CreateGraphicsPipeline();
 
             vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
@@ -1032,7 +1007,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -1041,7 +1015,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
     {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
@@ -1086,7 +1059,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_EXT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_EXT);
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -1095,7 +1067,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
     {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_EXT);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
@@ -1120,7 +1091,6 @@ void NegativeDynamicState::ExtendedDynamicState3PipelineFeatureDisabled(VkDynami
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(dynamic_state);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, vuid);
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1533,7 +1503,6 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState3DuplicateStatePipeline) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(dyn_states[i]);
         pipe.AddDynamicState(dyn_states[i]);
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -1555,7 +1524,6 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
     tess_domain_ci.domainOrigin = VK_TESSELLATION_DOMAIN_ORIGIN_LOWER_LEFT;
     VkPipelineTessellationStateCreateInfo tess_ci = vku::InitStructHelper(&tess_domain_ci);
     pipe.gp_ci_.pTessellationState = &tess_ci;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1588,7 +1556,6 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1622,7 +1589,6 @@ TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_POLYGON_MODE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1664,7 +1630,6 @@ TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1697,7 +1662,6 @@ TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1732,7 +1696,6 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1770,7 +1733,6 @@ TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1802,7 +1764,6 @@ TEST_F(NegativeDynamicState, DrawNotSetExtraPrimitiveOverestimationSize) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_EXTRA_PRIMITIVE_OVERESTIMATION_SIZE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1834,7 +1795,6 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1873,7 +1833,6 @@ TEST_F(NegativeDynamicState, DrawNotSetProvokingVertexMode) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1900,7 +1859,6 @@ TEST_F(NegativeDynamicState, DrawNotSetLineRasterizationMode) {
     m_commandBuffer->begin();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1934,7 +1892,6 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
     m_commandBuffer->begin();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_);
 
@@ -1971,7 +1928,6 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDisabled) {
     // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04807
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04807");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1999,7 +1955,6 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDynamicStateCreateInfo-pDynamicStates-01442");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -2225,8 +2180,7 @@ TEST_F(NegativeDynamicState, RasterizationSamples) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
-    pipe.pipe_ms_state_ci_ = ms_state_ci;
-    pipe.InitState();
+    pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2277,10 +2231,13 @@ TEST_F(NegativeDynamicState, ColorBlendAttchment) {
     fsSource << "}";
     VkShaderObj fs(this, fsSource.str().c_str(), VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    CreatePipelineHelper pipe(*this, color_attachments);
+    VkPipelineColorBlendAttachmentState cb_attachments[color_attachments];
+    memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * color_attachments);
+    CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
-    pipe.InitState();
+    pipe.cb_ci_.attachmentCount = color_attachments;
+    pipe.cb_ci_.pAttachments = cb_attachments;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2329,7 +2286,6 @@ TEST_F(NegativeDynamicState, RasterizationLineModeDefault) {
     pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR;  // ignored
     pipe.line_state_ci_.stippledLineEnable = VK_TRUE;                                        // ignored
     pipe.line_state_ci_.lineStippleFactor = 1;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2359,7 +2315,6 @@ TEST_F(NegativeDynamicState, RasterizationLineModeRectangular) {
     pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR;
     pipe.line_state_ci_.stippledLineEnable = VK_TRUE;  // ignored
     pipe.line_state_ci_.lineStippleFactor = 1;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2383,7 +2338,6 @@ TEST_F(NegativeDynamicState, RasterizationLineModeBresenham) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
     pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR;
     pipe.line_state_ci_.lineStippleFactor = 1;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2407,7 +2361,6 @@ TEST_F(NegativeDynamicState, RasterizationLineModeSmooth) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
     pipe.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_KHR;
     pipe.line_state_ci_.lineStippleFactor = 1;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2434,7 +2387,6 @@ TEST_F(NegativeDynamicState, PipelineColorWriteCreateInfoEXTDynaimcState3) {
     VkPipelineColorWriteCreateInfoEXT color_write = vku::InitStructHelper();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cb_ci_.pNext = &color_write;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorWriteCreateInfoEXT-attachmentCount-07608");
     pipe.CreateGraphicsPipeline();
@@ -2488,14 +2440,13 @@ TEST_F(NegativeDynamicState, DISABLED_MaxFragmentDualSrcAttachmentsDynamicBlendE
     cb_attachments.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     cb_attachments.alphaBlendOp = VK_BLEND_OP_ADD;
 
-    CreatePipelineHelper pipe(*this, count);
-    pipe.cb_attachments_[0] = cb_attachments;
+    CreatePipelineHelper pipe(*this);
+    pipe.cb_ci_.pAttachments = &cb_attachments;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2536,7 +2487,6 @@ TEST_F(NegativeDynamicState, ColorWriteDisabled) {
     // VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04800
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04800");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -2570,7 +2520,6 @@ TEST_F(NegativeDynamicState, ColorWriteNotSet) {
     pipe.cb_ci_.attachmentCount = 2;
     pipe.cb_ci_.pAttachments = color_blend;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2613,7 +2562,6 @@ TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
     std::vector<VkBool32> color_write_enable(m_device->phy().limits_.maxColorAttachments + 1, VK_TRUE);
 
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2648,7 +2596,6 @@ TEST_F(NegativeDynamicState, ColorWriteEnableFeature) {
     VkBool32 color_write_enable[2] = {VK_TRUE, VK_FALSE};
 
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2670,10 +2617,8 @@ TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
     discard_rect_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT;
     discard_rect_ci.discardRectangleCount = 4;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &discard_rect_ci;
+    CreatePipelineHelper pipe(*this, &discard_rect_ci);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -2707,10 +2652,8 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
     discard_rect_ci.discardRectangleMode = VK_DISCARD_RECTANGLE_MODE_INCLUSIVE_EXT;
     discard_rect_ci.discardRectangleCount = 1;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &discard_rect_ci;
+    CreatePipelineHelper pipe(*this, &discard_rect_ci);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     VkRect2D discard_rectangles = {{0, 0}, {16, 16}};
@@ -2764,7 +2707,6 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -2900,8 +2842,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
 
     {
         CreatePipelineHelper pipe(*this);
-        pipe.pipe_ms_state_ci_ = pipe_ms_state_ci;
-        pipe.InitState();
+        pipe.ms_ci_ = pipe_ms_state_ci;
         pipe.gp_ci_.renderPass = rp.Handle();
         pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
 
@@ -2944,7 +2885,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
         }
 
         // non-matching rasterizationSamples
-        pipe.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
+        pipe.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07612");
         // if grid size is different
         m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07610");
@@ -2952,14 +2893,13 @@ TEST_F(NegativeDynamicState, SampleLocations) {
         m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853");
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
-        pipe.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+        pipe.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     }
 
     // Creates valid pipelines with dynamic state
     CreatePipelineHelper dynamic_pipe(*this);
-    dynamic_pipe.pipe_ms_state_ci_ = pipe_ms_state_ci;
+    dynamic_pipe.ms_ci_ = pipe_ms_state_ci;
     dynamic_pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
-    dynamic_pipe.InitState();
     dynamic_pipe.gp_ci_.renderPass = rp.Handle();
     dynamic_pipe.gp_ci_.pDepthStencilState = &pipe_ds_state_ci;
     dynamic_pipe.CreateGraphicsPipeline();
@@ -3280,7 +3220,6 @@ TEST_F(NegativeDynamicState, DiscardRectanglesVersion) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dyn_state_ci_ = dyn_state_ci;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-07855");
     pipe.CreateGraphicsPipeline();
@@ -3325,7 +3264,6 @@ TEST_F(NegativeDynamicState, DISABLED_ExtensionDynamicStatesSetWOExtensionEnable
     for (const auto &test_case : dyn_test_cases) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(test_case.dynamic_state);
-        pipe.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, test_case.errmsg);
         pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -3344,12 +3282,10 @@ TEST_F(NegativeDynamicState, ViewportAndScissorUndefinedDrawState) {
     VkRect2D scissor = {{0, 0}, {16, 16}};
 
     CreatePipelineHelper pipeline_dyn_vp(*this);
-    pipeline_dyn_vp.InitState();
     pipeline_dyn_vp.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
     pipeline_dyn_vp.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipeline_dyn_sc(*this);
-    pipeline_dyn_sc.InitState();
     pipeline_dyn_sc.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
     pipeline_dyn_sc.CreateGraphicsPipeline();
 
@@ -3382,7 +3318,6 @@ TEST_F(NegativeDynamicState, Duplicate) {
                                         VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK, VK_DYNAMIC_STATE_STENCIL_REFERENCE};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.dyn_state_ci_ = vku::InitStructHelper();
     pipe.dyn_state_ci_.flags = 0;
     pipe.dyn_state_ci_.dynamicStateCount = 4;
@@ -3409,7 +3344,6 @@ TEST_F(NegativeDynamicState, NonGraphics) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-03578");
     pipe.CreateGraphicsPipeline();
@@ -3427,7 +3361,6 @@ TEST_F(NegativeDynamicState, ViewportCountWithExtendedDynamicState) {
     VkDynamicState dynamic_state = VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.dyn_state_ci_ = vku::InitStructHelper();
     pipe.dyn_state_ci_.dynamicStateCount = 1;
     pipe.dyn_state_ci_.pDynamicStates = &dynamic_state;
@@ -3475,7 +3408,6 @@ TEST_F(NegativeDynamicState, PipelineColorBlendStateCreateInfoArrayDynamic) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
-        pipe.InitState();
         pipe.cb_ci_.pAttachments = nullptr;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-07353");
         pipe.CreateGraphicsPipeline();
@@ -3490,7 +3422,6 @@ TEST_F(NegativeDynamicState, SettingCommands) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -3519,7 +3450,6 @@ void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(dynamic_state);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -3592,7 +3522,6 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
 
     CreatePipelineHelper pipe(*this);
     pipe.ds_ci_ = ds_ci;
-    pipe.InitState();
 
     pipe.ds_ci_.minDepthBounds = 1.5f;
     pipe.ds_ci_.maxDepthBounds = 1.0f;
@@ -3643,7 +3572,6 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     InitRenderTarget(&depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthTestEnable = VK_FALSE;  // ignored
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
@@ -3671,7 +3599,6 @@ TEST_F(NegativeDynamicState, ViewportStateIgnored) {
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_FALSE;
     pipe.gp_ci_.pViewportState = nullptr;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-09024");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -4027,7 +3954,6 @@ TEST_F(NegativeDynamicState, ScissorWithCount) {
     {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
-        pipe.InitState();
         pipe.vp_state_ci_.scissorCount = 0;
         pipe.vp_state_ci_.viewportCount = 0;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineViewportStateCreateInfo-scissorCount-04136");
@@ -4039,7 +3965,6 @@ TEST_F(NegativeDynamicState, ScissorWithCount) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
-        pipe.InitState();
         VkRect2D scissors = {};
         pipe.vp_state_ci_.scissorCount = 1;
         pipe.vp_state_ci_.pScissors = &scissors;
@@ -4067,7 +3992,6 @@ TEST_F(NegativeDynamicState, DrawNotSetSampleLocations) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -4128,11 +4052,9 @@ TEST_F(NegativeDynamicState, SetAfterStaticPipeline) {
 
     CreatePipelineHelper pipe_line(*this);
     pipe_line.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
-    pipe_line.InitState();
     pipe_line.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_static(*this);
-    pipe_static.InitState();
     pipe_static.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4165,7 +4087,6 @@ TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4189,7 +4110,6 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableFeatures) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4219,7 +4139,6 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4297,7 +4216,6 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe_line(*this);
-    pipe_line.InitState();
     pipe_line.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4363,8 +4281,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
-    pipe.pipe_ms_state_ci_ = ms_state_ci;
-    pipe.InitState();
+    pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4390,7 +4307,6 @@ TEST_F(NegativeDynamicState, ShadingRateImageEnableNotSet) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4415,7 +4331,6 @@ TEST_F(NegativeDynamicState, CoverageReductionModeNotSet) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4455,12 +4370,10 @@ TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
     pipe1.AddDynamicState(VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV);
     pipe1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_ENABLE_NV);
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV);
     pipe2.CreateGraphicsPipeline();
@@ -4520,7 +4433,6 @@ TEST_F(NegativeDynamicState, MultisampleStateIgnored) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     // missing VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT
     pipe.gp_ci_.pMultisampleState = nullptr;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pMultisampleState-09026");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -4543,7 +4455,6 @@ TEST_F(NegativeDynamicState, MultisampleStateIgnoredAlphaToOne) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
     // missing VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT
     pipe.gp_ci_.pMultisampleState = nullptr;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pMultisampleState-09026");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -4569,7 +4480,6 @@ TEST_F(NegativeDynamicState, InputAssemblyStateIgnored) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-dynamicPrimitiveTopologyUnrestricted-09031");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -4596,10 +4506,9 @@ TEST_F(NegativeDynamicState, ColorBlendStateIgnored) {
     VkPipelineColorBlendAttachmentState att_state = {};
     att_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
     att_state.blendEnable = VK_TRUE;
-    pipe.cb_attachments_[0] = att_state;
+    pipe.cb_attachments_ = att_state;
     pipe.gp_ci_.pColorBlendState = nullptr;
 
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-09030");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -4628,7 +4537,6 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdDraw-Input-07939");
@@ -4672,7 +4580,6 @@ TEST_F(NegativeDynamicState, MissingCmdSetVertexInput) {
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4699,7 +4606,6 @@ TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -4781,7 +4687,6 @@ TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
     pipe.cb_ci_.attachmentCount = 0;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -4845,7 +4750,6 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
@@ -4870,7 +4774,6 @@ TEST_F(NegativeDynamicState, SampleLocationsSamplesMismatch) {
     RETURN_IF_SKIP(InitRenderTarget());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -4903,7 +4806,6 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch)
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe.CreateGraphicsPipeline();
@@ -4952,7 +4854,6 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamples) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
@@ -5016,8 +4917,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     sample_location_state.sampleLocationsInfo.sampleLocationGridSize.width = multisample_prop.maxSampleLocationGridSize.width + 1u;
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
-    pipe1.pipe_ms_state_ci_ = pipe_ms_state_ci;
+    pipe1.ms_ci_ = pipe_ms_state_ci;
     pipe1.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe1.CreateGraphicsPipeline();
 
@@ -5025,8 +4925,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     sample_location_state.sampleLocationsInfo.sampleLocationGridSize.height = multisample_prop.maxSampleLocationGridSize.height + 1;
 
     CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
-    pipe2.pipe_ms_state_ci_ = pipe_ms_state_ci;
+    pipe2.ms_ci_ = pipe_ms_state_ci;
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe2.CreateGraphicsPipeline();
 
@@ -5044,8 +4943,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     sample_location_state.sampleLocationsInfo.pSampleLocations = sample_location2.data();
 
     CreatePipelineHelper pipe3(*this);
-    pipe3.InitState();
-    pipe3.pipe_ms_state_ci_ = pipe_ms_state_ci;
+    pipe3.ms_ci_ = pipe_ms_state_ci;
     pipe3.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe3.CreateGraphicsPipeline();
 
@@ -5107,17 +5005,15 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
     pipe1.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
-    pipe1.pipe_ms_state_ci_ = ms_state_ci;
+    pipe1.ms_ci_ = ms_state_ci;
     pipe1.gp_ci_.renderPass = rp.Handle();
     pipe1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
-    pipe2.pipe_ms_state_ci_ = ms_state_ci;
+    pipe2.ms_ci_ = ms_state_ci;
     pipe2.gp_ci_.renderPass = rp.Handle();
     pipe2.CreateGraphicsPipeline();
 
@@ -5166,7 +5062,6 @@ TEST_F(NegativeDynamicState, InvalidConservativeRasterizationMode) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT);
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     pipe.CreateGraphicsPipeline();
@@ -5209,7 +5104,6 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     clear_value.depthStencil = {1.0f, 0u};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -5269,7 +5163,6 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsGridSize) {
     sample_locations_info.pSampleLocations = sample_location.data();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
@@ -5334,7 +5227,6 @@ TEST_F(NegativeDynamicState, InterpolateAtSample) {
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
@@ -5395,7 +5287,6 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
     vkt::ImageView image_view = image.CreateView();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.cb_ci_.attachmentCount = 0;
@@ -5451,7 +5342,6 @@ TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
     vkt::QueryPool pg_query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -5477,7 +5367,6 @@ TEST_F(NegativeDynamicState, MissingScissorWithCount) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
     pipe.vp_state_ci_.viewportCount = 0u;
@@ -5527,7 +5416,6 @@ TEST_F(NegativeDynamicState, RebindSamePipeline) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -5558,7 +5446,6 @@ TEST_F(NegativeDynamicState, ColorBlendEnableNotSet) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
@@ -5590,7 +5477,6 @@ TEST_F(NegativeDynamicState, ColorBlendEquationNotSet) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
@@ -5622,7 +5508,6 @@ TEST_F(NegativeDynamicState, ColorWriteMaskNotSet) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
@@ -5654,7 +5539,6 @@ TEST_F(NegativeDynamicState, ColorBlendAdvancedNotSet) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 0, nullptr);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -34,7 +34,6 @@ TEST_F(PositiveDynamicState, DiscardRectanglesVersion) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -60,7 +59,6 @@ TEST_F(PositiveDynamicState, ViewportWithCountNoMultiViewport) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
     pipe.vp_state_ci_.viewportCount = 0;
     pipe.vp_state_ci_.scissorCount = 0;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -84,7 +82,6 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
-    pipe.InitState();
     pipe.gp_ci_.pVertexInputState = &vi_ci;  // ignored
     pipe.CreateGraphicsPipeline();
 
@@ -138,7 +135,6 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXTStride) {
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
-    pipe.InitState();
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.CreateGraphicsPipeline();
 
@@ -197,9 +193,7 @@ TEST_F(PositiveDynamicState, DiscardRectanglesWithDynamicState) {
     std::vector<VkRect2D> discard_rectangles(4);
     discard_rect_ci.pDiscardRectangles = discard_rectangles.data();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &discard_rect_ci;
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &discard_rect_ci);
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -231,7 +225,6 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     InitRenderTarget(&depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
 
     // Create a render pass without any color attachments
     VkAttachmentReference attach = {};
@@ -309,7 +302,6 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.ds_ci_ = ds_state;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -352,7 +344,6 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT);
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.ds_ci_ = ds_state;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -378,11 +369,9 @@ TEST_F(PositiveDynamicState, DynamicStateDoublePipelineBind) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_no_dynamic(*this);
-    pipe_no_dynamic.InitState();
     pipe_no_dynamic.CreateGraphicsPipeline();
 
     vkt::CommandBuffer command_buffer(*m_device, m_commandPool);
@@ -404,12 +393,10 @@ TEST_F(PositiveDynamicState, SetBeforePipeline) {
 
     CreatePipelineHelper pipe_line(*this);
     pipe_line.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
-    pipe_line.InitState();
     pipe_line.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_blend(*this);
     pipe_blend.AddDynamicState(VK_DYNAMIC_STATE_BLEND_CONSTANTS);
-    pipe_blend.InitState();
     pipe_blend.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -441,7 +428,6 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -483,7 +469,6 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
 
     // Create a pipeline with a dynamically set depth bias
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
@@ -536,7 +521,6 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
 
     // Create a pipeline with a dynamically set depth bias
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
@@ -599,7 +583,6 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
 
     // Create a pipeline with a dynamically set depth bias
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
     VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper();
     raster_state.depthBiasEnable = VK_TRUE;
@@ -659,8 +642,7 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
-    pipe.pipe_ms_state_ci_ = ms_state_ci;
-    pipe.InitState();
+    pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -681,7 +663,6 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetTrue) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -721,7 +702,6 @@ TEST_F(PositiveDynamicState, MultisampleStateIgnored) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_MASK_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
     pipe.gp_ci_.pMultisampleState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -742,7 +722,6 @@ TEST_F(PositiveDynamicState, MultisampleStateIgnoredAlphaToOne) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT);
     pipe.gp_ci_.pMultisampleState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -766,7 +745,6 @@ TEST_F(PositiveDynamicState, InputAssemblyStateIgnored) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -781,7 +759,6 @@ TEST_F(PositiveDynamicState, ViewportStateIgnored) {
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_FALSE;
     pipe.gp_ci_.pViewportState = nullptr;
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
     pipe.CreateGraphicsPipeline();
@@ -811,10 +788,9 @@ TEST_F(PositiveDynamicState, ColorBlendStateIgnored) {
     VkPipelineColorBlendAttachmentState att_state = {};
     att_state.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
     att_state.blendEnable = VK_TRUE;
-    pipe.cb_attachments_[0] = att_state;
+    pipe.cb_attachments_ = att_state;
     pipe.gp_ci_.pColorBlendState = nullptr;
 
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -834,7 +810,6 @@ TEST_F(PositiveDynamicState, DepthBoundsTestEnableState) {
     InitRenderTarget(&depth_image_view.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthTestEnable = VK_TRUE;  // ignored
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
@@ -863,7 +838,6 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.vp_state_ci_.viewportCount = 2u;
     pipe.vp_state_ci_.scissorCount = 2u;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
@@ -928,7 +902,6 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -260,7 +260,6 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewpo
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.vp_state_ci_.viewportCount = 0;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -1149,7 +1149,6 @@ TEST_F(NegativeGeometryTessellation, PipelineTessellationMissingPointSize) {
     tess_ci.patchControlPoints = 4u;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
                            pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
@@ -1205,7 +1204,6 @@ TEST_F(NegativeGeometryTessellation, PipelineTessellationPointSize) {
     tess_ci.patchControlPoints = 4u;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
                            pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
@@ -1310,7 +1308,6 @@ TEST_F(NegativeGeometryTessellation, GeometryStreamsCapability) {
     VkShaderObj gs(this, geom_src, VK_SHADER_STAGE_GEOMETRY_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-geometryStreams-02321");
@@ -1506,7 +1503,6 @@ TEST_F(NegativeGeometryTessellation, MismatchedTessellationExecutionModes) {
         tess_ci.patchControlPoints = 4u;
 
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
         pipe.tess_ci_ = tess_ci;
         pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), tesc.GetStageCreateInfo(), tese.GetStageCreateInfo(),

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -143,7 +143,6 @@ TEST_F(PositiveGeometryTessellation, TessellationPointMode) {
     tess_ci.patchControlPoints = 4u;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
                            gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -24,7 +24,6 @@ TEST_F(NegativeGpuAV, DestroyedPipelineLayout) {
 
     // Destroy pipeline layout after creating pipeline
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     {
         const vkt::PipelineLayout doomed_pipeline_layout(*m_device);
         pipe.gp_ci_.layout = doomed_pipeline_layout.handle();
@@ -126,7 +125,6 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
 
     VkShaderObj vs(this, vertshader, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -150,7 +148,6 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     VkShaderObj instrumented_vs(this, vertshader, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr, "main",
                                 &features);
     CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
     pipe2.shader_stages_[0] = instrumented_vs.GetStageCreateInfo();
     pipe2.gp_ci_.layout = pipeline_layout.handle();
     pipe2.CreateGraphicsPipeline();
@@ -248,7 +245,6 @@ TEST_F(NegativeGpuAV, DISABLED_InvalidAtomicStorageOperation) {
                             {2, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
     g_pipe.CreateGraphicsPipeline();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(3, image_view, sampler.handle(), VK_DESCRIPTOR_TYPE_STORAGE_IMAGE,
@@ -354,7 +350,6 @@ TEST_F(NegativeGpuAV, DISABLED_UnnormalizedCoordinatesInBoundsAccess) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
     g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -458,7 +453,6 @@ TEST_F(NegativeGpuAV, DISABLED_UnnormalizedCoordinatesCopyObject) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
     g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -767,7 +761,6 @@ TEST_F(NegativeGpuAV, DISABLED_YcbcrDrawFetchIndexed) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -52,7 +52,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -114,7 +113,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ReadAfterPointerPushConstant) 
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -186,7 +184,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -253,7 +250,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ReadAfterPointerDescriptor) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -302,7 +298,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_UVec3Array) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -372,7 +367,6 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ArrayOfStruct) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -56,7 +56,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Basic) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo()};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
@@ -117,7 +116,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, Store) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
@@ -185,7 +183,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -261,7 +258,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -330,7 +326,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, UVec3Array) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -398,7 +393,6 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DISABLED_ArrayOfStruct) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -102,7 +102,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBBuffer) {
         VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.shader_stages_.clear();
         pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
         pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -224,7 +223,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_.clear();
     pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
     pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -337,7 +335,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_.clear();
     pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
     pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -468,7 +465,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_.clear();
     pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
     pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -596,7 +592,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_.clear();
     pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
     pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -714,7 +709,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     tsci.patchControlPoints = 3;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
                            pipe.fs_->GetStageCreateInfo()};
     pipe.gp_ci_.pTessellationState = &tsci;
@@ -836,7 +830,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     VkShaderObj gs(this, gs_source, VK_SHADER_STAGE_GEOMETRY_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -938,7 +931,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -1063,7 +1055,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1186,7 +1177,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1313,7 +1303,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ImageArrayDynamicIndexing) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1429,7 +1418,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBind) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1623,7 +1611,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     )asm";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -1747,7 +1734,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     )asm";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -1801,7 +1787,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -1875,7 +1860,6 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -84,7 +84,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
     )glsl";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -205,7 +204,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
     )asm";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -327,7 +325,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     )asm";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
@@ -417,7 +414,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -517,7 +513,6 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2020-2023 The Khronos Group Inc.
- * Copyright (c) 2020-2023 Valve Corporation
- * Copyright (c) 2020-2023 LunarG, Inc.
- * Copyright (c) 2020-2023 Google, Inc.
+ * Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
+ * Copyright (c) 2020-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -65,7 +65,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -114,7 +113,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
         void main() {})glsl";
         VkShaderObj mesh_shader(this, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
         CreatePipelineHelper mesh_pipe(*this);
-        mesh_pipe.InitState();
         mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
         mesh_pipe.CreateGraphicsPipeline();
         vkt::Buffer mesh_draw_buffer(*m_device, 2 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
@@ -187,7 +185,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -247,7 +244,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -341,7 +337,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
         void main() {})glsl";
         VkShaderObj mesh_shader(this, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
         CreatePipelineHelper mesh_pipe(*this);
-        mesh_pipe.InitState();
         mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
         mesh_pipe.CreateGraphicsPipeline();
         vkt::Buffer mesh_draw_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
@@ -433,7 +428,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         void main() {})glsl";
     VkShaderObj mesh_shader(this, mesh_shader_source, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
     CreatePipelineHelper mesh_pipe(*this);
-    mesh_pipe.InitState();
     mesh_pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     mesh_pipe.CreateGraphicsPipeline();
     // 012 456 8910
@@ -494,7 +488,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     )glsl";
     VkShaderObj task_shader(this, task_shader_source, VK_SHADER_STAGE_TASK_BIT_EXT, SPV_ENV_VULKAN_1_3);
     CreatePipelineHelper task_pipe(*this);
-    task_pipe.InitState();
     task_pipe.shader_stages_[0] = task_shader.GetStageCreateInfo();
     task_pipe.shader_stages_[1] = mesh_shader.GetStageCreateInfo();
     task_pipe.CreateGraphicsPipeline();
@@ -577,7 +570,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -671,7 +663,6 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     indirect_buffer.memory().unmap();
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -61,11 +61,9 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     pipeline_robustness_ci.uniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT;
     pipeline_robustness_ci.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_EXT;
 
-    CreatePipelineHelper robust_pipe(*this);
-    robust_pipe.InitState();
+    CreatePipelineHelper robust_pipe(*this, &pipeline_robustness_ci);
     robust_pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     robust_pipe.gp_ci_.layout = pipeline_layout.handle();
-    robust_pipe.gp_ci_.pNext = &pipeline_robustness_ci;
     robust_pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -126,7 +124,6 @@ TEST_F(NegativeGpuAVOOB, Basic) {
 
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -211,7 +208,6 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
     VkShaderObj fs(this, fragment_shader, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
 
@@ -435,12 +431,10 @@ TEST_F(NegativeGpuAVOOB, GPL) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
-    pre_raster.InitState();
     pre_raster.gp_ci_.layout = pipeline_layout.handle();
     pre_raster.CreateGraphicsPipeline(false);
 
@@ -576,12 +570,10 @@ TEST_F(NegativeGpuAVOOB, GPLIndependentSets) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
-    pre_raster.InitState();
     pre_raster.gp_ci_.layout = pipeline_layout_vs.handle();
     pre_raster.CreateGraphicsPipeline(false);
 
@@ -698,7 +690,6 @@ TEST_F(NegativeGpuAVOOB, StorageBuffer) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -740,7 +731,6 @@ void NegativeGpuAVOOB::ComputeStorageBufferTest(const char *expected_error, cons
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -826,7 +816,6 @@ TEST_F(NegativeGpuAVOOB, TexelFetch) {
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -881,7 +870,6 @@ TEST_F(NegativeGpuAVOOB, ImageLoad) {
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -932,7 +920,6 @@ TEST_F(NegativeGpuAVOOB, ImageStore) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -989,7 +976,6 @@ TEST_F(NegativeGpuAVOOB, Geometry) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
@@ -1047,7 +1033,6 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationControl) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     pipe.tess_ci_ = tess_ci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),
@@ -1106,7 +1091,6 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationEvaluation) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     pipe.tess_ci_ = tess_ci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(),

--- a/tests/unit/gpu_av_oob_positive.cpp
+++ b/tests/unit/gpu_av_oob_positive.cpp
@@ -70,7 +70,6 @@ TEST_F(PositiveGpuAVOOB, Basic) {
 
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -126,7 +125,6 @@ TEST_F(PositiveGpuAVOOB, ImageLoadStoreTexelFetch) {
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -186,7 +184,6 @@ TEST_F(PositiveGpuAVOOB, AtomicImageLoadStore) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipe.CreateComputePipeline();
 
@@ -276,12 +273,10 @@ TEST_F(PositiveGpuAVOOB, GPL) {
 
     CreatePipelineHelper vi(*this);
     vi.InitVertexInputLibInfo();
-    vi.InitState();
     vi.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster(*this);
     pre_raster.InitPreRasterLibInfo(&pre_raster_stage.stage_ci);
-    pre_raster.InitState();
     pre_raster.gp_ci_.layout = pipeline_layout.handle();
     pre_raster.CreateGraphicsPipeline(false);
 

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -80,7 +80,6 @@ TEST_F(PositiveGpuAV, RobustBuffer) {
 
     VkShaderObj vs(this, vs_source, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -201,7 +200,6 @@ TEST_F(PositiveGpuAV, InlineUniformBlock) {
     CreateComputePipelineHelper pipe1(*this);
     pipe1.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe1.cp_ci_.layout = pipeline_layout.handle();
-    pipe1.InitState();
     pipe1.CreateComputePipeline();
 
     m_commandBuffer->begin();
@@ -311,7 +309,6 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
         // We should still be able to use the layout and create a temporary uninstrumented shader module
         pipe.cp_ci_.layout = pl_layout.handle();
-        pipe.InitState();
         pipe.CreateComputePipeline();
 
         m_commandBuffer->begin();
@@ -338,7 +335,6 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         CreateComputePipelineHelper pipe(*this);
         pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
         pipe.cp_ci_.layout = pipeline_layout.handle();
-        pipe.InitState();
         pipe.CreateComputePipeline();
 
         m_commandBuffer->begin();
@@ -394,7 +390,6 @@ TEST_F(PositiveGpuAV, SetSSBOBindDescriptor) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                           {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkBufferUsageFlags buffer_usage =
@@ -711,7 +706,6 @@ TEST_F(PositiveGpuAV, SelectInstrumentedShaders) {
     features.pEnabledValidationFeatures = enabled;
     VkShaderObj fs(this, vertshader, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, nullptr, "main", &features);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_.clear();
     pipe.shader_stages_.push_back(vs.GetStageCreateInfo());
     pipe.shader_stages_.push_back(fs.GetStageCreateInfo());
@@ -794,7 +788,6 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -860,7 +853,6 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_, &descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
@@ -897,7 +889,6 @@ TEST_F(PositiveGpuAV, FirstInstance) {
     draw_buffer.memory().unmap();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           float t_min;
@@ -38,7 +38,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
 
         void main() {
             rayQueryEXT query;
-            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0), 
+            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0),
               trace_rays_params.t_min, vec3(0,0,1), trace_rays_params.t_max);
             rayQueryProceedEXT(query);
         }
@@ -48,7 +48,6 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -84,7 +83,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           float t_min;
@@ -93,7 +92,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
 
         void main() {
             rayQueryEXT query;
-            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0), 
+            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0),
               trace_rays_params.t_min, vec3(0,0,1), trace_rays_params.t_max);
             rayQueryProceedEXT(query);
         }
@@ -103,7 +102,6 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -139,7 +137,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           uint ray_query_flags;
@@ -156,7 +154,6 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -208,7 +205,6 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -263,7 +259,6 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -319,7 +314,6 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -376,7 +370,6 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
@@ -468,7 +461,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     char const *fragment_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(location=0) out vec4 color;
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform SSBO {
@@ -493,7 +486,6 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     pipeline.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateGraphicsPipeline();
 
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -39,7 +39,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
 
         void main() {
@@ -52,7 +52,6 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     CreateComputePipelineHelper pipeline(*this);
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
@@ -78,7 +77,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           float t_min;
@@ -87,7 +86,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
 
         void main() {
             rayQueryEXT query;
-            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0), 
+            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0),
               trace_rays_params.t_min, vec3(0,0,1), trace_rays_params.t_max);
             rayQueryProceedEXT(query);
         }
@@ -97,7 +96,6 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
@@ -146,7 +144,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           uint ray_query_flags;
@@ -163,7 +161,6 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
@@ -203,7 +200,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     char const *shader_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
         layout(set = 0, binding = 1) uniform Uniforms {
           uint ray_query_flags;
@@ -220,7 +217,6 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     pipeline.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
@@ -258,7 +254,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     char const *vertex_source = R"glsl(
         #version 460
         #extension GL_EXT_ray_query : require
-        
+
         layout(set = 0, binding = 0) uniform accelerationStructureEXT tlas;
 
         void main() {
@@ -273,7 +269,6 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     CreatePipelineHelper pipeline(*this);
     pipeline.shader_stages_ = {vs.GetStageCreateInfo(), pipeline.fs_->GetStageCreateInfo()};
     pipeline.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
-    pipeline.InitState();
     pipeline.CreateGraphicsPipeline();
 
     // Add TLAS binding

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -90,7 +90,6 @@ TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.CreateComputePipeline();
 

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -154,7 +154,6 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -236,7 +235,6 @@ TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.CreateComputePipeline();
 
@@ -339,7 +337,6 @@ TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
         )";
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -86,7 +86,6 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkOnly) {
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.flags |= VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -95,7 +94,6 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkOnly) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -127,7 +125,6 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkCreate) {
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.flags |= VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -141,7 +138,6 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkCreate) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06614");
         frag_shader_lib.CreateGraphicsPipeline();
@@ -218,7 +214,6 @@ TEST_F(NegativeGraphicsLibrary, MissingDSState) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    frag_shader_lib.InitState();
 
     frag_shader_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     frag_shader_lib.gp_ci_.pDepthStencilState = nullptr;
@@ -247,7 +242,6 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci, &pipeline_rendering_info);
-        pre_raster_lib.InitState();
 
         pre_raster_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         pre_raster_lib.gp_ci_.pDepthStencilState = nullptr;
@@ -262,7 +256,6 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
     CreatePipelineHelper frag_output_lib(*this);
     {
         frag_output_lib.InitFragmentOutputLibInfo();
-        frag_output_lib.InitState();
 
         frag_output_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         frag_output_lib.gp_ci_.pDepthStencilState = nullptr;
@@ -288,7 +281,6 @@ TEST_F(NegativeGraphicsLibrary, MissingDSStateWithFragOutputState) {
         link_info.pLibraries = libraries;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
         frag_shader_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
@@ -315,7 +307,6 @@ TEST_F(NegativeGraphicsLibrary, DepthStencilStateIgnored) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    frag_shader_lib.InitState();
 
     frag_shader_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     frag_shader_lib.gp_ci_.pDepthStencilState = nullptr;
@@ -354,7 +345,6 @@ TEST_F(NegativeGraphicsLibrary, MissingColorBlendState) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
 
         pre_raster_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         pre_raster_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
@@ -368,7 +358,6 @@ TEST_F(NegativeGraphicsLibrary, MissingColorBlendState) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_output_lib.InitFragmentOutputLibInfo(&link_info);
-        frag_output_lib.InitState();
 
         frag_output_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         frag_output_lib.gp_ci_.pColorBlendState = nullptr;
@@ -386,7 +375,6 @@ TEST_F(NegativeGraphicsLibrary, ImplicitVUIDs) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
 
     pipe.gp_ci_.layout = VK_NULL_HANDLE;
@@ -424,7 +412,6 @@ TEST_F(NegativeGraphicsLibrary, CreateStateGPL) {
     {
         // Test creating a pipeline with incorrect create flags
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606");
@@ -434,7 +421,6 @@ TEST_F(NegativeGraphicsLibrary, CreateStateGPL) {
 
     {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.gp_ci_.layout = VK_NULL_HANDLE;
         pipe.gp_ci_.stageCount = pipe.shader_stages_.size();
         pipe.gp_ci_.pStages = pipe.shader_stages_.data();
@@ -450,7 +436,6 @@ TEST_F(NegativeGraphicsLibrary, CreateStateGPL) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pipe.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606");
         pipe.CreateGraphicsPipeline();
@@ -468,7 +453,6 @@ TEST_F(NegativeGraphicsLibrary, CreateLibraryFlag) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06608");
@@ -486,7 +470,6 @@ TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     // Ensure this library is created _without_ VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT
     vertex_input_lib.gp_ci_.flags &= ~VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
     vertex_input_lib.CreateGraphicsPipeline(false);
@@ -503,7 +486,6 @@ TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
 
         // Creating with VK_PIPELINE_CREATE_LINK_TIME_OPTIMIZATION_BIT_EXT while linking against a library without
         // VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT is invalid
@@ -517,7 +499,6 @@ TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
 
         // Creating with VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT while linking against a library without
         // VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT is invalid
@@ -531,7 +512,6 @@ TEST_F(NegativeGraphicsLibrary, LinkOptimization) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
 
         // Creating with VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT without
         // VK_PIPELINE_CREATE_LIBRARY_BIT_KHR is invalid
@@ -567,7 +547,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInCreate) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -582,7 +561,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInCreate) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06756");
@@ -615,7 +593,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInLink) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -630,7 +607,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsNullInLink) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06757");
         frag_shader_lib.CreateGraphicsPipeline(false);
@@ -662,7 +638,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsLinkOnly) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -672,7 +647,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsLinkOnly) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
@@ -705,7 +679,6 @@ TEST_F(NegativeGraphicsLibrary, PreRasterStateNoLayout) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pipe.InitState();
 
     pipe.gp_ci_.layout = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06642");
@@ -751,7 +724,6 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -766,7 +738,6 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_src);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -776,7 +747,6 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
@@ -847,7 +817,6 @@ TEST_F(NegativeGraphicsLibrary, PreRasterWithFS) {
     CreatePipelineHelper pipe(*this);
     pipe.InitPreRasterLibInfo(stages.data());
     pipe.gp_ci_.stageCount = 2;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-06894");
     pipe.CreateGraphicsPipeline();
@@ -887,7 +856,6 @@ TEST_F(NegativeGraphicsLibrary, FragmentStateWithPreRaster) {
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentLibInfo(stages.data());
     pipe.gp_ci_.stageCount = static_cast<uint32_t>(stages.size());
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-06895");
     pipe.CreateGraphicsPipeline();
@@ -902,7 +870,6 @@ TEST_F(NegativeGraphicsLibrary, StageCount) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.gp_ci_.stageCount = 0;
     pre_raster_lib.gp_ci_.layout = pre_raster_lib.pipeline_layout_.handle();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06644");
@@ -916,7 +883,6 @@ TEST_F(NegativeGraphicsLibrary, NullStages) {
 
     CreatePipelineHelper pre_raster_lib(*this);
     pre_raster_lib.InitPreRasterLibInfo(nullptr);
-    pre_raster_lib.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06640");
     pre_raster_lib.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -932,7 +898,6 @@ TEST_F(NegativeGraphicsLibrary, MissingShaderStages) {
         pipe.InitPreRasterLibInfo(nullptr);
         pipe.gp_ci_.stageCount = 0;
         pipe.shader_stages_.clear();
-        pipe.InitState();
 
         // set in stateless
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-flags-06644");
@@ -956,7 +921,6 @@ TEST_F(NegativeGraphicsLibrary, BadRenderPassPreRaster) {
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pipe(*this);
     pipe.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pipe.InitState();
     VkRenderPass bad_rp = CastToHandle<VkRenderPass, uintptr_t>(0xbaadbeef);
     pipe.gp_ci_.renderPass = bad_rp;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06643");
@@ -975,7 +939,6 @@ TEST_F(NegativeGraphicsLibrary, BadRenderPassFragmentShader) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     pipe.InitFragmentLibInfo(&fs_stage.stage_ci);
-    pipe.InitState();
     VkRenderPass bad_rp = CastToHandle<VkRenderPass, uintptr_t>(0xbaadbeef);
     pipe.gp_ci_.renderPass = bad_rp;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-09035");
@@ -993,7 +956,6 @@ TEST_F(NegativeGraphicsLibrary, BadRenderPassFragmentOutput) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentOutputLibInfo();
-    pipe.InitState();
     VkRenderPass bad_rp = CastToHandle<VkRenderPass, uintptr_t>(0xbaadbeef);
     pipe.gp_ci_.renderPass = bad_rp;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06643");
@@ -1012,7 +974,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -1022,7 +983,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
         pre_raster_lib.CreateGraphicsPipeline();
     }
@@ -1087,12 +1047,10 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
 
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo();
-    fo_lib.InitState();
     fo_lib.CreateGraphicsPipeline(false);
 
     // Check pre-raster library with shader accessing FS-only descriptor
@@ -1106,7 +1064,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
         vkt::GraphicsPipelineLibraryStage stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         CreatePipelineHelper vs_lib(*this);
         vs_lib.InitPreRasterLibInfo(&stage.stage_ci);
-        vs_lib.InitState();
         vs_lib.gp_ci_.layout = pipeline_layout.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
         vs_lib.CreateGraphicsPipeline(false);
@@ -1116,7 +1073,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         CreatePipelineHelper fs_lib(*this);
         fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        fs_lib.InitState();
         fs_lib.gp_ci_.layout = pipeline_layout.handle();
         fs_lib.CreateGraphicsPipeline(false);
     }
@@ -1132,7 +1088,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
         vkt::GraphicsPipelineLibraryStage stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         CreatePipelineHelper vs_lib(*this);
         vs_lib.InitPreRasterLibInfo(&stage.stage_ci);
-        vs_lib.InitState();
         vs_lib.gp_ci_.layout = pipeline_layout.handle();
         vs_lib.CreateGraphicsPipeline(false);
 
@@ -1140,7 +1095,6 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderStageMask) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         CreatePipelineHelper fs_lib(*this);
         fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        fs_lib.InitState();
         fs_lib.gp_ci_.layout = pipeline_layout.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
         fs_lib.CreateGraphicsPipeline(false);
@@ -1192,19 +1146,16 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
 
     CreatePipelineHelper vi_bad_lib(*this);
     vi_bad_lib.InitVertexInputLibInfo();
-    vi_bad_lib.InitState();
     iasci_bad.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;  // otherwise we get a failure about invalid topology
     vi_bad_lib.gp_ci_.pInputAssemblyState = &iasci_bad;
     vi_bad_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper fs_lib(*this);
     fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    fs_lib.InitState();
     fs_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo();
-    fo_lib.InitState();
     fo_lib.CreateGraphicsPipeline(false);
 
     // libs[0] == vertex input lib
@@ -1226,7 +1177,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         CreatePipelineHelper pre_raster_lib(*this);
         const std::array shaders = {vs_stage.stage_ci, tcs_stage.stage_ci};
         pre_raster_lib.InitPreRasterLibInfoFromContainer(shaders);
-        pre_raster_lib.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-09022");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-00729");
         pre_raster_lib.CreateGraphicsPipeline();
@@ -1238,7 +1188,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         CreatePipelineHelper pre_raster_lib(*this);
         const std::array shaders = {vs_stage.stage_ci, tes_stage.stage_ci};
         pre_raster_lib.InitPreRasterLibInfoFromContainer(shaders);
-        pre_raster_lib.InitState();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-00730");
         pre_raster_lib.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();
@@ -1248,13 +1197,11 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         // Pass patch topology without tessellation shaders
         CreatePipelineHelper vi_patch_lib(*this);
         vi_patch_lib.InitVertexInputLibInfo();
-        vi_patch_lib.InitState();
         vi_patch_lib.gp_ci_.pInputAssemblyState = &iasci;
         vi_patch_lib.CreateGraphicsPipeline(false);
 
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = fs_lib.gp_ci_.layout;
         pre_raster_lib.CreateGraphicsPipeline();
 
@@ -1273,7 +1220,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = fs_lib.gp_ci_.layout;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-09022");
         pre_raster_lib.CreateGraphicsPipeline();
@@ -1284,7 +1230,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
-        pre_raster_lib.InitState();
         // stype-check off
         tsci_bad.sType = VK_STRUCTURE_TYPE_SUBMIT_INFO;
         // stype-check on
@@ -1298,7 +1243,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
-        pre_raster_lib.InitState();
         tsci_bad = tsci;
         tsci_bad.patchControlPoints = 0;
         pre_raster_lib.gp_ci_.pTessellationState = &tsci_bad;
@@ -1310,7 +1254,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
-        pre_raster_lib.InitState();
         tsci_bad = tsci;
         tsci_bad.patchControlPoints = m_device->phy().limits_.maxTessellationPatchSize + 1;
         pre_raster_lib.gp_ci_.pTessellationState = &tsci_bad;
@@ -1323,7 +1266,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
     {
         CreatePipelineHelper vi_lib(*this);
         vi_lib.InitVertexInputLibInfo();
-        vi_lib.InitState();
         iasci_bad = iasci;
         iasci_bad.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         vi_lib.gp_ci_.pInputAssemblyState = &iasci_bad;
@@ -1331,7 +1273,6 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
 
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.pTessellationState = &tsci;
         pre_raster_lib.gp_ci_.layout = fs_lib.gp_ci_.layout;
         pre_raster_lib.CreateGraphicsPipeline(false);
@@ -1358,7 +1299,6 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     {
         CreatePipelineHelper vertex_input_lib(*this);
         vertex_input_lib.InitVertexInputLibInfo();
-        vertex_input_lib.InitState();
         vertex_input_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR;
         vertex_input_lib.CreateGraphicsPipeline(false);
 
@@ -1385,7 +1325,6 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     {
         CreatePipelineHelper vertex_input_lib(*this);
         vertex_input_lib.InitVertexInputLibInfo();
-        vertex_input_lib.InitState();
         vertex_input_lib.CreateGraphicsPipeline(false);
 
         VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -1404,7 +1343,6 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
     {
         CreatePipelineHelper vertex_input_lib(*this);
         vertex_input_lib.InitVertexInputLibInfo();
-        vertex_input_lib.InitState();
         vertex_input_lib.gp_ci_.flags =
             VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR;
         vertex_input_lib.CreateGraphicsPipeline(false);
@@ -1458,7 +1396,6 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -1473,7 +1410,6 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_src);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_lib.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -1483,7 +1419,6 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_lib.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
@@ -1491,7 +1426,6 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.InitState();
     frag_out_lib.CreateGraphicsPipeline(false);
 
     std::array libraries = {
@@ -1541,7 +1475,6 @@ TEST_F(NegativeGraphicsLibrary, BindLibraryPipeline) {
 
     CreatePipelineHelper pipeline(*this);
     pipeline.InitVertexInputLibInfo();
-    pipeline.InitState();
     pipeline.CreateGraphicsPipeline(false);
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-pipeline-03382");
@@ -1577,7 +1510,6 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
-    pipe.InitState();
 
     // Both a shader module ci and shader module id ci in pNext
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-06844");
@@ -1630,7 +1562,6 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
     pipe2.gp_ci_.stageCount = 1;
     pipe2.gp_ci_.pStages = &stage_ci;
     pipe2.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
-    pipe2.InitState();
     stage_ci.pNext = &sm_id_create_info;
     stage_ci.module = VK_NULL_HANDLE;
     VkResult result = pipe2.CreateGraphicsPipeline();
@@ -1674,7 +1605,6 @@ TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifierFeatures) {
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-stage-08771");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1721,12 +1651,10 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
 
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo();
-    fo_lib.InitState();
     fo_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -1735,7 +1663,6 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
         vkt::GraphicsPipelineLibraryStage stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
 
         pre_raster_lib.InitPreRasterLibInfo(&stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_lib.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -1746,7 +1673,6 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
         vkt::GraphicsPipelineLibraryStage stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         frag_shader_lib.InitFragmentLibInfo(&stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_lib.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
@@ -1792,12 +1718,10 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayoutsMultipleSubsets) {
 
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo();
-    fo_lib.InitState();
     fo_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper shader_lib(*this);
@@ -1808,7 +1732,6 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayoutsMultipleSubsets) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         std::vector<VkPipelineShaderStageCreateInfo> stages = {vs_stage.stage_ci, fs_stage.stage_ci};
         shader_lib.InitShaderLibInfo(stages);
-        shader_lib.InitState();
         shader_lib.gp_ci_.layout = pipeline_layout_lib.handle();
         shader_lib.CreateGraphicsPipeline();
     }
@@ -1842,7 +1765,6 @@ TEST_F(NegativeGraphicsLibrary, MissingLinkingLayout) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -1852,7 +1774,6 @@ TEST_F(NegativeGraphicsLibrary, MissingLinkingLayout) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -1897,14 +1818,12 @@ TEST_F(NegativeGraphicsLibrary, NullLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper frag_out_lib(*this);
@@ -1937,14 +1856,12 @@ TEST_F(NegativeGraphicsLibrary, BadLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.CreateGraphicsPipeline();
 
     CreatePipelineHelper frag_out_lib(*this);
@@ -1978,7 +1895,6 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -1989,7 +1905,6 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2058,7 +1973,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantStages) {
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range_vert;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2069,7 +1983,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantStages) {
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         frag_shader_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range_frag;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -2104,7 +2017,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantSize) {
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range_4;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2115,7 +2027,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantSize) {
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         frag_shader_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range_8;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -2150,7 +2061,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantMultiple) {
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 2;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = pc_ranges_a;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2161,7 +2071,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantMultiple) {
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 2;
         frag_shader_lib.pipeline_layout_ci_.pPushConstantRanges = pc_ranges_b;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -2195,7 +2104,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantDifferentCount) {
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 2;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = pc_ranges;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2206,7 +2114,6 @@ TEST_F(NegativeGraphicsLibrary, PushConstantDifferentCount) {
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         frag_shader_lib.pipeline_layout_ci_.pPushConstantRanges = pc_ranges;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -2247,7 +2154,6 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCount) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2262,7 +2168,6 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCount) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
@@ -2291,7 +2196,6 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCountLinking) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2301,7 +2205,6 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCountLinking) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
@@ -2354,7 +2257,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutCreateFlags) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2369,7 +2271,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutCreateFlags) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
@@ -2399,7 +2300,6 @@ TEST_F(NegativeGraphicsLibrary, BindingCount) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2414,7 +2314,6 @@ TEST_F(NegativeGraphicsLibrary, BindingCount) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
@@ -2443,7 +2342,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutBinding) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2458,7 +2356,6 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetLayoutBinding) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06612");
@@ -2489,7 +2386,6 @@ TEST_F(NegativeGraphicsLibrary, NullDSL) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2504,7 +2400,6 @@ TEST_F(NegativeGraphicsLibrary, NullDSL) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06679");
@@ -2535,7 +2430,6 @@ TEST_F(NegativeGraphicsLibrary, NullDSLLinking) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -2545,7 +2439,6 @@ TEST_F(NegativeGraphicsLibrary, NullDSLLinking) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
@@ -2587,10 +2480,9 @@ TEST_F(NegativeGraphicsLibrary, NullLayoutPreRasterFragShader) {
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     pipe.gp_ci_.pViewportState = &pipe.vp_state_ci_;
     pipe.gp_ci_.pRasterizationState = &pipe.rs_state_ci_;
-    pipe.gp_ci_.pMultisampleState = &pipe.pipe_ms_state_ci_;
+    pipe.gp_ci_.pMultisampleState = &pipe.ms_ci_;
     pipe.gp_ci_.renderPass = renderPass();
     pipe.gp_ci_.subpass = 0;
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06682");
@@ -2616,7 +2508,6 @@ TEST_F(NegativeGraphicsLibrary, NullLayoutPreRasterDiscardEnable) {
     CreatePipelineHelper pipe(*this);
     pipe.InitPreRasterLibInfo(&vs_stage.stage_ci);
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06683");
@@ -2632,8 +2523,8 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateFragOutputLibrary) {
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.minSampleShading = 0.5f;
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
+    frag_out_lib.ms_ci_.minSampleShading = 0.5f;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_TRUE;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -2646,7 +2537,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateFragOutputLibrary) {
     CreatePipelineHelper frag_shader_lib(*this);
 
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-    frag_shader_lib.pipe_ms_state_ci_.minSampleShading = 0.2f;
+    frag_shader_lib.ms_ci_.minSampleShading = 0.2f;
     frag_shader_lib.gp_ci_.layout = pipeline_layout.handle();
     frag_shader_lib.gp_ci_.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-06633");
@@ -2666,7 +2557,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateFragShaderLibrary) {
     CreatePipelineHelper frag_shader_lib(*this);
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
     frag_shader_lib.gp_ci_.layout = pipeline_layout.handle();
-    frag_shader_lib.pipe_ms_state_ci_.minSampleShading = 0.2f;
+    frag_shader_lib.ms_ci_.minSampleShading = 0.2f;
     frag_shader_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -2676,8 +2567,8 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateFragShaderLibrary) {
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo(&link_info);
     frag_out_lib.gp_ci_.layout = pipeline_layout.handle();
-    frag_out_lib.pipe_ms_state_ci_.minSampleShading = 0.5f;
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
+    frag_out_lib.ms_ci_.minSampleShading = 0.5f;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_TRUE;
     frag_out_lib.gp_ci_.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06634");
     frag_out_lib.CreateGraphicsPipeline(false);
@@ -2721,7 +2612,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateFragShaderNull) {
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_TRUE;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -2750,7 +2641,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateBothLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -2760,7 +2650,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateBothLibrary) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2772,14 +2661,14 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateBothLibrary) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.gp_ci_.layout = layout;
-        frag_shader_lib.pipe_ms_state_ci_.minSampleShading = 0.2f;
+        frag_shader_lib.ms_ci_.minSampleShading = 0.2f;
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.minSampleShading = 0.5f;
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
+    frag_out_lib.ms_ci_.minSampleShading = 0.5f;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_TRUE;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipeline libraries[4] = {
@@ -2817,7 +2706,6 @@ TEST_F(NegativeGraphicsLibrary, FragmentShadingRateStateFragShaderLibrary) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci, &fsr_state_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.CreateGraphicsPipeline();
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper(&fsr_state_ci);
@@ -2853,7 +2741,6 @@ TEST_F(NegativeGraphicsLibrary, FragmentShadingRateStateBothLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -2863,7 +2750,6 @@ TEST_F(NegativeGraphicsLibrary, FragmentShadingRateStateBothLibrary) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci, &fsr_state_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2909,7 +2795,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArray) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -2919,7 +2804,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArray) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2933,13 +2817,13 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArray) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.gp_ci_.layout = layout;
-        frag_shader_lib.pipe_ms_state_ci_.pSampleMask = &mask_a;
+        frag_shader_lib.ms_ci_.pSampleMask = &mask_a;
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.pSampleMask = &mask_b;
+    frag_out_lib.ms_ci_.pSampleMask = &mask_b;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipeline libraries[4] = {
@@ -2968,7 +2852,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArrayNull) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -2978,7 +2861,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArrayNull) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -2991,13 +2873,13 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArrayNull) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.gp_ci_.layout = layout;
-        frag_shader_lib.pipe_ms_state_ci_.pSampleMask = &mask_a;
+        frag_shader_lib.ms_ci_.pSampleMask = &mask_a;
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.pSampleMask = nullptr;
+    frag_out_lib.ms_ci_.pSampleMask = nullptr;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipeline libraries[4] = {
@@ -3025,7 +2907,6 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateMultipleSubsets) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper shader_lib(*this);
@@ -3036,15 +2917,14 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateMultipleSubsets) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         std::vector<VkPipelineShaderStageCreateInfo> stages = {vs_stage.stage_ci, fs_stage.stage_ci};
         shader_lib.InitShaderLibInfo(stages);
-        shader_lib.InitState();
-        shader_lib.pipe_ms_state_ci_.minSampleShading = 0.2f;
+        shader_lib.ms_ci_.minSampleShading = 0.2f;
         shader_lib.CreateGraphicsPipeline();
     }
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.minSampleShading = 0.5f;
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
+    frag_out_lib.ms_ci_.minSampleShading = 0.5f;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_TRUE;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipeline libraries[3] = {
@@ -3074,7 +2954,6 @@ TEST_F(NegativeGraphicsLibrary, VertexInput) {
     pipe.InitVertexInputLibInfo();
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-08898");
     pipe.CreateGraphicsPipeline(false);
@@ -3102,7 +2981,6 @@ TEST_F(NegativeGraphicsLibrary, VertexInputWithVertexShader) {
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.gp_ci_.pInputAssemblyState = nullptr;
     pipe.gpl_info->flags |= VK_GRAPHICS_PIPELINE_LIBRARY_VERTEX_INPUT_INTERFACE_BIT_EXT;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-08897");
     pipe.CreateGraphicsPipeline(false);
@@ -3117,7 +2995,6 @@ TEST_F(NegativeGraphicsLibrary, MissingPreRasterization) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     vkt::PipelineLayout pipeline_layout(*m_device);
@@ -3158,7 +3035,6 @@ TEST_F(NegativeGraphicsLibrary, MissingFragmentShader) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -3166,7 +3042,6 @@ TEST_F(NegativeGraphicsLibrary, MissingFragmentShader) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -3198,7 +3073,6 @@ TEST_F(NegativeGraphicsLibrary, MissingFragmentOutput) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -3206,7 +3080,6 @@ TEST_F(NegativeGraphicsLibrary, MissingFragmentOutput) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -30,7 +30,6 @@ TEST_F(PositiveGraphicsLibrary, VertexInput) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitVertexInputLibInfo();
-    pipe.InitState();
     pipe.CreateGraphicsPipeline(false);
 }
 
@@ -47,7 +46,6 @@ TEST_F(PositiveGraphicsLibrary, PreRaster) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -62,7 +60,6 @@ TEST_F(PositiveGraphicsLibrary, FragmentShader) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     pipe.InitFragmentLibInfo(&fs_stage.stage_ci);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -75,7 +72,6 @@ TEST_F(PositiveGraphicsLibrary, FragmentOutput) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentOutputLibInfo();
-    pipe.InitState();
     pipe.CreateGraphicsPipeline(false);
 }
 
@@ -89,7 +85,6 @@ TEST_F(PositiveGraphicsLibrary, FragmentMixedAttachmentSamplesAMD) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentOutputLibInfo();
-    pipe.InitState();
     pipe.gp_ci_.pRasterizationState = nullptr;
 
     pipe.gp_ci_.pRasterizationState = nullptr;
@@ -110,7 +105,6 @@ TEST_F(PositiveGraphicsLibrary, ExeLibrary) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -120,7 +114,6 @@ TEST_F(PositiveGraphicsLibrary, ExeLibrary) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -164,7 +157,6 @@ TEST_F(PositiveGraphicsLibrary, CombinedShaderSubsets) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper shader_lib(*this);
@@ -175,7 +167,6 @@ TEST_F(PositiveGraphicsLibrary, CombinedShaderSubsets) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         std::vector<VkPipelineShaderStageCreateInfo> stages = {vs_stage.stage_ci, fs_stage.stage_ci};
         shader_lib.InitShaderLibInfo(stages);
-        shader_lib.InitState();
         shader_lib.CreateGraphicsPipeline();
     }
 
@@ -230,7 +221,6 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -245,7 +235,6 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vs_src);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -255,7 +244,6 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
         const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        frag_shader_lib.InitState();
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
@@ -319,7 +307,6 @@ TEST_F(PositiveGraphicsLibrary, VertexInputAttributeDescriptionOffset) {
 
     // override vertex input
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    frag_shader_lib.InitState();
     frag_shader_lib.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
     frag_shader_lib.vi_ci_.vertexBindingDescriptionCount = 1;
     frag_shader_lib.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
@@ -353,7 +340,6 @@ TEST_F(PositiveGraphicsLibrary, VertexAttributeDivisorInstanceRateZero) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    frag_shader_lib.InitState();
 
     // override vertex input
     frag_shader_lib.vi_ci_.pNext = &divisor_state_create_info;
@@ -382,7 +368,6 @@ TEST_F(PositiveGraphicsLibrary, NotAttachmentDynamicBlendEnable) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentOutputLibInfo();
-    pipe.InitState();
     pipe.cb_ci_.pAttachments = nullptr;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
@@ -411,7 +396,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.gp_ci_.pDynamicState = &dynamic_create_info;
     vertex_input_lib.gp_ci_.pInputAssemblyState = &ia_state;
     vertex_input_lib.CreateGraphicsPipeline(false);
@@ -424,7 +408,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.pDynamicState = &dynamic_create_info;
         pre_raster_lib.gp_ci_.pInputAssemblyState = &ia_state;
         pre_raster_lib.CreateGraphicsPipeline();
@@ -500,7 +483,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.gp_ci_.pDynamicState = &dynamic_create_info;
     vertex_input_lib.gp_ci_.pInputAssemblyState = &ia_state;
     vertex_input_lib.CreateGraphicsPipeline(false);
@@ -513,7 +495,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -584,7 +565,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
     vertex_input_lib.gp_ci_.pInputAssemblyState = &ia_state;
     vertex_input_lib.CreateGraphicsPipeline(false);
@@ -597,7 +577,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -664,7 +643,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -672,7 +650,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -739,7 +716,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -747,7 +723,6 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -823,7 +798,6 @@ TEST_F(PositiveGraphicsLibrary, LinkingInputAttachment) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper pre_raster_lib(*this);
@@ -831,7 +805,6 @@ TEST_F(PositiveGraphicsLibrary, LinkingInputAttachment) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -898,7 +871,6 @@ TEST_F(PositiveGraphicsLibrary, TessellationWithoutPreRasterization) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitVertexInputLibInfo();
-    pipe.InitState();
 
     VkPipelineShaderStageCreateInfo stages[2];
 
@@ -941,7 +913,6 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     // Create a full pipeline with the same bad rendering info, but enable rasterizer discard to ignore the bad data
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline();
 
     // Create an executable pipeline with rasterization disabled
@@ -970,7 +941,6 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &pipeline_rendering_info);
-        fs_lib.InitState();
         fs_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         fs_lib.gp_ci_.pDepthStencilState = &ds_ci;
         fs_lib.CreateGraphicsPipeline();
@@ -982,7 +952,6 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     pr_lib.InitPreRasterLibInfo(&vs_stage.stage_ci, &pipeline_rendering_info);
     pr_lib.rs_state_ci_.rasterizerDiscardEnable =
         VK_TRUE;  // This should cause the bad info in pipeline_rendering_info to be ignored
-    pr_lib.InitState();
     pr_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     pr_lib.CreateGraphicsPipeline();
 
@@ -1016,7 +985,6 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     // Create a full pipeline with the same bad rendering info, but enable rasterizer discard to ignore the bad data
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline();
 
     // Create an executable pipeline with rasterization enabled and make a draw call using dynamic rendering
@@ -1041,7 +1009,6 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        fs_lib.InitState();
         fs_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         fs_lib.gp_ci_.pDepthStencilState = &ds_ci;
         fs_lib.CreateGraphicsPipeline();
@@ -1051,7 +1018,6 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     CreatePipelineHelper pr_lib(*this);
     pr_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pr_lib.InitState();
     pr_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     pr_lib.CreateGraphicsPipeline();
 
@@ -1063,7 +1029,6 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo(&pipeline_rendering_info);
-    fo_lib.InitState();
     fo_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     fo_lib.CreateGraphicsPipeline(false);
 
@@ -1140,19 +1105,16 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         fs_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-        fs_lib.InitState();
         fs_lib.gp_ci_.pDepthStencilState = &ds_ci;
         fs_lib.CreateGraphicsPipeline();
     }
 
     CreatePipelineHelper vi_lib(*this);
     vi_lib.InitVertexInputLibInfo();
-    vi_lib.InitState();
     vi_lib.CreateGraphicsPipeline(false);
 
     CreatePipelineHelper fo_lib(*this);
     fo_lib.InitFragmentOutputLibInfo();
-    fo_lib.InitState();
     fo_lib.CreateGraphicsPipeline(false);
 
     // Create a GPL and subpass that utilizes depth
@@ -1163,7 +1125,6 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
             vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
 
             pr_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-            pr_lib.InitState();
             pr_lib.CreateGraphicsPipeline();
         }
 
@@ -1192,7 +1153,6 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
 
         pr_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pr_lib.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;  // This should get ignored due to its state being set as dynamic
-        pr_lib.InitState();
         pr_lib.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE_EXT);
         pr_lib.gp_ci_.layout = fs_lib.gp_ci_.layout;
         pr_lib.CreateGraphicsPipeline(false);
@@ -1260,9 +1220,7 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
 
     std::array stages = {vs_stage.stage_ci, fs_stage.stage_ci};
 
-    CreatePipelineHelper lib(*this);
-    lib.InitState();
-    lib.gp_ci_.pNext = &lib_info;
+    CreatePipelineHelper lib(*this, &lib_info);
     lib.gp_ci_.flags |= VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib.gp_ci_.pDepthStencilState = &ds_ci;
     lib.gp_ci_.stageCount = size32(stages);
@@ -1319,7 +1277,6 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
     CreatePipelineHelper pipe(*this);
     pipe.InitPreRasterLibInfo(&stage_ci);
     pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Create a fragment shader library with FS referencing an identifier queried from VkShaderModuleCreateInfo
@@ -1343,7 +1300,6 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
     fs_pipe.InitFragmentLibInfo(&fs_stage_ci);
     fs_pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     fs_pipe.gp_ci_.layout = pipe.gp_ci_.layout;
-    fs_pipe.InitState();
     fs_pipe.CreateGraphicsPipeline(false);
 
     // Create a complete pipeline with the above pre-raster fs libraries
@@ -1393,7 +1349,6 @@ TEST_F(PositiveGraphicsLibrary, DepthStencilStateIgnored) {
     const auto fs_spv = GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
     frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
-    frag_shader_lib.InitState();
 
     frag_shader_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     frag_shader_lib.gp_ci_.pDepthStencilState = nullptr;
@@ -1435,7 +1390,6 @@ TEST_F(PositiveGraphicsLibrary, ColorBlendStateIgnored) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
 
         pre_raster_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         pre_raster_lib.gp_ci_.flags |= VK_PIPELINE_CREATE_RETAIN_LINK_TIME_OPTIMIZATION_INFO_BIT_EXT;
@@ -1449,7 +1403,6 @@ TEST_F(PositiveGraphicsLibrary, ColorBlendStateIgnored) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_output_lib.InitFragmentOutputLibInfo(&link_info);
-        frag_output_lib.InitState();
 
         frag_output_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
         frag_output_lib.gp_ci_.pColorBlendState = nullptr;
@@ -1472,7 +1425,6 @@ TEST_F(PositiveGraphicsLibrary, PipelineLibraryNoRendering) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -1482,7 +1434,6 @@ TEST_F(PositiveGraphicsLibrary, PipelineLibraryNoRendering) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -1531,7 +1482,6 @@ TEST_F(PositiveGraphicsLibrary, IgnoredTessellationState) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
     vertex_input_lib.CreateGraphicsPipeline(false);
 
@@ -1562,7 +1512,6 @@ TEST_F(PositiveGraphicsLibrary, IgnoredTessellationState) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.AddDynamicState(VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT);
         pre_raster_lib.shader_stages_ = {pre_raster_lib.vs_->GetStageCreateInfo(), stages[0], stages[1]};
         pre_raster_lib.gp_ci_.stageCount = pre_raster_lib.shader_stages_.size();
@@ -1618,7 +1567,6 @@ TEST_F(PositiveGraphicsLibrary, PushConstant) {
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -1629,7 +1577,6 @@ TEST_F(PositiveGraphicsLibrary, PushConstant) {
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 0;
         frag_shader_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -1660,7 +1607,6 @@ TEST_F(PositiveGraphicsLibrary, PushConstantOneLibrary) {
         VkPushConstantRange pc_range = {VK_SHADER_STAGE_ALL, 0, 4};
         pre_raster_lib.pipeline_layout_ci_.pushConstantRangeCount = 1;
         pre_raster_lib.pipeline_layout_ci_.pPushConstantRanges = &pc_range;
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -1670,7 +1616,6 @@ TEST_F(PositiveGraphicsLibrary, PushConstantOneLibrary) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.pipeline_layout_ci_.pushConstantRangeCount = 0;
-        frag_shader_lib.InitState();
         frag_shader_lib.CreateGraphicsPipeline();
     }
 
@@ -1711,7 +1656,6 @@ TEST_F(PositiveGraphicsLibrary, SetLayoutCount) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.gp_ci_.layout = pipeline_layout_vs.handle();
         pre_raster_lib.CreateGraphicsPipeline(false);
     }
@@ -1726,7 +1670,6 @@ TEST_F(PositiveGraphicsLibrary, SetLayoutCount) {
         link_info.pLibraries = &pre_raster_lib.pipeline_;
 
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci, &link_info);
-        frag_shader_lib.InitState();
 
         frag_shader_lib.gp_ci_.layout = pipeline_layout_fs.handle();
         frag_shader_lib.CreateGraphicsPipeline(false);
@@ -1743,7 +1686,7 @@ TEST_F(PositiveGraphicsLibrary, MultisampleStateFragShaderNull) {
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.sampleShadingEnable = VK_FALSE;
+    frag_out_lib.ms_ci_.sampleShadingEnable = VK_FALSE;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -1770,7 +1713,6 @@ TEST_F(PositiveGraphicsLibrary, BadRenderPassVertexInput) {
 
     CreatePipelineHelper pipe(*this);
     pipe.InitVertexInputLibInfo();
-    pipe.InitState();
     // Vertex Input doesn't need the renderpass so it should be ignored
     VkRenderPass bad_rp = CastToHandle<VkRenderPass, uintptr_t>(0xbaadbeef);
     pipe.gp_ci_.renderPass = bad_rp;
@@ -1787,7 +1729,6 @@ TEST_F(PositiveGraphicsLibrary, LinkWithNoLayout) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.CreateGraphicsPipeline();
 
     // Linking != Required pre-rasterization shader state
@@ -1797,7 +1738,6 @@ TEST_F(PositiveGraphicsLibrary, LinkWithNoLayout) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo(&link_info);
-    vertex_input_lib.InitState();
     vertex_input_lib.gp_ci_.layout = VK_NULL_HANDLE;
     vertex_input_lib.gp_ci_.renderPass = renderPass();
     vertex_input_lib.CreateGraphicsPipeline(false);
@@ -1813,7 +1753,6 @@ TEST_F(PositiveGraphicsLibrary, LinkWithNoRenderPass) {
     const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
     vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
     pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-    pre_raster_lib.InitState();
     pre_raster_lib.CreateGraphicsPipeline();
 
     VkPipelineLibraryCreateInfoKHR link_info = vku::InitStructHelper();
@@ -1822,7 +1761,6 @@ TEST_F(PositiveGraphicsLibrary, LinkWithNoRenderPass) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo(&link_info);
-    vertex_input_lib.InitState();
     vertex_input_lib.gp_ci_.renderPass = VK_NULL_HANDLE;
     vertex_input_lib.CreateGraphicsPipeline(false);
 }
@@ -1836,7 +1774,6 @@ TEST_F(PositiveGraphicsLibrary, MultisampleStateSampleMaskArray) {
 
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo();
-    vertex_input_lib.InitState();
     vertex_input_lib.CreateGraphicsPipeline(false);
 
     VkPipelineLayout layout = VK_NULL_HANDLE;
@@ -1846,7 +1783,6 @@ TEST_F(PositiveGraphicsLibrary, MultisampleStateSampleMaskArray) {
         const auto vs_spv = GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl);
         vkt::GraphicsPipelineLibraryStage vs_stage(vs_spv, VK_SHADER_STAGE_VERTEX_BIT);
         pre_raster_lib.InitPreRasterLibInfo(&vs_stage.stage_ci);
-        pre_raster_lib.InitState();
         pre_raster_lib.CreateGraphicsPipeline();
     }
 
@@ -1860,13 +1796,13 @@ TEST_F(PositiveGraphicsLibrary, MultisampleStateSampleMaskArray) {
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);
         frag_shader_lib.gp_ci_.layout = layout;
-        frag_shader_lib.pipe_ms_state_ci_.pSampleMask = &mask_a;
+        frag_shader_lib.ms_ci_.pSampleMask = &mask_a;
         frag_shader_lib.CreateGraphicsPipeline(false);
     }
 
     CreatePipelineHelper frag_out_lib(*this);
     frag_out_lib.InitFragmentOutputLibInfo();
-    frag_out_lib.pipe_ms_state_ci_.pSampleMask = &mask_b;
+    frag_out_lib.ms_ci_.pSampleMask = &mask_b;
     frag_out_lib.CreateGraphicsPipeline(false);
 
     VkPipeline libraries[4] = {
@@ -1895,7 +1831,6 @@ TEST_F(PositiveGraphicsLibrary, VertexInputIgnoreVertexInputState) {
     pipe.InitVertexInputLibInfo();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.gp_ci_.pVertexInputState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline(false);
 }
 
@@ -1923,7 +1858,6 @@ TEST_F(PositiveGraphicsLibrary, VertexInputIgnoreAllState) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY);
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline(false);
 }
 
@@ -1932,7 +1866,6 @@ TEST_F(PositiveGraphicsLibrary, VertexInputIgnoreStages) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
     CreatePipelineHelper pipe(*this);
     pipe.InitVertexInputLibInfo();
-    pipe.InitState();
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = nullptr;
     pipe.CreateGraphicsPipeline(false);
@@ -1944,7 +1877,6 @@ TEST_F(PositiveGraphicsLibrary, FragmentOutputIgnoreStages) {
     InitRenderTarget();
     CreatePipelineHelper pipe(*this);
     pipe.InitFragmentOutputLibInfo();
-    pipe.InitState();
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = nullptr;
     pipe.CreateGraphicsPipeline(false);

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -5799,7 +5799,6 @@ TEST_F(NegativeImage, ComputeImageLayout) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     const VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
@@ -5859,7 +5858,6 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     const VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -992,7 +992,6 @@ TEST_F(PositiveImage, DescriptorSubresourceLayout) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentSamplerGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1180,7 +1179,6 @@ TEST_F(PositiveImage, Descriptor3D2DSubresourceLayout) {
     // Create PSO to be used for draw-time errors below
     VkShaderObj fs(this, kFragmentSamplerGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.handle();

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -922,12 +922,10 @@ TEST_F(NegativeMesh, DrawCmds) {
     vkt::Buffer count_buffer(*m_device, buffer_create_info);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
     pipe1.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1072,7 +1070,6 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     vkt::Buffer buffer(*m_device, buffer_create_info);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
@@ -1173,12 +1170,10 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
     vkt::Buffer count_buffer(*m_device, buffer_create_info);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
     pipe1.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1367,7 +1362,6 @@ TEST_F(NegativeMesh, MeshShaderConservativeRasterization) {
     conservative_state.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.rs_state_ci_.pNext = &conservative_state;
     pipe.shader_stages_ = {ms.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -1412,7 +1406,6 @@ TEST_F(NegativeMesh, MeshIncompatibleActiveQueries) {
     VkShaderObj ms(this, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {ms.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -44,7 +44,6 @@ TEST_F(PositiveMesh, BasicUsage) {
     // Ensure pVertexInputState and pInputAssembly state are null, as these should be ignored.
     pipe.gp_ci_.pVertexInputState = nullptr;
     pipe.gp_ci_.pInputAssemblyState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -102,9 +101,6 @@ TEST_F(PositiveMesh, MeshShaderOnly) {
     // Ensure pVertexInputState and pInputAssembly state are null, as these should be ignored.
     helper.gp_ci_.pVertexInputState = nullptr;
     helper.gp_ci_.pInputAssemblyState = nullptr;
-
-    helper.InitState();
-
     helper.CreateGraphicsPipeline();
 }
 
@@ -150,9 +146,6 @@ TEST_F(PositiveMesh, PointSize) {
     // Ensure pVertexInputState and pInputAssembly state are null, as these should be ignored.
     helper.gp_ci_.pVertexInputState = nullptr;
     helper.gp_ci_.pInputAssemblyState = nullptr;
-
-    helper.InitState();
-
     helper.CreateGraphicsPipeline();
 }
 
@@ -315,7 +308,6 @@ TEST_F(PositiveMesh, PrimitiveTopology) {
     VkShaderObj ms(this, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_2);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {ms.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;  // requires primitiveTopologyListRestart
     pipe.ia_ci_.primitiveRestartEnable = VK_TRUE;

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -38,7 +38,6 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
         GTEST_SKIP() << "maxMultiviewInstanceIndex is uint32_t max";
     }
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -234,7 +233,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     {
         // No need to create individual pipelines for each subpass since we are checking no bound pipeline
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         m_commandBuffer->begin();
@@ -268,7 +266,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         CreatePipelineHelper pipe(*this);
         pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
         pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Pipelines for all other subpasses
@@ -331,7 +328,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         CreatePipelineHelper pipe(*this);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         pipe.pipeline_layout_ci_ = pipeline_layout_info;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Pipelines for all other subpasses
@@ -405,7 +401,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         CreatePipelineHelper pipe(*this);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         pipe.pipeline_layout_ci_ = pipeline_layout_info;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Pipelines for all other subpasses
@@ -479,7 +474,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
         pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
         pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Pipelines for all other subpasses
@@ -557,7 +551,6 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
         pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
         pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         // Pipelines for all other subpasses
@@ -650,7 +643,6 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -943,14 +935,12 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
 
     // Create a graphics pipeline with rp[1]
     CreatePipelineHelper pipe_1(*this);
-    pipe_1.InitState();
     pipe_1.gp_ci_.layout = pipeline_layout.handle();
     pipe_1.gp_ci_.renderPass = rp[1].handle();
     pipe_1.CreateGraphicsPipeline();
 
     // Create a graphics pipeline with rp[2]
     CreatePipelineHelper pipe_2(*this);
-    pipe_2.InitState();
     pipe_2.gp_ci_.layout = pipeline_layout.handle();
     pipe_2.gp_ci_.renderPass = rp[2].handle();
     pipe_2.CreateGraphicsPipeline();
@@ -958,12 +948,10 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
     CreatePipelineHelper pipe2_1(*this);
     CreatePipelineHelper pipe2_2(*this);
     if (rp2Supported) {
-        pipe2_1.InitState();
         pipe2_1.gp_ci_.layout = pipeline_layout.handle();
         pipe2_1.gp_ci_.renderPass = rp[1].handle();
         pipe2_1.CreateGraphicsPipeline();
 
-        pipe2_2.InitState();
         pipe2_2.gp_ci_.layout = pipeline_layout.handle();
         pipe2_2.gp_ci_.renderPass = rp[2].handle();
         pipe2_2.CreateGraphicsPipeline();
@@ -1163,7 +1151,6 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         pipe.gp_ci_.pInputAssemblyState = &iasci;
         pipe.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
         pipe.shader_stages_.emplace_back(tes.GetStageCreateInfo());
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06047");
         pipe.CreateGraphicsPipeline();
@@ -1191,7 +1178,6 @@ TEST_F(NegativeMultiview, FeaturesDisabled) {
         pipe.cb_ci_.attachmentCount = 1;
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
         pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06048");
         pipe.CreateGraphicsPipeline();
@@ -1225,9 +1211,7 @@ TEST_F(NegativeMultiview, DynamicRenderingMaxMultiviewInstanceIndex) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.CreateGraphicsPipeline();
 
     vkt::Image img(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -63,7 +63,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -92,7 +92,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, TilingLinear) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -124,7 +124,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, Depth32Format) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     if (!m_device->phy().features().sparseBinding) {
         GTEST_SKIP() << "Test requires sparseBinding";
@@ -293,7 +293,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkMemoryAllocateInfo memory_ai = vku::InitStructHelper();
     memory_ai.allocationSize = 0x100000;
@@ -318,7 +318,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_SetPriority) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, AllocateMemory_ReuseAllocations) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkMemoryAllocateInfo memory_ai = vku::InitStructHelper();
     memory_ai.allocationSize = 0x100000;
@@ -350,7 +350,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
 
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkDeviceQueueCreateInfo queue_ci = vku::InitStructHelper();
     queue_ci.queueFamilyIndex = 0;
@@ -427,7 +427,7 @@ static VkDescriptorSetLayoutBinding CreateSingleDescriptorBinding(VkDescriptorTy
 
 TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkDescriptorSetLayoutBinding separate_bindings[] = {
         CreateSingleDescriptorBinding(VK_DESCRIPTOR_TYPE_SAMPLER, 0),
@@ -470,7 +470,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
 
 TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkDescriptorSetLayoutBinding large_bindings[] = {
         { 0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 16, VK_SHADER_STAGE_VERTEX_BIT, nullptr },
@@ -548,16 +548,12 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
 
     VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
 
-    CreatePipelineHelper vsPipe(*this);
+    CreatePipelineHelper vsPipe(*this, &pipeline_rendering_info);
     vsPipe.shader_stages_ = {vs.GetStageCreateInfo()};
-    vsPipe.InitState();
-    vsPipe.gp_ci_.pNext = &pipeline_rendering_info;
     vsPipe.CreateGraphicsPipeline();
 
-    CreatePipelineHelper vgsPipe(*this);
+    CreatePipelineHelper vgsPipe(*this, &pipeline_rendering_info);
     vgsPipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo()};
-    vgsPipe.InitState();
-    vgsPipe.gp_ci_.pNext = &pipeline_rendering_info;
     vgsPipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -660,9 +656,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection)
 
     VkPipelineDepthStencilStateCreateInfo depth_stencil_state_ci = vku::InitStructHelper();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.ds_ci_ = depth_stencil_state_ci;
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_COMPARE_OP);
@@ -1061,7 +1055,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
 
 TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
-    InitState();
+    RETURN_IF_SKIP(InitState());
 
     VkCommandPoolCreateInfo command_pool_ci = vku::InitStructHelper();
     command_pool_ci.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -329,7 +329,6 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
         VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT);
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-        pipe.InitState();
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
         err = pipe.CreateGraphicsPipeline();
@@ -556,7 +555,6 @@ TEST_F(NegativeObjectLifetime, DescriptorPoolInUseDestroyedSignaled) {
     pipe.dsl_bindings_ = {
         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Update descriptor with image and sampler
@@ -645,7 +643,6 @@ TEST_F(NegativeObjectLifetime, PushDescriptorUniformDestroySignaled) {
 
     // Use helper to create graphics pipeline
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&push_ds_layout, &ds_layout});
     helper.CreateGraphicsPipeline();
 
@@ -753,7 +750,6 @@ TEST_F(NegativeObjectLifetime, InUseDestroyedSignaled) {
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
@@ -819,7 +815,6 @@ TEST_F(NegativeObjectLifetime, PipelineInUseDestroyedSignaled) {
     VkPipeline delete_this_pipeline;
     {  // Scope pipeline so it will be auto-deleted
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
 
         delete_this_pipeline = pipe.pipeline_;
@@ -867,7 +862,6 @@ TEST_F(NegativeObjectLifetime, ImageViewInUseDestroyedSignaled) {
     pipe.dsl_bindings_ = {
         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -936,7 +930,6 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
     pipe.dsl_bindings_ = {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
-    pipe.InitState();
     err = pipe.CreateGraphicsPipeline();
     if (err != VK_SUCCESS) {
         GTEST_SKIP() << "Unable to compile shader";
@@ -992,7 +985,6 @@ TEST_F(NegativeObjectLifetime, SamplerInUseDestroyedSignaled) {
     pipe.dsl_bindings_ = {
         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -588,7 +588,6 @@ TEST_F(VkLayerTest, UsePnextOnlyStructWithoutExtensionEnabled) {
     pipe.gp_ci_.pTessellationState = &tsci;
     pipe.gp_ci_.pInputAssemblyState = &iasci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     // one for each struct
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineTessellationStateCreateInfo-pNext-pNext");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineTessellationStateCreateInfo-pNext-pNext");

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -608,7 +608,6 @@ TEST_F(NegativeParent, PipelineExecutableInfo) {
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, nullptr, &pipeline_exe_features);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     VkPipelineExecutableInfoKHR pipeline_exe_info = vku::InitStructHelper();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -44,7 +44,6 @@ TEST_F(NegativePipeline, WrongBindPointGraphics) {
     InitRenderTarget();
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     m_commandBuffer->begin();
@@ -67,7 +66,6 @@ TEST_F(NegativePipeline, BasicCompute) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     VkBufferCreateInfo bci = vku::InitStructHelper();
@@ -95,7 +93,6 @@ TEST_F(NegativePipeline, WrongBindPointCompute) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -122,13 +119,17 @@ TEST_F(NegativePipeline, DisabledIndependentBlend) {
     rp.AddColorAttachment(1);
     rp.CreateRenderPass();
 
-    CreatePipelineHelper pipe(*this, 2);
-    pipe.InitState();
+    VkPipelineColorBlendAttachmentState cb_attachments[2];
+    memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
+    cb_attachments[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    cb_attachments[0].blendEnable = VK_TRUE;
+    cb_attachments[1].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    cb_attachments[1].blendEnable = VK_FALSE;
+
+    CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.cb_attachments_[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[0].blendEnable = VK_TRUE;
-    pipe.cb_attachments_[1].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[1].blendEnable = VK_FALSE;
+    pipe.cb_ci_.attachmentCount = 2;
+    pipe.cb_ci_.pAttachments = cb_attachments;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605");
     pipe.CreateGraphicsPipeline();
@@ -164,10 +165,9 @@ TEST_F(NegativePipeline, BlendingOnFormatWithoutBlendingSupport) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.cb_attachments_[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[0].blendEnable = VK_TRUE;
+    pipe.cb_attachments_.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->VerifyFound();
@@ -185,7 +185,7 @@ TEST_F(NegativePipeline, PipelineRenderpassCompatibility) {
     att_state1.blendEnable = VK_TRUE;
 
     auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.cb_attachments_[0] = att_state1;
+        helper.cb_attachments_ = att_state1;
         helper.gp_ci_.pColorBlendState = nullptr;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-09030");
@@ -199,7 +199,6 @@ TEST_F(NegativePipeline, CmdBufferPipelineDestroyed) {
     {
         // Use helper to create graphics pipeline
         CreatePipelineHelper helper(*this);
-        helper.InitState();
         helper.CreateGraphicsPipeline();
 
         // Bind helper pipeline to command buffer
@@ -351,7 +350,6 @@ TEST_F(NegativePipeline, ShaderStageBit) {
 
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_VERTEX_BIT;  // override with wrong value
@@ -368,7 +366,7 @@ TEST_F(NegativePipeline, SampleRateFeatureDisable) {
     InitRenderTarget();
 
     // Cause the error by enabling sample shading...
-    auto set_shading_enable = [](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE; };
+    auto set_shading_enable = [](CreatePipelineHelper &helper) { helper.ms_ci_.sampleShadingEnable = VK_TRUE; };
     CreatePipelineHelper::OneshotTest(*this, set_shading_enable, kErrorBit,
                                       "VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784");
 }
@@ -381,8 +379,8 @@ TEST_F(NegativePipeline, SampleRateFeatureEnable) {
 
     auto range_test = [this](float value, bool positive_test) {
         auto info_override = [value](CreatePipelineHelper &helper) {
-            helper.pipe_ms_state_ci_.sampleShadingEnable = VK_TRUE;
-            helper.pipe_ms_state_ci_.minSampleShading = value;
+            helper.ms_ci_.sampleShadingEnable = VK_TRUE;
+            helper.ms_ci_.minSampleShading = value;
         };
         if (positive_test) {
             CreatePipelineHelper::OneshotTest(*this, info_override, kErrorBit);
@@ -420,11 +418,11 @@ TEST_F(NegativePipeline, SamplePNextUnknown) {
 
     VkPipelineSampleLocationsStateCreateInfoEXT sample_locations = vku::InitStructHelper();
     sample_locations.sampleLocationsInfo = vku::InitStructHelper();
-    auto good_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &sample_locations; };
+    auto good_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.ms_ci_.pNext = &sample_locations; };
     CreatePipelineHelper::OneshotTest(*this, good_chain, kErrorBit);
 
     VkInstanceCreateInfo instance_ci = vku::InitStructHelper();
-    auto bad_chain = [&instance_ci](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &instance_ci; };
+    auto bad_chain = [&instance_ci](CreatePipelineHelper &helper) { helper.ms_ci_.pNext = &instance_ci; };
     CreatePipelineHelper::OneshotTest(*this, bad_chain, kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
 }
 
@@ -437,7 +435,7 @@ TEST_F(NegativePipeline, DISABLED_SamplePNextDisabled) {
 
     VkPipelineSampleLocationsStateCreateInfoEXT sample_locations = vku::InitStructHelper();
     sample_locations.sampleLocationsInfo = vku::InitStructHelper();
-    auto bad_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_.pNext = &sample_locations; };
+    auto bad_chain = [&sample_locations](CreatePipelineHelper &helper) { helper.ms_ci_.pNext = &sample_locations; };
     CreatePipelineHelper::OneshotTest(*this, bad_chain, kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-pNext-pNext");
 }
 
@@ -480,14 +478,12 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     vkt::Framebuffer framebuffer(*m_device, renderpass, 1, &render_target_view.handle(), fb_width, fb_height);
 
     CreatePipelineHelper pipeline_1(*this);
-    pipeline_1.InitState();
-    pipeline_1.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    pipeline_1.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
     pipeline_1.gp_ci_.renderPass = renderpass.handle();
     pipeline_1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipeline_2(*this);
-    pipeline_2.InitState();
-    pipeline_2.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
+    pipeline_2.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
     pipeline_2.gp_ci_.renderPass = renderpass.handle();
     pipeline_2.CreateGraphicsPipeline();
 
@@ -577,10 +573,9 @@ TEST_F(NegativePipeline, RenderPassShaderResolveQCOM) {
     ms_state.alphaToOneEnable = VK_FALSE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = renderpass.handle();
-    pipe.cb_attachments_[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[0].blendEnable = VK_TRUE;
+    pipe.cb_attachments_.dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.gp_ci_.pMultisampleState = &ms_state;
 
     // Create a pipeline with a subpass using VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM,
@@ -812,9 +807,8 @@ TEST_F(NegativePipeline, NumSamplesMismatch) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
-    pipe.pipe_ms_state_ci_ = pipe_ms_state_ci;
+    pipe.ms_ci_ = pipe_ms_state_ci;
     m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853");
     pipe.CreateGraphicsPipeline();
 
@@ -848,7 +842,7 @@ TEST_F(NegativePipeline, NumBlendAttachMismatch) {
     pipe_ms_state_ci.pSampleMask = NULL;
 
     const auto set_MSAA = [&](CreatePipelineHelper &helper) {
-        helper.pipe_ms_state_ci_ = pipe_ms_state_ci;
+        helper.ms_ci_ = pipe_ms_state_ci;
         helper.cb_ci_.attachmentCount = 0;
     };
     CreatePipelineHelper::OneshotTest(*this, set_MSAA, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-07609");
@@ -890,7 +884,7 @@ TEST_F(NegativePipeline, ColorBlendUnsupportedDualSourceBlend) {
 
     VkPipelineColorBlendAttachmentState cb_attachments = {};
 
-    const auto set_dsb_src_color_enable = [&](CreatePipelineHelper &helper) { helper.cb_attachments_[0] = cb_attachments; };
+    const auto set_dsb_src_color_enable = [&](CreatePipelineHelper &helper) { helper.cb_attachments_ = cb_attachments; };
 
     cb_attachments.blendEnable = VK_TRUE;
     cb_attachments.srcColorBlendFactor = VK_BLEND_FACTOR_SRC1_COLOR;  // bad!
@@ -972,12 +966,10 @@ TEST_F(NegativePipeline, MissingEntrypoint) {
     // Multiple pipeline, middle has missing entrypoint
     {
         CreateComputePipelineHelper pipe_0(*this);  // valid
-        pipe_0.InitState();
         pipe_0.LateBindPipelineInfo();
         CreateComputePipelineHelper pipe_1(*this);  // invalid
         pipe_1.cs_ = std::make_unique<VkShaderObj>(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0,
                                                    SPV_SOURCE_GLSL, nullptr, "foo");
-        pipe_1.InitState();
         pipe_1.LateBindPipelineInfo();
 
         VkComputePipelineCreateInfo create_infos[3] = {pipe_0.cp_ci_, pipe_1.cp_ci_, pipe_0.cp_ci_};
@@ -1003,7 +995,6 @@ TEST_F(NegativePipeline, DepthStencilRequired) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
@@ -1019,7 +1010,6 @@ TEST_F(NegativePipeline, NullStagepName) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo()};
     pipe.shader_stages_[0].pName = nullptr;
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {});
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pName-parameter");
     pipe.CreateGraphicsPipeline();
@@ -1037,7 +1027,7 @@ TEST_F(NegativePipeline, AMDMixedAttachmentSamplesValidateGraphicsPipeline) {
     VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
     ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
 
-    const auto set_info = [&](CreatePipelineHelper &helper) { helper.pipe_ms_state_ci_ = ms_state_ci; };
+    const auto set_info = [&](CreatePipelineHelper &helper) { helper.ms_ci_ = ms_state_ci; };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-subpass-01505");
 }
 
@@ -1110,9 +1100,9 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesNV) {
 
             ds.depthTestEnable = test_case.depth_test;
 
-            helper.pipe_ms_state_ci_.pNext = &cmi;
-            helper.pipe_ms_state_ci_.rasterizationSamples = test_case.raster_samples;
-            helper.pipe_ms_state_ci_.sampleShadingEnable = test_case.sample_shading;
+            helper.ms_ci_.pNext = &cmi;
+            helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
+            helper.ms_ci_.sampleShadingEnable = test_case.sample_shading;
 
             helper.gp_ci_.renderPass = rp.Handle();
             helper.gp_ci_.pDepthStencilState = &ds;
@@ -1172,7 +1162,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamples) {
         VkPipelineDepthStencilStateCreateInfo ds = vku::InitStructHelper();
 
         const auto break_samples = [&rp, &ds, &test_case](CreatePipelineHelper &helper) {
-            helper.pipe_ms_state_ci_.rasterizationSamples = test_case.raster_samples;
+            helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
 
             helper.gp_ci_.renderPass = rp.Handle();
             helper.gp_ci_.pDepthStencilState = &ds;
@@ -1285,8 +1275,8 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
             crs.flags = 0;
             crs.coverageReductionMode = test_case.coverage_reduction_mode;
 
-            helper.pipe_ms_state_ci_.pNext = &crs;
-            helper.pipe_ms_state_ci_.rasterizationSamples = test_case.raster_samples;
+            helper.ms_ci_.pNext = &crs;
+            helper.ms_ci_.rasterizationSamples = test_case.raster_samples;
             helper.gp_ci_.renderPass = rp.Handle();
             helper.gp_ci_.pDepthStencilState = (test_case.depth_samples) ? &dss : nullptr;
         };
@@ -1375,7 +1365,7 @@ TEST_F(NegativePipeline, FragmentCoverageToColorNV) {
             cci.coverageToColorEnable = test_case.enabled;
             cci.coverageToColorLocation = test_case.location;
 
-            helper.pipe_ms_state_ci_.pNext = &cci;
+            helper.ms_ci_.pNext = &cci;
             helper.gp_ci_.renderPass = rp.handle();
             helper.gp_ci_.pColorBlendState = &cbi;
         };
@@ -1528,7 +1518,7 @@ TEST_F(NegativePipeline, LineRasterization) {
             *this,
             [&](CreatePipelineHelper &helper) {
                 helper.line_state_ci_.lineRasterizationMode = VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR;
-                helper.pipe_ms_state_ci_.alphaToCoverageEnable = VK_TRUE;
+                helper.ms_ci_.alphaToCoverageEnable = VK_TRUE;
             },
             kErrorBit, vuids);
     }
@@ -1735,7 +1725,6 @@ TEST_F(NegativePipeline, MaxPerStageResources) {
     const vkt::DescriptorSetLayout ds_layout_combined1(*m_device, layout_binding_combined1);
 
     CreateComputePipelineHelper compute_pipe(*this);
-    compute_pipe.InitState();
     compute_pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds_layout_comp});
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-01687");
@@ -1794,7 +1783,6 @@ TEST_F(NegativePipeline, PipelineExecutablePropertiesFeature) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     uint32_t count;
@@ -1898,13 +1886,9 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
     VkShaderObj fs_function(this, fs_source_function, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipeline_combined(*this);
-    pipeline_combined.InitState();
     CreatePipelineHelper pipeline_seperate(*this);
-    pipeline_seperate.InitState();
     CreatePipelineHelper pipeline_unused(*this);
-    pipeline_unused.InitState();
     CreatePipelineHelper pipeline_function(*this);
-    pipeline_function.InitState();
 
     // 4 different pipelines for 4 different shaders
     // 3 are invalid and 1 (pipeline_unused) is valid
@@ -2168,11 +2152,9 @@ TEST_F(NegativePipeline, MergePipelineCachesInvalidDst) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     CreatePipelineHelper other_pipe(*this);
-    other_pipe.InitState();
     other_pipe.CreateGraphicsPipeline();
 
     VkPipelineCache dstCache = pipe.pipeline_cache_;
@@ -2233,12 +2215,10 @@ TEST_F(NegativePipeline, GraphicsPipelineWithBadBasePointer) {
     InitRenderTarget();
 
     CreatePipelineHelper base_pipe(*this);
-    base_pipe.InitState();
     base_pipe.CreateGraphicsPipeline();
 
     {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.gp_ci_.flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
         pipe.gp_ci_.basePipelineHandle = VK_NULL_HANDLE;
         pipe.gp_ci_.basePipelineIndex = 2;
@@ -2249,7 +2229,6 @@ TEST_F(NegativePipeline, GraphicsPipelineWithBadBasePointer) {
 
     {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.gp_ci_.flags = VK_PIPELINE_CREATE_DERIVATIVE_BIT;
         pipe.gp_ci_.basePipelineHandle = base_pipe.Handle();
         pipe.gp_ci_.basePipelineIndex = 2;
@@ -2278,9 +2257,7 @@ TEST_F(NegativePipeline, DiscardRectangle) {
     discard_rectangle_state.discardRectangleCount = count;
     discard_rectangle_state.pDiscardRectangles = discard_rectangles.data();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &discard_rectangle_state;
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &discard_rectangle_state);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineDiscardRectangleStateCreateInfoEXT-discardRectangleCount-00582");
     pipe.CreateGraphicsPipeline();
@@ -2297,7 +2274,6 @@ TEST_F(NegativePipeline, ColorWriteCreateInfoEXT) {
     VkPipelineColorWriteCreateInfoEXT color_write = vku::InitStructHelper();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cb_ci_.pNext = &color_write;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorWriteCreateInfoEXT-attachmentCount-07608");
     pipe.CreateGraphicsPipeline();
@@ -2328,7 +2304,6 @@ TEST_F(NegativePipeline, ColorWriteCreateInfoEXTMaxAttachments) {
     std::vector<VkPipelineColorBlendAttachmentState> color_blends(max_color_attachments);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cb_ci_.pNext = &color_write;
     pipe.cb_ci_.attachmentCount = max_color_attachments;
     pipe.cb_ci_.pAttachments = color_blends.data();
@@ -2418,7 +2393,6 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     multi_sample_state.minSampleShading = 1.0;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.pMultisampleState = &multi_sample_state;
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
@@ -2497,7 +2471,6 @@ TEST_F(NegativePipeline, RasterizationConservativeStateCreateInfo) {
 
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.pNext = &conservative_state;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(
         kErrorBit, "VUID-VkPipelineRasterizationConservativeStateCreateInfoEXT-extraPrimitiveOverestimationSize-01769");
@@ -2517,7 +2490,6 @@ TEST_F(NegativePipeline, NullRenderPass) {
     RETURN_IF_SKIP(Init());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.cb_ci_.attachmentCount = 0;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-dynamicRendering-06576");
@@ -2784,7 +2756,6 @@ TEST_F(NegativePipeline, MismatchedRenderPassAndPipelineAttachments) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout});
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.cb_ci_ = vku::InitStructHelper();
@@ -3009,7 +2980,6 @@ TEST_F(NegativePipeline, PipelineSubpassOutOfBounds) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.subpass = 4u;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06046");
     pipe.CreateGraphicsPipeline();
@@ -3026,10 +2996,8 @@ TEST_F(NegativePipeline, PipelineRenderingInfoInvalidFormats) {
     VkPipelineRenderingCreateInfo pipeline_rendering_ci = vku::InitStructHelper();
     pipeline_rendering_ci.depthAttachmentFormat = VK_FORMAT_ASTC_12x12_SFLOAT_BLOCK_EXT;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_ci);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
-    pipe.gp_ci_.pNext = &pipeline_rendering_ci;
     pipe.cb_ci_.attachmentCount = 0u;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06583");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06587");
@@ -3072,7 +3040,6 @@ TEST_F(NegativePipeline, RasterStateWithDepthBiasRepresentationInfo) {
 
     const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT &depth_bias_representation) {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
         const VkPipelineRasterizationStateCreateInfo raster_state = vku::InitStructHelper(&depth_bias_representation);
         pipe.rs_state_ci_ = raster_state;
@@ -3105,7 +3072,6 @@ TEST_F(NegativePipeline, InvalidPipelineDepthBias) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.rs_state_ci_.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_.depthBiasClamp = 0.5f;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00754");
@@ -3163,9 +3129,7 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &image_ci.format;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
@@ -3194,7 +3158,6 @@ TEST_F(NegativePipeline, PipelineMissingFeatures) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.ds_ci_ = vku::InitStructHelper();
     pipe.ds_ci_.depthBoundsTestEnable = VK_TRUE;
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -3203,12 +3166,12 @@ TEST_F(NegativePipeline, PipelineMissingFeatures) {
     m_errorMonitor->VerifyFound();
 
     pipe.ds_ci_.depthBoundsTestEnable = VK_FALSE;
-    pipe.pipe_ms_state_ci_.alphaToOneEnable = VK_TRUE;
+    pipe.ms_ci_.alphaToOneEnable = VK_TRUE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineMultisampleStateCreateInfo-alphaToOneEnable-00785");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    pipe.pipe_ms_state_ci_.alphaToOneEnable = VK_FALSE;
+    pipe.ms_ci_.alphaToOneEnable = VK_FALSE;
     pipe.rs_state_ci_.depthClampEnable = VK_TRUE;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateCreateInfo-depthClampEnable-00782");
     pipe.CreateGraphicsPipeline();
@@ -3291,9 +3254,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     color_blend_state.attachmentCount = 1u;
     color_blend_state.pAttachments = &color_blend_attachment_state;
 
-    CreatePipelineHelper color_pipe(*this);
-    color_pipe.InitState();
-    color_pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper color_pipe(*this, &pipeline_rendering_info);
     color_pipe.ds_ci_ = ds_state;
     color_pipe.cb_ci_ = color_blend_state;
     color_pipe.CreateGraphicsPipeline();
@@ -3301,9 +3262,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     pipeline_rendering_info.pColorAttachmentFormats = &color_format;
     pipeline_rendering_info.depthAttachmentFormat = undefined;
 
-    CreatePipelineHelper depth_pipe(*this);
-    depth_pipe.InitState();
-    depth_pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper depth_pipe(*this, &pipeline_rendering_info);
     depth_pipe.ds_ci_ = ds_state;
     color_pipe.cb_ci_ = color_blend_state;
     depth_pipe.CreateGraphicsPipeline();
@@ -3311,9 +3270,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     pipeline_rendering_info.depthAttachmentFormat = ds_format;
     pipeline_rendering_info.stencilAttachmentFormat = undefined;
 
-    CreatePipelineHelper stencil_pipe(*this);
-    stencil_pipe.InitState();
-    stencil_pipe.gp_ci_.pNext = &pipeline_rendering_info;
+    CreatePipelineHelper stencil_pipe(*this, &pipeline_rendering_info);
     stencil_pipe.ds_ci_ = ds_state;
     color_pipe.cb_ci_ = color_blend_state;
     stencil_pipe.CreateGraphicsPipeline();
@@ -3356,7 +3313,6 @@ TEST_F(NegativePipeline, MissingPipelineViewportState) {
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
         pipe.gp_ci_.pViewportState = nullptr;
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-09024");
         pipe.CreateGraphicsPipeline();
@@ -3367,7 +3323,6 @@ TEST_F(NegativePipeline, MissingPipelineViewportState) {
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
         pipe.gp_ci_.pViewportState = nullptr;
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-09024");
         pipe.CreateGraphicsPipeline();
@@ -3377,7 +3332,6 @@ TEST_F(NegativePipeline, MissingPipelineViewportState) {
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
         pipe.gp_ci_.pViewportState = nullptr;
-        pipe.InitState();
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-rasterizerDiscardEnable-09024");
         pipe.CreateGraphicsPipeline();
@@ -3397,10 +3351,8 @@ TEST_F(NegativePipeline, PipelineRenderingInfoInvalidFormatWithoutFragmentState)
 
     VkPipelineDepthStencilStateCreateInfo ds = vku::InitStructHelper();
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_ci);
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
-    pipe.gp_ci_.pNext = &pipeline_rendering_ci;
     pipe.gp_ci_.pColorBlendState = nullptr;
     pipe.cb_ci_.attachmentCount = 0u;
     pipe.ds_ci_ = ds;
@@ -3420,7 +3372,6 @@ TEST_F(NegativePipeline, IndirectBindablePipelineWithoutFeature) {
     RETURN_IF_SKIP(Init());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-flags-02877");
     pipe.CreateGraphicsPipeline();
@@ -3464,7 +3415,6 @@ TEST_F(NegativePipeline, GeometryShaderConservativeRasterization) {
     conservative_state.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.rs_state_ci_.pNext = &conservative_state;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -3497,7 +3447,6 @@ TEST_F(NegativePipeline, VertexPointOutputConservativeRasterization) {
     conservative_state.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.rs_state_ci_.pNext = &conservative_state;
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -3609,9 +3558,7 @@ TEST_F(NegativePipeline, PipelineCreateFlags2) {
     VkPipelineCreateFlags2CreateInfoKHR flags2 = vku::InitStructHelper();
     flags2.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &flags2;
+    CreatePipelineHelper pipe(*this, &flags2);
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -3623,7 +3570,6 @@ TEST_F(NegativePipeline, RasterizationStateFlag) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.rs_state_ci_.flags = 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateCreateInfo-flags-zerobitmask");
     pipe.CreateGraphicsPipeline();
@@ -3636,7 +3582,6 @@ TEST_F(NegativePipeline, GetPipelinePropertiesEXT) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     VkPipelineInfoEXT pipeline_info = vku::InitStructHelper();

--- a/tests/unit/pipeline_advanced_blend.cpp
+++ b/tests/unit/pipeline_advanced_blend.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -121,7 +121,6 @@ TEST_F(NegativePipelineAdvancedBlend, Properties) {
     color_blend_advanced.srcPremultiplied = VK_FALSE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cb_ci_.pNext = &color_blend_advanced;
     if (!blend_operation_advanced_props.advancedBlendCorrelatedOverlap) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendAdvancedStateCreateInfoEXT-blendOverlap-01426");
@@ -165,7 +164,6 @@ TEST_F(NegativePipelineAdvancedBlend, AllOperations) {
     color_blend_state.pAttachments = &attachment_state;
     pipe.gp_ci_.pColorBlendState = &color_blend_state;
 
-    pipe.InitState();
     // When using profiles, advancedBlendMaxColorAttachments might be zero
     m_errorMonitor->SetUnexpectedError("VUID-VkPipelineColorBlendAttachmentState-colorBlendOp-01410");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineColorBlendAttachmentState-advancedBlendAllOperations-01409");

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -806,7 +806,6 @@ TEST_F(NegativePipelineLayout, DescriptorTypeMismatch) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07990");
@@ -918,7 +917,6 @@ TEST_F(NegativePipelineLayout, DescriptorNotAccessible) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
@@ -937,7 +935,6 @@ TEST_F(NegativePipelineLayout, UniformBlockNotProvided) {
 
     VkShaderObj fs(this, kFragmentUniformGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
 
     OneOffDescriptorSet descriptor_set(m_device, {});  // no descriptor in layout
@@ -967,7 +964,6 @@ TEST_F(NegativePipelineLayout, MissingDescriptor) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {});
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-07988");
     pipe.CreateComputePipeline();

--- a/tests/unit/pipeline_layout_positive.cpp
+++ b/tests/unit/pipeline_layout_positive.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  * Modifications Copyright (C) 2022 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -56,7 +56,6 @@ TEST_F(PositivePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
 
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -36,7 +36,6 @@ TEST_F(PositivePipeline, ComplexTypes) {
     pipe.gp_ci_.pTessellationState = &tsci;
     pipe.gp_ci_.pInputAssemblyState = &iasci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -45,7 +44,6 @@ TEST_F(PositivePipeline, BasicUsage) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -68,7 +66,6 @@ TEST_F(PositivePipeline, MissingDescriptorUnused) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -98,7 +95,6 @@ TEST_F(PositivePipeline, FragmentShadingRate) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -128,7 +124,6 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsSampler) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -158,7 +153,6 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsImage) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -188,7 +182,6 @@ TEST_F(PositivePipeline, CombinedImageSamplerConsumedAsBoth) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -452,7 +445,6 @@ TEST_F(PositivePipeline, CoreChecksDisabled) {
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.pInputAssemblyState = &iasci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -486,7 +478,6 @@ TEST_F(PositivePipeline, TessellationDomainOrigin) {
     pipe.gp_ci_.pTessellationState = &tsci;
     pipe.gp_ci_.pInputAssemblyState = &iasci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -533,7 +524,6 @@ TEST_F(PositivePipeline, ViewportArray2NV) {
     // stages does not cause any errors.
     for (auto stage : vertex_stages) {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.ia_ci_.topology =
             (stage != TestStage::VERTEX) ? VK_PRIMITIVE_TOPOLOGY_PATCH_LIST : VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
         pipe.shader_stages_.clear();
@@ -703,7 +693,6 @@ TEST_F(PositivePipeline, SampleMaskOverrideCoverageNV) {
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pl.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
@@ -739,7 +728,6 @@ TEST_F(PositivePipeline, RasterizationDiscardEnableTrue) {
     // Skip the test in NexusPlayer. The driver crashes when pViewportState, pMultisampleState, pDepthStencilState, pColorBlendState
     // are NULL.
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -783,7 +771,6 @@ TEST_F(PositivePipeline, SamplerDataForCombinedImageSampler) {
         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
     pipe.shader_stages_ = {fs.GetStageCreateInfo(), pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -901,12 +888,10 @@ TEST_F(PositivePipeline, ShaderTileImage) {
         auto fs = VkShaderObj::CreateFromASM(this, kShaderTileImageDepthReadSpv, VK_SHADER_STAGE_FRAGMENT_BIT);
 
         ds_ci.depthWriteEnable = false;
-        CreatePipelineHelper pipe(*this);
+        CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs->GetStageCreateInfo()};
-        pipe.gp_ci_.pNext = &pipeline_rendering_info;
         pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
         pipe.gp_ci_.pDepthStencilState = &ds_ci;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
     }
 
@@ -926,12 +911,10 @@ TEST_F(PositivePipeline, ShaderTileImage) {
         ds_ci.front = stencil_state;
         ds_ci.back = stencil_state;
 
-        CreatePipelineHelper pipe(*this);
+        CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs->GetStageCreateInfo()};
-        pipe.gp_ci_.pNext = &pipeline_rendering_info;
         pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
         pipe.gp_ci_.pDepthStencilState = &ds_ci;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
     }
 
@@ -943,13 +926,11 @@ TEST_F(PositivePipeline, ShaderTileImage) {
         ms_ci.minSampleShading = 1.0;
         ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_4_BIT;
 
-        CreatePipelineHelper ms_pipeline(*this);
+        CreatePipelineHelper ms_pipeline(*this, &pipeline_rendering_info);
         ms_pipeline.shader_stages_ = {vs.GetStageCreateInfo(), fs->GetStageCreateInfo()};
-        ms_pipeline.gp_ci_.pNext = &pipeline_rendering_info;
         ms_pipeline.gp_ci_.renderPass = VK_NULL_HANDLE;
         ms_pipeline.gp_ci_.pDepthStencilState = &ds_ci;
         ms_pipeline.gp_ci_.pMultisampleState = &ms_ci;
-        ms_pipeline.InitState();
         ms_pipeline.CreateGraphicsPipeline();
     }
 }
@@ -1017,7 +998,6 @@ TEST_F(PositivePipeline, PervertexNVShaderAttributes) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1098,7 +1078,6 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -1288,7 +1267,6 @@ TEST_F(PositivePipeline, AttachmentsDisableRasterization) {
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     // Rasterization discard enable prohibits fragment shader.
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1330,9 +1308,8 @@ TEST_F(PositivePipeline, DualBlendShader) {
     cb_attachments.alphaBlendOp = VK_BLEND_OP_ADD;
 
     CreatePipelineHelper pipe(*this);
-    pipe.cb_attachments_[0] = cb_attachments;
+    pipe.cb_attachments_ = cb_attachments;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1400,7 +1377,6 @@ TEST_F(PositivePipeline, ShaderModuleIdentifier) {
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1491,7 +1467,6 @@ TEST_F(PositivePipeline, RasterStateWithDepthBiasRepresentationInfo) {
 
     const auto create_pipe_with_depth_bias_representation = [this](VkDepthBiasRepresentationInfoEXT &depth_bias_representation) {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
         pipe.rs_state_ci_.pNext = &depth_bias_representation;
         pipe.CreateGraphicsPipeline();
@@ -1534,9 +1509,7 @@ TEST_F(PositivePipeline, DeviceGeneratedCommands) {
     shader_groups_ci.pipelineCount = 0u;
     shader_groups_ci.pPipelines = nullptr;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &shader_groups_ci;
+    CreatePipelineHelper pipe(*this, &shader_groups_ci);
     pipe.shader_stages_ = {stages[0], stages[1]};
     pipe.CreateGraphicsPipeline();
 }
@@ -1561,7 +1534,6 @@ TEST_F(PositivePipeline, DepthStencilStateIgnored) {
     // disable with rasterizerDiscardEnable
     {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
         pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
         pipe.gp_ci_.renderPass = rp.Handle();
@@ -1571,7 +1543,6 @@ TEST_F(PositivePipeline, DepthStencilStateIgnored) {
     // disable with dynamic state
     {
         CreatePipelineHelper pipe(*this);
-        pipe.InitState();
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_COMPARE_OP);
@@ -1600,7 +1571,6 @@ TEST_F(PositivePipeline, ViewportStateNotSet) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
     pipe.gp_ci_.pViewportState = nullptr;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1627,7 +1597,6 @@ TEST_F(PositivePipeline, ViewportStateNotSetRasterizerDiscardEnabled) {
     pipe.gp_ci_.pRasterizationState = &rasterization_state;
     pipe.gp_ci_.pViewportState = nullptr;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -1674,7 +1643,6 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
@@ -1695,7 +1663,6 @@ TEST_F(PositivePipeline, ShaderModuleIdentifierZeroLength) {
     VkPipelineShaderStageModuleIdentifierCreateInfoEXT moduleIdentifier = vku::InitStructHelper();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[0].pNext = &moduleIdentifier;
     pipe.CreateGraphicsPipeline();
 }
@@ -1710,9 +1677,7 @@ TEST_F(PositivePipeline, IgnoredPipelineCreateFlags) {
     VkPipelineCreateFlags2CreateInfoKHR pipelineCreateFlags2 = vku::InitStructHelper();
     pipelineCreateFlags2.flags = VK_PIPELINE_CREATE_2_DISABLE_OPTIMIZATION_BIT_KHR;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.InitState();
-    pipe.gp_ci_.pNext = &pipelineCreateFlags2;
+    CreatePipelineHelper pipe(*this, &pipelineCreateFlags2);
     pipe.gp_ci_.flags = 0x80000000;
     pipe.CreateGraphicsPipeline();
 }

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -27,7 +27,6 @@ TEST_F(PositivePipelineTopology, PointSizeWriteInFunction) {
         CreatePipelineHelper pipe(*this);
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), ps.GetStageCreateInfo()};
         pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
     }
 }
@@ -50,7 +49,6 @@ TEST_F(PositivePipelineTopology, PointSizeGeomShaderSuccess) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), ps.GetStageCreateInfo()};
     // Set Input Assembly to TOPOLOGY POINT LIST
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -164,7 +162,6 @@ TEST_F(PositivePipelineTopology, LoosePointSizeWrite) {
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), ps.GetStageCreateInfo()};
         // Set Input Assembly to TOPOLOGY POINT LIST
         pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
     }
 }
@@ -301,7 +298,6 @@ TEST_F(PositivePipelineTopology, PointSizeStructMemeberWritten) {
         pipe.vi_ci_.vertexBindingDescriptionCount = 2;
         pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
         pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
-        pipe.InitState();
         pipe.CreateGraphicsPipeline();
     } else {
         printf("Error creating shader from assembly\n");
@@ -359,7 +355,6 @@ TEST_F(PositivePipelineTopology, PolygonModeValid) {
     {
         CreatePipelineHelper pipe(*this);
         pipe.device_ = &test_device;
-        pipe.InitState();
         pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         pipe.gp_ci_.layout = pipeline_layout.handle();
         pipe.gp_ci_.renderPass = render_pass.handle();
@@ -392,7 +387,6 @@ TEST_F(PositivePipelineTopology, NotPointSizeGeometry) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -446,7 +440,6 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
     pipe.shader_stages_.emplace_back(gs.GetStageCreateInfo());
     pipe.shader_stages_.emplace_back(tcs.GetStageCreateInfo());
     pipe.shader_stages_.emplace_back(tes.GetStageCreateInfo());
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
     pipe.CreateGraphicsPipeline();
 
@@ -479,7 +472,6 @@ TEST_F(PositivePipelineTopology, LineTopologyClasses) {
     VkVertexInputAttributeDescription attribute = {0, 0, VK_FORMAT_R32_SFLOAT, 0};
     pipe.vi_ci_.pVertexAttributeDescriptions = &attribute;
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -238,7 +238,6 @@ TEST_F(NegativePortabilitySubset, TriangleFans) {
                                                          VK_PRIMITIVE_TOPOLOGY_TRIANGLE_FAN, VK_FALSE};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-triangleFans-04452");
     pipe.CreateGraphicsPipeline();
@@ -279,7 +278,6 @@ TEST_F(NegativePortabilitySubset, VertexInputStride) {
                                                          VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST, VK_FALSE};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkVertexInputBindingDescription-stride-04456");
     pipe.CreateGraphicsPipeline();
@@ -318,7 +316,6 @@ TEST_F(NegativePortabilitySubset, VertexAttributes) {
         VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO, nullptr, 0, 1, &vertex_desc, 1, &vertex_attrib};
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkVertexInputAttributeDescription-vertexAttributeAccessBeyondStride-04457");
@@ -363,7 +360,6 @@ TEST_F(NegativePortabilitySubset, RasterizationState) {
 
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.polygonMode = VK_POLYGON_MODE_POINT;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateCreateInfo-pointPolygons-04458");
     pipe.CreateGraphicsPipeline();
@@ -396,7 +392,6 @@ TEST_F(NegativePortabilitySubset, DepthStencilState) {
     pipe.gp_ci_.pDepthStencilState = &depth_stencil_ci;
     pipe.rs_state_ci_.cullMode = VK_CULL_MODE_NONE;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineDepthStencilStateCreateInfo-separateStencilMaskRef-04453");
     pipe.CreateGraphicsPipeline();
@@ -422,28 +417,27 @@ TEST_F(NegativePortabilitySubset, ColorBlendAttachmentState) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.cb_attachments_[0].srcColorBlendFactor = VK_BLEND_FACTOR_CONSTANT_ALPHA;
-    pipe.InitState();
+    pipe.cb_attachments_.srcColorBlendFactor = VK_BLEND_FACTOR_CONSTANT_ALPHA;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04454");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    pipe.cb_attachments_[0].srcColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+    pipe.cb_attachments_.srcColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04454");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    pipe.cb_attachments_[0].srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
-    pipe.cb_attachments_[0].dstColorBlendFactor = VK_BLEND_FACTOR_CONSTANT_ALPHA;
+    pipe.cb_attachments_.srcColorBlendFactor = VK_BLEND_FACTOR_ONE;
+    pipe.cb_attachments_.dstColorBlendFactor = VK_BLEND_FACTOR_CONSTANT_ALPHA;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04455");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    pipe.cb_attachments_[0].dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
+    pipe.cb_attachments_.dstColorBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineColorBlendAttachmentState-constantAlphaColorBlendFactors-04455");
     pipe.CreateGraphicsPipeline();
@@ -521,7 +515,6 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.tess_ci_ = tsci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tsc_obj.GetStageCreateInfo()};
-    pipe.InitState();
 
     // Attempt to use isolines in the TES shader when not available
     {
@@ -588,8 +581,6 @@ TEST_F(VkPortabilitySubsetTest, ShaderValidation) {
         raster_pipe.ia_ci_ = iasci;
         raster_pipe.tess_ci_ = tsci;
         raster_pipe.shader_stages_ = {vs_obj.GetStageCreateInfo(), fs_obj.GetStageCreateInfo()};
-        raster_pipe.InitState();
-
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-shaderSampleRateInterpolationFunctions-06325");
         raster_pipe.CreateGraphicsPipeline();
         m_errorMonitor->VerifyFound();

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -487,7 +487,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT | VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
 
@@ -504,7 +503,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     m_errorMonitor->VerifyFound();
 
     CreatePipelineHelper protected_pipe(*this);
-    protected_pipe.InitState();
     protected_pipe.shader_stages_ = {protected_pipe.vs_->GetStageCreateInfo()};
     protected_pipe.gp_ci_.flags = VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
     protected_pipe.CreateGraphicsPipeline();
@@ -530,7 +528,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
 
         pre_raster_lib.InitPreRasterLibInfo(&stage_ci);
         pre_raster_lib.pipeline_layout_ci_.flags |= VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT;
-        pre_raster_lib.InitState();
         ASSERT_EQ(VK_SUCCESS, pre_raster_lib.CreateGraphicsPipeline());
 
         VkPipeline libraries[1] = {
@@ -556,7 +553,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         CreatePipelineHelper protected_pre_raster_lib(*this);
         protected_pre_raster_lib.InitPreRasterLibInfo(&stage_ci);
         protected_pre_raster_lib.pipeline_layout_ci_.flags |= VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT;
-        protected_pre_raster_lib.InitState();
         protected_pre_raster_lib.gp_ci_.flags =
             VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
         ASSERT_EQ(VK_SUCCESS, protected_pre_raster_lib.CreateGraphicsPipeline());
@@ -573,7 +569,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
         CreatePipelineHelper unprotected_pre_raster_lib(*this);
         unprotected_pre_raster_lib.InitPreRasterLibInfo(&stage_ci);
         unprotected_pre_raster_lib.pipeline_layout_ci_.flags |= VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT;
-        unprotected_pre_raster_lib.InitState();
         unprotected_pre_raster_lib.gp_ci_.flags =
             VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT;
         ASSERT_EQ(VK_SUCCESS, unprotected_pre_raster_lib.CreateGraphicsPipeline());
@@ -620,7 +615,6 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pipelineProtectedAccess-07368");
     CreatePipelineHelper featureless_pipe(*this);
     featureless_pipe.device_ = &test_device;
-    featureless_pipe.InitState();
     featureless_pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     featureless_pipe.shader_stages_ = {vs2.GetStageCreateInfo()};
     featureless_pipe.gp_ci_.flags = VK_PIPELINE_CREATE_PROTECTED_ACCESS_ONLY_BIT_EXT;
@@ -661,7 +655,6 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
@@ -871,13 +864,16 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     )glsl";
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
-    CreatePipelineHelper g_pipe(*this, 2u);
+    VkPipelineColorBlendAttachmentState cb_attachments[2] = {};
+    memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
+    CreatePipelineHelper g_pipe(*this);
     g_pipe.gp_ci_.renderPass = rp.Handle();
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.cb_ci_.attachmentCount = 2;
+    g_pipe.cb_ci_.pAttachments = cb_attachments;
+    g_pipe.CreateGraphicsPipeline();
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
@@ -1182,7 +1178,6 @@ TEST_F(NegativeProtectedMemory, RayQuery) {
     VkShaderObj fs(this, spv_source, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -274,7 +274,6 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -37,7 +37,6 @@ TEST_F(PositivePushDescriptor, NullDstSet) {
 
     // Use helper to create graphics pipeline
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&push_ds_layout, &ds_layout});
     helper.CreateGraphicsPipeline();
 
@@ -102,7 +101,6 @@ TEST_F(PositivePushDescriptor, UnboundSet) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     // Now use the descriptor layouts to create a pipeline layout
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&push_ds_layout, &descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
@@ -180,7 +178,6 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         )glsl";
 
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-        pipe0.InitState();
         pipe0.shader_stages_[1] = fs.GetStageCreateInfo();
         pipe0.gp_ci_.layout = pipeline_layout.handle();
         pipe0.CreateGraphicsPipeline();
@@ -214,7 +211,6 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
         )glsl";
 
         VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
-        pipe1.InitState();
         pipe1.shader_stages_[1] = fs.GetStageCreateInfo();
         pipe1.gp_ci_.layout = pipeline_layout.handle();
         pipe1.CreateGraphicsPipeline();

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -1428,9 +1428,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
     TEST_DESCRIPTION("Test InvalidCmdEndQueryIndexedEXT with invalid index");
 
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-
-    InitState();
+    RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_properties);
@@ -1878,7 +1876,6 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     pipe.rs_state_ci_ = rs_ci;
     // Rasterization discard enable prohibits fragment shader.
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
@@ -1934,7 +1931,6 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
 
     CreatePipelineHelper pipe(*this);
     pipe.rs_state_ci_.pNext = &rasterization_streams;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
@@ -2546,7 +2542,6 @@ TEST_F(NegativeQuery, InvalidMeshQueryAtDraw) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT, 1);

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -128,7 +128,6 @@ TEST_F(PositiveQuery, BasicQuery) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 2);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -192,7 +191,6 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
     vk::CreateQueryPool(m_device->handle(), &query_pool_info, nullptr, &query_pool);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // If VK_QUERY_RESULT_WAIT_BIT is not set, vkGetQueryPoolResults may return VK_NOT_READY

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -1041,7 +1041,6 @@ TEST_F(NegativeRayTracingPipeline, PipelineTypeGroupStackSize) {
     RETURN_IF_SKIP(Init());
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkGetRayTracingShaderGroupStackSizeKHR-pipeline-04622");
@@ -1087,7 +1086,6 @@ TEST_F(NegativeRayTracingPipeline, PipelineTypeGroupHandles) {
     RETURN_IF_SKIP(Init());
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     int data = 0;
@@ -1105,7 +1103,6 @@ TEST_F(NegativeRayTracingPipeline, PipelineTypeCaptureReplay) {
     RETURN_IF_SKIP(Init());
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     int data = 0;

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -168,7 +168,6 @@ TEST_F(NegativeRayTracingPipelineNV, BindPoint) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -1787,7 +1787,6 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPass) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
@@ -1869,7 +1868,6 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
     vkt::Framebuffer fb(*m_device, rp1.handle(), 1u, &iv.handle(), 128, 128);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp2.handle();
     pipe.CreateGraphicsPipeline();
@@ -2499,7 +2497,6 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout, &descriptor_set_layout});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
@@ -2898,9 +2895,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     ms_state.alphaToOneEnable = VK_FALSE;
 
     CreatePipelineHelper pipe_helper(*this);
-    pipe_helper.InitState();
     pipe_helper.gp_ci_.renderPass = test_rp.handle();
-    pipe_helper.pipe_ms_state_ci_ = ms_state;
+    pipe_helper.ms_ci_ = ms_state;
 
     // ms_render_to_ss.rasterizationSamples != ms_state.rasterizationSamples
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06854");
@@ -2908,7 +2904,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     m_errorMonitor->VerifyFound();
 
     // Actually create a usable pipeline
-    pipe_helper.pipe_ms_state_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
+    pipe_helper.ms_ci_.rasterizationSamples = VK_SAMPLE_COUNT_2_BIT;
     pipe_helper.CreateGraphicsPipeline();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -3012,9 +3008,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     // Positive Test: Image view with VK_SAMPLE_COUNT_1_BIT should not get error 07285 in pipeline created with attachment with
     // VK_SAMPLE_COUNT_2_BIT
     CreatePipelineHelper dr_pipe_helper(*this);
-    dr_pipe_helper.InitState();
     dr_pipe_helper.gp_ci_.renderPass = VK_NULL_HANDLE;
-    dr_pipe_helper.pipe_ms_state_ci_ = ms_state;
+    dr_pipe_helper.ms_ci_ = ms_state;
     dr_pipe_helper.cb_ci_.attachmentCount = 0;
     dr_pipe_helper.CreateGraphicsPipeline();
     begin_rendering_info.pNext = nullptr;
@@ -3028,8 +3023,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
 
     // Positive Test: Same as previous test but using render pass and should not get error 07284
     CreatePipelineHelper test_pipe(*this);
-    test_pipe.InitState();
-    test_pipe.pipe_ms_state_ci_ = ms_state;
+    test_pipe.ms_ci_ = ms_state;
     test_pipe.CreateGraphicsPipeline();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, test_pipe.pipeline_);
@@ -3411,7 +3405,6 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPassSubpassFlags) {
     clear_values[1].color = {{0, 0, 0, 0}};
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = render_pass2.handle();
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -323,7 +323,6 @@ TEST_F(PositiveRenderPass, DestroyPipeline) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
@@ -573,7 +572,6 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
     ds_ci.depthCompareOp = VK_COMPARE_OP_LESS;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -703,7 +701,6 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
 
     // Use helper to create graphics pipeline
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&push_ds_layout, &ds_layout});
     helper.gp_ci_.renderPass = render_pass.handle();
     helper.CreateGraphicsPipeline();
@@ -778,7 +775,6 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     ds_state.front.writeMask = 0x1;
     ds_state.back.writeMask = 0x1;
     CreatePipelineHelper helper(*this);
-    helper.InitState();
     helper.gp_ci_.pDepthStencilState = &ds_state;
     helper.gp_ci_.renderPass = rp.Handle();
     helper.CreateGraphicsPipeline();

--- a/tests/unit/robustness.cpp
+++ b/tests/unit/robustness.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,11 +22,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     RETURN_IF_SKIP(Init());
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06926");
         pipe.CreateComputePipeline();
@@ -34,11 +32,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     }
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.uniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06927");
         pipe.CreateComputePipeline();
@@ -46,11 +42,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     }
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.vertexInputs = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06928");
         pipe.CreateComputePipeline();
@@ -58,11 +52,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     }
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
         pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-pipelineRobustness-06929");
         pipe.CreateComputePipeline();
@@ -79,7 +71,6 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabledShaderStage) {
 
     CreateComputePipelineHelper pipe(*this);
 
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
 
     VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
@@ -107,7 +98,6 @@ TEST_F(NegativeRobustness, PipelineRobustnessDisabledShaderStageWithIdentifier) 
 
     CreateComputePipelineHelper pipe(*this);
 
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
 
     VkPipelineShaderStageModuleIdentifierCreateInfoEXT sm_id_create_info = vku::InitStructHelper();
@@ -159,11 +149,9 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
         pipeline_robustness_info.storageBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06931");
         pipe.CreateComputePipeline();
@@ -171,11 +159,9 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     }
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
         pipeline_robustness_info.uniformBuffers = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06932");
         pipe.CreateComputePipeline();
@@ -183,11 +169,9 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustBufferAccess2Unsuppo
     }
 
     {
-        CreateComputePipelineHelper pipe(*this);
-        pipe.InitState();
         VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+        CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
         pipeline_robustness_info.vertexInputs = VK_PIPELINE_ROBUSTNESS_BUFFER_BEHAVIOR_ROBUST_BUFFER_ACCESS_2_EXT;
-        pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-robustBufferAccess2-06933");
         pipe.CreateComputePipeline();
@@ -224,11 +208,9 @@ TEST_F(NegativeRobustness, DISABLED_PipelineRobustnessRobustImageAccess2Unsuppor
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+    CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_2_EXT;
-    pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess2-06934");
     pipe.CreateComputePipeline();
@@ -254,11 +236,9 @@ TEST_F(NegativeRobustness, PipelineRobustnessRobustImageAccessNotExposed) {
         GTEST_SKIP() << "VK_EXT_image_robustness is supported";
     }
 
-    CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+    CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT;
-    pipe.cp_ci_.pNext = &pipeline_robustness_info;
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRobustnessCreateInfoEXT-robustImageAccess-06930");
     pipe.CreateComputePipeline();

--- a/tests/unit/robustness_positive.cpp
+++ b/tests/unit/robustness_positive.cpp
@@ -100,10 +100,8 @@ TEST_F(PositiveRobustness, PipelineRobustnessRobustImageAccessExposed) {
     }
     RETURN_IF_SKIP(InitState(nullptr, &pipeline_robustness_features));
 
-    CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     VkPipelineRobustnessCreateInfoEXT pipeline_robustness_info = vku::InitStructHelper();
+    CreateComputePipelineHelper pipe(*this, &pipeline_robustness_info);
     pipeline_robustness_info.images = VK_PIPELINE_ROBUSTNESS_IMAGE_BEHAVIOR_ROBUST_IMAGE_ACCESS_EXT;
-    pipe.cp_ci_.pNext = &pipeline_robustness_info;
     pipe.CreateComputePipeline();
 }

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -399,7 +399,6 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
         pipe.dsl_bindings_ = {
             {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
         };
-        pipe.InitState();
         ASSERT_EQ(VK_SUCCESS, pipe.CreateGraphicsPipeline());
 
         pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -462,7 +461,6 @@ TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     pipe.dsl_bindings_ = {
         {0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL, nullptr},
     };
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
@@ -860,7 +858,6 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -928,8 +925,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_ALL_GRAPHICS, nullptr},
                             {2, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1029,8 +1025,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
                             {2, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {3, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {4, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1110,8 +1105,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {2, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1177,8 +1171,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                             {2, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1276,8 +1269,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -1368,8 +1360,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -36,7 +36,6 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimit) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -64,7 +63,6 @@ TEST_F(NegativeShaderCompute, SharedMemoryBooleanOverLimit) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -115,7 +113,6 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -728,7 +725,6 @@ TEST_F(NegativeShaderCompute, CmdDispatchExceedLimits) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, spv_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-x-06429");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-y-06430");
@@ -823,7 +819,6 @@ TEST_F(NegativeShaderCompute, DispatchBaseFlag) {
     RETURN_IF_SKIP(Init());
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     // Bind pipeline to command buffer

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -303,7 +303,6 @@ TEST_F(PositiveShaderCompute, SharedMemory) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -69,7 +69,6 @@ TEST_F(NegativeShaderCooperativeMatrix, SpecInfo) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, &specInfo);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -110,7 +109,6 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageUint32) {
     CreatePipelineHelper pipe(*this);
     pipe.vs_ = std::make_unique<VkShaderObj>(this, vtSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-cooperativeMatrixSupportedStages-08985");
     pipe.CreateGraphicsPipeline();
@@ -153,7 +151,6 @@ TEST_F(NegativeShaderCooperativeMatrix, UnsupportedStageFloat16) {
     CreatePipelineHelper pipe(*this);
     pipe.vs_ = std::make_unique<VkShaderObj>(this, vtSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-cooperativeMatrixSupportedStages-08985");
     pipe.CreateGraphicsPipeline();
@@ -186,7 +183,6 @@ TEST_F(NegativeShaderCooperativeMatrix, ParametersMatchProperties) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpTypeCooperativeMatrixKHR-08974");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -239,7 +235,6 @@ TEST_F(NegativeShaderCooperativeMatrix, DimXMultipleSubgroupSize) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, &specInfo);
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-module-08987");
     pipe.CreateComputePipeline();
@@ -296,7 +291,6 @@ TEST_F(NegativeShaderCooperativeMatrix, SameScope) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, &specInfo);
-    pipe.InitState();
 
     // SPIR-V code is expected to be bad after specialization, due to scopes are different
     // Need to ignore the spirv-val
@@ -345,7 +339,6 @@ TEST_F(NegativeShaderCooperativeMatrix, MatchSizeWithProperties) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-MSize-08975");
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
-    pipe.InitState();
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -427,7 +420,6 @@ TEST_F(NegativeShaderCooperativeMatrix, SignedCheck) {
         CreateComputePipelineHelper pipe(*this);
 
         pipe.cs_ = std::make_unique<VkShaderObj>(this, css, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-        pipe.InitState();
 
         for (const auto &y : subtests) {
             if (x.remove == y.remove) {

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -141,7 +141,6 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixNV) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL, &specInfo);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -222,7 +221,6 @@ TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixKHR) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, css.c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&dsl});
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -180,8 +180,7 @@ TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {g_pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -382,7 +381,6 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     descriptor_set.UpdateDescriptorSets();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -40,7 +40,6 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariable) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -77,7 +76,6 @@ TEST_F(PositiveShaderImageAccess, MultipleFunctionParameterToVariable) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -111,7 +109,6 @@ TEST_F(PositiveShaderImageAccess, DifferentFunctionParameterToVariable) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -172,7 +169,6 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoad) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -206,7 +202,6 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToVariableSampledImage) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -274,7 +269,6 @@ TEST_F(PositiveShaderImageAccess, FunctionParameterToLoadSampledImage) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -327,7 +321,6 @@ TEST_F(PositiveShaderImageAccess, CopyObjectFromLoad) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -381,7 +374,6 @@ TEST_F(PositiveShaderImageAccess, UndefImage) {
     pipe.dsl_bindings_.resize(bindings.size());
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -497,7 +489,6 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     descriptor_set.UpdateDescriptorSets();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -1097,7 +1097,6 @@ TEST_F(NegativeShaderInterface, InputOutputMismatch) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpEntryPoint-07754");
     pipe.CreateGraphicsPipeline();
@@ -1311,7 +1310,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputLocation0) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
@@ -1338,7 +1337,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputNoAlpha) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
@@ -1364,7 +1363,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayIndex) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
@@ -1390,7 +1389,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageArrayVec3) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
@@ -1530,7 +1529,7 @@ TEST_F(NegativeShaderInterface, CreatePipelineFragmentOutputNotWritten) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.cb_attachments_[0].colorWriteMask = 1;
+        helper.cb_attachments_.colorWriteMask = 1;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kWarningBit, "Undefined-Value-ShaderInputNotProduced");
 }

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -321,7 +321,6 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotWrittenButMasked) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 }
@@ -365,7 +364,6 @@ TEST_F(PositiveShaderInterface, RelaxedTypeMatch) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -410,7 +408,6 @@ TEST_F(PositiveShaderInterface, TessPerVertex) {
     pipe.gp_ci_.pTessellationState = &tsci;
     pipe.gp_ci_.pInputAssemblyState = &iasci;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), tcs.GetStageCreateInfo(), tes.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -450,7 +447,6 @@ TEST_F(PositiveShaderInterface, GeometryInputBlockPositive) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -485,7 +481,6 @@ TEST_F(PositiveShaderInterface, InputAttachment) {
     rp.CreateRenderPass();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
     pipe.gp_ci_.renderPass = rp.Handle();
@@ -738,7 +733,7 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotConsumedButAlphaToCoverageEnabl
     ms_state_ci.alphaToCoverageEnable = VK_TRUE;
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
         helper.cb_ci_.attachmentCount = 0;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
@@ -777,7 +772,6 @@ TEST_F(PositiveShaderInterface, DISABLED_InputOutputMatch2) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -858,7 +852,6 @@ TEST_F(PositiveShaderInterface, InputOutputMatch) {
     pipe.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 4;
     pipe.vi_ci_.pVertexAttributeDescriptions = vertex_input_attribute_descriptions;
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 
@@ -925,7 +918,6 @@ TEST_F(PositiveShaderInterface, NestedStructs) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -950,7 +942,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageOffsetToAlpha) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
@@ -976,7 +968,7 @@ TEST_F(PositiveShaderInterface, AlphaToCoverageArray) {
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-        helper.pipe_ms_state_ci_ = ms_state_ci;
+        helper.ms_ci_ = ms_state_ci;
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -267,10 +267,9 @@ TEST_F(NegativeShaderLimits, DISABLED_MaxFragmentDualSrcAttachments) {
     cb_attachments.dstAlphaBlendFactor = VK_BLEND_FACTOR_ONE_MINUS_SRC_ALPHA;
     cb_attachments.alphaBlendOp = VK_BLEND_OP_ADD;
 
-    CreatePipelineHelper pipe(*this, count);
-    pipe.cb_attachments_[0] = cb_attachments;
+    CreatePipelineHelper pipe(*this);
+    pipe.cb_ci_.pAttachments = &cb_attachments;
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -337,7 +336,6 @@ TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2,
                                              SPV_SOURCE_ASM);
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-Workgroup-06530");
     pipe.CreateComputePipeline();

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryWorkgroupMemoryExplicitLayout) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -82,7 +81,6 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryAtLimit) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -106,7 +104,6 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryBooleanAtLimit) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -43,7 +43,6 @@ TEST_F(NegativeShaderPushConstants, NotDeclared) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07987");
@@ -141,7 +140,6 @@ TEST_F(NegativeShaderPushConstants, NotInLayout) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {});
     /* should have generated an error -- no push constant ranges provided! */
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07987");
@@ -187,7 +185,6 @@ TEST_F(NegativeShaderPushConstants, Range) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
@@ -295,8 +292,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.pipeline_layout_ci_ = pipeline_layout_info;
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     pipeline_layout_info.pPushConstantRanges = &push_constant_range_small;
     vkt::PipelineLayout pipeline_layout_small(*m_device, pipeline_layout_info);
@@ -304,7 +300,6 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     CreatePipelineHelper g_pipe_small_range(*this);
     g_pipe_small_range.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe_small_range.pipeline_layout_ci_ = pipeline_layout_info;
-    g_pipe_small_range.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07987");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07987");
@@ -483,7 +478,6 @@ TEST_F(NegativeShaderPushConstants, DISABLED_SpecConstantSize) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL,
                                              &specialization_info);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkComputePipelineCreateInfo-layout-07987");
     pipe.CreateComputePipeline();

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,7 +49,6 @@ TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ci_ = pipeline_layout_info;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -307,15 +306,12 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     CreatePipelineHelper pipeline_helper_c(*this);  // layout_c and range_c
     pipeline_helper_a.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline_helper_a.pipeline_layout_ci_ = pipeline_layout_info_a;
-    pipeline_helper_a.InitState();
     pipeline_helper_a.CreateGraphicsPipeline();
     pipeline_helper_b.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline_helper_b.pipeline_layout_ci_ = pipeline_layout_info_b;
-    pipeline_helper_b.InitState();
     pipeline_helper_b.CreateGraphicsPipeline();
     pipeline_helper_c.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline_helper_c.pipeline_layout_ci_ = pipeline_layout_info_c;
-    pipeline_helper_c.InitState();
     pipeline_helper_c.CreateGraphicsPipeline();
 
     // Easier to see in command buffers
@@ -443,14 +439,12 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
     CreatePipelineHelper pipeline_unused(*this);
     pipeline_unused.shader_stages_ = {vsUnused.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline_unused.pipeline_layout_ci_ = pipeline_layout_info;
-    pipeline_unused.InitState();
     pipeline_unused.CreateGraphicsPipeline();
 
     // Shader never had a reference
     CreatePipelineHelper pipeline_empty(*this);
     pipeline_empty.shader_stages_ = {vsEmpty.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline_empty.pipeline_layout_ci_ = pipeline_layout_info;
-    pipeline_empty.InitState();
     pipeline_empty.CreateGraphicsPipeline();
 
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
@@ -500,7 +494,6 @@ TEST_F(PositiveShaderPushConstants, OffsetVector) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
@@ -556,7 +549,6 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
@@ -642,7 +634,6 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferVertFrag) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.pipeline_layout_ci_ = pipeline_layout_info;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -700,7 +691,6 @@ TEST_F(PositiveShaderPushConstants, MultipleStructs) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
@@ -736,7 +726,6 @@ TEST_F(PositiveShaderPushConstants, SpecConstantSizeDefault) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateComputePipeline();
 }
@@ -777,7 +766,6 @@ TEST_F(PositiveShaderPushConstants, SpecConstantSizeSet) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL,
                                              &specialization_info);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateComputePipeline();
 }

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -1121,7 +1121,6 @@ TEST_F(NegativeShaderSpirv, SpecializationOffsetOutOfBoundsWithIdentifier) {
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     pipe.gp_ci_.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSpecializationInfo-offset-00773");
     pipe.CreateGraphicsPipeline();
@@ -1194,7 +1193,6 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeZero) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_src, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL,
                                              &specialization_info);
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkSpecializationMapEntry-constantID-00776");
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
@@ -2073,7 +2071,6 @@ TEST_F(NegativeShaderSpirv, DISABLED_ImageFormatTypeMismatchWithZeroExtend) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_.reset(new VkShaderObj(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM));
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
-    pipe.InitState();
     pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
@@ -2108,7 +2105,6 @@ TEST_F(NegativeShaderSpirv, DISABLED_SpecConstantTextureIndex) {
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pSpecializationInfo-06849");
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_ALL_GRAPHICS, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -165,7 +165,6 @@ TEST_F(PositiveShaderSpirv, GroupDecorations) {
     memcpy(pipe.dsl_bindings_.data(), dslb, dslb_size * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ =
         std::make_unique<VkShaderObj>(this, spv_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -192,7 +191,6 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension1of2) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -219,7 +217,6 @@ TEST_F(PositiveShaderSpirv, CapabilityExtension2of2) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -373,7 +370,6 @@ void main() {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }
@@ -428,7 +424,6 @@ void main() {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }
@@ -575,7 +570,6 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     memcpy(pipe.dsl_bindings_.data(), bindings.data(), bindings.size() * sizeof(VkDescriptorSetLayoutBinding));
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_src.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM,
                                              &specialization_info);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 
     // Submit shader to see SSBO output
@@ -800,8 +794,7 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
     CreatePipelineHelper g_pipe(*this);
     g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
-    g_pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+    g_pipe.CreateGraphicsPipeline();
 
     VkImageUsageFlags usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -897,7 +890,6 @@ TEST_F(PositiveShaderSpirv, GeometryShaderPassthroughNV) {
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
 
     // Create pipeline and make sure that the usage of NV_geometry_shader_passthrough
@@ -960,7 +952,6 @@ TEST_F(PositiveShaderSpirv, SpecializeInt8) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.shader_stages_[1].pSpecializationInfo = &specialization_info;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -1018,7 +1009,6 @@ TEST_F(PositiveShaderSpirv, SpecializeInt16) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.shader_stages_[1].pSpecializationInfo = &specialization_info;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -1067,7 +1057,6 @@ TEST_F(PositiveShaderSpirv, SpecializeInt32) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.shader_stages_[1].pSpecializationInfo = &specialization_info;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -1126,7 +1115,6 @@ TEST_F(PositiveShaderSpirv, SpecializeInt64) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.shader_stages_[1].pSpecializationInfo = &specialization_info;
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -1783,7 +1771,6 @@ void main() {
         {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
         {1, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
     };
-    pipe.InitState();
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }
@@ -1857,7 +1844,6 @@ TEST_F(PositiveShaderSpirv, SpecConstantTextureIndexDefault) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_ALL_GRAPHICS, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }
@@ -1912,7 +1898,6 @@ TEST_F(PositiveShaderSpirv, SpecConstantTextureIndexValue) {
 
     CreatePipelineHelper pipe(*this);
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, 2, VK_SHADER_STAGE_ALL_GRAPHICS, nullptr}};
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 }

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -84,7 +84,6 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -156,7 +155,6 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -263,7 +261,6 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -417,7 +414,6 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -541,7 +537,6 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -607,7 +602,6 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
@@ -860,7 +854,6 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
@@ -942,7 +935,6 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -83,7 +83,6 @@ TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
@@ -174,7 +173,6 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
@@ -269,7 +267,6 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM,
                                              &specialization_info);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
@@ -388,7 +385,6 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -150,7 +150,6 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
@@ -231,7 +230,6 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     CreateComputePipelineHelper cs_pipeline(*this);
     cs_pipeline.cs_ =
         std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.InitState();
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     cs_pipeline.LateBindPipelineInfo();
     cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value

--- a/tests/unit/shader_storage_texel_positive.cpp
+++ b/tests/unit/shader_storage_texel_positive.cpp
@@ -85,7 +85,6 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -314,7 +314,6 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
 
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -320,7 +320,6 @@ TEST_F(NegativeSubgroup, ExtendedTypesEnabled) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
-    pipe.InitState();
     pipe.CreateComputePipeline();
 }
 
@@ -397,7 +396,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
 
     {
         CreateComputePipelineHelper cs_pipeline(*this);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.pNext = &subgroup_size_control;
         cs_pipeline.cp_ci_.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;
@@ -417,7 +415,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
         )glsl";
         CreateComputePipelineHelper cs_pipeline(*this);
         cs_pipeline.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT |
                                          VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;
@@ -437,7 +434,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
         )glsl";
         CreateComputePipelineHelper cs_pipeline(*this);
         cs_pipeline.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-flags-02759");
@@ -451,7 +447,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
         subgroup_properties.maxSubgroupSize >= 16) {
         subgroup_size_control.requiredSubgroupSize = 10;  // non-power of 2
         CreateComputePipelineHelper cs_pipeline(*this);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.pNext = &subgroup_size_control;
         cs_pipeline.cp_ci_.stage.flags = 0;
@@ -464,7 +459,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
     if (subgroup_properties.minSubgroupSize > 1) {
         subgroup_size_control.requiredSubgroupSize = 1;  // below min
         CreateComputePipelineHelper cs_pipeline(*this);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.pNext = &subgroup_size_control;
         cs_pipeline.cp_ci_.stage.flags = 0;
@@ -477,7 +471,6 @@ TEST_F(NegativeSubgroup, PipelineSubgroupSizeControl) {
     {
         subgroup_size_control.requiredSubgroupSize = subgroup_properties.maxSubgroupSize * 2;  // above max
         CreateComputePipelineHelper cs_pipeline(*this);
-        cs_pipeline.InitState();
         cs_pipeline.LateBindPipelineInfo();
         cs_pipeline.cp_ci_.stage.pNext = &subgroup_size_control;
         cs_pipeline.cp_ci_.stage.flags = 0;
@@ -518,7 +511,6 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesNotEnabled) {
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
     pipe.cp_ci_.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT;
 
@@ -568,7 +560,6 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierGraphics) {
     pipe.gp_ci_.stageCount = 1;
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06851");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -610,10 +601,11 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeaturesWithIdentifierCompute) {
     stage_ci.module = VK_NULL_HANDLE;
     stage_ci.pName = "main";
 
+    vkt::PipelineLayout pipeline_layout(*m_device, {});
+
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.cp_ci_.stage = stage_ci;
-    pipe.cp_ci_.layout = pipe.pipeline_layout_.handle();
+    pipe.cp_ci_.layout = pipeline_layout.handle();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageModuleIdentifierCreateInfoEXT-pNext-06851");
     pipe.CreateComputePipeline(false);
@@ -660,7 +652,6 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlStage) {
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.shader_stages_[0].flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT;
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-flags-08988");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -757,7 +748,6 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
 
         CreateComputePipelineHelper pipe(*this);
         pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-        pipe.InitState();
         pipe.LateBindPipelineInfo();
         pipe.cp_ci_.stage.pNext = &subgroup_size_control;
         if (size * size * 2 > m_device->phy().limits_.maxComputeWorkGroupInvocations) {
@@ -783,7 +773,6 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
 
         CreateComputePipelineHelper pipe(*this);
         pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
-        pipe.InitState();
         pipe.LateBindPipelineInfo();
         pipe.cp_ci_.stage.pNext = &subgroup_size_control;
         pipe.cp_ci_.stage.flags = VK_PIPELINE_SHADER_STAGE_CREATE_REQUIRE_FULL_SUBGROUPS_BIT;
@@ -888,7 +877,6 @@ TEST_F(NegativeSubgroup, MeshLocalWorkgroupSize) {
     VkShaderObj mesh_shader(this, kMeshMinimalGlsl, VK_SHADER_STAGE_MESH_BIT_EXT, SPV_ENV_VULKAN_1_3, SPV_SOURCE_GLSL);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
     pipe.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo()};
     pipe.shader_stages_[0].pNext = &subgroup_size_control;
@@ -909,7 +897,6 @@ TEST_F(NegativeSubgroup, SubgroupSizeControlFeature) {
     subgroup_size_control.requiredSubgroupSize = subgroup_properties.minSubgroupSize;
 
     CreateComputePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.LateBindPipelineInfo();
     pipe.cp_ci_.stage.pNext = &subgroup_size_control;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineShaderStageCreateInfo-pNext-02755");

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -446,7 +446,6 @@ TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
     vkt::Framebuffer fb(*m_device, rp.handle(), 1u, &imageView.handle());
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -602,8 +601,6 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
         g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs_fail.GetStageCreateInfo()};
         g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
         g_pipe.gp_ci_.renderPass = rp.handle();
-        g_pipe.InitState();
-
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-renderPass-06038");
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-layout-07988");
         g_pipe.CreateGraphicsPipeline();
@@ -624,8 +621,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
         g_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         g_pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
         g_pipe.gp_ci_.renderPass = rp.handle();
-        g_pipe.InitState();
-        ASSERT_EQ(VK_SUCCESS, g_pipe.CreateGraphicsPipeline());
+        g_pipe.CreateGraphicsPipeline();
 
         g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_input, sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
         g_pipe.descriptor_set_->UpdateDescriptorSets();
@@ -746,13 +742,11 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     CreatePipelineHelper pipe1(*this);
     pipe1.gp_ci_.renderPass = render_pass.handle();
     pipe1.gp_ci_.subpass = 0;
-    pipe1.InitState();
     pipe1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2(*this);
     pipe2.gp_ci_.renderPass = render_pass.handle();
     pipe2.gp_ci_.subpass = 1;
-    pipe2.InitState();
     pipe2.CreateGraphicsPipeline();
 
     VkClearValue clear_value = {};
@@ -1213,7 +1207,6 @@ TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkShaderModuleCreateInfo-pCode-08740");
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pl.handle();
     pipe.gp_ci_.renderPass = rp.handle();
@@ -1263,9 +1256,8 @@ TEST_F(NegativeSubpass, FramebufferNoAttachmentsSampleCounts) {
     ms_state.alphaToOneEnable = VK_FALSE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.pipe_ms_state_ci_ = ms_state;
+    pipe.ms_ci_ = ms_state;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-subpass-00758");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -109,8 +109,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = render_pass;
-    pipe.InitState();
-    ASSERT_EQ(VK_SUCCESS, pipe.CreateGraphicsPipeline());
+    pipe.CreateGraphicsPipeline();
 
     VkImageCopy copy_region = {};
     copy_region.srcSubresource = {VkImageAspectFlags(VK_IMAGE_ASPECT_COLOR_BIT), 0, 0, 1};
@@ -371,7 +370,6 @@ TEST_F(PositiveSyncVal, ShaderReferencesNotBoundSet) {
     OneOffDescriptorSet set(m_device, {binding});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
@@ -1484,7 +1482,6 @@ TEST_F(PositiveSyncVal, DISABLED_RenderPassStoreOpNone) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_[1] = fs.GetStageCreateInfo();
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.gp_ci_.renderPass = rp.Handle();

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -66,7 +66,6 @@ TEST_F(NegativeTransformFeedback, FeatureEnabled) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -123,7 +122,6 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
@@ -271,7 +269,6 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
@@ -358,7 +355,6 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
@@ -467,7 +463,6 @@ TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
     secondary.end();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -489,13 +484,11 @@ TEST_F(NegativeTransformFeedback, BindPipeline) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe_one(*this);
-    pipe_one.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe_one.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe_one.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe_two(*this);
-    pipe_two.InitState();
     pipe_two.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -518,7 +511,6 @@ TEST_F(NegativeTransformFeedback, EndRenderPass) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
@@ -554,7 +546,6 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
 
     {
         CreatePipelineHelper pipeline(*this);
-        pipeline.InitState();
         pipeline.CreateGraphicsPipeline();
 
         m_commandBuffer->begin();
@@ -609,7 +600,6 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
 
     CreatePipelineHelper pipeline(*this);
     pipeline.device_ = &test_device;
-    pipeline.InitState();
     pipeline.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipeline.gp_ci_.layout = pipelineLayout.handle();
     pipeline.gp_ci_.renderPass = renderpass.handle();
@@ -646,7 +636,6 @@ TEST_F(NegativeTransformFeedback, UsingRasterizationStateStreamExtDisabled) {
     CreatePipelineHelper pipe(*this);
     VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_state_stream_ci = vku::InitStructHelper();
     pipe.rs_state_ci_.pNext = &rasterization_state_stream_ci;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkPipelineRasterizationStateStreamCreateInfoEXT-geometryStreams-02324");
     pipe.CreateGraphicsPipeline();
@@ -1030,7 +1019,6 @@ TEST_F(NegativeTransformFeedback, PipelineRasterizationStateStreamCreateInfoEXT)
     VkPipelineRasterizationStateStreamCreateInfoEXT rasterization_state_stream_ci = vku::InitStructHelper();
     rasterization_state_stream_ci.rasterizationStream = transfer_feedback_props.maxTransformFeedbackStreams;
     pipe.rs_state_ci_.pNext = &rasterization_state_stream_ci;
-    pipe.InitState();
 
     if (transfer_feedback_props.transformFeedbackRasterizationStreamSelect) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
@@ -1083,7 +1071,6 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
 
     CreatePipelineHelper pipe(*this);
     pipe.gp_ci_.renderPass = rp.handle();
-    pipe.InitState();
     auto vs = VkShaderObj::CreateFromASM(this, kXfbVsSource, VK_SHADER_STAGE_VERTEX_BIT);
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
@@ -1104,7 +1091,6 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackOutsideRenderPass) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1129,7 +1115,6 @@ TEST_F(NegativeTransformFeedback, XfbExecutionModeCommand) {
 
     // default Vertex shader will not have Xfb
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1152,7 +1137,6 @@ TEST_F(NegativeTransformFeedback, XfbExecutionModePipeline) {
     VkShaderObj gs(this, kGeometryMinimalGlsl, VK_SHADER_STAGE_GEOMETRY_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {vs->GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pStages-02318");

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -549,7 +549,6 @@ TEST_F(NegativeVertexInput, UsingProvokingVertexModeLastVertexExtDisabled) {
     VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state_ci = vku::InitStructHelper();
     provoking_vertex_state_ci.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT;
     pipe.rs_state_ci_.pNext = &provoking_vertex_state_ci;
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkPipelineRasterizationProvokingVertexStateCreateInfoEXT-provokingVertexMode-04883");
@@ -582,17 +581,14 @@ TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
     VkPipelineRasterizationProvokingVertexStateCreateInfoEXT provoking_vertex_state_ci = vku::InitStructHelper();
     provoking_vertex_state_ci.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_FIRST_VERTEX_EXT;
     pipe1.rs_state_ci_.pNext = &provoking_vertex_state_ci;
-    pipe1.InitState();
     pipe1.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe2(*this);
     provoking_vertex_state_ci.provokingVertexMode = VK_PROVOKING_VERTEX_MODE_LAST_VERTEX_EXT;
     pipe2.rs_state_ci_.pNext = &provoking_vertex_state_ci;
-    pipe2.InitState();
     pipe2.CreateGraphicsPipeline();
 
     CreatePipelineHelper pipe3(*this);
-    pipe3.InitState();
     pipe3.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -637,7 +633,6 @@ TEST_F(NegativeVertexInput, VertextBinding) {
     pipe.vi_ci_.pVertexBindingDescriptions = vtx_binding_des;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -674,7 +669,6 @@ TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
     pipe.vi_ci_.pVertexBindingDescriptions = vtx_binding_des;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -702,7 +696,6 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -808,7 +801,6 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     vi_state.pVertexAttributeDescriptions = &input_attribs[0];
 
     CreatePipelineHelper pipe1(*this);
-    pipe1.InitState();
     pipe1.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe1.vi_ci_ = vi_state;
     pipe1.CreateGraphicsPipeline();
@@ -816,7 +808,6 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     input_binding.stride = 6;
 
     CreatePipelineHelper pipe2(*this);
-    pipe2.InitState();
     pipe2.shader_stages_[0] = vs.GetStageCreateInfo();
     pipe2.vi_ci_ = vi_state;
     pipe2.CreateGraphicsPipeline();
@@ -864,7 +855,6 @@ TEST_F(NegativeVertexInput, BindVertexOffset) {
     pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -896,7 +886,6 @@ TEST_F(NegativeVertexInput, VertexStride) {
     pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -921,7 +910,6 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -971,7 +959,6 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
     pipe.vi_ci_.pVertexBindingDescriptions = &bindings;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
@@ -1008,7 +995,6 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
     pipe.vi_ci_.pVertexBindingDescriptions = bindings;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.vi_ci_.pVertexAttributeDescriptions = attributes;
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
@@ -1038,7 +1024,6 @@ TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
@@ -1229,7 +1214,6 @@ TEST_F(NegativeVertexInput, AttributeStructTypeFirstLocation) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1284,7 +1268,6 @@ TEST_F(NegativeVertexInput, AttributeStructTypeSecondLocation) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1337,7 +1320,6 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
@@ -1362,7 +1344,6 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatchDynamic) {
     VkShaderObj vs(this, vsSource, VK_SHADER_STAGE_VERTEX_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
@@ -1456,7 +1437,6 @@ TEST_F(NegativeVertexInput, Attribute64bitInputAttribute) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08929");
     pipe.CreateGraphicsPipeline();
@@ -1492,7 +1472,6 @@ TEST_F(NegativeVertexInput, Attribute64bitShaderInput) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-08930");
     pipe.CreateGraphicsPipeline();
@@ -1528,7 +1507,6 @@ TEST_F(NegativeVertexInput, Attribute64bitUnusedComponent) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-pVertexInputState-09198");
     pipe.CreateGraphicsPipeline();
@@ -1593,7 +1571,6 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation64bit) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");  // loc 4
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-Input-08733");  // loc 7
     pipe.CreateGraphicsPipeline();
@@ -1634,7 +1611,6 @@ TEST_F(NegativeVertexInput, UnsupportedDivisor) {
     input_vertex_binding_description.inputRate = VK_VERTEX_INPUT_RATE_INSTANCE;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.vi_ci_.pNext = &vertex_input_divisor_state;
     pipe.vi_ci_.vertexBindingDescriptionCount = 1u;
     pipe.vi_ci_.pVertexBindingDescriptions = &input_vertex_binding_description;
@@ -1683,7 +1659,6 @@ TEST_F(NegativeVertexInput, UnsupportedDynamicStateDivisor) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -1740,7 +1715,6 @@ TEST_F(NegativeVertexInput, BindVertexBufferNullDraw) {
     pipe.vi_ci_.pVertexBindingDescriptions = &bindings;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -1769,7 +1743,6 @@ TEST_F(NegativeVertexInput, VertextBufferDestroyed) {
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -50,7 +50,6 @@ TEST_F(PositiveVertexInput, AttributeMatrixType) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
     /* expect success */
 }
@@ -89,7 +88,6 @@ TEST_F(PositiveVertexInput, AttributeArrayType) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -138,7 +136,6 @@ TEST_F(PositiveVertexInput, AttributeStructType) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attrib;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -199,7 +196,6 @@ TEST_F(PositiveVertexInput, AttributeStructTypeWithArray) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -252,7 +248,6 @@ TEST_F(PositiveVertexInput, AttributeStructTypeSecondLocation) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -304,7 +299,6 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 2;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -365,12 +359,16 @@ TEST_F(PositiveVertexInput, AttributeComponents) {
     rp.AddColorAttachment(1);
     rp.CreateRenderPass();
 
-    CreatePipelineHelper pipe(*this, 2);
-    pipe.InitState();
+    VkPipelineColorBlendAttachmentState cb_attachments[2];
+    memset(cb_attachments, 0, sizeof(VkPipelineColorBlendAttachmentState) * 2);
+    cb_attachments[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
+    cb_attachments[0].blendEnable = VK_FALSE;
+
+    CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.renderPass = rp.Handle();
-    pipe.cb_attachments_[0].dstAlphaBlendFactor = VK_BLEND_FACTOR_CONSTANT_COLOR;
-    pipe.cb_attachments_[0].blendEnable = VK_FALSE;
+    pipe.cb_ci_.attachmentCount = 2;
+    pipe.cb_ci_.pAttachments = cb_attachments;
     pipe.vi_ci_.pVertexBindingDescriptions = &input_binding;
     pipe.vi_ci_.vertexBindingDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
@@ -428,7 +426,6 @@ TEST_F(PositiveVertexInput, CreatePipeline64BitAttributes) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 4;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -463,7 +460,6 @@ TEST_F(PositiveVertexInput, VertexAttribute64bit) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -525,7 +521,6 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation64bit) {
     pipe.vi_ci_.pVertexAttributeDescriptions = input_attribs;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 }
 
@@ -558,7 +553,6 @@ TEST_F(PositiveVertexInput, Attribute64bitMissingComponent) {
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
-    pipe.InitState();
 
     pipe.CreateGraphicsPipeline();
 }
@@ -588,7 +582,6 @@ TEST_F(PositiveVertexInput, VertexAttributeDivisorFirstInstance) {
     }
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.vi_ci_.pNext = &pvids_ci;
     pipe.vi_ci_.vertexBindingDescriptionCount = 1;
     pipe.vi_ci_.pVertexBindingDescriptions = &vibd;
@@ -624,7 +617,6 @@ TEST_F(PositiveVertexInput, VertextBindingNonLinear) {
     pipe.vi_ci_.pVertexBindingDescriptions = vtx_binding_des;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 3;
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -649,7 +641,6 @@ TEST_F(PositiveVertexInput, VertextBindingDynamicState) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.CreateGraphicsPipeline();
 
@@ -710,7 +701,6 @@ TEST_F(PositiveVertexInput, VertexStrideDynamicStride) {
     pipe.vi_ci_.pVertexBindingDescriptions = &bindings;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
@@ -737,7 +727,6 @@ TEST_F(PositiveVertexInput, VertexStrideDoubleDynamicStride) {
     InitRenderTarget();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_EXT);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
@@ -808,7 +797,6 @@ TEST_F(PositiveVertexInput, BindVertexBufferNull) {
     pipe.vi_ci_.pVertexBindingDescriptions = &bindings;
     pipe.vi_ci_.vertexAttributeDescriptionCount = 1;
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -977,10 +977,8 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
     dyn_state_ci.dynamicStateCount = 2;
     dyn_state_ci.pDynamicStates = dyn_states;
 
-    CreatePipelineHelper pipe(*this);
-    pipe.gp_ci_.pNext = &discard_rectangle_state;
+    CreatePipelineHelper pipe(*this, &discard_rectangle_state);
     pipe.gp_ci_.pDynamicState = &dyn_state_ci;
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     vk::BeginCommandBuffer(secondary.handle(), &cbbi);
@@ -994,7 +992,6 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
 
         CreatePipelineHelper pipe2(*this);
         pipe2.gp_ci_.pDynamicState = &dyn_state_ci;
-        pipe2.InitState();
         pipe2.CreateGraphicsPipeline();
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkCmdBindPipeline-commandBuffer-04809");
         vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.pipeline_);

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -3339,7 +3339,6 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view_handle, 1, 1);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = rp.handle();
     pipe.CreateGraphicsPipeline();
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -977,9 +977,8 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
         VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.gp_ci_.renderPass = render_pass.handle();
-    pipe.cb_attachments_[0] = pcbas;
+    pipe.cb_attachments_ = pcbas;
     pipe.CreateGraphicsPipeline();
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
@@ -1208,7 +1207,6 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
     VkShaderObj fs(this, kFragmentMinimalGlsl, VK_SHADER_STAGE_FRAGMENT_BIT);
     CreatePipelineHelper pipe(*this);
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     // Create a protected command buffer/pool to use

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -1679,7 +1679,6 @@ TEST_F(NegativeYcbcr, DrawFetch) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
@@ -1784,7 +1783,6 @@ TEST_F(NegativeYcbcr, DrawConstOffset) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -369,7 +369,6 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     descriptor_set.UpdateDescriptorSets();
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.CreateGraphicsPipeline();
 
     m_commandBuffer->begin();
@@ -458,7 +457,6 @@ TEST_F(PositiveYcbcr, DrawCombinedImageSampler) {
     VkShaderObj fs(this, fsSource, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     CreatePipelineHelper pipe(*this);
-    pipe.InitState();
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();


### PR DESCRIPTION
This is a "remove unnecessary test code" change

The big 3 things are

1. Remove the `InitState` from the pipeline helpers... it is confusing and not needed 99% of the time
2. Remove legacy "set the color blend attachment vector" logic
3. Allow for `pNext` to be used when doing the construction (nice for dynamic rendering)