### PR TITLE
layers: Move SubresourceRangeErrorCodes to map file

### DIFF
--- a/layers/core_checks/cc_vuid_maps.cpp
+++ b/layers/core_checks/cc_vuid_maps.cpp
@@ -567,4 +567,53 @@ const std::string &GetImageArrayLayerRangeVUID(const Location &loc) {
     return result;
 }
 
+const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRangeError error) {
+    static const std::map<SubresourceRangeError, std::array<Entry, 6>> errors{
+        {SubresourceRangeError::BaseMip_01486,
+         {{
+             {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-subresourceRange-01486"},
+             {Key(Struct::VkImageMemoryBarrier2), "VUID-VkImageMemoryBarrier2-subresourceRange-01486"},
+             {Key(Func::vkTransitionImageLayoutEXT), "VUID-VkHostImageLayoutTransitionInfoEXT-subresourceRange-01486"},
+             {Key(Func::vkCmdClearColorImage), "VUID-vkCmdClearColorImage-baseMipLevel-01470"},
+             {Key(Func::vkCmdClearDepthStencilImage), "VUID-vkCmdClearDepthStencilImage-baseMipLevel-01474"},
+             {Key(Func::vkCreateImageView), "VUID-VkImageViewCreateInfo-subresourceRange-01478"},
+         }}},
+        {SubresourceRangeError::MipCount_01724,
+         {{
+             {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-subresourceRange-01724"},
+             {Key(Struct::VkImageMemoryBarrier2), "VUID-VkImageMemoryBarrier2-subresourceRange-01724"},
+             {Key(Func::vkTransitionImageLayoutEXT), "VUID-VkHostImageLayoutTransitionInfoEXT-subresourceRange-01724"},
+             {Key(Func::vkCmdClearColorImage), "VUID-vkCmdClearColorImage-pRanges-01692"},
+             {Key(Func::vkCmdClearDepthStencilImage), "VUID-vkCmdClearDepthStencilImage-pRanges-01694"},
+             {Key(Func::vkCreateImageView), "VUID-VkImageViewCreateInfo-subresourceRange-01718"},
+         }}},
+        {SubresourceRangeError::BaseLayer_01488,
+         {{
+             {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-subresourceRange-01488"},
+             {Key(Struct::VkImageMemoryBarrier2), "VUID-VkImageMemoryBarrier2-subresourceRange-01488"},
+             {Key(Func::vkTransitionImageLayoutEXT), "VUID-VkHostImageLayoutTransitionInfoEXT-subresourceRange-01488"},
+             {Key(Func::vkCmdClearColorImage), "VUID-vkCmdClearColorImage-baseArrayLayer-01472"},
+             {Key(Func::vkCmdClearDepthStencilImage), "VUID-vkCmdClearDepthStencilImage-baseArrayLayer-01476"},
+             {Key(Func::vkCreateImageView), "VUID-VkImageViewCreateInfo-image-06724"},
+         }}},
+        {SubresourceRangeError::LayerCount_01725,
+         {{
+             {Key(Struct::VkImageMemoryBarrier), "VUID-VkImageMemoryBarrier-subresourceRange-01725"},
+             {Key(Struct::VkImageMemoryBarrier2), "VUID-VkImageMemoryBarrier2-subresourceRange-01725"},
+             {Key(Func::vkTransitionImageLayoutEXT), "VUID-VkHostImageLayoutTransitionInfoEXT-subresourceRange-01725"},
+             {Key(Func::vkCmdClearColorImage), "VUID-vkCmdClearColorImage-pRanges-01693"},
+             {Key(Func::vkCmdClearDepthStencilImage), "VUID-vkCmdClearDepthStencilImage-pRanges-01695"},
+             {Key(Func::vkCreateImageView), "VUID-VkImageViewCreateInfo-subresourceRange-06725"},
+         }}},
+    };
+
+    const auto &result = FindVUID(error, loc, errors);
+    assert(!result.empty());
+    if (result.empty()) {
+        static const std::string unhandled("UNASSIGNED-CoreChecks-unhandled-subresource-range");
+        return unhandled;
+    }
+    return result;
+}
+
 }  // namespace vvl

--- a/layers/core_checks/cc_vuid_maps.h
+++ b/layers/core_checks/cc_vuid_maps.h
@@ -92,4 +92,13 @@ const std::string &GetCopyImageVUID(const Location &loc, CopyError error);
 const std::string &GetImageMipLevelVUID(const Location &loc);
 const std::string &GetImageArrayLayerRangeVUID(const Location &loc);
 
+enum class SubresourceRangeError {
+    BaseMip_01486,
+    MipCount_01724,
+    BaseLayer_01488,
+    LayerCount_01725,
+};
+
+const std::string &GetSubresourceRangeVUID(const Location &loc, SubresourceRangeError error);
+
 }  // namespace vvl

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -26,10 +26,6 @@
 #include "error_message/record_object.h"
 #include "containers/qfo_transfer.h"
 
-struct SubresourceRangeErrorCodes {
-    const char *base_mip_err, *mip_count_err, *base_layer_err, *layer_count_err;
-};
-
 typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
 // Much of the data stored in vvl::CommandBuffer is only used by core validation, and is
@@ -698,9 +694,8 @@ class CoreChecks : public ValidationStateTracker {
                                                           const vvl::Image& dst_image_state, const RegionType* region,
                                                           const Location& region_loc) const;
     bool ValidateImageSubresourceRange(const uint32_t image_mip_count, const uint32_t image_layer_count,
-                                       const VkImageSubresourceRange& subresourceRange, const char* image_layer_count_var_name,
-                                       const LogObjectList& objlist, const SubresourceRangeErrorCodes& errorCodes,
-                                       const Location& subresource_loc) const;
+                                       const VkImageSubresourceRange& subresourceRange, vvl::Field image_layer_count_var,
+                                       const LogObjectList& objlist, const Location& subresource_loc) const;
     bool ValidateMultipassRenderedToSingleSampledSampleCount(VkFramebuffer framebuffer, VkRenderPass renderpass,
                                                              vvl::Image& image_state, VkSampleCountFlagBits msrtss_samples,
                                                              const Location& rasterization_samples_loc) const;

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -1216,22 +1216,6 @@ const std::string &GetImageBarrierVUID(const Location &loc, ImageError error) {
     return result;
 }
 
-const SubresourceRangeErrorCodes &GetSubResourceVUIDs(const Location &loc) {
-    static const SubresourceRangeErrorCodes v1{
-        "VUID-VkImageMemoryBarrier-subresourceRange-01486",
-        "VUID-VkImageMemoryBarrier-subresourceRange-01724",
-        "VUID-VkImageMemoryBarrier-subresourceRange-01488",
-        "VUID-VkImageMemoryBarrier-subresourceRange-01725",
-    };
-    static const SubresourceRangeErrorCodes v2{
-        "VUID-VkImageMemoryBarrier2-subresourceRange-01486",
-        "VUID-VkImageMemoryBarrier2-subresourceRange-01724",
-        "VUID-VkImageMemoryBarrier2-subresourceRange-01488",
-        "VUID-VkImageMemoryBarrier2-subresourceRange-01725",
-    };
-    return (loc.structure == Struct::VkImageMemoryBarrier2) ? v2 : v1;
-}
-
 static const std::map<SubmitError, std::vector<Entry>> kSubmitErrors{
     {SubmitError::kTimelineSemSmallValue,
      {

--- a/layers/sync/sync_vuid_maps.h
+++ b/layers/sync/sync_vuid_maps.h
@@ -96,8 +96,6 @@ struct GetImageBarrierVUIDFunctor {
     const std::string &operator()(const Location &loc) const { return GetImageBarrierVUID(loc, error); }
 };
 
-const SubresourceRangeErrorCodes &GetSubResourceVUIDs(const Location &loc);
-
 enum class SubmitError {
     kTimelineSemSmallValue,
     kSemAlreadySignalled,


### PR DESCRIPTION
Move another good candidate of VUIDs to `cc_vuid_maps.cpp`

These VUs use to be scatter around the place and now are all grouped together properly