### PR TITLE
layers: Do shallow pNext pointer compare

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -442,10 +442,13 @@ static bool ComparePipelineMultisampleStateCreateInfo(VkPipelineMultisampleState
         valid_mask = false;  // one is not null
     }
 
-    return (a.sType == b.sType) && (a.pNext == b.pNext) && (a.flags == b.flags) &&
-           (a.rasterizationSamples == b.rasterizationSamples) && (a.sampleShadingEnable == b.sampleShadingEnable) &&
-           (a.minSampleShading == b.minSampleShading) && (valid_mask) && (a.alphaToCoverageEnable == b.alphaToCoverageEnable) &&
-           (a.alphaToOneEnable == b.alphaToOneEnable);
+    // TODO - to do a deep pNext chain check would require us generating these compare functions for all structs
+    // For now, just check if pNext both null or not
+    const bool valid_pNext = (a.pNext && b.pNext) || (a.pNext == b.pNext);
+
+    return (a.sType == b.sType) && (valid_pNext) && (a.flags == b.flags) && (a.rasterizationSamples == b.rasterizationSamples) &&
+           (a.sampleShadingEnable == b.sampleShadingEnable) && (a.minSampleShading == b.minSampleShading) && (valid_mask) &&
+           (a.alphaToCoverageEnable == b.alphaToCoverageEnable) && (a.alphaToOneEnable == b.alphaToOneEnable);
 }
 
 static bool CompareDescriptorSetLayoutBinding(VkDescriptorSetLayoutBinding a, VkDescriptorSetLayoutBinding b) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7666

For now the chance of the pNext struct values in two different GPL is low, and rather not give false positive and come back later to catch these edge cases