### PR TITLE
apple: Added version strings to framework plists

### DIFF
--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -339,6 +339,8 @@ elseif(APPLE)
 if(IOS)
     set_target_properties(vvl PROPERTIES
 		FRAMEWORK			TRUE
+                MACOSX_FRAMEWORK_BUNDLE_VERSION "${VulkanHeaders_VERSION}"
+                MACOSX_FRAMEWORK_SHORT_VERSION_STRING "${VulkanHeaders_VERSION}"
 		MACOSX_FRAMEWORK_IDENTIFIER 	com.khronos.validation
     )
 else()


### PR DESCRIPTION
For Apples app store frameworks Info.plist files must contain these two version strings. I've used the Vulkan Header version used to build the layer as the version string as well.