### PR TITLE
script: Fix object types generator include issue

### DIFF
--- a/layers/vulkan/generated/vk_object_types.cpp
+++ b/layers/vulkan/generated/vk_object_types.cpp
@@ -23,7 +23,7 @@
 
 // NOLINTBEGIN
 
-#include <vulkan/vulkan_core.h>
+#include <vulkan/vulkan.h>
 #include "vk_object_types.h"
 
 // Helper array to get Vulkan VK_EXT_debug_report object type enum from the internal layers version

--- a/scripts/generators/object_types_generator.py
+++ b/scripts/generators/object_types_generator.py
@@ -245,7 +245,7 @@ class ObjectTypesOutputGenerator(BaseGenerator):
     def generateSource(self):
         out = []
         out.append('''
-            #include <vulkan/vulkan_core.h>
+            #include <vulkan/vulkan.h>
             #include "vk_object_types.h"
 
             ''')


### PR DESCRIPTION
`vk_object_types.cpp` only included `vulkan_core.h`, but some object type definitions may be platform specific and thus are defined in one of the other headers. So this is just a trivial fix to include `vulkan.h` instead.