### PR TITLE
sync: Fix WaitForFences leak

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -357,6 +357,7 @@ class Fence : public internal::NonDispHandle<VkFence> {
     Fence() = default;
     Fence(const Device &dev) { init(dev, create_info()); }
     Fence(const Device &dev, const VkFenceCreateInfo &info) { init(dev, info); }
+    Fence(Fence &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
     ~Fence() noexcept;
     void destroy() noexcept;
 


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7250

There are syncval endpoints that compute state in the Validate phase
and use thread local storage to propagate it to the Record phase,
which does the final update.

This change fixes one side effect of this approach in the multithreaded
environment. In some cases, the accesses that should be synchronized by
vkWaitForFences can leak through this synchronization point, and then
hazard with the following accesses.

In following scenario two threads work with the same queue.
The queue access is externally synchronized.

1. Thread A: Submits some memory accesses. Signals a fence.
2. Thread B: Submits empty command buffer. Finishes only Validate.
   This imports accesses from step 1 and the batch is stored in the
   thread local storage to be consumed later by the Record.
3. Thread A: Calls WaitForFences with a fence from step 1.
   This processes the accesses from step 1, but cannot see the copy
   of those accesses (in TLS) produced by step 2.
4. Thread B. Finishes Record. This restores accesses from step 2, that
   otherwise should have been processed by the WaitForFences.
5. Thread A. Submits more accesses. They hazard with accesses that
   were restored in step 4.
