### PR TITLE
layers: Fix CommandBuffer image layout state tracking

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1246,7 +1246,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
         for (const auto &sub_layout_map_entry : sub_cb_state.image_layout_map) {
             const auto image = sub_layout_map_entry.first;
 
-            const auto *cb_subres_map = cb_state.GetImageSubresourceLayoutMap(image);
+            const auto cb_subres_map = cb_state.GetImageSubresourceLayoutMap(image);
             // Const getter can be null in which case we have nothing to check against for this image...
             if (!cb_subres_map) continue;
 

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -1250,7 +1250,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
             // Const getter can be null in which case we have nothing to check against for this image...
             if (!cb_subres_map) continue;
 
-            const auto &sub_layout_map = sub_layout_map_entry.second->GetLayoutMap();
+            const auto &sub_layout_map = sub_layout_map_entry.second.map->GetLayoutMap();
             const auto &cb_layout_map = cb_subres_map->GetLayoutMap();
             for (sparse_container::parallel_iterator<const ImageSubresourceLayoutMap::LayoutMap> iter(sub_layout_map, cb_layout_map,
                                                                                                       0);

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -766,7 +766,7 @@ bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const
 //  This includes validating that all descriptors in the given bindings are updated,
 //  that any update buffers are valid, and that any dynamic offsets are within the bounds of their buffers.
 // Return true if state is acceptable, or false and write an error message into error string
-bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, const BindingVariableMap &bindings,
+bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t set_index, const BindingVariableMap &bindings,
                                    const std::vector<uint32_t> &dynamic_offsets, const vvl::CommandBuffer &cb_state,
                                    const Location &loc, const vvl::DrawDispatchVuid &vuids) const {
     bool result = false;
@@ -775,7 +775,7 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, const Bi
     // descriptors, via the non-const version of ValidateBinding(), this code uses the const path only even it gives up
     // non-const versions of its state objects here.
     const vvl::DescriptorValidator desc_val(const_cast<CoreChecks &>(*this), const_cast<vvl::CommandBuffer &>(cb_state),
-                                            const_cast<DescriptorSet &>(descriptor_set), framebuffer, loc);
+                                            const_cast<DescriptorSet &>(descriptor_set), set_index, framebuffer, loc);
 
     for (const auto &binding_pair : bindings) {
         const auto *binding = descriptor_set.GetBinding(binding_pair.first);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1635,7 +1635,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                              set_info.validated_set_image_layout_change_count != cb_state.image_layout_change_count);
 
                         if (need_validate) {
-                            skip |= ValidateDrawState(*descriptor_set, set_binding_pair.second, set_info.dynamicOffsets, cb_state,
+                            skip |= ValidateDrawState(*descriptor_set, set_index, set_binding_pair.second, set_info.dynamicOffsets, cb_state,
                                                       loc, vuid);
                         }
                     }
@@ -1707,7 +1707,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                              set_info.validated_set_image_layout_change_count != cb_state.image_layout_change_count);
 
                         if (need_validate) {
-                            skip |= ValidateDrawState(*descriptor_set, set_binding_pair.second, set_info.dynamicOffsets, cb_state,
+                            skip |= ValidateDrawState(*descriptor_set, set_index, set_binding_pair.second, set_info.dynamicOffsets, cb_state,
                                                       loc, vuid);
                         }
                     }

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1602,12 +1602,12 @@ std::vector<uint32_t> GetUsedAttachments(const vvl::CommandBuffer &cb_state) {
 // Verify image barriers are compatible with the images they reference.
 bool CoreChecks::ValidateBarriersToImages(const Location &barrier_loc, const vvl::CommandBuffer &cb_state,
                                           const ImageBarrier &img_barrier,
-                                          CommandBufferImageLayoutMap &layout_updates_state) const {
+                                          vvl::CommandBuffer::ImageLayoutMap &layout_updates_state) const {
     bool skip = false;
     using sync_vuid_maps::GetImageBarrierVUID;
     using sync_vuid_maps::ImageError;
 
-    const CommandBufferImageLayoutMap &current_map = cb_state.GetImageSubresourceLayoutMap();
+    const auto &current_map = cb_state.GetImageSubresourceLayoutMap();
 
     {
         auto image_state = Get<vvl::Image>(img_barrier.image);
@@ -2426,7 +2426,7 @@ bool CoreChecks::ValidateBarriers(const Location &outer_loc, const vvl::CommandB
 
     // Tracks duplicate layout transition for image barriers.
     // Keeps state between ValidateBarriersToImages calls.
-    CommandBufferImageLayoutMap layout_updates_state;
+    vvl::CommandBuffer::ImageLayoutMap layout_updates_state;
 
     for (uint32_t i = 0; i < memBarrierCount; ++i) {
         const Location barrier_loc = outer_loc.dot(Struct::VkMemoryBarrier, Field::pMemoryBarriers, i);
@@ -2455,7 +2455,7 @@ bool CoreChecks::ValidateDependencyInfo(const LogObjectList &objects, const Loca
 
     // Tracks duplicate layout transition for image barriers.
     // Keeps state between ValidateBarriersToImages calls.
-    CommandBufferImageLayoutMap layout_updates_state;
+    vvl::CommandBuffer::ImageLayoutMap layout_updates_state;
 
     for (uint32_t i = 0; i < dep_info.memoryBarrierCount; ++i) {
         const Location barrier_loc = dep_info_loc.dot(Struct::VkMemoryBarrier2, Field::pMemoryBarriers, i);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -539,7 +539,7 @@ class CoreChecks : public ValidationStateTracker {
     VkResult CoreLayerGetValidationCacheDataEXT(VkDevice device, VkValidationCacheEXT validationCache, size_t* pDataSize,
                                                 void* pData) override;
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
-    bool ValidateDrawState(const vvl::DescriptorSet& descriptor_set, const BindingVariableMap& bindings,
+    bool ValidateDrawState(const vvl::DescriptorSet& descriptor_set, uint32_t set_index, const BindingVariableMap& bindings,
                            const std::vector<uint32_t>& dynamic_offsets, const vvl::CommandBuffer& cb_state, const Location& loc,
                            const vvl::DrawDispatchVuid& vuids) const;
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -853,14 +853,14 @@ class CoreChecks : public ValidationStateTracker {
     void TransitionBeginRenderPassLayouts(vvl::CommandBuffer& cb_state, const vvl::RenderPass& render_pass_state);
 
     bool UpdateCommandBufferImageLayoutMap(const vvl::CommandBuffer& cb_state, const Location& image_loc,
-                                           const ImageBarrier& img_barrier, const CommandBufferImageLayoutMap& current_map,
-                                           CommandBufferImageLayoutMap& layout_updates) const;
+                                           const ImageBarrier& img_barrier, const vvl::CommandBuffer::ImageLayoutMap& current_map,
+                                           vvl::CommandBuffer::ImageLayoutMap& layout_updates) const;
 
     bool ValidateBarrierLayoutToImageUsage(const Location& layout_loc, VkImage image, VkImageLayout layout,
                                            VkImageUsageFlags usage) const;
 
     bool ValidateBarriersToImages(const Location& barrier_loc, const vvl::CommandBuffer& cb_state,
-                                  const ImageBarrier& image_barrier, CommandBufferImageLayoutMap& layout_updates_state) const;
+                                  const ImageBarrier& image_barrier, vvl::CommandBuffer::ImageLayoutMap& layout_updates_state) const;
 
     void RecordQueuedQFOTransfers(vvl::CommandBuffer& cb_state);
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -28,8 +28,8 @@
 #include "drawdispatch/drawdispatch_vuids.h"
 
 vvl::DescriptorValidator::DescriptorValidator(ValidationStateTracker &dev, vvl::CommandBuffer &cb, vvl::DescriptorSet &set,
-                                              VkFramebuffer fb, const Location &l)
-    : dev_state(dev), cb_state(cb), descriptor_set(set), framebuffer(fb), loc(l), vuids(GetDrawDispatchVuid(loc.function)) {}
+                                              uint32_t set_index_, VkFramebuffer fb, const Location &l)
+    : dev_state(dev), cb_state(cb), descriptor_set(set), set_index(set_index_), framebuffer(fb), loc(l), vuids(GetDrawDispatchVuid(loc.function)) {}
 
 template <typename T>
 bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &binding_info, const T &binding) const {
@@ -524,15 +524,6 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
             bool descriptor_read_from = false;
             bool descriptor_written_to = false;
-            uint32_t set_index = std::numeric_limits<uint32_t>::max();
-            for (uint32_t i = 0; i < cb_state.lastBound[VK_PIPELINE_BIND_POINT_GRAPHICS].per_set.size(); ++i) {
-                const auto &set = cb_state.lastBound[VK_PIPELINE_BIND_POINT_GRAPHICS].per_set[i];
-                if (set.bound_descriptor_set.get() == &(descriptor_set)) {
-                    set_index = i;
-                    break;
-                }
-            }
-            assert(set_index != std::numeric_limits<uint32_t>::max());
             const auto pipeline = cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
             for (const auto &stage : pipeline->stage_states) {
                 if (!stage.entrypoint) {

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -39,8 +39,8 @@ using DescriptorBindingInfo = std::pair<uint32_t, std::vector<DescriptorRequirem
 
 class DescriptorValidator {
  public:
-   DescriptorValidator(ValidationStateTracker& dev, vvl::CommandBuffer& cb, vvl::DescriptorSet& set, VkFramebuffer fb,
-                       const Location& l);
+   DescriptorValidator(ValidationStateTracker& dev, vvl::CommandBuffer& cb, vvl::DescriptorSet& set, uint32_t set_index,
+                       VkFramebuffer fb, const Location& l);
 
    template <typename T>
    std::string FormatHandle(T&& h) const {
@@ -79,6 +79,7 @@ class DescriptorValidator {
     ValidationStateTracker& dev_state;
     vvl::CommandBuffer& cb_state;
     vvl::DescriptorSet& descriptor_set;
+    const uint32_t set_index;
     const VkFramebuffer framebuffer;
     const Location& loc;
     const DrawDispatchVuid& vuids;

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -80,9 +80,12 @@ struct GlobalLayoutUpdater {
 void gpuav::Validator::UpdateCmdBufImageLayouts(const vvl::CommandBuffer &cb_state) {
     for (const auto &layout_map_entry : cb_state.image_layout_map) {
         const auto image = layout_map_entry.first;
-        const auto &subres_map = layout_map_entry.second;
+        const auto subres_map = layout_map_entry.second;
+        if (!subres_map) {
+            continue;
+        }
         auto image_state = Get<vvl::Image>(image);
-        if (image_state && subres_map) {
+        if (image_state) {
             auto guard = image_state->layout_range_map->WriteLock();
             sparse_container::splice(*image_state->layout_range_map, subres_map->GetLayoutMap(), GlobalLayoutUpdater());
         }
@@ -694,7 +697,7 @@ bool gpuav::Validator::VerifyImageLayoutRange(const vvl::CommandBuffer &cb_state
                                               const RangeFactory &range_factory, const Location &loc,
                                               const char *mismatch_layout_vuid, bool *error) const {
     bool skip = false;
-    const auto *subresource_map = cb_state.GetImageSubresourceLayoutMap(image_state.VkHandle());
+    const auto subresource_map = cb_state.GetImageSubresourceLayoutMap(image_state.VkHandle());
     if (!subresource_map) {
         return skip;
     }

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -80,12 +80,12 @@ struct GlobalLayoutUpdater {
 void gpuav::Validator::UpdateCmdBufImageLayouts(const vvl::CommandBuffer &cb_state) {
     for (const auto &layout_map_entry : cb_state.image_layout_map) {
         const auto image = layout_map_entry.first;
-        const auto subres_map = layout_map_entry.second;
+        const auto subres_map = layout_map_entry.second.map;
         if (!subres_map) {
             continue;
         }
         auto image_state = Get<vvl::Image>(image);
-        if (image_state) {
+        if (image_state && image_state->GetId() == layout_map_entry.second.id) {
             auto guard = image_state->layout_range_map->WriteLock();
             sparse_container::splice(*image_state->layout_range_map, subres_map->GetLayoutMap(), GlobalLayoutUpdater());
         }

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -188,14 +188,15 @@ void gpuav::CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
         for (auto &di_info : di_input_buffer_list) {
             Location draw_loc(vvl::Func::vkCmdDraw);
             // For each descriptor set ...
-            for (auto &set : di_info.descriptor_set_buffers) {
+            for (uint32_t i = 0;  i < di_info.descriptor_set_buffers.size(); i++) {
+                auto &set = di_info.descriptor_set_buffers[i];
                 if (validated_desc_sets.count(set.state->VkHandle()) > 0) {
                     continue;
                 }
                 validated_desc_sets.emplace(set.state->VkHandle());
                 assert(set.output_state);
 
-                vvl::DescriptorValidator context(state_, *this, *set.state, VK_NULL_HANDLE /*framebuffer*/, draw_loc);
+                vvl::DescriptorValidator context(state_, *this, *set.state, i, VK_NULL_HANDLE /*framebuffer*/, draw_loc);
                 auto used_descs = set.output_state->UsedDescriptors(*set.state);
                 // For each used binding ...
                 for (const auto &u : used_descs) {

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -371,8 +371,8 @@ class Validator : public gpu_tracker::Validator {
     void TransitionBeginRenderPassLayouts(vvl::CommandBuffer& cb_state, const vvl::RenderPass& render_pass_state);
 
     bool UpdateCommandBufferImageLayoutMap(const vvl::CommandBuffer& cb_state, const Location& image_loc,
-                                           const ImageBarrier& img_barrier, const CommandBufferImageLayoutMap& current_map,
-                                           CommandBufferImageLayoutMap& layout_updates) const;
+                                           const ImageBarrier& img_barrier, const vvl::CommandBuffer::ImageLayoutMap& current_map,
+                                           vvl::CommandBuffer::ImageLayoutMap& layout_updates) const;
     void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                    VkImage* pImage, const RecordObject& record_obj) override;
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -494,8 +494,8 @@ class CommandBuffer : public RefcountedStateObject {
 
     void ResetPushConstantDataIfIncompatible(const vvl::PipelineLayout *pipeline_layout_state);
 
-    const ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(VkImage image) const;
-    ImageSubresourceLayoutMap *GetImageSubresourceLayoutMap(const vvl::Image &image_state);
+    std::shared_ptr<const ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(VkImage image) const;
+    std::shared_ptr<ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(const vvl::Image &image_state);
     const CommandBufferImageLayoutMap &GetImageSubresourceLayoutMap() const;
 
     const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const QFOImageTransferBarrier &type_tag) const {

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -124,17 +124,19 @@ enum class CbState {
     InvalidIncomplete,  // fouled before recording was completed
 };
 
-typedef vvl::unordered_map<VkImage, std::shared_ptr<ImageSubresourceLayoutMap>> CommandBufferImageLayoutMap;
-
-typedef vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutMap>>
-    CommandBufferAliasedLayoutMap;
 
 namespace vvl {
 
 class CommandBuffer : public RefcountedStateObject {
     using Func = vvl::Func;
-
   public:
+    struct LayoutState {
+        StateObject::IdType id;
+        std::shared_ptr<ImageSubresourceLayoutMap> map;
+    };
+    using ImageLayoutMap = vvl::unordered_map<VkImage, LayoutState>;
+    using AliasedLayoutMap = vvl::unordered_map<const GlobalImageLayoutRangeMap *, std::shared_ptr<ImageSubresourceLayoutMap>>;
+
     VkCommandBufferAllocateInfo createInfo = {};
     VkCommandBufferBeginInfo beginInfo;
     VkCommandBufferInheritanceInfo inheritanceInfo;
@@ -405,8 +407,8 @@ class CommandBuffer : public RefcountedStateObject {
     vvl::unordered_set<QueryObject> startedQueries;
     vvl::unordered_set<QueryObject> updatedQueries;
     vvl::unordered_set<QueryObject> renderPassQueries;
-    CommandBufferImageLayoutMap image_layout_map;
-    CommandBufferAliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
+    ImageLayoutMap image_layout_map;
+    AliasedLayoutMap aliased_image_layout_map;  // storage for potentially aliased images
 
     vvl::unordered_map<uint32_t, vvl::VertexBufferBinding> current_vertex_buffer_binding_info;
     vvl::IndexBufferBinding index_buffer_binding;
@@ -496,7 +498,7 @@ class CommandBuffer : public RefcountedStateObject {
 
     std::shared_ptr<const ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(VkImage image) const;
     std::shared_ptr<ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(const vvl::Image &image_state);
-    const CommandBufferImageLayoutMap &GetImageSubresourceLayoutMap() const;
+    const ImageLayoutMap &GetImageSubresourceLayoutMap() const;
 
     const QFOTransferBarrierSets<QFOImageTransferBarrier> &GetQFOBarrierSets(const QFOImageTransferBarrier &type_tag) const {
         return qfo_transfer_image_barriers;

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -277,6 +277,7 @@ class ValidationStateTracker : public ValidationObject {
     void Add(std::shared_ptr<State>&& state_object) {
         auto& map = GetStateMap<State>();
         auto handle = state_object->Handle().template Cast<HandleType>();
+        state_object->SetId(object_id_++);
         // Finish setting up the object node tree, which cannot be done from the state object contructors
         // due to use of shared_from_this()
         state_object->LinkChildNodes();
@@ -1915,6 +1916,8 @@ class ValidationStateTracker : public ValidationObject {
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkSurfaceKHR, vvl::Surface, surface_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkDisplayModeKHR, vvl::DisplayMode, display_mode_map_)
     VALSTATETRACK_MAP_AND_TRAITS_INSTANCE_SCOPE(VkPhysicalDevice, vvl::PhysicalDevice, physical_device_map_)
+
+    std::atomic<vvl::StateObject::IdType> object_id_{1}; // 0 is an invalid id
 
     // Simple base address allocator allow allow VkDeviceMemory allocations to appear to exist in a common address space.
     // At 256GB allocated/sec  ( > 8GB at 30Hz), will overflow in just over 2 years


### PR DESCRIPTION
Rework management of CommandBuffer::image_layout_map to not contain invalid pointers and tolerate stale state when drivers reuse image handle values. More details in the commit messages for the PR

Fixes #7435 