### PR TITLE
scripts: Remove manual header update step

### DIFF
--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -230,8 +230,7 @@ static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirvCapabilit
     {spv::CapabilityTextureSampleWeightedQCOM, {0, &DeviceFeatures::textureSampleWeighted, nullptr, ""}},
     {spv::CapabilityTextureBoxFilterQCOM, {0, &DeviceFeatures::textureBoxFilter, nullptr, ""}},
     {spv::CapabilityTextureBlockMatchQCOM, {0, &DeviceFeatures::textureBlockMatch, nullptr, ""}},
-    // Not found in current SPIR-V Headers
-    //    {spv::CapabilityTextureBlockMatch2QCOM, {0, &DeviceFeatures::textureBlockMatch2, nullptr, ""}},
+    {spv::CapabilityTextureBlockMatch2QCOM, {0, &DeviceFeatures::textureBlockMatch2, nullptr, ""}},
     {spv::CapabilityMeshShadingEXT, {0, nullptr, &DeviceExtensions::vk_ext_mesh_shader, ""}},
     {spv::CapabilityRayTracingOpacityMicromapEXT, {0, nullptr, &DeviceExtensions::vk_ext_opacity_micromap, ""}},
     {spv::CapabilityCoreBuiltinsARM, {0, &DeviceFeatures::shaderCoreBuiltins, nullptr, ""}},
@@ -250,8 +249,7 @@ static const std::unordered_multimap<uint32_t, RequiredSpirvInfo> spirvCapabilit
     {spv::CapabilityQuadControlKHR, {0, &DeviceFeatures::shaderQuadControl, nullptr, ""}},
     // Not found in current SPIR-V Headers
     //    {spv::CapabilityMaximallyReconvergesKHR, {0, &DeviceFeatures::shaderMaximalReconvergence, nullptr, ""}},
-    // Not found in current SPIR-V Headers
-    //    {spv::CapabilityRawAccessChainsNV, {0, &DeviceFeatures::shaderRawAccessChains, nullptr, ""}},
+    {spv::CapabilityRawAccessChainsNV, {0, &DeviceFeatures::shaderRawAccessChains, nullptr, ""}},
 };
 // clang-format on
 
@@ -366,46 +364,32 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "Matrix";
         case spv::CapabilityShader:
             return "Shader";
-        case spv::CapabilityInputAttachment:
-            return "InputAttachment";
-        case spv::CapabilitySampled1D:
-            return "Sampled1D";
-        case spv::CapabilityImage1D:
-            return "Image1D";
-        case spv::CapabilitySampledBuffer:
-            return "SampledBuffer";
-        case spv::CapabilityImageBuffer:
-            return "ImageBuffer";
-        case spv::CapabilityImageQuery:
-            return "ImageQuery";
-        case spv::CapabilityDerivativeControl:
-            return "DerivativeControl";
         case spv::CapabilityGeometry:
             return "Geometry";
         case spv::CapabilityTessellation:
             return "Tessellation";
+        case spv::CapabilityAddresses:
+            return "Addresses";
+        case spv::CapabilityLinkage:
+            return "Linkage";
+        case spv::CapabilityKernel:
+            return "Kernel";
+        case spv::CapabilityFloat16:
+            return "Float16";
         case spv::CapabilityFloat64:
             return "Float64";
         case spv::CapabilityInt64:
             return "Int64";
         case spv::CapabilityInt64Atomics:
             return "Int64Atomics";
-        case spv::CapabilityAtomicFloat16AddEXT:
-            return "AtomicFloat16AddEXT";
-        case spv::CapabilityAtomicFloat32AddEXT:
-            return "AtomicFloat32AddEXT";
-        case spv::CapabilityAtomicFloat64AddEXT:
-            return "AtomicFloat64AddEXT";
-        case spv::CapabilityAtomicFloat16MinMaxEXT:
-            return "AtomicFloat16MinMaxEXT";
-        case spv::CapabilityAtomicFloat32MinMaxEXT:
-            return "AtomicFloat32MinMaxEXT";
-        case spv::CapabilityAtomicFloat64MinMaxEXT:
-            return "AtomicFloat64MinMaxEXT";
-        case spv::CapabilityAtomicFloat16VectorNV:
-            return "AtomicFloat16VectorNV";
-        case spv::CapabilityInt64ImageEXT:
-            return "Int64ImageEXT";
+        case spv::CapabilityImageReadWrite:
+            return "ImageReadWrite";
+        case spv::CapabilityImageMipmap:
+            return "ImageMipmap";
+        case spv::CapabilityGroups:
+            return "Groups";
+        case spv::CapabilityAtomicStorage:
+            return "AtomicStorage";
         case spv::CapabilityInt16:
             return "Int16";
         case spv::CapabilityTessellationPointSize:
@@ -432,70 +416,54 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "ImageCubeArray";
         case spv::CapabilitySampleRateShading:
             return "SampleRateShading";
+        case spv::CapabilityImageRect:
+            return "ImageRect";
+        case spv::CapabilitySampledRect:
+            return "SampledRect";
+        case spv::CapabilityGenericPointer:
+            return "GenericPointer";
+        case spv::CapabilityInt8:
+            return "Int8";
+        case spv::CapabilityInputAttachment:
+            return "InputAttachment";
         case spv::CapabilitySparseResidency:
             return "SparseResidency";
         case spv::CapabilityMinLod:
             return "MinLod";
+        case spv::CapabilitySampled1D:
+            return "Sampled1D";
+        case spv::CapabilityImage1D:
+            return "Image1D";
         case spv::CapabilitySampledCubeArray:
             return "SampledCubeArray";
+        case spv::CapabilitySampledBuffer:
+            return "SampledBuffer";
+        case spv::CapabilityImageBuffer:
+            return "ImageBuffer";
         case spv::CapabilityImageMSArray:
             return "ImageMSArray";
         case spv::CapabilityStorageImageExtendedFormats:
             return "StorageImageExtendedFormats";
+        case spv::CapabilityImageQuery:
+            return "ImageQuery";
+        case spv::CapabilityDerivativeControl:
+            return "DerivativeControl";
         case spv::CapabilityInterpolationFunction:
             return "InterpolationFunction";
+        case spv::CapabilityTransformFeedback:
+            return "TransformFeedback";
+        case spv::CapabilityGeometryStreams:
+            return "GeometryStreams";
         case spv::CapabilityStorageImageReadWithoutFormat:
             return "StorageImageReadWithoutFormat";
         case spv::CapabilityStorageImageWriteWithoutFormat:
             return "StorageImageWriteWithoutFormat";
         case spv::CapabilityMultiViewport:
             return "MultiViewport";
-        case spv::CapabilityDrawParameters:
-            return "DrawParameters";
-        case spv::CapabilityMultiView:
-            return "MultiView";
-        case spv::CapabilityDeviceGroup:
-            return "DeviceGroup";
-        case spv::CapabilityVariablePointersStorageBuffer:
-            return "VariablePointersStorageBuffer";
-        case spv::CapabilityVariablePointers:
-            return "VariablePointers";
-        case spv::CapabilityShaderClockKHR:
-            return "ShaderClockKHR";
-        case spv::CapabilityStencilExportEXT:
-            return "StencilExportEXT";
-        case spv::CapabilitySubgroupBallotKHR:
-            return "SubgroupBallotKHR";
-        case spv::CapabilitySubgroupVoteKHR:
-            return "SubgroupVoteKHR";
-        case spv::CapabilityImageReadWriteLodAMD:
-            return "ImageReadWriteLodAMD";
-        case spv::CapabilityImageGatherBiasLodAMD:
-            return "ImageGatherBiasLodAMD";
-        case spv::CapabilityFragmentMaskAMD:
-            return "FragmentMaskAMD";
-        case spv::CapabilitySampleMaskOverrideCoverageNV:
-            return "SampleMaskOverrideCoverageNV";
-        case spv::CapabilityGeometryShaderPassthroughNV:
-            return "GeometryShaderPassthroughNV";
-        case spv::CapabilityShaderViewportIndex:
-            return "ShaderViewportIndex";
-        case spv::CapabilityShaderLayer:
-            return "ShaderLayer";
-        case spv::CapabilityShaderViewportIndexLayerEXT:
-            return "ShaderViewportIndexLayerEXT";
-        case spv::CapabilityShaderViewportMaskNV:
-            return "ShaderViewportMaskNV";
-        case spv::CapabilityPerViewAttributesNV:
-            return "PerViewAttributesNV";
-        case spv::CapabilityStorageBuffer16BitAccess:
-            return "StorageBuffer16BitAccess";
-        case spv::CapabilityUniformAndStorageBuffer16BitAccess:
-            return "UniformAndStorageBuffer16BitAccess";
-        case spv::CapabilityStoragePushConstant16:
-            return "StoragePushConstant16";
-        case spv::CapabilityStorageInputOutput16:
-            return "StorageInputOutput16";
+        case spv::CapabilitySubgroupDispatch:
+            return "SubgroupDispatch";
+        case spv::CapabilityPipeStorage:
+            return "PipeStorage";
         case spv::CapabilityGroupNonUniform:
             return "GroupNonUniform";
         case spv::CapabilityGroupNonUniformVote:
@@ -512,10 +480,132 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "GroupNonUniformClustered";
         case spv::CapabilityGroupNonUniformQuad:
             return "GroupNonUniformQuad";
-        case spv::CapabilityGroupNonUniformPartitionedNV:
-            return "GroupNonUniformPartitionedNV";
+        case spv::CapabilityShaderLayer:
+            return "ShaderLayer";
+        case spv::CapabilityShaderViewportIndex:
+            return "ShaderViewportIndex";
+        case spv::CapabilityUniformDecoration:
+            return "UniformDecoration";
+        case spv::CapabilityCoreBuiltinsARM:
+            return "CoreBuiltinsARM";
+        case spv::CapabilityTileImageColorReadAccessEXT:
+            return "TileImageColorReadAccessEXT";
+        case spv::CapabilityTileImageDepthReadAccessEXT:
+            return "TileImageDepthReadAccessEXT";
+        case spv::CapabilityTileImageStencilReadAccessEXT:
+            return "TileImageStencilReadAccessEXT";
+        case spv::CapabilityFragmentShadingRateKHR:
+            return "FragmentShadingRateKHR";
+        case spv::CapabilitySubgroupBallotKHR:
+            return "SubgroupBallotKHR";
+        case spv::CapabilityDrawParameters:
+            return "DrawParameters";
+        case spv::CapabilityWorkgroupMemoryExplicitLayoutKHR:
+            return "WorkgroupMemoryExplicitLayoutKHR";
+        case spv::CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR:
+            return "WorkgroupMemoryExplicitLayout8BitAccessKHR";
+        case spv::CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR:
+            return "WorkgroupMemoryExplicitLayout16BitAccessKHR";
+        case spv::CapabilitySubgroupVoteKHR:
+            return "SubgroupVoteKHR";
+        case spv::CapabilityStorageBuffer16BitAccess:
+            return "StorageBuffer16BitAccess";
+        case spv::CapabilityUniformAndStorageBuffer16BitAccess:
+            return "UniformAndStorageBuffer16BitAccess";
+        case spv::CapabilityStoragePushConstant16:
+            return "StoragePushConstant16";
+        case spv::CapabilityStorageInputOutput16:
+            return "StorageInputOutput16";
+        case spv::CapabilityDeviceGroup:
+            return "DeviceGroup";
+        case spv::CapabilityMultiView:
+            return "MultiView";
+        case spv::CapabilityVariablePointersStorageBuffer:
+            return "VariablePointersStorageBuffer";
+        case spv::CapabilityVariablePointers:
+            return "VariablePointers";
+        case spv::CapabilityAtomicStorageOps:
+            return "AtomicStorageOps";
         case spv::CapabilitySampleMaskPostDepthCoverage:
             return "SampleMaskPostDepthCoverage";
+        case spv::CapabilityStorageBuffer8BitAccess:
+            return "StorageBuffer8BitAccess";
+        case spv::CapabilityUniformAndStorageBuffer8BitAccess:
+            return "UniformAndStorageBuffer8BitAccess";
+        case spv::CapabilityStoragePushConstant8:
+            return "StoragePushConstant8";
+        case spv::CapabilityDenormPreserve:
+            return "DenormPreserve";
+        case spv::CapabilityDenormFlushToZero:
+            return "DenormFlushToZero";
+        case spv::CapabilitySignedZeroInfNanPreserve:
+            return "SignedZeroInfNanPreserve";
+        case spv::CapabilityRoundingModeRTE:
+            return "RoundingModeRTE";
+        case spv::CapabilityRoundingModeRTZ:
+            return "RoundingModeRTZ";
+        case spv::CapabilityRayQueryProvisionalKHR:
+            return "RayQueryProvisionalKHR";
+        case spv::CapabilityRayQueryKHR:
+            return "RayQueryKHR";
+        case spv::CapabilityRayTraversalPrimitiveCullingKHR:
+            return "RayTraversalPrimitiveCullingKHR";
+        case spv::CapabilityRayTracingKHR:
+            return "RayTracingKHR";
+        case spv::CapabilityTextureSampleWeightedQCOM:
+            return "TextureSampleWeightedQCOM";
+        case spv::CapabilityTextureBoxFilterQCOM:
+            return "TextureBoxFilterQCOM";
+        case spv::CapabilityTextureBlockMatchQCOM:
+            return "TextureBlockMatchQCOM";
+        case spv::CapabilityTextureBlockMatch2QCOM:
+            return "TextureBlockMatch2QCOM";
+        case spv::CapabilityFloat16ImageAMD:
+            return "Float16ImageAMD";
+        case spv::CapabilityImageGatherBiasLodAMD:
+            return "ImageGatherBiasLodAMD";
+        case spv::CapabilityFragmentMaskAMD:
+            return "FragmentMaskAMD";
+        case spv::CapabilityStencilExportEXT:
+            return "StencilExportEXT";
+        case spv::CapabilityImageReadWriteLodAMD:
+            return "ImageReadWriteLodAMD";
+        case spv::CapabilityInt64ImageEXT:
+            return "Int64ImageEXT";
+        case spv::CapabilityShaderClockKHR:
+            return "ShaderClockKHR";
+        case spv::CapabilityShaderEnqueueAMDX:
+            return "ShaderEnqueueAMDX";
+        case spv::CapabilityQuadControlKHR:
+            return "QuadControlKHR";
+        case spv::CapabilitySampleMaskOverrideCoverageNV:
+            return "SampleMaskOverrideCoverageNV";
+        case spv::CapabilityGeometryShaderPassthroughNV:
+            return "GeometryShaderPassthroughNV";
+        case spv::CapabilityShaderViewportIndexLayerEXT:
+            return "ShaderViewportIndexLayerEXT";
+        case spv::CapabilityShaderViewportMaskNV:
+            return "ShaderViewportMaskNV";
+        case spv::CapabilityShaderStereoViewNV:
+            return "ShaderStereoViewNV";
+        case spv::CapabilityPerViewAttributesNV:
+            return "PerViewAttributesNV";
+        case spv::CapabilityFragmentFullyCoveredEXT:
+            return "FragmentFullyCoveredEXT";
+        case spv::CapabilityMeshShadingNV:
+            return "MeshShadingNV";
+        case spv::CapabilityImageFootprintNV:
+            return "ImageFootprintNV";
+        case spv::CapabilityMeshShadingEXT:
+            return "MeshShadingEXT";
+        case spv::CapabilityFragmentBarycentricKHR:
+            return "FragmentBarycentricKHR";
+        case spv::CapabilityComputeDerivativeGroupQuadsNV:
+            return "ComputeDerivativeGroupQuadsNV";
+        case spv::CapabilityFragmentDensityEXT:
+            return "FragmentDensityEXT";
+        case spv::CapabilityGroupNonUniformPartitionedNV:
+            return "GroupNonUniformPartitionedNV";
         case spv::CapabilityShaderNonUniform:
             return "ShaderNonUniform";
         case spv::CapabilityRuntimeDescriptorArray:
@@ -540,126 +630,188 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "UniformTexelBufferArrayNonUniformIndexing";
         case spv::CapabilityStorageTexelBufferArrayNonUniformIndexing:
             return "StorageTexelBufferArrayNonUniformIndexing";
-        case spv::CapabilityFragmentFullyCoveredEXT:
-            return "FragmentFullyCoveredEXT";
-        case spv::CapabilityFloat16:
-            return "Float16";
-        case spv::CapabilityInt8:
-            return "Int8";
-        case spv::CapabilityStorageBuffer8BitAccess:
-            return "StorageBuffer8BitAccess";
-        case spv::CapabilityUniformAndStorageBuffer8BitAccess:
-            return "UniformAndStorageBuffer8BitAccess";
-        case spv::CapabilityStoragePushConstant8:
-            return "StoragePushConstant8";
-        case spv::CapabilityVulkanMemoryModel:
-            return "VulkanMemoryModel";
-        case spv::CapabilityVulkanMemoryModelDeviceScope:
-            return "VulkanMemoryModelDeviceScope";
-        case spv::CapabilityDenormPreserve:
-            return "DenormPreserve";
-        case spv::CapabilityDenormFlushToZero:
-            return "DenormFlushToZero";
-        case spv::CapabilitySignedZeroInfNanPreserve:
-            return "SignedZeroInfNanPreserve";
-        case spv::CapabilityRoundingModeRTE:
-            return "RoundingModeRTE";
-        case spv::CapabilityRoundingModeRTZ:
-            return "RoundingModeRTZ";
-        case spv::CapabilityComputeDerivativeGroupQuadsNV:
-            return "ComputeDerivativeGroupQuadsNV";
-        case spv::CapabilityComputeDerivativeGroupLinearNV:
-            return "ComputeDerivativeGroupLinearNV";
-        case spv::CapabilityImageFootprintNV:
-            return "ImageFootprintNV";
-        case spv::CapabilityMeshShadingNV:
-            return "MeshShadingNV";
-        case spv::CapabilityRayTracingKHR:
-            return "RayTracingKHR";
-        case spv::CapabilityRayQueryKHR:
-            return "RayQueryKHR";
-        case spv::CapabilityRayTraversalPrimitiveCullingKHR:
-            return "RayTraversalPrimitiveCullingKHR";
-        case spv::CapabilityRayCullMaskKHR:
-            return "RayCullMaskKHR";
+        case spv::CapabilityRayTracingPositionFetchKHR:
+            return "RayTracingPositionFetchKHR";
         case spv::CapabilityRayTracingNV:
             return "RayTracingNV";
         case spv::CapabilityRayTracingMotionBlurNV:
             return "RayTracingMotionBlurNV";
-        case spv::CapabilityTransformFeedback:
-            return "TransformFeedback";
-        case spv::CapabilityGeometryStreams:
-            return "GeometryStreams";
-        case spv::CapabilityFragmentDensityEXT:
-            return "FragmentDensityEXT";
+        case spv::CapabilityVulkanMemoryModel:
+            return "VulkanMemoryModel";
+        case spv::CapabilityVulkanMemoryModelDeviceScope:
+            return "VulkanMemoryModelDeviceScope";
         case spv::CapabilityPhysicalStorageBufferAddresses:
             return "PhysicalStorageBufferAddresses";
+        case spv::CapabilityComputeDerivativeGroupLinearNV:
+            return "ComputeDerivativeGroupLinearNV";
+        case spv::CapabilityRayTracingProvisionalKHR:
+            return "RayTracingProvisionalKHR";
         case spv::CapabilityCooperativeMatrixNV:
             return "CooperativeMatrixNV";
-        case spv::CapabilityIntegerFunctions2INTEL:
-            return "IntegerFunctions2INTEL";
-        case spv::CapabilityShaderSMBuiltinsNV:
-            return "ShaderSMBuiltinsNV";
         case spv::CapabilityFragmentShaderSampleInterlockEXT:
             return "FragmentShaderSampleInterlockEXT";
-        case spv::CapabilityFragmentShaderPixelInterlockEXT:
-            return "FragmentShaderPixelInterlockEXT";
         case spv::CapabilityFragmentShaderShadingRateInterlockEXT:
             return "FragmentShaderShadingRateInterlockEXT";
-        case spv::CapabilityDemoteToHelperInvocationEXT:
-            return "DemoteToHelperInvocationEXT";
-        case spv::CapabilityFragmentShadingRateKHR:
-            return "FragmentShadingRateKHR";
-        case spv::CapabilityWorkgroupMemoryExplicitLayoutKHR:
-            return "WorkgroupMemoryExplicitLayoutKHR";
-        case spv::CapabilityWorkgroupMemoryExplicitLayout8BitAccessKHR:
-            return "WorkgroupMemoryExplicitLayout8BitAccessKHR";
-        case spv::CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR:
-            return "WorkgroupMemoryExplicitLayout16BitAccessKHR";
-        case spv::CapabilityDotProductInputAllKHR:
-            return "DotProductInputAllKHR";
-        case spv::CapabilityDotProductInput4x8BitKHR:
-            return "DotProductInput4x8BitKHR";
-        case spv::CapabilityDotProductInput4x8BitPackedKHR:
-            return "DotProductInput4x8BitPackedKHR";
-        case spv::CapabilityDotProductKHR:
-            return "DotProductKHR";
-        case spv::CapabilityFragmentBarycentricKHR:
-            return "FragmentBarycentricKHR";
-        case spv::CapabilityTextureSampleWeightedQCOM:
-            return "TextureSampleWeightedQCOM";
-        case spv::CapabilityTextureBoxFilterQCOM:
-            return "TextureBoxFilterQCOM";
-        case spv::CapabilityTextureBlockMatchQCOM:
-            return "TextureBlockMatchQCOM";
-        case spv::CapabilityMeshShadingEXT:
-            return "MeshShadingEXT";
+        case spv::CapabilityShaderSMBuiltinsNV:
+            return "ShaderSMBuiltinsNV";
+        case spv::CapabilityFragmentShaderPixelInterlockEXT:
+            return "FragmentShaderPixelInterlockEXT";
+        case spv::CapabilityDemoteToHelperInvocation:
+            return "DemoteToHelperInvocation";
+        case spv::CapabilityDisplacementMicromapNV:
+            return "DisplacementMicromapNV";
         case spv::CapabilityRayTracingOpacityMicromapEXT:
             return "RayTracingOpacityMicromapEXT";
-        case spv::CapabilityCoreBuiltinsARM:
-            return "CoreBuiltinsARM";
         case spv::CapabilityShaderInvocationReorderNV:
             return "ShaderInvocationReorderNV";
-        case spv::CapabilityRayTracingPositionFetchKHR:
-            return "RayTracingPositionFetchKHR";
-        case spv::CapabilityTileImageColorReadAccessEXT:
-            return "TileImageColorReadAccessEXT";
-        case spv::CapabilityTileImageDepthReadAccessEXT:
-            return "TileImageDepthReadAccessEXT";
-        case spv::CapabilityTileImageStencilReadAccessEXT:
-            return "TileImageStencilReadAccessEXT";
-        case spv::CapabilityCooperativeMatrixKHR:
-            return "CooperativeMatrixKHR";
-        case spv::CapabilityShaderEnqueueAMDX:
-            return "ShaderEnqueueAMDX";
-        case spv::CapabilityGroupNonUniformRotateKHR:
-            return "GroupNonUniformRotateKHR";
+        case spv::CapabilityBindlessTextureNV:
+            return "BindlessTextureNV";
+        case spv::CapabilityRayQueryPositionFetchKHR:
+            return "RayQueryPositionFetchKHR";
+        case spv::CapabilityAtomicFloat16VectorNV:
+            return "AtomicFloat16VectorNV";
+        case spv::CapabilityRayTracingDisplacementMicromapNV:
+            return "RayTracingDisplacementMicromapNV";
+        case spv::CapabilityRawAccessChainsNV:
+            return "RawAccessChainsNV";
+        case spv::CapabilitySubgroupShuffleINTEL:
+            return "SubgroupShuffleINTEL";
+        case spv::CapabilitySubgroupBufferBlockIOINTEL:
+            return "SubgroupBufferBlockIOINTEL";
+        case spv::CapabilitySubgroupImageBlockIOINTEL:
+            return "SubgroupImageBlockIOINTEL";
+        case spv::CapabilitySubgroupImageMediaBlockIOINTEL:
+            return "SubgroupImageMediaBlockIOINTEL";
+        case spv::CapabilityRoundToInfinityINTEL:
+            return "RoundToInfinityINTEL";
+        case spv::CapabilityFloatingPointModeINTEL:
+            return "FloatingPointModeINTEL";
+        case spv::CapabilityIntegerFunctions2INTEL:
+            return "IntegerFunctions2INTEL";
+        case spv::CapabilityFunctionPointersINTEL:
+            return "FunctionPointersINTEL";
+        case spv::CapabilityIndirectReferencesINTEL:
+            return "IndirectReferencesINTEL";
+        case spv::CapabilityAsmINTEL:
+            return "AsmINTEL";
+        case spv::CapabilityAtomicFloat32MinMaxEXT:
+            return "AtomicFloat32MinMaxEXT";
+        case spv::CapabilityAtomicFloat64MinMaxEXT:
+            return "AtomicFloat64MinMaxEXT";
+        case spv::CapabilityAtomicFloat16MinMaxEXT:
+            return "AtomicFloat16MinMaxEXT";
+        case spv::CapabilityVectorComputeINTEL:
+            return "VectorComputeINTEL";
+        case spv::CapabilityVectorAnyINTEL:
+            return "VectorAnyINTEL";
         case spv::CapabilityExpectAssumeKHR:
             return "ExpectAssumeKHR";
+        case spv::CapabilitySubgroupAvcMotionEstimationINTEL:
+            return "SubgroupAvcMotionEstimationINTEL";
+        case spv::CapabilitySubgroupAvcMotionEstimationIntraINTEL:
+            return "SubgroupAvcMotionEstimationIntraINTEL";
+        case spv::CapabilitySubgroupAvcMotionEstimationChromaINTEL:
+            return "SubgroupAvcMotionEstimationChromaINTEL";
+        case spv::CapabilityVariableLengthArrayINTEL:
+            return "VariableLengthArrayINTEL";
+        case spv::CapabilityFunctionFloatControlINTEL:
+            return "FunctionFloatControlINTEL";
+        case spv::CapabilityFPGAMemoryAttributesINTEL:
+            return "FPGAMemoryAttributesINTEL";
+        case spv::CapabilityArbitraryPrecisionIntegersINTEL:
+            return "ArbitraryPrecisionIntegersINTEL";
+        case spv::CapabilityArbitraryPrecisionFloatingPointINTEL:
+            return "ArbitraryPrecisionFloatingPointINTEL";
+        case spv::CapabilityUnstructuredLoopControlsINTEL:
+            return "UnstructuredLoopControlsINTEL";
+        case spv::CapabilityFPGALoopControlsINTEL:
+            return "FPGALoopControlsINTEL";
+        case spv::CapabilityKernelAttributesINTEL:
+            return "KernelAttributesINTEL";
+        case spv::CapabilityFPGAKernelAttributesINTEL:
+            return "FPGAKernelAttributesINTEL";
+        case spv::CapabilityFPGAMemoryAccessesINTEL:
+            return "FPGAMemoryAccessesINTEL";
+        case spv::CapabilityFPGAClusterAttributesINTEL:
+            return "FPGAClusterAttributesINTEL";
+        case spv::CapabilityLoopFuseINTEL:
+            return "LoopFuseINTEL";
+        case spv::CapabilityFPGADSPControlINTEL:
+            return "FPGADSPControlINTEL";
+        case spv::CapabilityMemoryAccessAliasingINTEL:
+            return "MemoryAccessAliasingINTEL";
+        case spv::CapabilityFPGAInvocationPipeliningAttributesINTEL:
+            return "FPGAInvocationPipeliningAttributesINTEL";
+        case spv::CapabilityFPGABufferLocationINTEL:
+            return "FPGABufferLocationINTEL";
+        case spv::CapabilityArbitraryPrecisionFixedPointINTEL:
+            return "ArbitraryPrecisionFixedPointINTEL";
+        case spv::CapabilityUSMStorageClassesINTEL:
+            return "USMStorageClassesINTEL";
+        case spv::CapabilityRuntimeAlignedAttributeINTEL:
+            return "RuntimeAlignedAttributeINTEL";
+        case spv::CapabilityIOPipesINTEL:
+            return "IOPipesINTEL";
+        case spv::CapabilityBlockingPipesINTEL:
+            return "BlockingPipesINTEL";
+        case spv::CapabilityFPGARegINTEL:
+            return "FPGARegINTEL";
+        case spv::CapabilityDotProductInputAll:
+            return "DotProductInputAll";
+        case spv::CapabilityDotProductInput4x8Bit:
+            return "DotProductInput4x8Bit";
+        case spv::CapabilityDotProductInput4x8BitPacked:
+            return "DotProductInput4x8BitPacked";
+        case spv::CapabilityDotProduct:
+            return "DotProduct";
+        case spv::CapabilityRayCullMaskKHR:
+            return "RayCullMaskKHR";
+        case spv::CapabilityCooperativeMatrixKHR:
+            return "CooperativeMatrixKHR";
+        case spv::CapabilityBitInstructions:
+            return "BitInstructions";
+        case spv::CapabilityGroupNonUniformRotateKHR:
+            return "GroupNonUniformRotateKHR";
         case spv::CapabilityFloatControls2:
             return "FloatControls2";
-        case spv::CapabilityQuadControlKHR:
-            return "QuadControlKHR";
+        case spv::CapabilityAtomicFloat32AddEXT:
+            return "AtomicFloat32AddEXT";
+        case spv::CapabilityAtomicFloat64AddEXT:
+            return "AtomicFloat64AddEXT";
+        case spv::CapabilityLongCompositesINTEL:
+            return "LongCompositesINTEL";
+        case spv::CapabilityOptNoneINTEL:
+            return "OptNoneINTEL";
+        case spv::CapabilityAtomicFloat16AddEXT:
+            return "AtomicFloat16AddEXT";
+        case spv::CapabilityDebugInfoModuleINTEL:
+            return "DebugInfoModuleINTEL";
+        case spv::CapabilityBFloat16ConversionINTEL:
+            return "BFloat16ConversionINTEL";
+        case spv::CapabilitySplitBarrierINTEL:
+            return "SplitBarrierINTEL";
+        case spv::CapabilityFPGAClusterAttributesV2INTEL:
+            return "FPGAClusterAttributesV2INTEL";
+        case spv::CapabilityFPGAKernelAttributesv2INTEL:
+            return "FPGAKernelAttributesv2INTEL";
+        case spv::CapabilityFPMaxErrorINTEL:
+            return "FPMaxErrorINTEL";
+        case spv::CapabilityFPGALatencyControlINTEL:
+            return "FPGALatencyControlINTEL";
+        case spv::CapabilityFPGAArgumentInterfacesINTEL:
+            return "FPGAArgumentInterfacesINTEL";
+        case spv::CapabilityGlobalVariableHostAccessINTEL:
+            return "GlobalVariableHostAccessINTEL";
+        case spv::CapabilityGlobalVariableFPGADecorationsINTEL:
+            return "GlobalVariableFPGADecorationsINTEL";
+        case spv::CapabilityGroupUniformArithmeticKHR:
+            return "GroupUniformArithmeticKHR";
+        case spv::CapabilityMaskedGatherScatterINTEL:
+            return "MaskedGatherScatterINTEL";
+        case spv::CapabilityCacheControlsINTEL:
+            return "CacheControlsINTEL";
+        case spv::CapabilityRegisterLimitsINTEL:
+            return "RegisterLimitsINTEL";
         default:
             return "Unhandled OpCapability";
     };
@@ -899,6 +1051,7 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
     {spv::CapabilityTextureSampleWeightedQCOM, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureSampleWeighted"},
     {spv::CapabilityTextureBoxFilterQCOM, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureBoxFilter"},
     {spv::CapabilityTextureBlockMatchQCOM, "VkPhysicalDeviceImageProcessingFeaturesQCOM::textureBlockMatch"},
+    {spv::CapabilityTextureBlockMatch2QCOM, "VkPhysicalDeviceImageProcessing2FeaturesQCOM::textureBlockMatch2"},
     {spv::CapabilityMeshShadingEXT, "VK_EXT_mesh_shader"},
     {spv::CapabilityRayTracingOpacityMicromapEXT, "VK_EXT_opacity_micromap"},
     {spv::CapabilityCoreBuiltinsARM, "VkPhysicalDeviceShaderCoreBuiltinsFeaturesARM::shaderCoreBuiltins"},
@@ -913,6 +1066,7 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
     {spv::CapabilityExpectAssumeKHR, "VkPhysicalDeviceShaderExpectAssumeFeaturesKHR::shaderExpectAssume"},
     {spv::CapabilityFloatControls2, "VkPhysicalDeviceShaderFloatControls2FeaturesKHR::shaderFloatControls2"},
     {spv::CapabilityQuadControlKHR, "VkPhysicalDeviceShaderQuadControlFeaturesKHR::shaderQuadControl"},
+    {spv::CapabilityRawAccessChainsNV, "VkPhysicalDeviceRawAccessChainsFeaturesNV::shaderRawAccessChains"},
     };
 
     // VUs before catch unknown capabilities

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -255,6 +255,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
         'spirv_validation_helper.cpp' : {
             'generator' : SpirvValidationHelperOutputGenerator,
             'genCombined': False,
+            'options' : [grammar],
         },
         'spirv_grammar_helper.h' : {
             'generator' : SpirvGrammarHelperOutputGenerator,


### PR DESCRIPTION
Make the spirv_validation_generator.py more robust to header updates by replacing the hard-coded capability lists with ones generated from the SPIR-V grammar.

I consider this a prerequisite for adding more automation to the header updates since it breaks so frequently

The `string_SpvCapability` diff is kinda hard to read so here is the sorted version of the added/removed switch cases:
```diff
--- before.txt  2024-03-05 21:15:54.098254315 -0800
+++ after.txt   2024-03-06 08:39:45.904650307 -0800
@@ -1,3 +1,8 @@
+case spv::CapabilityAddresses
+case spv::CapabilityArbitraryPrecisionFixedPointINTEL
+case spv::CapabilityArbitraryPrecisionFloatingPointINTEL
+case spv::CapabilityArbitraryPrecisionIntegersINTEL
+case spv::CapabilityAsmINTEL
 case spv::CapabilityAtomicFloat16AddEXT
 case spv::CapabilityAtomicFloat16MinMaxEXT
 case spv::CapabilityAtomicFloat16VectorNV
@@ -5,6 +10,13 @@
 case spv::CapabilityAtomicFloat32MinMaxEXT
 case spv::CapabilityAtomicFloat64AddEXT
 case spv::CapabilityAtomicFloat64MinMaxEXT
+case spv::CapabilityAtomicStorage
+case spv::CapabilityAtomicStorageOps
+case spv::CapabilityBFloat16ConversionINTEL
+case spv::CapabilityBindlessTextureNV
+case spv::CapabilityBitInstructions
+case spv::CapabilityBlockingPipesINTEL
+case spv::CapabilityCacheControlsINTEL
 case spv::CapabilityClipDistance
 case spv::CapabilityComputeDerivativeGroupLinearNV
 case spv::CapabilityComputeDerivativeGroupQuadsNV
@@ -12,20 +24,38 @@
 case spv::CapabilityCooperativeMatrixNV
 case spv::CapabilityCoreBuiltinsARM
 case spv::CapabilityCullDistance
-case spv::CapabilityDemoteToHelperInvocationEXT
+case spv::CapabilityDebugInfoModuleINTEL
+case spv::CapabilityDemoteToHelperInvocation
 case spv::CapabilityDenormFlushToZero
 case spv::CapabilityDenormPreserve
 case spv::CapabilityDerivativeControl
 case spv::CapabilityDeviceGroup
-case spv::CapabilityDotProductInput4x8BitKHR
-case spv::CapabilityDotProductInput4x8BitPackedKHR
-case spv::CapabilityDotProductInputAllKHR
-case spv::CapabilityDotProductKHR
+case spv::CapabilityDisplacementMicromapNV
+case spv::CapabilityDotProduct
+case spv::CapabilityDotProductInput4x8Bit
+case spv::CapabilityDotProductInput4x8BitPacked
+case spv::CapabilityDotProductInputAll
 case spv::CapabilityDrawParameters
 case spv::CapabilityExpectAssumeKHR
 case spv::CapabilityFloat16
+case spv::CapabilityFloat16ImageAMD
 case spv::CapabilityFloat64
 case spv::CapabilityFloatControls2
+case spv::CapabilityFloatingPointModeINTEL
+case spv::CapabilityFPGAArgumentInterfacesINTEL
+case spv::CapabilityFPGABufferLocationINTEL
+case spv::CapabilityFPGAClusterAttributesINTEL
+case spv::CapabilityFPGAClusterAttributesV2INTEL
+case spv::CapabilityFPGADSPControlINTEL
+case spv::CapabilityFPGAInvocationPipeliningAttributesINTEL
+case spv::CapabilityFPGAKernelAttributesINTEL
+case spv::CapabilityFPGAKernelAttributesv2INTEL
+case spv::CapabilityFPGALatencyControlINTEL
+case spv::CapabilityFPGALoopControlsINTEL
+case spv::CapabilityFPGAMemoryAccessesINTEL
+case spv::CapabilityFPGAMemoryAttributesINTEL
+case spv::CapabilityFPGARegINTEL
+case spv::CapabilityFPMaxErrorINTEL
 case spv::CapabilityFragmentBarycentricKHR
 case spv::CapabilityFragmentDensityEXT
 case spv::CapabilityFragmentFullyCoveredEXT
@@ -34,10 +64,15 @@
 case spv::CapabilityFragmentShaderSampleInterlockEXT
 case spv::CapabilityFragmentShaderShadingRateInterlockEXT
 case spv::CapabilityFragmentShadingRateKHR
+case spv::CapabilityFunctionFloatControlINTEL
+case spv::CapabilityFunctionPointersINTEL
+case spv::CapabilityGenericPointer
 case spv::CapabilityGeometry
 case spv::CapabilityGeometryPointSize
 case spv::CapabilityGeometryShaderPassthroughNV
 case spv::CapabilityGeometryStreams
+case spv::CapabilityGlobalVariableFPGADecorationsINTEL
+case spv::CapabilityGlobalVariableHostAccessINTEL
 case spv::CapabilityGroupNonUniform
 case spv::CapabilityGroupNonUniformArithmetic
 case spv::CapabilityGroupNonUniformBallot
@@ -48,15 +83,21 @@
 case spv::CapabilityGroupNonUniformShuffle
 case spv::CapabilityGroupNonUniformShuffleRelative
 case spv::CapabilityGroupNonUniformVote
+case spv::CapabilityGroups
+case spv::CapabilityGroupUniformArithmeticKHR
 case spv::CapabilityImage1D
 case spv::CapabilityImageBuffer
 case spv::CapabilityImageCubeArray
 case spv::CapabilityImageFootprintNV
 case spv::CapabilityImageGatherBiasLodAMD
 case spv::CapabilityImageGatherExtended
+case spv::CapabilityImageMipmap
 case spv::CapabilityImageMSArray
 case spv::CapabilityImageQuery
+case spv::CapabilityImageReadWrite
 case spv::CapabilityImageReadWriteLodAMD
+case spv::CapabilityImageRect
+case spv::CapabilityIndirectReferencesINTEL
 case spv::CapabilityInputAttachment
 case spv::CapabilityInputAttachmentArrayDynamicIndexing
 case spv::CapabilityInputAttachmentArrayNonUniformIndexing
@@ -67,31 +108,49 @@
 case spv::CapabilityInt8
 case spv::CapabilityIntegerFunctions2INTEL
 case spv::CapabilityInterpolationFunction
+case spv::CapabilityIOPipesINTEL
+case spv::CapabilityKernel
+case spv::CapabilityKernelAttributesINTEL
+case spv::CapabilityLinkage
+case spv::CapabilityLongCompositesINTEL
+case spv::CapabilityLoopFuseINTEL
+case spv::CapabilityMaskedGatherScatterINTEL
 case spv::CapabilityMatrix
+case spv::CapabilityMemoryAccessAliasingINTEL
 case spv::CapabilityMeshShadingEXT
 case spv::CapabilityMeshShadingNV
 case spv::CapabilityMinLod
 case spv::CapabilityMultiView
 case spv::CapabilityMultiViewport
+case spv::CapabilityOptNoneINTEL
 case spv::CapabilityPerViewAttributesNV
 case spv::CapabilityPhysicalStorageBufferAddresses
+case spv::CapabilityPipeStorage
 case spv::CapabilityQuadControlKHR
 case spv::CapabilityRayCullMaskKHR
 case spv::CapabilityRayQueryKHR
+case spv::CapabilityRayQueryPositionFetchKHR
+case spv::CapabilityRayQueryProvisionalKHR
+case spv::CapabilityRayTracingDisplacementMicromapNV
 case spv::CapabilityRayTracingKHR
 case spv::CapabilityRayTracingMotionBlurNV
 case spv::CapabilityRayTracingNV
 case spv::CapabilityRayTracingOpacityMicromapEXT
 case spv::CapabilityRayTracingPositionFetchKHR
+case spv::CapabilityRayTracingProvisionalKHR
 case spv::CapabilityRayTraversalPrimitiveCullingKHR
+case spv::CapabilityRegisterLimitsINTEL
 case spv::CapabilityRoundingModeRTE
 case spv::CapabilityRoundingModeRTZ
+case spv::CapabilityRoundToInfinityINTEL
+case spv::CapabilityRuntimeAlignedAttributeINTEL
 case spv::CapabilityRuntimeDescriptorArray
 case spv::CapabilitySampled1D
 case spv::CapabilitySampledBuffer
 case spv::CapabilitySampledCubeArray
 case spv::CapabilitySampledImageArrayDynamicIndexing
 case spv::CapabilitySampledImageArrayNonUniformIndexing
+case spv::CapabilitySampledRect
 case spv::CapabilitySampleMaskOverrideCoverageNV
 case spv::CapabilitySampleMaskPostDepthCoverage
 case spv::CapabilitySampleRateShading
@@ -102,11 +161,13 @@
 case spv::CapabilityShaderLayer
 case spv::CapabilityShaderNonUniform
 case spv::CapabilityShaderSMBuiltinsNV
+case spv::CapabilityShaderStereoViewNV
 case spv::CapabilityShaderViewportIndex
 case spv::CapabilityShaderViewportIndexLayerEXT
 case spv::CapabilityShaderViewportMaskNV
 case spv::CapabilitySignedZeroInfNanPreserve
 case spv::CapabilitySparseResidency
+case spv::CapabilitySplitBarrierINTEL
 case spv::CapabilityStencilExportEXT
 case spv::CapabilityStorageBuffer16BitAccess
 case spv::CapabilityStorageBuffer8BitAccess
@@ -123,10 +184,19 @@
 case spv::CapabilityStoragePushConstant8
 case spv::CapabilityStorageTexelBufferArrayDynamicIndexing
 case spv::CapabilityStorageTexelBufferArrayNonUniformIndexing
+case spv::CapabilitySubgroupAvcMotionEstimationChromaINTEL
+case spv::CapabilitySubgroupAvcMotionEstimationINTEL
+case spv::CapabilitySubgroupAvcMotionEstimationIntraINTEL
 case spv::CapabilitySubgroupBallotKHR
+case spv::CapabilitySubgroupBufferBlockIOINTEL
+case spv::CapabilitySubgroupDispatch
+case spv::CapabilitySubgroupImageBlockIOINTEL
+case spv::CapabilitySubgroupImageMediaBlockIOINTEL
+case spv::CapabilitySubgroupShuffleINTEL
 case spv::CapabilitySubgroupVoteKHR
 case spv::CapabilityTessellation
 case spv::CapabilityTessellationPointSize
+case spv::CapabilityTextureBlockMatch2QCOM
 case spv::CapabilityTextureBlockMatchQCOM
 case spv::CapabilityTextureBoxFilterQCOM
 case spv::CapabilityTextureSampleWeightedQCOM
@@ -138,10 +208,16 @@
 case spv::CapabilityUniformAndStorageBuffer8BitAccess
 case spv::CapabilityUniformBufferArrayDynamicIndexing
 case spv::CapabilityUniformBufferArrayNonUniformIndexing
+case spv::CapabilityUniformDecoration
 case spv::CapabilityUniformTexelBufferArrayDynamicIndexing
 case spv::CapabilityUniformTexelBufferArrayNonUniformIndexing
+case spv::CapabilityUnstructuredLoopControlsINTEL
+case spv::CapabilityUSMStorageClassesINTEL
+case spv::CapabilityVariableLengthArrayINTEL
 case spv::CapabilityVariablePointers
 case spv::CapabilityVariablePointersStorageBuffer
+case spv::CapabilityVectorAnyINTEL
+case spv::CapabilityVectorComputeINTEL
 case spv::CapabilityVulkanMemoryModel
 case spv::CapabilityVulkanMemoryModelDeviceScope
 case spv::CapabilityWorkgroupMemoryExplicitLayout16BitAccessKHR
```