### PR TITLE
layers: Fix std build error in main

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -299,7 +299,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         return false;
     }
     // If not an image array, the set of indexes will be empty and we guarantee this is the only element
-    if (!variable->image_access_chain_indexes.empty() && !variable->image_access_chain_indexes.contains(index)) {
+    if (!variable->image_access_chain_indexes.empty() &&
+        variable->image_access_chain_indexes.find(index) == variable->image_access_chain_indexes.end()) {
         return false;
     }
 


### PR DESCRIPTION
Fix `std::unordered_set` in main when not using robin hood