### PR TITLE
scripts: Remove OpenCL SPIR-V from genearted helpers

### DIFF
--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2024 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -505,16 +505,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpImageSparseRead";
         case spv::OpSizeOf:
             return "OpSizeOf";
-        case spv::OpTypePipeStorage:
-            return "OpTypePipeStorage";
-        case spv::OpConstantPipeStorage:
-            return "OpConstantPipeStorage";
-        case spv::OpCreatePipeFromPipeStorage:
-            return "OpCreatePipeFromPipeStorage";
-        case spv::OpGetKernelLocalSizeForSubgroupCount:
-            return "OpGetKernelLocalSizeForSubgroupCount";
-        case spv::OpGetKernelMaxNumSubgroups:
-            return "OpGetKernelMaxNumSubgroups";
         case spv::OpModuleProcessed:
             return "OpModuleProcessed";
         case spv::OpExecutionModeId:
@@ -845,26 +835,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpSamplerImageAddressingModeNV";
         case spv::OpRawAccessChainNV:
             return "OpRawAccessChainNV";
-        case spv::OpSubgroupShuffleINTEL:
-            return "OpSubgroupShuffleINTEL";
-        case spv::OpSubgroupShuffleDownINTEL:
-            return "OpSubgroupShuffleDownINTEL";
-        case spv::OpSubgroupShuffleUpINTEL:
-            return "OpSubgroupShuffleUpINTEL";
-        case spv::OpSubgroupShuffleXorINTEL:
-            return "OpSubgroupShuffleXorINTEL";
-        case spv::OpSubgroupBlockReadINTEL:
-            return "OpSubgroupBlockReadINTEL";
-        case spv::OpSubgroupBlockWriteINTEL:
-            return "OpSubgroupBlockWriteINTEL";
-        case spv::OpSubgroupImageBlockReadINTEL:
-            return "OpSubgroupImageBlockReadINTEL";
-        case spv::OpSubgroupImageBlockWriteINTEL:
-            return "OpSubgroupImageBlockWriteINTEL";
-        case spv::OpSubgroupImageMediaBlockReadINTEL:
-            return "OpSubgroupImageMediaBlockReadINTEL";
-        case spv::OpSubgroupImageMediaBlockWriteINTEL:
-            return "OpSubgroupImageMediaBlockWriteINTEL";
         case spv::OpUCountLeadingZerosINTEL:
             return "OpUCountLeadingZerosINTEL";
         case spv::OpUCountTrailingZerosINTEL:
@@ -897,12 +867,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpConstantFunctionPointerINTEL";
         case spv::OpFunctionPointerCallINTEL:
             return "OpFunctionPointerCallINTEL";
-        case spv::OpAsmTargetINTEL:
-            return "OpAsmTargetINTEL";
-        case spv::OpAsmINTEL:
-            return "OpAsmINTEL";
-        case spv::OpAsmCallINTEL:
-            return "OpAsmCallINTEL";
         case spv::OpAtomicFMinEXT:
             return "OpAtomicFMinEXT";
         case spv::OpAtomicFMaxEXT:
@@ -915,30 +879,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpDecorateString";
         case spv::OpMemberDecorateString:
             return "OpMemberDecorateString";
-        case spv::OpVariableLengthArrayINTEL:
-            return "OpVariableLengthArrayINTEL";
-        case spv::OpSaveMemoryINTEL:
-            return "OpSaveMemoryINTEL";
-        case spv::OpRestoreMemoryINTEL:
-            return "OpRestoreMemoryINTEL";
-        case spv::OpLoopControlINTEL:
-            return "OpLoopControlINTEL";
-        case spv::OpAliasDomainDeclINTEL:
-            return "OpAliasDomainDeclINTEL";
-        case spv::OpAliasScopeDeclINTEL:
-            return "OpAliasScopeDeclINTEL";
-        case spv::OpAliasScopeListDeclINTEL:
-            return "OpAliasScopeListDeclINTEL";
-        case spv::OpPtrCastToCrossWorkgroupINTEL:
-            return "OpPtrCastToCrossWorkgroupINTEL";
-        case spv::OpCrossWorkgroupCastToPtrINTEL:
-            return "OpCrossWorkgroupCastToPtrINTEL";
-        case spv::OpReadPipeBlockingINTEL:
-            return "OpReadPipeBlockingINTEL";
-        case spv::OpWritePipeBlockingINTEL:
-            return "OpWritePipeBlockingINTEL";
-        case spv::OpFPGARegINTEL:
-            return "OpFPGARegINTEL";
         case spv::OpRayQueryGetRayTMinKHR:
             return "OpRayQueryGetRayTMinKHR";
         case spv::OpRayQueryGetRayFlagsKHR:
@@ -975,24 +915,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpRayQueryGetIntersectionWorldToObjectKHR";
         case spv::OpAtomicFAddEXT:
             return "OpAtomicFAddEXT";
-        case spv::OpTypeBufferSurfaceINTEL:
-            return "OpTypeBufferSurfaceINTEL";
-        case spv::OpTypeStructContinuedINTEL:
-            return "OpTypeStructContinuedINTEL";
-        case spv::OpConstantCompositeContinuedINTEL:
-            return "OpConstantCompositeContinuedINTEL";
-        case spv::OpSpecConstantCompositeContinuedINTEL:
-            return "OpSpecConstantCompositeContinuedINTEL";
-        case spv::OpCompositeConstructContinuedINTEL:
-            return "OpCompositeConstructContinuedINTEL";
-        case spv::OpConvertFToBF16INTEL:
-            return "OpConvertFToBF16INTEL";
-        case spv::OpConvertBF16ToFINTEL:
-            return "OpConvertBF16ToFINTEL";
-        case spv::OpControlBarrierArriveINTEL:
-            return "OpControlBarrierArriveINTEL";
-        case spv::OpControlBarrierWaitINTEL:
-            return "OpControlBarrierWaitINTEL";
         case spv::OpGroupIMulKHR:
             return "OpGroupIMulKHR";
         case spv::OpGroupFMulKHR:
@@ -1009,10 +931,6 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpGroupLogicalOrKHR";
         case spv::OpGroupLogicalXorKHR:
             return "OpGroupLogicalXorKHR";
-        case spv::OpMaskedGatherINTEL:
-            return "OpMaskedGatherINTEL";
-        case spv::OpMaskedScatterINTEL:
-            return "OpMaskedScatterINTEL";
 
         default:
             return "Unknown Opcode";
@@ -2139,11 +2057,6 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpNoLine, {{}}},
         {spv::OpImageSparseRead, {{OperandKind::Id, OperandKind::Id, OperandKind::BitEnum}}},
         {spv::OpSizeOf, {{OperandKind::Id}}},
-        {spv::OpTypePipeStorage, {{}}},
-        {spv::OpConstantPipeStorage, {{OperandKind::Literal, OperandKind::Literal, OperandKind::Literal}}},
-        {spv::OpCreatePipeFromPipeStorage, {{OperandKind::Id}}},
-        {spv::OpGetKernelLocalSizeForSubgroupCount, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpGetKernelMaxNumSubgroups, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpModuleProcessed, {{OperandKind::LiteralString}}},
         {spv::OpExecutionModeId, {{OperandKind::Id, OperandKind::ValueEnum}}},
         {spv::OpDecorateId, {{OperandKind::Id, OperandKind::ValueEnum}}},
@@ -2309,16 +2222,6 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpConvertSampledImageToUNV, {{OperandKind::Id}}},
         {spv::OpSamplerImageAddressingModeNV, {{OperandKind::Literal}}},
         {spv::OpRawAccessChainNV, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::BitEnum}}},
-        {spv::OpSubgroupShuffleINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupShuffleDownINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupShuffleUpINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupShuffleXorINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupBlockReadINTEL, {{OperandKind::Id}}},
-        {spv::OpSubgroupBlockWriteINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupImageBlockReadINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupImageBlockWriteINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupImageMediaBlockReadINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpSubgroupImageMediaBlockWriteINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpUCountLeadingZerosINTEL, {{OperandKind::Id}}},
         {spv::OpUCountTrailingZerosINTEL, {{OperandKind::Id}}},
         {spv::OpAbsISubINTEL, {{OperandKind::Id, OperandKind::Id}}},
@@ -2335,27 +2238,12 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpUMul32x16INTEL, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpConstantFunctionPointerINTEL, {{OperandKind::Id}}},
         {spv::OpFunctionPointerCallINTEL, {{OperandKind::Id}}},
-        {spv::OpAsmTargetINTEL, {{OperandKind::LiteralString}}},
-        {spv::OpAsmINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::LiteralString, OperandKind::LiteralString}}},
-        {spv::OpAsmCallINTEL, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpAtomicFMinEXT, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpAtomicFMaxEXT, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpAssumeTrueKHR, {{OperandKind::Id}}},
         {spv::OpExpectKHR, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpDecorateString, {{OperandKind::Id, OperandKind::ValueEnum}}},
         {spv::OpMemberDecorateString, {{OperandKind::Id, OperandKind::Literal, OperandKind::ValueEnum}}},
-        {spv::OpVariableLengthArrayINTEL, {{OperandKind::Id}}},
-        {spv::OpSaveMemoryINTEL, {{}}},
-        {spv::OpRestoreMemoryINTEL, {{OperandKind::Id}}},
-        {spv::OpLoopControlINTEL, {{OperandKind::Literal}}},
-        {spv::OpAliasDomainDeclINTEL, {{OperandKind::Id}}},
-        {spv::OpAliasScopeDeclINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpAliasScopeListDeclINTEL, {{OperandKind::Id}}},
-        {spv::OpPtrCastToCrossWorkgroupINTEL, {{OperandKind::Id}}},
-        {spv::OpCrossWorkgroupCastToPtrINTEL, {{OperandKind::Id}}},
-        {spv::OpReadPipeBlockingINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpWritePipeBlockingINTEL, {{OperandKind::Id, OperandKind::Id}}},
-        {spv::OpFPGARegINTEL, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpRayQueryGetRayTMinKHR, {{OperandKind::Id}}},
         {spv::OpRayQueryGetRayFlagsKHR, {{OperandKind::Id}}},
         {spv::OpRayQueryGetIntersectionTKHR, {{OperandKind::Id, OperandKind::Id}}},
@@ -2374,15 +2262,6 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpRayQueryGetIntersectionObjectToWorldKHR, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpRayQueryGetIntersectionWorldToObjectKHR, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpAtomicFAddEXT, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpTypeBufferSurfaceINTEL, {{OperandKind::ValueEnum}}},
-        {spv::OpTypeStructContinuedINTEL, {{OperandKind::Id}}},
-        {spv::OpConstantCompositeContinuedINTEL, {{OperandKind::Id}}},
-        {spv::OpSpecConstantCompositeContinuedINTEL, {{OperandKind::Id}}},
-        {spv::OpCompositeConstructContinuedINTEL, {{OperandKind::Id}}},
-        {spv::OpConvertFToBF16INTEL, {{OperandKind::Id}}},
-        {spv::OpConvertBF16ToFINTEL, {{OperandKind::Id}}},
-        {spv::OpControlBarrierArriveINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpControlBarrierWaitINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
         {spv::OpGroupIMulKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupFMulKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupBitwiseAndKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
@@ -2391,8 +2270,6 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpGroupLogicalAndKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupLogicalOrKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupLogicalXorKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
-        {spv::OpMaskedGatherINTEL, {{OperandKind::Id, OperandKind::Literal, OperandKind::Id, OperandKind::Id}}},
-        {spv::OpMaskedScatterINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::Literal, OperandKind::Id}}},
     };  // clang-format on
 
     auto info = kOperandTable.find(opcode);

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2021-2023 The Khronos Group Inc.
+ * Copyright (c) 2021-2024 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -222,10 +222,6 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpImageSparseTexelsResident:
         case spv::OpImageSparseRead:
         case spv::OpSizeOf:
-        case spv::OpConstantPipeStorage:
-        case spv::OpCreatePipeFromPipeStorage:
-        case spv::OpGetKernelLocalSizeForSubgroupCount:
-        case spv::OpGetKernelMaxNumSubgroups:
         case spv::OpGroupNonUniformElect:
         case spv::OpGroupNonUniformAll:
         case spv::OpGroupNonUniformAny:
@@ -344,13 +340,6 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpConvertUToSampledImageNV:
         case spv::OpConvertSampledImageToUNV:
         case spv::OpRawAccessChainNV:
-        case spv::OpSubgroupShuffleINTEL:
-        case spv::OpSubgroupShuffleDownINTEL:
-        case spv::OpSubgroupShuffleUpINTEL:
-        case spv::OpSubgroupShuffleXorINTEL:
-        case spv::OpSubgroupBlockReadINTEL:
-        case spv::OpSubgroupImageBlockReadINTEL:
-        case spv::OpSubgroupImageMediaBlockReadINTEL:
         case spv::OpUCountLeadingZerosINTEL:
         case spv::OpUCountTrailingZerosINTEL:
         case spv::OpAbsISubINTEL:
@@ -367,19 +356,9 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpUMul32x16INTEL:
         case spv::OpConstantFunctionPointerINTEL:
         case spv::OpFunctionPointerCallINTEL:
-        case spv::OpAsmTargetINTEL:
-        case spv::OpAsmINTEL:
-        case spv::OpAsmCallINTEL:
         case spv::OpAtomicFMinEXT:
         case spv::OpAtomicFMaxEXT:
         case spv::OpExpectKHR:
-        case spv::OpVariableLengthArrayINTEL:
-        case spv::OpSaveMemoryINTEL:
-        case spv::OpPtrCastToCrossWorkgroupINTEL:
-        case spv::OpCrossWorkgroupCastToPtrINTEL:
-        case spv::OpReadPipeBlockingINTEL:
-        case spv::OpWritePipeBlockingINTEL:
-        case spv::OpFPGARegINTEL:
         case spv::OpRayQueryGetRayTMinKHR:
         case spv::OpRayQueryGetRayFlagsKHR:
         case spv::OpRayQueryGetIntersectionTKHR:
@@ -398,9 +377,6 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpRayQueryGetIntersectionObjectToWorldKHR:
         case spv::OpRayQueryGetIntersectionWorldToObjectKHR:
         case spv::OpAtomicFAddEXT:
-        case spv::OpCompositeConstructContinuedINTEL:
-        case spv::OpConvertFToBF16INTEL:
-        case spv::OpConvertBF16ToFINTEL:
         case spv::OpGroupIMulKHR:
         case spv::OpGroupFMulKHR:
         case spv::OpGroupBitwiseAndKHR:
@@ -409,7 +385,6 @@ static constexpr bool OpcodeHasType(uint32_t opcode) {
         case spv::OpGroupLogicalAndKHR:
         case spv::OpGroupLogicalOrKHR:
         case spv::OpGroupLogicalXorKHR:
-        case spv::OpMaskedGatherINTEL:
             return true;
         default:
             return false;
@@ -617,11 +592,6 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpImageSparseTexelsResident:
         case spv::OpImageSparseRead:
         case spv::OpSizeOf:
-        case spv::OpTypePipeStorage:
-        case spv::OpConstantPipeStorage:
-        case spv::OpCreatePipeFromPipeStorage:
-        case spv::OpGetKernelLocalSizeForSubgroupCount:
-        case spv::OpGetKernelMaxNumSubgroups:
         case spv::OpGroupNonUniformElect:
         case spv::OpGroupNonUniformAll:
         case spv::OpGroupNonUniformAny:
@@ -745,13 +715,6 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpConvertUToSampledImageNV:
         case spv::OpConvertSampledImageToUNV:
         case spv::OpRawAccessChainNV:
-        case spv::OpSubgroupShuffleINTEL:
-        case spv::OpSubgroupShuffleDownINTEL:
-        case spv::OpSubgroupShuffleUpINTEL:
-        case spv::OpSubgroupShuffleXorINTEL:
-        case spv::OpSubgroupBlockReadINTEL:
-        case spv::OpSubgroupImageBlockReadINTEL:
-        case spv::OpSubgroupImageMediaBlockReadINTEL:
         case spv::OpUCountLeadingZerosINTEL:
         case spv::OpUCountTrailingZerosINTEL:
         case spv::OpAbsISubINTEL:
@@ -768,22 +731,9 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpUMul32x16INTEL:
         case spv::OpConstantFunctionPointerINTEL:
         case spv::OpFunctionPointerCallINTEL:
-        case spv::OpAsmTargetINTEL:
-        case spv::OpAsmINTEL:
-        case spv::OpAsmCallINTEL:
         case spv::OpAtomicFMinEXT:
         case spv::OpAtomicFMaxEXT:
         case spv::OpExpectKHR:
-        case spv::OpVariableLengthArrayINTEL:
-        case spv::OpSaveMemoryINTEL:
-        case spv::OpAliasDomainDeclINTEL:
-        case spv::OpAliasScopeDeclINTEL:
-        case spv::OpAliasScopeListDeclINTEL:
-        case spv::OpPtrCastToCrossWorkgroupINTEL:
-        case spv::OpCrossWorkgroupCastToPtrINTEL:
-        case spv::OpReadPipeBlockingINTEL:
-        case spv::OpWritePipeBlockingINTEL:
-        case spv::OpFPGARegINTEL:
         case spv::OpRayQueryGetRayTMinKHR:
         case spv::OpRayQueryGetRayFlagsKHR:
         case spv::OpRayQueryGetIntersectionTKHR:
@@ -802,10 +752,6 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpRayQueryGetIntersectionObjectToWorldKHR:
         case spv::OpRayQueryGetIntersectionWorldToObjectKHR:
         case spv::OpAtomicFAddEXT:
-        case spv::OpTypeBufferSurfaceINTEL:
-        case spv::OpCompositeConstructContinuedINTEL:
-        case spv::OpConvertFToBF16INTEL:
-        case spv::OpConvertBF16ToFINTEL:
         case spv::OpGroupIMulKHR:
         case spv::OpGroupFMulKHR:
         case spv::OpGroupBitwiseAndKHR:
@@ -814,7 +760,6 @@ static constexpr bool OpcodeHasResult(uint32_t opcode) {
         case spv::OpGroupLogicalAndKHR:
         case spv::OpGroupLogicalOrKHR:
         case spv::OpGroupLogicalXorKHR:
-        case spv::OpMaskedGatherINTEL:
             return true;
         default:
             return false;
@@ -1007,8 +952,6 @@ static constexpr uint32_t OpcodeMemoryScopePosition(uint32_t opcode) {
             return 1;
         case spv::OpControlBarrier:
         case spv::OpAtomicStore:
-        case spv::OpControlBarrierArriveINTEL:
-        case spv::OpControlBarrierWaitINTEL:
             return 2;
         case spv::OpAtomicLoad:
         case spv::OpAtomicExchange:
@@ -1040,8 +983,6 @@ static constexpr uint32_t OpcodeExecutionScopePosition(uint32_t opcode) {
     uint32_t position = 0;
     switch (opcode) {
         case spv::OpControlBarrier:
-        case spv::OpControlBarrierArriveINTEL:
-        case spv::OpControlBarrierWaitINTEL:
             return 1;
         case spv::OpGroupAll:
         case spv::OpGroupAny:
@@ -1221,14 +1162,11 @@ enum class SpvType {
     kPointer,
     kFunction,
     kForwardPointer,
-    kPipeStorage,
     kCooperativeMatrixKHR,
     kRayQueryKHR,
     kHitObjectNV,
     kAccelerationStructureKHR,
     kCooperativeMatrixNV,
-    kBufferSurfaceINTEL,
-    kStructContinuedINTEL,
 };
 
 static constexpr SpvType GetSpvType(uint32_t opcode) {
@@ -1263,8 +1201,6 @@ static constexpr SpvType GetSpvType(uint32_t opcode) {
             return SpvType::kFunction;
         case spv::OpTypeForwardPointer:
             return SpvType::kForwardPointer;
-        case spv::OpTypePipeStorage:
-            return SpvType::kPipeStorage;
         case spv::OpTypeCooperativeMatrixKHR:
             return SpvType::kCooperativeMatrixKHR;
         case spv::OpTypeRayQueryKHR:
@@ -1275,10 +1211,6 @@ static constexpr SpvType GetSpvType(uint32_t opcode) {
             return SpvType::kAccelerationStructureKHR;
         case spv::OpTypeCooperativeMatrixNV:
             return SpvType::kCooperativeMatrixNV;
-        case spv::OpTypeBufferSurfaceINTEL:
-            return SpvType::kBufferSurfaceINTEL;
-        case spv::OpTypeStructContinuedINTEL:
-            return SpvType::kStructContinuedINTEL;
         default:
             return SpvType::Empty;
     }

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -3,7 +3,7 @@
 
 /***************************************************************************
  *
- * Copyright (c) 2020-2023 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 The Khronos Group Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -372,8 +372,6 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "Addresses";
         case spv::CapabilityLinkage:
             return "Linkage";
-        case spv::CapabilityKernel:
-            return "Kernel";
         case spv::CapabilityFloat16:
             return "Float16";
         case spv::CapabilityFloat64:
@@ -382,10 +380,6 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "Int64";
         case spv::CapabilityInt64Atomics:
             return "Int64Atomics";
-        case spv::CapabilityImageReadWrite:
-            return "ImageReadWrite";
-        case spv::CapabilityImageMipmap:
-            return "ImageMipmap";
         case spv::CapabilityGroups:
             return "Groups";
         case spv::CapabilityAtomicStorage:
@@ -460,10 +454,6 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "StorageImageWriteWithoutFormat";
         case spv::CapabilityMultiViewport:
             return "MultiViewport";
-        case spv::CapabilitySubgroupDispatch:
-            return "SubgroupDispatch";
-        case spv::CapabilityPipeStorage:
-            return "PipeStorage";
         case spv::CapabilityGroupNonUniform:
             return "GroupNonUniform";
         case spv::CapabilityGroupNonUniformVote:
@@ -674,88 +664,18 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "RayTracingDisplacementMicromapNV";
         case spv::CapabilityRawAccessChainsNV:
             return "RawAccessChainsNV";
-        case spv::CapabilitySubgroupShuffleINTEL:
-            return "SubgroupShuffleINTEL";
-        case spv::CapabilitySubgroupBufferBlockIOINTEL:
-            return "SubgroupBufferBlockIOINTEL";
-        case spv::CapabilitySubgroupImageBlockIOINTEL:
-            return "SubgroupImageBlockIOINTEL";
-        case spv::CapabilitySubgroupImageMediaBlockIOINTEL:
-            return "SubgroupImageMediaBlockIOINTEL";
-        case spv::CapabilityRoundToInfinityINTEL:
-            return "RoundToInfinityINTEL";
-        case spv::CapabilityFloatingPointModeINTEL:
-            return "FloatingPointModeINTEL";
         case spv::CapabilityIntegerFunctions2INTEL:
             return "IntegerFunctions2INTEL";
         case spv::CapabilityFunctionPointersINTEL:
             return "FunctionPointersINTEL";
-        case spv::CapabilityIndirectReferencesINTEL:
-            return "IndirectReferencesINTEL";
-        case spv::CapabilityAsmINTEL:
-            return "AsmINTEL";
         case spv::CapabilityAtomicFloat32MinMaxEXT:
             return "AtomicFloat32MinMaxEXT";
         case spv::CapabilityAtomicFloat64MinMaxEXT:
             return "AtomicFloat64MinMaxEXT";
         case spv::CapabilityAtomicFloat16MinMaxEXT:
             return "AtomicFloat16MinMaxEXT";
-        case spv::CapabilityVectorComputeINTEL:
-            return "VectorComputeINTEL";
-        case spv::CapabilityVectorAnyINTEL:
-            return "VectorAnyINTEL";
         case spv::CapabilityExpectAssumeKHR:
             return "ExpectAssumeKHR";
-        case spv::CapabilitySubgroupAvcMotionEstimationINTEL:
-            return "SubgroupAvcMotionEstimationINTEL";
-        case spv::CapabilitySubgroupAvcMotionEstimationIntraINTEL:
-            return "SubgroupAvcMotionEstimationIntraINTEL";
-        case spv::CapabilitySubgroupAvcMotionEstimationChromaINTEL:
-            return "SubgroupAvcMotionEstimationChromaINTEL";
-        case spv::CapabilityVariableLengthArrayINTEL:
-            return "VariableLengthArrayINTEL";
-        case spv::CapabilityFunctionFloatControlINTEL:
-            return "FunctionFloatControlINTEL";
-        case spv::CapabilityFPGAMemoryAttributesINTEL:
-            return "FPGAMemoryAttributesINTEL";
-        case spv::CapabilityArbitraryPrecisionIntegersINTEL:
-            return "ArbitraryPrecisionIntegersINTEL";
-        case spv::CapabilityArbitraryPrecisionFloatingPointINTEL:
-            return "ArbitraryPrecisionFloatingPointINTEL";
-        case spv::CapabilityUnstructuredLoopControlsINTEL:
-            return "UnstructuredLoopControlsINTEL";
-        case spv::CapabilityFPGALoopControlsINTEL:
-            return "FPGALoopControlsINTEL";
-        case spv::CapabilityKernelAttributesINTEL:
-            return "KernelAttributesINTEL";
-        case spv::CapabilityFPGAKernelAttributesINTEL:
-            return "FPGAKernelAttributesINTEL";
-        case spv::CapabilityFPGAMemoryAccessesINTEL:
-            return "FPGAMemoryAccessesINTEL";
-        case spv::CapabilityFPGAClusterAttributesINTEL:
-            return "FPGAClusterAttributesINTEL";
-        case spv::CapabilityLoopFuseINTEL:
-            return "LoopFuseINTEL";
-        case spv::CapabilityFPGADSPControlINTEL:
-            return "FPGADSPControlINTEL";
-        case spv::CapabilityMemoryAccessAliasingINTEL:
-            return "MemoryAccessAliasingINTEL";
-        case spv::CapabilityFPGAInvocationPipeliningAttributesINTEL:
-            return "FPGAInvocationPipeliningAttributesINTEL";
-        case spv::CapabilityFPGABufferLocationINTEL:
-            return "FPGABufferLocationINTEL";
-        case spv::CapabilityArbitraryPrecisionFixedPointINTEL:
-            return "ArbitraryPrecisionFixedPointINTEL";
-        case spv::CapabilityUSMStorageClassesINTEL:
-            return "USMStorageClassesINTEL";
-        case spv::CapabilityRuntimeAlignedAttributeINTEL:
-            return "RuntimeAlignedAttributeINTEL";
-        case spv::CapabilityIOPipesINTEL:
-            return "IOPipesINTEL";
-        case spv::CapabilityBlockingPipesINTEL:
-            return "BlockingPipesINTEL";
-        case spv::CapabilityFPGARegINTEL:
-            return "FPGARegINTEL";
         case spv::CapabilityDotProductInputAll:
             return "DotProductInputAll";
         case spv::CapabilityDotProductInput4x8Bit:
@@ -778,40 +698,10 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "AtomicFloat32AddEXT";
         case spv::CapabilityAtomicFloat64AddEXT:
             return "AtomicFloat64AddEXT";
-        case spv::CapabilityLongCompositesINTEL:
-            return "LongCompositesINTEL";
-        case spv::CapabilityOptNoneINTEL:
-            return "OptNoneINTEL";
         case spv::CapabilityAtomicFloat16AddEXT:
             return "AtomicFloat16AddEXT";
-        case spv::CapabilityDebugInfoModuleINTEL:
-            return "DebugInfoModuleINTEL";
-        case spv::CapabilityBFloat16ConversionINTEL:
-            return "BFloat16ConversionINTEL";
-        case spv::CapabilitySplitBarrierINTEL:
-            return "SplitBarrierINTEL";
-        case spv::CapabilityFPGAClusterAttributesV2INTEL:
-            return "FPGAClusterAttributesV2INTEL";
-        case spv::CapabilityFPGAKernelAttributesv2INTEL:
-            return "FPGAKernelAttributesv2INTEL";
-        case spv::CapabilityFPMaxErrorINTEL:
-            return "FPMaxErrorINTEL";
-        case spv::CapabilityFPGALatencyControlINTEL:
-            return "FPGALatencyControlINTEL";
-        case spv::CapabilityFPGAArgumentInterfacesINTEL:
-            return "FPGAArgumentInterfacesINTEL";
-        case spv::CapabilityGlobalVariableHostAccessINTEL:
-            return "GlobalVariableHostAccessINTEL";
-        case spv::CapabilityGlobalVariableFPGADecorationsINTEL:
-            return "GlobalVariableFPGADecorationsINTEL";
         case spv::CapabilityGroupUniformArithmeticKHR:
             return "GroupUniformArithmeticKHR";
-        case spv::CapabilityMaskedGatherScatterINTEL:
-            return "MaskedGatherScatterINTEL";
-        case spv::CapabilityCacheControlsINTEL:
-            return "CacheControlsINTEL";
-        case spv::CapabilityRegisterLimitsINTEL:
-            return "RegisterLimitsINTEL";
         default:
             return "Unhandled OpCapability";
     };

--- a/scripts/generators/generator_utils.py
+++ b/scripts/generators/generator_utils.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2023 Valve Corporation
-# Copyright (c) 2023 LunarG, Inc.
+# Copyright (c) 2023-2024 Valve Corporation
+# Copyright (c) 2023-2024 LunarG, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -85,3 +85,73 @@ class PlatformGuardHelper():
             out.append(f'#ifdef {guard}\n')
         self.current_guard = guard
         return out
+
+# The SPIR-V grammar json doesn't have an easy way to detect these, so have listed by hand
+# If we are missing one, its not critical, the goal of this list is to reduce the generated output size
+def IsNonVulkanSprivCapability(capability):
+    return capability in [
+        'Kernel',
+        'Vector16',
+        'Float16Buffer',
+        'ImageBasic',
+        'ImageReadWrite',
+        'ImageMipmap',
+        'DeviceEnqueue',
+        'SubgroupDispatch',
+        'Pipes',
+        'LiteralSampler',
+        'NamedBarrier',
+        'PipeStorage',
+        'SubgroupShuffleINTEL',
+        'SubgroupShuffleINTEL',
+        'SubgroupBufferBlockIOINTEL',
+        'SubgroupImageBlockIOINTEL',
+        'SubgroupImageMediaBlockIOINTEL',
+        'RoundToInfinityINTEL',
+        'FloatingPointModeINTEL',
+        'IndirectReferencesINTEL',
+        'AsmINTEL',
+        'VectorComputeINTEL',
+        'VectorAnyINTEL',
+        'SubgroupAvcMotionEstimationINTEL',
+        'SubgroupAvcMotionEstimationIntraINTEL',
+        'SubgroupAvcMotionEstimationChromaINTEL',
+        'VariableLengthArrayINTEL',
+        'FunctionFloatControlINTEL',
+        'FPGAMemoryAttributesINTEL',
+        'FPFastMathModeINTEL',
+        'ArbitraryPrecisionIntegersINTEL',
+        'ArbitraryPrecisionFloatingPointINTEL',
+        'UnstructuredLoopControlsINTEL',
+        'FPGALoopControlsINTEL',
+        'KernelAttributesINTEL',
+        'FPGAKernelAttributesINTEL',
+        'FPGAMemoryAccessesINTEL',
+        'FPGAClusterAttributesINTEL',
+        'LoopFuseINTEL',
+        'FPGADSPControlINTEL',
+        'MemoryAccessAliasingINTEL',
+        'FPGAInvocationPipeliningAttributesINTEL',
+        'FPGABufferLocationINTEL',
+        'ArbitraryPrecisionFixedPointINTEL',
+        'USMStorageClassesINTEL',
+        'RuntimeAlignedAttributeINTEL',
+        'IOPipesINTEL',
+        'BlockingPipesINTEL',
+        'FPGARegINTEL',
+        'LongCompositesINTEL',
+        'OptNoneINTEL',
+        'DebugInfoModuleINTEL',
+        'BFloat16ConversionINTEL',
+        'SplitBarrierINTEL',
+        'FPGAClusterAttributesV2INTEL',
+        'FPGAKernelAttributesv2INTEL',
+        'FPMaxErrorINTEL',
+        'FPGALatencyControlINTEL',
+        'FPGAArgumentInterfacesINTEL',
+        'GlobalVariableHostAccessINTEL',
+        'GlobalVariableFPGADecorationsINTEL',
+        'MaskedGatherScatterINTEL',
+        'CacheControlsINTEL',
+        'RegisterLimitsINTEL'
+    ]

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -1,6 +1,6 @@
 #!/usr/bin/python3 -i
 #
-# Copyright (c) 2020-2023 The Khronos Group Inc.
+# Copyright (c) 2020-2024 The Khronos Group Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -19,6 +19,7 @@ import os
 import json
 from generators.vulkan_object import SpirvEnables
 from generators.base_generator import BaseGenerator
+from generators.generator_utils import IsNonVulkanSprivCapability
 
 #
 # Generate SPIR-V validation for SPIR-V extensions and capabilities
@@ -37,8 +38,7 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
             if kind['kind'] == 'Capability':
                 enum_values = set()
                 for enum in kind['enumerants']:
-                    # Skip capabilities specific to OpenCL
-                    if enum.get('capabilities') == ['Kernel']:
+                    if IsNonVulkanSprivCapability(enum['enumerant']):
                         continue
                     # Detect aliases
                     if enum['value'] in enum_values:
@@ -124,7 +124,7 @@ class SpirvValidationHelperOutputGenerator(BaseGenerator):
 
             /***************************************************************************
             *
-            * Copyright (c) 2020-2023 The Khronos Group Inc.
+            * Copyright (c) 2020-2024 The Khronos Group Inc.
             *
             * Licensed under the Apache License, Version 2.0 (the "License");
             * you may not use this file except in compliance with the License.


### PR DESCRIPTION
This creates a list of all OpenCL only SPIR-V to help reduce the size of the spirv helpers and remove things that we clearly will never see