### PR TITLE
Fixing Encode2D/3D address calculation for compressed textures.

### DIFF
--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -358,13 +358,19 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
 IndexType ImageRangeEncoder::Encode2D(const VkSubresourceLayout& layout, uint32_t layer, uint32_t aspect_index,
                                       const VkOffset3D& offset) const {
     assert(offset.z == 0U);
+    // The address offset of the beginning of offset.x's block is:
+    // floor(offset.x * / texel_extent_.width) * texel_extent_.width * texel_extent_.height * texel_sizes_[apsect].
+    // Since offset.x must be a multiple of texel_extent_.width, we can simplify the formula by canceling out texel_extent_.width.
+    double xSize = static_cast<double>(texel_extent_.height * texel_sizes_[aspect_index]);
     return layout.offset + layer * layout.arrayPitch + offset.y * layout.rowPitch +
-           (offset.x ? static_cast<IndexType>(floor(offset.x * texel_sizes_[aspect_index])) : 0U);
+           (offset.x ? static_cast<IndexType>(floor(offset.x * xSize)) : 0U);
 }
 
 IndexType ImageRangeEncoder::Encode3D(const VkSubresourceLayout& layout, uint32_t aspect_index, const VkOffset3D& offset) const {
+    // See comment in Encode2D.
+    double xSize = static_cast<double>(texel_extent_.height * texel_sizes_[aspect_index]);
     return layout.offset + offset.z * layout.depthPitch + offset.y * layout.rowPitch +
-           (offset.x ? static_cast<IndexType>(floor(offset.x * texel_sizes_[aspect_index])) : 0U);
+           (offset.x ? static_cast<IndexType>(floor(offset.x * xSize)) : 0U);
 }
 
 void ImageRangeEncoder::Decode(const VkImageSubresource& subres, const IndexType& encode, uint32_t& out_layer,

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4292,6 +4292,45 @@ TEST_F(NegativeSyncVal, TestCopyingToCompressedImage) {
     }
 }
 
+TEST_F(NegativeSyncVal, TestCopyingBufferToCompressedImage) {
+    TEST_DESCRIPTION("Copy from a buffer to compressed image with and without overlap.");
+
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    VkFormatProperties format_properties;
+    VkFormat mp_format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), mp_format, &format_properties);
+    if ((format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
+        GTEST_SKIP()
+            << "Device does not support VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
+    }
+
+    vkt::Buffer src_buffer(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Image dst_image(*m_device, 16, 16, 1, mp_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferImageCopy buffer_copy[2] = {};
+    buffer_copy[0].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    buffer_copy[0].imageSubresource.mipLevel = 0;
+    buffer_copy[0].imageSubresource.baseArrayLayer = 0;
+    buffer_copy[0].imageSubresource.layerCount = 1;
+    buffer_copy[0].imageOffset = {0, 0, 0};
+    buffer_copy[0].imageExtent = {8, 8, 1};
+    buffer_copy[1].imageSubresource = buffer_copy[0].imageSubresource;
+    buffer_copy[1].imageOffset = {8, 0, 0};
+    buffer_copy[1].imageExtent = {8, 8, 1};
+
+    m_commandBuffer->begin();
+
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "SYNC-HAZARD-WRITE-AFTER-WRITE");
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->end();
+}
+
 TEST_F(NegativeSyncVal, StageAccessExpansion) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
 


### PR DESCRIPTION
We were getting sync write-after-write errors when copying non-overlapping blocks of 320x320 pixels from a buffer to an ETC2 RGB texture. 320x320 is clearly a multiple of the block size (4x4) - so this should not fail validation.

I was able to track the problem down to `ImageRangeEncoder::Encode2D`. It was computing the x-offset into the row by multiplying `offset.x` with `texel_Sizes_[aspect_index`]. That is incorrect. Imagine an 8x8 ETC2 RGB (or BC1) texture. Each 4x4 block is 8 bytes. The address of `(x = 4, y = 0)` is the address of the second block, 8. However, the old code computed it as `offset.x * texel_sizes_[aspect_index] = 4 * 0.5 = 2`.

The problem was that the rest of the code was correctly computing y-offsets and spans. For example, the span of a 4x4 copy is correctly computed as 8. This created a false-positive overlap if another copy happened to be exactly adjacent, because the base address was __inside__ the region of the previous copy (due to the incorrect x offset calculation).

This change correctly computes the x-offset by taking into account the stride of each block. In the example above, the x-offset at `(x = 4, y = 0)` is now correct: 8.

I also did the same change in Encode3D. 

I created a new unit test. I confirmed that the unit test fails without this change. I also ran all the Windows/Android unit tests.