### PR TITLE
layers: Fix crash from sampler pNext

### DIFF
--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -18,6 +18,7 @@
  */
 #pragma once
 #include "state_tracker/state_object.h"
+#include "generated/vk_safe_struct.h"
 
 // Note: some of the types in this header are needed by both the DescriptorSet and Pipeline
 // state objects. It is helpful to have a separate header to avoid circular #include madness.
@@ -58,13 +59,13 @@ namespace vvl {
 
 class Sampler : public StateObject {
   public:
-    const VkSamplerCreateInfo createInfo;
+    const safe_VkSamplerCreateInfo createInfo;
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
     Sampler(const VkSampler s, const VkSamplerCreateInfo *pci)
         : StateObject(s, kVulkanObjectTypeSampler),
-          createInfo(*pci),
+          createInfo(pci),
           samplerConversion(GetConversion(pci)),
           customCreateInfo(GetCustomCreateInfo(pci)) {}
 


### PR DESCRIPTION
Fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7675#discussion_r1526178065 (cc @y-novikov)

... The fact this broken is concerning, I will make an issue and go through and make sure we are properly using safe struct to capture the pNext chain in all our state tracking