### PR TITLE
layers: Fix checking null imported handle type

### DIFF
--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -120,7 +120,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
                              string_VkExternalSemaphoreHandleTypeFlags(sem_state->exportHandleTypes).c_str());
         }
 
-        if (sem_state->Scope() != vvl::Semaphore::kInternal &&
+        if (sem_state->Scope() != vvl::Semaphore::kInternal && sem_state->HasImportedHandleType() &&
             !CanSemaphoreExportFromImported(physical_device, pGetFdInfo->handleType, sem_state->ImportedHandleType())) {
             skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-semaphore-01133", sem_state->Handle(), info_loc.dot(Field::handleType),
                              "(%s) cannot be exported from semaphore with imported payload with handle type %s",
@@ -171,7 +171,7 @@ bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetF
                              string_VkExternalFenceHandleTypeFlags(fence_state->exportHandleTypes).c_str());
         }
 
-        if (fence_state->Scope() != vvl::Fence::kInternal &&
+        if (fence_state->Scope() != vvl::Fence::kInternal && fence_state->HasImportedHandleType() &&
             !CanFenceExportFromImported(physical_device, pGetFdInfo->handleType, fence_state->ImportedHandleType())) {
             skip |= LogError("VUID-VkFenceGetFdInfoKHR-fence-01455", fence_state->Handle(), info_loc.dot(Field::handleType),
                              "(%s) cannot be exported from fence with imported payload with handle type %s",
@@ -243,7 +243,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,
                              string_VkExternalSemaphoreHandleTypeFlags(sem_state->exportHandleTypes).c_str());
         }
 
-        if (sem_state->Scope() != vvl::Semaphore::kInternal &&
+        if (sem_state->Scope() != vvl::Semaphore::kInternal && sem_state->HasImportedHandleType() &&
             !CanSemaphoreExportFromImported(physical_device, pGetWin32HandleInfo->handleType, sem_state->ImportedHandleType())) {
             skip |= LogError("VUID-VkSemaphoreGetWin32HandleInfoKHR-semaphore-01128", sem_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
@@ -275,7 +275,7 @@ bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const Vk
                              string_VkExternalFenceHandleTypeFlags(fence_state->exportHandleTypes).c_str());
         }
 
-        if (fence_state->Scope() != vvl::Fence::kInternal &&
+        if (fence_state->Scope() != vvl::Fence::kInternal && fence_state->HasImportedHandleType() &&
             !CanFenceExportFromImported(physical_device, pGetWin32HandleInfo->handleType, fence_state->ImportedHandleType())) {
             skip |= LogError("VUID-VkFenceGetWin32HandleInfoKHR-fence-01450", fence_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -91,6 +91,12 @@ class Fence : public RefcountedStateObject {
     enum State State() const { return state_; }
     enum Scope Scope() const { return scope_; }
 
+    // used to catch if GetFence() is called multiple times
+    bool HasImportedHandleType() const {
+        auto guard = ReadLock();
+        return imported_handle_type_.has_value();
+    }
+
     VkExternalFenceHandleTypeFlagBits ImportedHandleType() const {
         auto guard = ReadLock();
         assert(imported_handle_type_.has_value());

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -144,6 +144,12 @@ class Semaphore : public RefcountedStateObject {
         auto guard = ReadLock();
         return scope_;
     }
+
+    // used to catch if GetSemaphore() is called multiple times
+    bool HasImportedHandleType() const {
+        auto guard = ReadLock();
+        return imported_handle_type_.has_value();
+    }
     VkExternalSemaphoreHandleTypeFlagBits ImportedHandleType() const {
         auto guard = ReadLock();
         assert(imported_handle_type_.has_value());

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -494,3 +494,25 @@ TEST_F(PositiveExternalMemorySync, ExportFromImportedFence) {
     }
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+
+TEST_F(PositiveExternalMemorySync, MultipleExportOpaqueFd) {
+    TEST_DESCRIPTION("regression from dEQP-VK.api.external.semaphore.opaque_fd.export_multiple_times_temporary");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    IgnoreHandleTypeError(m_errorMonitor);
+
+    const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
+    if ((handle_types & VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT) == 0) {
+        GTEST_SKIP() << "VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT is not exportable";
+    }
+
+    VkExportSemaphoreCreateInfo export_info = vku::InitStructHelper();
+    export_info.handleTypes = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
+    const VkSemaphoreCreateInfo create_info = vku::InitStructHelper(&export_info);
+    vkt::Semaphore semaphore(*m_device, create_info);
+
+    int handle = 0;
+    semaphore.export_handle(handle, VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT);
+    semaphore.export_handle(handle, VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT);
+}


### PR DESCRIPTION
Found running against CTS we didn't handle two 

```
vkGetSemaphoreFdKHR();
vkGetSemaphoreFdKHR();
```

calls next to each other