### PR TITLE
Safe Struct CreatInfo rework

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -47,10 +47,10 @@ WriteLockGuard BestPractices::WriteLock() {
     }
 }
 
-std::shared_ptr<vvl::CommandBuffer> BestPractices::CreateCmdBufferState(VkCommandBuffer cb,
+std::shared_ptr<vvl::CommandBuffer> BestPractices::CreateCmdBufferState(VkCommandBuffer handle,
                                                                         const VkCommandBufferAllocateInfo* pCreateInfo,
                                                                         const vvl::CommandPool* pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<bp_state::CommandBuffer>(this, cb, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<bp_state::CommandBuffer>(this, handle, pCreateInfo, pool));
 }
 
 bp_state::CommandBuffer::CommandBuffer(BestPractices* bp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -297,9 +297,9 @@ class BestPractices : public ValidationStateTracker {
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                const ErrorObject& error_obj, void* pipe_state) const override;
 
-    bool ValidateCreateComputePipelineArm(const VkComputePipelineCreateInfo& createInfo, const Location& create_info_loc) const;
+    bool ValidateCreateComputePipelineArm(const VkComputePipelineCreateInfo& create_info, const Location& create_info_loc) const;
 
-    bool ValidateCreateComputePipelineAmd(const VkComputePipelineCreateInfo& createInfo, const Location& create_info_loc) const;
+    bool ValidateCreateComputePipelineAmd(const VkComputePipelineCreateInfo& create_info, const Location& create_info_loc) const;
 
     bool CheckPipelineStageFlags(const LogObjectList& objlist, const Location& loc, VkPipelineStageFlags flags) const;
     bool CheckPipelineStageFlags(const LogObjectList& objlist, const Location& loc, VkPipelineStageFlags2KHR flags) const;

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -90,8 +90,8 @@ void BestPractices::RecordBindZcullScope(bp_state::CommandBuffer& cmd_state, VkI
     auto image_state = Get<vvl::Image>(depth_attachment);
     assert(image_state);
 
-    const uint32_t mip_levels = image_state->createInfo.mipLevels;
-    const uint32_t array_layers = image_state->createInfo.arrayLayers;
+    const uint32_t mip_levels = image_state->create_info.mipLevels;
+    const uint32_t array_layers = image_state->create_info.arrayLayers;
 
     auto& tree = cmd_state.nv.zcull_per_image[depth_attachment];
     if (tree.states.empty()) {

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -31,13 +31,12 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
     auto* rp_state = cb_state->activeRenderPass.get();
     auto* fb_state = cb_state->activeFramebuffer.get();
-    const bool is_secondary = cb_state->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY;
 
     if (rectCount == 0 || !rp_state) {
         return;
     }
 
-    if (!is_secondary && !fb_state && !rp_state->use_dynamic_rendering && !rp_state->use_dynamic_rendering_inherited) {
+    if (!cb_state->IsSeconary() && !fb_state && !rp_state->use_dynamic_rendering && !rp_state->use_dynamic_rendering_inherited) {
         return;
     }
 
@@ -105,7 +104,7 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
 
 bool BestPractices::ClearAttachmentsIsFullClear(const bp_state::CommandBuffer& cb_state, uint32_t rectCount,
                                                 const VkClearRect* pRects) const {
-    if (cb_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+    if (cb_state.IsSeconary()) {
         // We don't know the accurate render area in a secondary,
         // so assume we clear the entire frame buffer.
         // This is resolved in CmdExecuteCommands where we can check if the clear is a full clear.
@@ -201,7 +200,7 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
     const auto cb_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
     if (!cb_state) return skip;
 
-    if (cb_state->createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+    if (cb_state->IsSeconary()) {
         // Defer checks to ExecuteCommands.
         return skip;
     }

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -68,7 +68,7 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
         // TODO: Implement other best practices for dynamic rendering
 
     } else {
-        auto& subpass = rp_state->createInfo.pSubpasses[cb_state->GetActiveSubpass()];
+        auto& subpass = rp_state->create_info.pSubpasses[cb_state->GetActiveSubpass()];
         for (uint32_t i = 0; i < attachmentCount; i++) {
             auto& attachment = pClearAttachments[i];
             uint32_t fb_attachment = VK_ATTACHMENT_UNUSED;
@@ -94,7 +94,7 @@ void BestPractices::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuff
                     RecordAttachmentAccess(*cb_state, fb_attachment, aspects);
                 }
                 if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-                    const VkFormat format = rp_state->createInfo.pAttachments[fb_attachment].format;
+                    const VkFormat format = rp_state->create_info.pAttachments[fb_attachment].format;
                     RecordClearColor(format, attachment.clearValue.color);
                 }
             }
@@ -154,7 +154,7 @@ bool BestPractices::ValidateClearAttachment(const bp_state::CommandBuffer& cb_st
     }
 
     if ((new_aspects & VK_IMAGE_ASPECT_COLOR_BIT) &&
-        rp->createInfo.pAttachments[fb_attachment].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
+        rp->create_info.pAttachments[fb_attachment].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
         const LogObjectList objlist(cb_state.Handle(), rp->Handle());
         skip |=
             LogPerformanceWarning(kVUID_BestPractices_ClearAttachments_ClearAfterLoad, objlist, loc,
@@ -165,7 +165,7 @@ bool BestPractices::ValidateClearAttachment(const bp_state::CommandBuffer& cb_st
     }
 
     if ((new_aspects & VK_IMAGE_ASPECT_DEPTH_BIT) &&
-        rp->createInfo.pAttachments[fb_attachment].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
+        rp->create_info.pAttachments[fb_attachment].loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
         const LogObjectList objlist(cb_state.Handle(), rp->Handle());
         skip |=
             LogPerformanceWarning(kVUID_BestPractices_ClearAttachments_ClearAfterLoad, objlist, loc,
@@ -180,7 +180,7 @@ bool BestPractices::ValidateClearAttachment(const bp_state::CommandBuffer& cb_st
     }
 
     if ((new_aspects & VK_IMAGE_ASPECT_STENCIL_BIT) &&
-        rp->createInfo.pAttachments[fb_attachment].stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
+        rp->create_info.pAttachments[fb_attachment].stencilLoadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
         const LogObjectList objlist(cb_state.Handle(), rp->Handle());
         skip |=
             LogPerformanceWarning(kVUID_BestPractices_ClearAttachments_ClearAfterLoad, objlist, loc,
@@ -237,7 +237,7 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
             }
 
         } else {
-            const auto& subpass = rp->createInfo.pSubpasses[cb_state->GetActiveSubpass()];
+            const auto& subpass = rp->create_info.pSubpasses[cb_state->GetActiveSubpass()];
 
             if (is_full_clear) {
                 for (uint32_t i = 0; i < attachmentCount; i++) {
@@ -258,14 +258,14 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
                     }
                 }
             }
-            if (VendorCheckEnabled(kBPVendorNVIDIA) && rp->createInfo.pAttachments) {
+            if (VendorCheckEnabled(kBPVendorNVIDIA) && rp->create_info.pAttachments) {
                 for (uint32_t attachment_idx = 0; attachment_idx < attachmentCount; ++attachment_idx) {
                     const auto& attachment = pAttachments[attachment_idx];
 
                     if (attachment.aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) {
                         const uint32_t fb_attachment = subpass.pColorAttachments[attachment.colorAttachment].attachment;
                         if (fb_attachment != VK_ATTACHMENT_UNUSED) {
-                            const VkFormat format = rp->createInfo.pAttachments[fb_attachment].format;
+                            const VkFormat format = rp->create_info.pAttachments[fb_attachment].format;
                             skip |= ValidateClearColor(commandBuffer, format, attachment.clearValue.color, error_obj.location);
                         }
                     }
@@ -327,8 +327,8 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
 bool BestPractices::ValidateCmdResolveImage(VkCommandBuffer command_buffer, VkImage src_image, VkImage dst_image,
                                             const Location& loc) const {
     bool skip = false;
-    auto src_image_type = Get<vvl::Image>(src_image)->createInfo.imageType;
-    auto dst_image_type = Get<vvl::Image>(dst_image)->createInfo.imageType;
+    auto src_image_type = Get<vvl::Image>(src_image)->create_info.imageType;
+    auto dst_image_type = Get<vvl::Image>(dst_image)->create_info.imageType;
 
     if (src_image_type != dst_image_type) {
         const LogObjectList objlist(command_buffer, src_image, dst_image);
@@ -420,7 +420,7 @@ void BestPractices::PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffe
     }
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        RecordClearColor(dst->createInfo.format, *pColor);
+        RecordClearColor(dst->create_info.format, *pColor);
     }
 }
 
@@ -556,7 +556,7 @@ bool BestPractices::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
                                       VendorSpecificTag(kBPVendorAMD));
     }
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        skip |= ValidateClearColor(commandBuffer, dst->createInfo.format, *pColor, error_obj.location);
+        skip |= ValidateClearColor(commandBuffer, dst->create_info.format, *pColor, error_obj.location);
     }
 
     return skip;
@@ -595,8 +595,8 @@ bool BestPractices::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
         auto dst_state = Get<vvl::Image>(dstImage);
 
         if (src_state && dst_state) {
-            VkImageTiling src_Tiling = src_state->createInfo.tiling;
-            VkImageTiling dst_Tiling = dst_state->createInfo.tiling;
+            VkImageTiling src_Tiling = src_state->create_info.tiling;
+            VkImageTiling dst_Tiling = dst_state->create_info.tiling;
             if (src_Tiling != dst_Tiling && (src_Tiling == VK_IMAGE_TILING_LINEAR || dst_Tiling == VK_IMAGE_TILING_LINEAR)) {
                 const LogObjectList objlist(commandBuffer, srcImage, dstImage);
                 skip |= LogPerformanceWarning(kVUID_BestPractices_vkImage_AvoidImageToImageCopy, objlist, error_obj.location,

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -182,7 +182,7 @@ bool BestPractices::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice devic
     return skip;
 }
 
-std::shared_ptr<vvl::DescriptorPool> BestPractices::CreateDescriptorPoolState(VkDescriptorPool pool,
+std::shared_ptr<vvl::DescriptorPool> BestPractices::CreateDescriptorPoolState(VkDescriptorPool handle,
                                                                               const VkDescriptorPoolCreateInfo* pCreateInfo) {
-    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(this, pool, pCreateInfo));
+    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(this, handle, pCreateInfo));
 }

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -32,8 +32,8 @@ bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Locati
     if (pipe) {
         const auto& rp_state = pipe->RenderPassState();
         if (rp_state) {
-            for (uint32_t i = 0; i < rp_state->createInfo.subpassCount; ++i) {
-                const auto& subpass = rp_state->createInfo.pSubpasses[i];
+            for (uint32_t i = 0; i < rp_state->create_info.subpassCount; ++i) {
+                const auto& subpass = rp_state->create_info.pSubpasses[i];
                 const auto* ds_state = pipe->DepthStencilState();
                 const uint32_t depth_stencil_attachment =
                     GetSubpassDepthStencilAttachmentIndex(ds_state, subpass.pDepthStencilAttachment);

--- a/layers/best_practices/bp_framebuffer.cpp
+++ b/layers/best_practices/bp_framebuffer.cpp
@@ -39,7 +39,7 @@ bool BestPractices::ValidateAttachments(const VkRenderPassCreateInfo2* rpci, uin
 
         auto view_state = Get<vvl::ImageView>(image_views[i]);
         if (view_state) {
-            const auto& ici = view_state->image_state->createInfo;
+            const auto& ici = view_state->image_state->create_info;
 
             const bool image_is_transient = (ici.usage & VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT) != 0;
 
@@ -82,7 +82,7 @@ bool BestPractices::PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
 
     auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     if (rp_state && !(pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
-        skip |= ValidateAttachments(rp_state->createInfo.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
+        skip |= ValidateAttachments(rp_state->create_info.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
                                     error_obj.location);
     }
 

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -508,8 +508,8 @@ void BestPractices::ManualPostCallRecordQueueSubmit(VkQueue queue, uint32_t subm
     num_queue_submissions_ += submitCount;
 }
 
-std::shared_ptr<vvl::PhysicalDevice> BestPractices::CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) {
-    return std::static_pointer_cast<vvl::PhysicalDevice>(std::make_shared<bp_state::PhysicalDevice>(phys_dev));
+std::shared_ptr<vvl::PhysicalDevice> BestPractices::CreatePhysicalDeviceState(VkPhysicalDevice handle) {
+    return std::static_pointer_cast<vvl::PhysicalDevice>(std::make_shared<bp_state::PhysicalDevice>(handle));
 }
 
 bp_state::PhysicalDevice* BestPractices::GetPhysicalDeviceState() {

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -919,7 +919,7 @@ void BestPractices::RecordAttachmentClearAttachments(bp_state::CommandBuffer& cm
         return;
     }
 
-    if (cmd_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+    if (cmd_state.IsSeconary()) {
         // The first command might be a clear, but might not be the first in the render pass, defer any checks until
         // CmdExecuteCommands.
         rp_state.earlyClearAttachments.push_back(

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -23,9 +23,9 @@
 #include "best_practices/bp_state.h"
 #include "state_tracker/render_pass_state.h"
 
-static inline bool RenderPassUsesAttachmentAsResolve(const safe_VkRenderPassCreateInfo2& createInfo, uint32_t attachment) {
-    for (uint32_t subpass = 0; subpass < createInfo.subpassCount; subpass++) {
-        const auto& subpass_info = createInfo.pSubpasses[subpass];
+static inline bool RenderPassUsesAttachmentAsResolve(const safe_VkRenderPassCreateInfo2& create_info, uint32_t attachment) {
+    for (uint32_t subpass = 0; subpass < create_info.subpassCount; subpass++) {
+        const auto& subpass_info = create_info.pSubpasses[subpass];
         if (subpass_info.pResolveAttachments) {
             for (uint32_t i = 0; i < subpass_info.colorAttachmentCount; i++) {
                 if (subpass_info.pResolveAttachments[i].attachment == attachment) return true;
@@ -36,9 +36,9 @@ static inline bool RenderPassUsesAttachmentAsResolve(const safe_VkRenderPassCrea
     return false;
 }
 
-static inline bool RenderPassUsesAttachmentOnTile(const safe_VkRenderPassCreateInfo2& createInfo, uint32_t attachment) {
-    for (uint32_t subpass = 0; subpass < createInfo.subpassCount; subpass++) {
-        const auto& subpass_info = createInfo.pSubpasses[subpass];
+static inline bool RenderPassUsesAttachmentOnTile(const safe_VkRenderPassCreateInfo2& create_info, uint32_t attachment) {
+    for (uint32_t subpass = 0; subpass < create_info.subpassCount; subpass++) {
+        const auto& subpass_info = create_info.pSubpasses[subpass];
 
         // If an attachment is ever used as a color attachment,
         // resolve attachment or depth stencil attachment,
@@ -60,13 +60,13 @@ static inline bool RenderPassUsesAttachmentOnTile(const safe_VkRenderPassCreateI
     return false;
 }
 
-static inline bool RenderPassUsesAttachmentAsImageOnly(const safe_VkRenderPassCreateInfo2& createInfo, uint32_t attachment) {
-    if (RenderPassUsesAttachmentOnTile(createInfo, attachment)) {
+static inline bool RenderPassUsesAttachmentAsImageOnly(const safe_VkRenderPassCreateInfo2& create_info, uint32_t attachment) {
+    if (RenderPassUsesAttachmentOnTile(create_info, attachment)) {
         return false;
     }
 
-    for (uint32_t subpass = 0; subpass < createInfo.subpassCount; subpass++) {
-        const auto& subpassInfo = createInfo.pSubpasses[subpass];
+    for (uint32_t subpass = 0; subpass < create_info.subpassCount; subpass++) {
+        const auto& subpassInfo = create_info.pSubpasses[subpass];
 
         for (uint32_t i = 0; i < subpassInfo.inputAttachmentCount; i++) {
             if (subpassInfo.pInputAttachments[i].attachment == attachment) {
@@ -176,15 +176,15 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
 
     auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
-        if (rp_state->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
+        if (rp_state->create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
             const VkRenderPassAttachmentBeginInfo* rpabi = vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
             if (rpabi) {
-                skip |= ValidateAttachments(rp_state->createInfo.ptr(), rpabi->attachmentCount, rpabi->pAttachments, loc);
+                skip |= ValidateAttachments(rp_state->create_info.ptr(), rpabi->attachmentCount, rpabi->pAttachments, loc);
             }
         }
         // Check if any attachments have LOAD operation on them
-        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
-            const auto& attachment = rp_state->createInfo.pAttachments[att];
+        for (uint32_t att = 0; att < rp_state->create_info.attachmentCount; att++) {
+            const auto& attachment = rp_state->create_info.pAttachments[att];
 
             bool attachment_has_readback = false;
             if (!vkuFormatIsStencilOnly(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_LOAD) {
@@ -198,7 +198,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
             bool attachment_needs_readback = false;
 
             // Check if the attachment is actually used in any subpass on-tile
-            if (attachment_has_readback && RenderPassUsesAttachmentOnTile(rp_state->createInfo, att)) {
+            if (attachment_has_readback && RenderPassUsesAttachmentOnTile(rp_state->create_info, att)) {
                 attachment_needs_readback = true;
             }
 
@@ -221,8 +221,8 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
 
         bool clearing = false;
 
-        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
-            const auto& attachment = rp_state->createInfo.pAttachments[att];
+        for (uint32_t att = 0; att < rp_state->create_info.attachmentCount; att++) {
+            const auto& attachment = rp_state->create_info.pAttachments[att];
 
             if (attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                 clearing = true;
@@ -242,7 +242,7 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
         }
 
         // Check if there are more clearValues than attachments
-        if (pRenderPassBegin->clearValueCount > rp_state->createInfo.attachmentCount) {
+        if (pRenderPassBegin->clearValueCount > rp_state->create_info.attachmentCount) {
             // Flag as warning because the overflowing clearValues will be ignored and could even be undefined on certain platforms.
             // This could signal a bug and there seems to be no reason for this to happen on purpose.
             const LogObjectList objlist(commandBuffer, pRenderPassBegin->renderPass);
@@ -251,12 +251,12 @@ bool BestPractices::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, co
                            "This render pass has VkRenderPassBeginInfo.clearValueCount > VkRenderPassCreateInfo.attachmentCount "
                            "(%" PRIu32 " > %" PRIu32
                            ") and as such the clearValues that do not have a corresponding attachment will be ignored.",
-                           pRenderPassBegin->clearValueCount, rp_state->createInfo.attachmentCount);
+                           pRenderPassBegin->clearValueCount, rp_state->create_info.attachmentCount);
         }
 
-        if (VendorCheckEnabled(kBPVendorNVIDIA) && rp_state->createInfo.pAttachments) {
+        if (VendorCheckEnabled(kBPVendorNVIDIA) && rp_state->create_info.pAttachments) {
             for (uint32_t i = 0; i < pRenderPassBegin->clearValueCount; ++i) {
-                const auto& attachment = rp_state->createInfo.pAttachments[i];
+                const auto& attachment = rp_state->create_info.pAttachments[i];
                 if (attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                     const auto& clear_color = pRenderPassBegin->pClearValues[i].color;
                     skip |= ValidateClearColor(commandBuffer, attachment.format, clear_color, loc);
@@ -288,15 +288,15 @@ bool BestPractices::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, con
         // Check if accidently set resolve mode to none since everything else looks like it should be resolving
         if (color_attachment.resolveMode == VK_RESOLVE_MODE_NONE && color_attachment.resolveImageView != VK_NULL_HANDLE) {
             auto resolve_image_view_state = Get<vvl::ImageView>(color_attachment.resolveImageView);
-            if (resolve_image_view_state && resolve_image_view_state->image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT &&
-                image_view_state->image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
+            if (resolve_image_view_state && resolve_image_view_state->image_state->create_info.samples == VK_SAMPLE_COUNT_1_BIT &&
+                image_view_state->image_state->create_info.samples != VK_SAMPLE_COUNT_1_BIT) {
                 const LogObjectList objlist(commandBuffer, resolve_image_view_state->Handle(), image_view_state->Handle());
                 skip |= LogWarning(kVUID_BestPractices_RenderingInfo_ResolveModeNone, commandBuffer,
                                    color_attachment_info.dot(Field::resolveMode),
                                    "is VK_RESOLVE_MODE_NONE but resolveImageView is pointed to a valid VkImageView with "
                                    "VK_SAMPLE_COUNT_1_BIT and imageView is pointed to a VkImageView with %s. If "
                                    "VK_RESOLVE_MODE_NONE is set, the resolveImageView value is ignored.",
-                                   string_VkSampleCountFlagBits(image_view_state->image_state->createInfo.samples));
+                                   string_VkSampleCountFlagBits(image_view_state->image_state->create_info.samples));
             }
         }
     }
@@ -392,7 +392,7 @@ void BestPractices::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         vvl::ImageView* depth_image_view = nullptr;
 
-        const auto depth_attachment = rp->createInfo.pSubpasses[cb_state->GetActiveSubpass()].pDepthStencilAttachment;
+        const auto depth_attachment = rp->create_info.pSubpasses[cb_state->GetActiveSubpass()].pDepthStencilAttachment;
         if (depth_attachment) {
             const uint32_t attachment_index = depth_attachment->attachment;
             if (attachment_index != VK_ATTACHMENT_UNUSED) {
@@ -419,11 +419,11 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
     auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
         // Check load ops
-        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
-            const auto& attachment = rp_state->createInfo.pAttachments[att];
+        for (uint32_t att = 0; att < rp_state->create_info.attachmentCount; att++) {
+            const auto& attachment = rp_state->create_info.pAttachments[att];
 
-            if (!RenderPassUsesAttachmentAsImageOnly(rp_state->createInfo, att) &&
-                !RenderPassUsesAttachmentOnTile(rp_state->createInfo, att)) {
+            if (!RenderPassUsesAttachmentAsImageOnly(rp_state->create_info, att) &&
+                !RenderPassUsesAttachmentOnTile(rp_state->create_info, att)) {
                 continue;
             }
 
@@ -441,31 +441,31 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
             } else if ((!vkuFormatIsStencilOnly(attachment.format) && attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) ||
                        (vkuFormatHasStencil(attachment.format) && attachment.stencilLoadOp == VK_ATTACHMENT_LOAD_OP_CLEAR)) {
                 usage = IMAGE_SUBRESOURCE_USAGE_BP::RENDER_PASS_CLEARED;
-            } else if (RenderPassUsesAttachmentAsImageOnly(rp_state->createInfo, att)) {
+            } else if (RenderPassUsesAttachmentAsImageOnly(rp_state->create_info, att)) {
                 usage = IMAGE_SUBRESOURCE_USAGE_BP::DESCRIPTOR_ACCESS;
             }
 
             auto framebuffer = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
             std::shared_ptr<vvl::ImageView> image_view = nullptr;
 
-            if (framebuffer->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
+            if (framebuffer->create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
                 const VkRenderPassAttachmentBeginInfo* rpabi =
                     vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
                 if (rpabi) {
                     image_view = Get<vvl::ImageView>(rpabi->pAttachments[att]);
                 }
             } else {
-                image_view = Get<vvl::ImageView>(framebuffer->createInfo.pAttachments[att]);
+                image_view = Get<vvl::ImageView>(framebuffer->create_info.pAttachments[att]);
             }
 
             QueueValidateImageView(cb->queue_submit_functions, Func::vkCmdBeginRenderPass, image_view.get(), usage);
         }
 
         // Check store ops
-        for (uint32_t att = 0; att < rp_state->createInfo.attachmentCount; att++) {
-            const auto& attachment = rp_state->createInfo.pAttachments[att];
+        for (uint32_t att = 0; att < rp_state->create_info.attachmentCount; att++) {
+            const auto& attachment = rp_state->create_info.pAttachments[att];
 
-            if (!RenderPassUsesAttachmentOnTile(rp_state->createInfo, att)) {
+            if (!RenderPassUsesAttachmentOnTile(rp_state->create_info, att)) {
                 continue;
             }
 
@@ -485,14 +485,14 @@ void BestPractices::RecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, cons
             auto framebuffer = Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
 
             std::shared_ptr<vvl::ImageView> image_view;
-            if (framebuffer->createInfo.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
+            if (framebuffer->create_info.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) {
                 const VkRenderPassAttachmentBeginInfo* rpabi =
                     vku::FindStructInPNextChain<VkRenderPassAttachmentBeginInfo>(pRenderPassBegin->pNext);
                 if (rpabi) {
                     image_view = Get<vvl::ImageView>(rpabi->pAttachments[att]);
                 }
             } else {
-                image_view = Get<vvl::ImageView>(framebuffer->createInfo.pAttachments[att]);
+                image_view = Get<vvl::ImageView>(framebuffer->create_info.pAttachments[att]);
             }
 
             QueueValidateImageView(cb->queue_submit_functions_after_render_pass, Func::vkCmdEndRenderPass, image_view.get(), usage);
@@ -529,19 +529,19 @@ void BestPractices::RecordCmdBeginRenderingCommon(VkCommandBuffer commandBuffer)
             }
 
         } else {
-            if (rp->createInfo.pAttachments) {
-                if (rp->createInfo.subpassCount > 0) {
-                    const auto depth_attachment = rp->createInfo.pSubpasses[0].pDepthStencilAttachment;
+            if (rp->create_info.pAttachments) {
+                if (rp->create_info.subpassCount > 0) {
+                    const auto depth_attachment = rp->create_info.pSubpasses[0].pDepthStencilAttachment;
                     if (depth_attachment) {
                         const uint32_t attachment_index = depth_attachment->attachment;
                         if (attachment_index != VK_ATTACHMENT_UNUSED) {
-                            load_op.emplace(rp->createInfo.pAttachments[attachment_index].loadOp);
+                            load_op.emplace(rp->create_info.pAttachments[attachment_index].loadOp);
                             depth_image_view = (*cb_state->active_attachments)[attachment_index];
                         }
                     }
                 }
                 for (uint32_t i = 0; i < cb_state->active_render_pass_begin_info.clearValueCount; ++i) {
-                    const auto& attachment = rp->createInfo.pAttachments[i];
+                    const auto& attachment = rp->create_info.pAttachments[i];
                     if (attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                         const auto& clear_color = cb_state->active_render_pass_begin_info.pClearValues[i].color;
                         RecordClearColor(attachment.format, clear_color);
@@ -586,13 +586,13 @@ void BestPractices::RecordCmdEndRenderingCommon(VkCommandBuffer commandBuffer) {
                 store_op.emplace(depth_attachment->storeOp);
             }
         } else {
-            if (rp->createInfo.subpassCount > 0) {
-                const uint32_t last_subpass = rp->createInfo.subpassCount - 1;
-                const auto depth_attachment = rp->createInfo.pSubpasses[last_subpass].pDepthStencilAttachment;
+            if (rp->create_info.subpassCount > 0) {
+                const uint32_t last_subpass = rp->create_info.subpassCount - 1;
+                const auto depth_attachment = rp->create_info.pSubpasses[last_subpass].pDepthStencilAttachment;
                 if (depth_attachment) {
                     const uint32_t attachment = depth_attachment->attachment;
                     if (attachment != VK_ATTACHMENT_UNUSED) {
-                        store_op.emplace(rp->createInfo.pAttachments[attachment].storeOp);
+                        store_op.emplace(rp->create_info.pAttachments[attachment].storeOp);
                     }
                 }
             }
@@ -714,11 +714,11 @@ void BestPractices::PostRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, 
     auto rp_state = Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     if (rp_state) {
         // track depth / color attachment usage within the renderpass
-        for (size_t i = 0; i < rp_state->createInfo.subpassCount; i++) {
+        for (size_t i = 0; i < rp_state->create_info.subpassCount; i++) {
             // record if depth/color attachments are in use for this renderpass
-            if (rp_state->createInfo.pSubpasses[i].pDepthStencilAttachment != nullptr) render_pass_state.depthAttachment = true;
+            if (rp_state->create_info.pSubpasses[i].pDepthStencilAttachment != nullptr) render_pass_state.depthAttachment = true;
 
-            if (rp_state->createInfo.pSubpasses[i].colorAttachmentCount > 0) render_pass_state.colorAttachment = true;
+            if (rp_state->create_info.pSubpasses[i].colorAttachmentCount > 0) render_pass_state.colorAttachment = true;
         }
         if (cb_state->activeRenderPass) {
             // Spec states that after BeginRenderPass all resources should be rebound
@@ -833,13 +833,13 @@ bool BestPractices::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, cons
         // the optimal thing to do is to defer the clear until you're actually
         // going to render to the image.
 
-        uint32_t num_attachments = rp->createInfo.attachmentCount;
+        uint32_t num_attachments = rp->create_info.attachmentCount;
         for (uint32_t i = 0; i < num_attachments; i++) {
-            if (!RenderPassUsesAttachmentOnTile(rp->createInfo, i) || RenderPassUsesAttachmentAsResolve(rp->createInfo, i)) {
+            if (!RenderPassUsesAttachmentOnTile(rp->create_info, i) || RenderPassUsesAttachmentAsResolve(rp->create_info, i)) {
                 continue;
             }
 
-            auto& attachment = rp->createInfo.pAttachments[i];
+            auto& attachment = rp->create_info.pAttachments[i];
 
             VkImageAspectFlags bandwidth_aspects = 0;
 

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -31,15 +31,15 @@ class BestPractices;
 namespace bp_state {
 class Image : public vvl::Image {
   public:
-    Image(const ValidationStateTracker* dev_data, VkImage img, const VkImageCreateInfo* pCreateInfo,
+    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo,
           VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, features) {
+        : vvl::Image(dev_data, handle, pCreateInfo, features) {
         SetupUsages();
     }
 
-    Image(const ValidationStateTracker* dev_data, VkImage img, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, swapchain, swapchain_index, features) {
+        : vvl::Image(dev_data, handle, pCreateInfo, swapchain, swapchain_index, features) {
         SetupUsages();
     }
 
@@ -100,18 +100,18 @@ class PhysicalDevice : public vvl::PhysicalDevice {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR swapchain)
-        : vvl::Swapchain(dev_data, pCreateInfo, swapchain) {}
+    Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
+        : vvl::Swapchain(dev_data, pCreateInfo, handle) {}
 
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
 };
 
 class DeviceMemory : public vvl::DeviceMemory {
   public:
-    DeviceMemory(VkDeviceMemory mem, const VkMemoryAllocateInfo* p_alloc_info, uint64_t fake_address,
+    DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo* pAllocateInfo, uint64_t fake_address,
                  const VkMemoryType& memory_type, const VkMemoryHeap& memory_heap,
                  std::optional<vvl::DedicatedBinding>&& dedicated_binding, uint32_t physical_device_count)
-        : vvl::DeviceMemory(mem, p_alloc_info, fake_address, memory_type, memory_heap, std::move(dedicated_binding),
+        : vvl::DeviceMemory(handle, pAllocateInfo, fake_address, memory_type, memory_heap, std::move(dedicated_binding),
                             physical_device_count) {}
 
     std::optional<float> dynamic_priority;  // VK_EXT_pageable_device_local_memory priority
@@ -189,7 +189,7 @@ struct CommandBufferStateNV {
 
 class CommandBuffer : public vvl::CommandBuffer {
   public:
-    CommandBuffer(BestPractices* bp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CommandBuffer(BestPractices* bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
                   const vvl::CommandPool* pool);
 
     RenderPassState render_pass_state;
@@ -203,8 +203,8 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 class DescriptorPool : public vvl::DescriptorPool {
   public:
-    DescriptorPool(ValidationStateTracker* dev, const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo* pCreateInfo)
-        : vvl::DescriptorPool(dev, pool, pCreateInfo) {}
+    DescriptorPool(ValidationStateTracker* dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
+        : vvl::DescriptorPool(dev, handle, pCreateInfo) {}
 
     uint32_t freed_count{0};
 };

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -67,9 +67,9 @@ class Image : public vvl::Image {
 
   private:
     void SetupUsages() {
-        usages_.resize(createInfo.arrayLayers);
+        usages_.resize(create_info.arrayLayers);
         for (auto& mip_vec : usages_) {
-            mip_vec.resize(createInfo.mipLevels, {IMAGE_SUBRESOURCE_USAGE_BP::UNDEFINED, VK_QUEUE_FAMILY_IGNORED});
+            mip_vec.resize(create_info.mipLevels, {IMAGE_SUBRESOURCE_USAGE_BP::UNDEFINED, VK_QUEUE_FAMILY_IGNORED});
         }
     }
     // A 2d vector for all the array layers and mip levels.

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -317,7 +317,7 @@ bool BestPractices::PreCallValidateCmdPipelineBarrier(
             // general with no storage
             if (VendorCheckEnabled(kBPVendorAMD) && image_barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL) {
                 auto image_state = Get<vvl::Image>(pImageMemoryBarriers[i].image);
-                if (!(image_state->createInfo.usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
+                if (!(image_state->create_info.usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
                     const LogObjectList objlist(commandBuffer, pImageMemoryBarriers[i].image);
                     skip |= LogPerformanceWarning(kVUID_BestPractices_vkImage_AvoidGeneral, objlist, error_obj.location,
                                                   "%s VK_IMAGE_LAYOUT_GENERAL should only be used with "

--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -384,7 +384,7 @@ void BestPractices::ManualPostCallRecordGetSwapchainImagesKHR(VkDevice device, V
     }
 }
 
-std::shared_ptr<vvl::Swapchain> BestPractices::CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
-                                                                    VkSwapchainKHR swapchain) {
-    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(this, create_info, swapchain));
+std::shared_ptr<vvl::Swapchain> BestPractices::CreateSwapchainState(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                                    VkSwapchainKHR handle) {
+    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(this, pCreateInfo, handle));
 }

--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -275,8 +275,8 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image)
 
 ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParameters* param)
     : RangeEncoder(image.full_range, param), total_size_(0U) {
-    if (image.createInfo.extent.depth > 1) {
-        limits_.arrayLayer = image.createInfo.extent.depth;
+    if (image.create_info.extent.depth > 1) {
+        limits_.arrayLayer = image.create_info.extent.depth;
     }
     VkSubresourceLayout layout = {};
     VkImageSubresource subres = {};
@@ -284,7 +284,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
     linear_image_ = false;
 
     // WORKAROUND for profile and mock_icd not containing valid VkSubresourceLayout yet. Treat it as optimal image.
-    if (image.createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
+    if (image.create_info.tiling == VK_IMAGE_TILING_LINEAR) {
         const VkImageAspectFlags first_aspect = AspectBit(0);  // AspectBit returns aspects by index
         subres = {first_aspect, 0, 0};
         DispatchGetImageSubresourceLayout(image.store_device_as_workaround, image.VkHandle(), &subres, &layout);
@@ -305,15 +305,16 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
     // aliased resources can be done correctly.
     linear_image_ = false;
 
-    is_compressed_ = vkuFormatIsCompressed(image.createInfo.format);
-    texel_extent_ = vkuFormatTexelBlockExtent(image.createInfo.format);
+    is_compressed_ = vkuFormatIsCompressed(image.create_info.format);
+    texel_extent_ = vkuFormatTexelBlockExtent(image.create_info.format);
 
-    is_3_d_ = image.createInfo.imageType == VK_IMAGE_TYPE_3D;
+    is_3_d_ = image.create_info.imageType == VK_IMAGE_TYPE_3D;
     y_interleave_ = false;
     for (uint32_t aspect_index = 0; aspect_index < limits_.aspect_index; ++aspect_index) {
         subres.aspectMask = static_cast<VkImageAspectFlags>(AspectBit(aspect_index));
         subres_layers.aspectMask = subres.aspectMask;
-        texel_sizes_.push_back(vkuFormatTexelSizeWithAspect(image.createInfo.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
+        texel_sizes_.push_back(
+            vkuFormatTexelSizeWithAspect(image.create_info.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
         IndexType aspect_size = 0;
         for (uint32_t mip_index = 0; mip_index < limits_.mipLevel; ++mip_index) {
             subres_layers.mipLevel = mip_index;
@@ -351,7 +352,7 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
         }
         aspect_sizes_.emplace_back(aspect_size);
         aspect_extent_divisors_.emplace_back(
-            vkuFindMultiplaneExtentDivisors(image.createInfo.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
+            vkuFindMultiplaneExtentDivisors(image.create_info.format, static_cast<VkImageAspectFlagBits>(subres.aspectMask)));
     }
 }
 

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -296,7 +296,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
             }
 
             auto image_state = Get<vvl::Image>(mem_ded_alloc_info->image);
-            const auto *ici = &image_state->createInfo;
+            const auto *ici = &image_state->create_info;
             const Location &dedicated_image_loc = allocate_info_loc.dot(Struct::VkMemoryDedicatedAllocateInfo, Field::image);
 
             //  the format of image must be VK_FORMAT_UNDEFINED or the format returned by

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -78,14 +78,14 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
                              phys_dev_props.limits.maxTexelBufferElements);
         }
         // The sum of range and offset must be less than or equal to the size of buffer
-        if (range + create_info.offset > buffer_state.createInfo.size) {
+        if (range + create_info.offset > buffer_state.create_info.size) {
             skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00931", buffer_state.Handle(), loc.dot(Field::range),
                              "(%" PRIuLEAST64 ") does not equal VK_WHOLE_SIZE, the sum of offset (%" PRIuLEAST64
                              ") and range must be less than or equal to the size of the buffer (%" PRIuLEAST64 ").",
-                             range, create_info.offset, buffer_state.createInfo.size);
+                             range, create_info.offset, buffer_state.create_info.size);
         }
     } else {
-        const VkDeviceSize offset_range = buffer_state.createInfo.size - create_info.offset;
+        const VkDeviceSize offset_range = buffer_state.create_info.size - create_info.offset;
         const VkDeviceSize texels = SafeDivision(offset_range, format_info.block_size) * texel_per_block;
         if (texels > static_cast<VkDeviceSize>(phys_dev_props.limits.maxTexelBufferElements)) {
             skip |= LogError("VUID-VkBufferViewCreateInfo-range-04059", buffer_state.Handle(), loc.dot(Field::range),
@@ -93,7 +93,7 @@ bool CoreChecks::ValidateBufferViewRange(const vvl::Buffer &buffer_state, const 
                              "), %s texel block size (%" PRIu32 "), and texels-per-block (%" PRIuLEAST64
                              ") is a total of (%" PRIuLEAST64
                              ") texels which is more than VkPhysicalDeviceLimits::maxTexelBufferElements (%" PRIuLEAST32 ").",
-                             buffer_state.createInfo.size, create_info.offset, string_VkFormat(format), format_info.block_size,
+                             buffer_state.create_info.size, create_info.offset, string_VkFormat(format), format_info.block_size,
                              texel_per_block, texels, phys_dev_props.limits.maxTexelBufferElements);
         }
     }
@@ -339,10 +339,10 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                                      "VUID-VkBufferViewCreateInfo-buffer-00932", create_info_loc.dot(Field::buffer));
 
     // Buffer view offset must be less than the size of buffer
-    if (pCreateInfo->offset >= buffer_state.createInfo.size) {
+    if (pCreateInfo->offset >= buffer_state.create_info.size) {
         skip |= LogError("VUID-VkBufferViewCreateInfo-offset-00925", buffer_state.Handle(), create_info_loc.dot(Field::offset),
                          "(%" PRIuLEAST64 ") must be less than the size of the buffer (%" PRIuLEAST64 ").", pCreateInfo->offset,
-                         buffer_state.createInfo.size);
+                         buffer_state.create_info.size);
     }
 
     // Buffer view offset must be a multiple of VkPhysicalDeviceLimits::minTexelBufferOffsetAlignment
@@ -468,16 +468,16 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     skip |= ValidateProtectedBuffer(cb_state, *buffer_state, buffer_loc, "VUID-vkCmdFillBuffer-commandBuffer-01811");
     skip |= ValidateUnprotectedBuffer(cb_state, *buffer_state, buffer_loc, "VUID-vkCmdFillBuffer-commandBuffer-01812");
 
-    if (dstOffset >= buffer_state->createInfo.size) {
+    if (dstOffset >= buffer_state->create_info.size) {
         skip |= LogError("VUID-vkCmdFillBuffer-dstOffset-00024", objlist, error_obj.location.dot(Field::dstOffset),
                          "(%" PRIu64 ") is not less than destination buffer (%s) size (%" PRIu64 ").", dstOffset,
-                         FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size);
+                         FormatHandle(dstBuffer).c_str(), buffer_state->create_info.size);
     }
 
-    if ((size != VK_WHOLE_SIZE) && (size > (buffer_state->createInfo.size - dstOffset))) {
+    if ((size != VK_WHOLE_SIZE) && (size > (buffer_state->create_info.size - dstOffset))) {
         skip |= LogError("VUID-vkCmdFillBuffer-size-00027", objlist, error_obj.location.dot(Field::size),
                          "(%" PRIu64 ") is greater than dstBuffer (%s) size (%" PRIu64 ") minus dstOffset (%" PRIu64 ").", size,
-                         FormatHandle(dstBuffer).c_str(), buffer_state->createInfo.size, dstOffset);
+                         FormatHandle(dstBuffer).c_str(), buffer_state->create_info.size, dstOffset);
     }
 
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance1)) {

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -93,7 +93,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
             if (pBeginInfo->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
                 auto framebuffer = Get<vvl::Framebuffer>(info->framebuffer);
                 if (framebuffer) {
-                    if (framebuffer->createInfo.renderPass != info->renderPass) {
+                    if (framebuffer->create_info.renderPass != info->renderPass) {
                         auto render_pass = Get<vvl::RenderPass>(info->renderPass);
                         // renderPass that framebuffer was created with must be compatible with local renderPass
                         skip |= ValidateRenderPassCompatibility(framebuffer->Handle(), *framebuffer->rp_state.get(),
@@ -108,11 +108,11 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                         skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-06000", commandBuffer,
                                          inheritance_loc.dot(Field::renderPass), "is not a valid VkRenderPass.");
                     } else {
-                        if (info->subpass >= render_pass->createInfo.subpassCount) {
+                        if (info->subpass >= render_pass->create_info.subpassCount) {
                             skip |= LogError("VUID-VkCommandBufferBeginInfo-flags-06001", commandBuffer,
                                              inheritance_loc.dot(Field::subpass),
                                              "(%" PRIu32 ") is not valid, renderPass was created with subpassCount %" PRIu32 ".",
-                                             info->subpass, render_pass->createInfo.subpassCount);
+                                             info->subpass, render_pass->create_info.subpassCount);
                         }
                     }
                 } else {
@@ -285,7 +285,7 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                          "vkEndCommandBuffer().",
                          FormatHandle(commandBuffer).c_str());
     } else if (CbState::Recorded == cb_state->state || CbState::InvalidComplete == cb_state->state) {
-        VkCommandPool cmd_pool = cb_state->createInfo.commandPool;
+        VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
         const auto *pool = cb_state->command_pool;
         if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
             const LogObjectList objlist(commandBuffer, cmd_pool);
@@ -358,7 +358,7 @@ bool CoreChecks::PreCallValidateResetCommandBuffer(VkCommandBuffer commandBuffer
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     if (!cb_state) return false;
-    VkCommandPool cmd_pool = cb_state->createInfo.commandPool;
+    VkCommandPool cmd_pool = cb_state->allocate_info.commandPool;
     const auto *pool = cb_state->command_pool;
 
     if (!(VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT & pool->createFlags)) {
@@ -409,10 +409,10 @@ bool CoreChecks::ValidateCmdBindIndexBuffer(const vvl::CommandBuffer &cb_state, 
         skip |= LogError(vuid, objlist, loc.dot(Field::offset), "(%" PRIu64 ") does not fall on alignment (%s) boundary.", offset,
                          string_VkIndexType(indexType));
     }
-    if (offset >= buffer_state->createInfo.size) {
+    if (offset >= buffer_state->create_info.size) {
         vuid = is_2 ? "VUID-vkCmdBindIndexBuffer2KHR-offset-08782" : "VUID-vkCmdBindIndexBuffer-offset-08782";
         skip |= LogError(vuid, objlist, loc.dot(Field::offset), "(%" PRIu64 ") is not less than the size (%" PRIu64 ").", offset,
-                         buffer_state->createInfo.size);
+                         buffer_state->create_info.size);
     }
 
     return skip;
@@ -443,11 +443,11 @@ bool CoreChecks::PreCallValidateCmdBindIndexBuffer2KHR(VkCommandBuffer commandBu
             skip |= LogError("VUID-vkCmdBindIndexBuffer2KHR-size-08767", objlist, error_obj.location.dot(Field::size),
                              "(%" PRIu64 ") does not fall on alignment (%s) boundary.", size, string_VkIndexType(indexType));
         }
-        if ((offset + size) > buffer_state->createInfo.size) {
+        if ((offset + size) > buffer_state->create_info.size) {
             const LogObjectList objlist(commandBuffer, buffer);
             skip |= LogError("VUID-vkCmdBindIndexBuffer2KHR-size-08768", objlist, error_obj.location.dot(Field::size),
                              "(%" PRIu64 ") + offset (%" PRIu64 ") is larger than the buffer size (%" PRIu64 ").", size, offset,
-                             buffer_state->createInfo.size);
+                             buffer_state->create_info.size);
         }
     }
     return skip;
@@ -471,10 +471,10 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers(VkCommandBuffer commandBuff
                                          "VUID-vkCmdBindVertexBuffers-pBuffers-00627", error_obj.location.dot(Field::pBuffers, i));
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *buffer_state, error_obj.location.dot(Field::pBuffers, i),
                                               "VUID-vkCmdBindVertexBuffers-pBuffers-00628");
-        if (pOffsets[i] >= buffer_state->createInfo.size) {
-            skip |=
-                LogError("VUID-vkCmdBindVertexBuffers-pOffsets-00626", objlist, error_obj.location.dot(Field::pOffsets, i),
-                         "(%" PRIu64 ") is larger than the buffer size (%" PRIu64 ").", pOffsets[i], buffer_state->createInfo.size);
+        if (pOffsets[i] >= buffer_state->create_info.size) {
+            skip |= LogError("VUID-vkCmdBindVertexBuffers-pOffsets-00626", objlist, error_obj.location.dot(Field::pOffsets, i),
+                             "(%" PRIu64 ") is larger than the buffer size (%" PRIu64 ").", pOffsets[i],
+                             buffer_state->create_info.size);
         }
     }
     return skip;
@@ -499,13 +499,13 @@ bool CoreChecks::PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, V
     skip |= ValidateCmd(cb_state, error_obj.location);
     skip |= ValidateProtectedBuffer(cb_state, *dst_buffer_state, buffer_loc, "VUID-vkCmdUpdateBuffer-commandBuffer-01813");
     skip |= ValidateUnprotectedBuffer(cb_state, *dst_buffer_state, buffer_loc, "VUID-vkCmdUpdateBuffer-commandBuffer-01814");
-    if (dstOffset >= dst_buffer_state->createInfo.size) {
+    if (dstOffset >= dst_buffer_state->create_info.size) {
         skip |= LogError("VUID-vkCmdUpdateBuffer-dstOffset-00032", objlist, error_obj.location.dot(Field::dstOffset),
-                         "(%" PRIu64 ") is not less than the size (%" PRIu64 ").", dstOffset, dst_buffer_state->createInfo.size);
-    } else if (dataSize > dst_buffer_state->createInfo.size - dstOffset) {
+                         "(%" PRIu64 ") is not less than the size (%" PRIu64 ").", dstOffset, dst_buffer_state->create_info.size);
+    } else if (dataSize > dst_buffer_state->create_info.size - dstOffset) {
         skip |= LogError("VUID-vkCmdUpdateBuffer-dataSize-00033", objlist, error_obj.location.dot(Field::dataSize),
                          "(%" PRIu64 ") is not less than the buffer size (%" PRIu64 ") minus dstOffset (%" PRIu64 ").", dataSize,
-                         dst_buffer_state->createInfo.size, dstOffset);
+                         dst_buffer_state->create_info.size, dstOffset);
     }
     return skip;
 }
@@ -529,31 +529,31 @@ bool CoreChecks::ValidateSecondaryCommandBufferState(const vvl::CommandBuffer &c
             if (!query_pool_state) {
                 continue;
             }
-            if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS &&
+            if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PIPELINE_STATISTICS &&
                 sub_cb_state.beginInfo.pInheritanceInfo) {
                 VkQueryPipelineStatisticFlags cmd_buf_statistics = sub_cb_state.beginInfo.pInheritanceInfo->pipelineStatistics;
-                if ((cmd_buf_statistics & query_pool_state->createInfo.pipelineStatistics) !=
-                    query_pool_state->createInfo.pipelineStatistics) {
+                if ((cmd_buf_statistics & query_pool_state->create_info.pipelineStatistics) !=
+                    query_pool_state->create_info.pipelineStatistics) {
                     const LogObjectList objlist(cb_state.Handle(), sub_cb_state.Handle(), query_object.pool);
-                    skip |= LogError("VUID-vkCmdExecuteCommands-commandBuffer-00104", objlist, cb_loc,
-                                     "was created with pInheritanceInfo::pipelineStatistics %s but the active query pool (%s) was "
-                                     "created with %s.",
-                                     string_VkQueryPipelineStatisticFlags(cmd_buf_statistics).c_str(),
-                                     FormatHandle(query_object.pool).c_str(),
-                                     string_VkQueryPipelineStatisticFlags(query_pool_state->createInfo.pipelineStatistics).c_str());
+                    skip |= LogError(
+                        "VUID-vkCmdExecuteCommands-commandBuffer-00104", objlist, cb_loc,
+                        "was created with pInheritanceInfo::pipelineStatistics %s but the active query pool (%s) was "
+                        "created with %s.",
+                        string_VkQueryPipelineStatisticFlags(cmd_buf_statistics).c_str(), FormatHandle(query_object.pool).c_str(),
+                        string_VkQueryPipelineStatisticFlags(query_pool_state->create_info.pipelineStatistics).c_str());
                 }
             }
-            active_types.insert(query_pool_state->createInfo.queryType);
+            active_types.insert(query_pool_state->create_info.queryType);
         }
         for (const auto &query_object : sub_cb_state.startedQueries) {
             auto query_pool_state = Get<vvl::QueryPool>(query_object.pool);
-            if (query_pool_state && active_types.count(query_pool_state->createInfo.queryType)) {
+            if (query_pool_state && active_types.count(query_pool_state->create_info.queryType)) {
                 const LogObjectList objlist(cb_state.Handle(), sub_cb_state.Handle(), query_object.pool);
                 skip |= LogError("VUID-vkCmdExecuteCommands-pCommandBuffers-00105", objlist, cb_loc,
                                  "called with invalid %s which has invalid active %s"
                                  " of type %s but a query of that type has been started on secondary command buffer %s.",
                                  FormatHandle(cb_state).c_str(), FormatHandle(query_object.pool).c_str(),
-                                 string_VkQueryType(query_pool_state->createInfo.queryType), FormatHandle(sub_cb_state).c_str());
+                                 string_VkQueryType(query_pool_state->create_info.queryType), FormatHandle(sub_cb_state).c_str());
             }
         }
     }
@@ -821,7 +821,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     const QueryObject *active_occlusion_query = nullptr;
     for (const auto &active_query : cb_state.activeQueries) {
         auto query_pool_state = Get<vvl::QueryPool>(active_query.pool);
-        const auto queryType = query_pool_state->createInfo.queryType;
+        const auto queryType = query_pool_state->create_info.queryType;
         if (queryType == VK_QUERY_TYPE_OCCLUSION) {
             active_occlusion_query = &active_query;
         }
@@ -1363,14 +1363,14 @@ bool CoreChecks::ValidateCmdDrawStrideWithBuffer(const vvl::CommandBuffer &cb_st
                                                  const Location &loc) const {
     bool skip = false;
     uint64_t validation_value = stride * (drawCount - 1) + offset + struct_size;
-    if (validation_value > buffer_state.createInfo.size) {
+    if (validation_value > buffer_state.create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer_state.Handle());
         skip |=
             LogError(vuid, objlist, loc,
                      "stride (%" PRIu32 ") * [drawCount (%" PRIu32 ") - 1] + offset (%" PRIu64 ") + sizeof(%s) (%" PRIu32
                      ") is %" PRIu64 ", which is greater than the buffer size (%" PRIu64 ").",
-                     stride, drawCount, offset, String(struct_name), struct_size, validation_value, buffer_state.createInfo.size);
+                     stride, drawCount, offset, String(struct_name), struct_size, validation_value, buffer_state.create_info.size);
     }
     return skip;
 }
@@ -1396,12 +1396,12 @@ bool CoreChecks::PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuff
         auto buffer_state = Get<vvl::Buffer>(pBuffers[i]);
         assert(buffer_state != nullptr);
 
-        if (pOffsets[i] >= buffer_state->createInfo.size) {
+        if (pOffsets[i] >= buffer_state->create_info.size) {
             const LogObjectList objlist(commandBuffer, pBuffers[i]);
             skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pOffsets-02358", objlist,
                              error_obj.location.dot(Field::pOffsets, i),
                              "(%" PRIu64 ") is greater than or equal to the size of pBuffers[%" PRIu32 "] (%" PRIu64 ").",
-                             pOffsets[i], i, buffer_state->createInfo.size);
+                             pOffsets[i], i, buffer_state->create_info.size);
         }
 
         if ((buffer_state->usage & VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT) == 0) {
@@ -1413,18 +1413,18 @@ bool CoreChecks::PreCallValidateCmdBindTransformFeedbackBuffersEXT(VkCommandBuff
         // pSizes is optional and may be nullptr. Also might be VK_WHOLE_SIZE which VU don't apply
         if ((pSizes != nullptr) && (pSizes[i] != VK_WHOLE_SIZE)) {
             // only report one to prevent redundant error if the size is larger since adding offset will be as well
-            if (pSizes[i] > buffer_state->createInfo.size) {
+            if (pSizes[i] > buffer_state->create_info.size) {
                 const LogObjectList objlist(commandBuffer, pBuffers[i]);
                 skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pSizes-02362", objlist,
                                  error_obj.location.dot(Field::pSizes, i),
                                  "(%" PRIu64 ") is greater than the size of pBuffers[%" PRIu32 "](%" PRIu64 ").", pSizes[i], i,
-                                 buffer_state->createInfo.size);
-            } else if (pOffsets[i] + pSizes[i] > buffer_state->createInfo.size) {
+                                 buffer_state->create_info.size);
+            } else if (pOffsets[i] + pSizes[i] > buffer_state->create_info.size) {
                 const LogObjectList objlist(commandBuffer, pBuffers[i]);
                 skip |= LogError("VUID-vkCmdBindTransformFeedbackBuffersEXT-pOffsets-02363", objlist, error_obj.location,
                                  "The sum of pOffsets[%" PRIu32 "] (%" PRIu64 ") and pSizes[%" PRIu32 "] (%" PRIu64
                                  ") is greater than the size of pBuffers[%" PRIu32 "] (%" PRIu64 ").",
-                                 i, pOffsets[i], i, pSizes[i], i, buffer_state->createInfo.size);
+                                 i, pOffsets[i], i, pSizes[i], i, buffer_state->create_info.size);
             }
         }
 
@@ -1473,7 +1473,7 @@ bool CoreChecks::PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer com
                          "transform feedback is active.");
     }
 
-    const auto &rp_ci = cb_state->activeRenderPass->createInfo;
+    const auto &rp_ci = cb_state->activeRenderPass->create_info;
     for (uint32_t i = 0; i < rp_ci.subpassCount; ++i) {
         // When a subpass uses a non-zero view mask, multiview functionality is considered to be enabled
         if (rp_ci.pSubpasses[i].viewMask > 0) {
@@ -1499,7 +1499,7 @@ bool CoreChecks::PreCallValidateCmdBeginTransformFeedbackEXT(VkCommandBuffer com
             auto buffer_state = Get<vvl::Buffer>(pCounterBuffers[i]);
             assert(buffer_state != nullptr);
 
-            if (pCounterBufferOffsets != nullptr && pCounterBufferOffsets[i] + 4 > buffer_state->createInfo.size) {
+            if (pCounterBufferOffsets != nullptr && pCounterBufferOffsets[i] + 4 > buffer_state->create_info.size) {
                 const LogObjectList objlist(commandBuffer, pCounterBuffers[i]);
                 skip |= LogError("VUID-vkCmdBeginTransformFeedbackEXT-pCounterBufferOffsets-02370", objlist,
                                  error_obj.location.dot(Field::pCounterBuffers, i),
@@ -1552,7 +1552,7 @@ bool CoreChecks::PreCallValidateCmdEndTransformFeedbackEXT(VkCommandBuffer comma
             auto buffer_state = Get<vvl::Buffer>(pCounterBuffers[i]);
             assert(buffer_state != nullptr);
 
-            if (pCounterBufferOffsets != nullptr && pCounterBufferOffsets[i] + 4 > buffer_state->createInfo.size) {
+            if (pCounterBufferOffsets != nullptr && pCounterBufferOffsets[i] + 4 > buffer_state->create_info.size) {
                 const LogObjectList objlist(commandBuffer, pCounterBuffers[i]);
                 skip |= LogError("VUID-vkCmdEndTransformFeedbackEXT-pCounterBufferOffsets-02378", objlist,
                                  error_obj.location.dot(Field::pCounterBuffers, i),
@@ -1595,10 +1595,10 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer commandBuf
 
         const VkDeviceSize offset = pOffsets[i];
         if (pSizes) {
-            if (offset >= buffer_state->createInfo.size) {
+            if (offset >= buffer_state->create_info.size) {
                 skip |= LogError("VUID-vkCmdBindVertexBuffers2-pOffsets-03357", objlist, error_obj.location.dot(Field::pOffsets, i),
                                  "(0x%" PRIu64 ") is beyond the end of the buffer of size (%" PRIu64 ").", offset,
-                                 buffer_state->createInfo.size);
+                                 buffer_state->create_info.size);
             }
             const VkDeviceSize size = pSizes[i];
             if (size == VK_WHOLE_SIZE) {
@@ -1607,11 +1607,11 @@ bool CoreChecks::PreCallValidateCmdBindVertexBuffers2(VkCommandBuffer commandBuf
                                      "is VK_WHOLE_SIZE, which is not valid in this context. This can be fixed by enabling the "
                                      "VkPhysicalDeviceMaintenance5FeaturesKHR::maintenance5 feature.");
                 }
-            } else if (offset + size > buffer_state->createInfo.size) {
+            } else if (offset + size > buffer_state->create_info.size) {
                 skip |= LogError("VUID-vkCmdBindVertexBuffers2-pSizes-03358", objlist, error_obj.location.dot(Field::pOffsets, i),
                                  "(%" PRIu64 ") + pSizes[%" PRIu32 "] (%" PRIu64
                                  ") is beyond the end of the buffer of size (%" PRIu64 ").",
-                                 offset, i, size, buffer_state->createInfo.size);
+                                 offset, i, size, buffer_state->create_info.size);
             }
         }
     }
@@ -1652,12 +1652,12 @@ bool CoreChecks::PreCallValidateCmdBeginConditionalRenderingEXT(
                              "(%s) was created with %s.", FormatHandle(pConditionalRenderingBegin->buffer).c_str(),
                              string_VkBufferUsageFlags2KHR(buffer_state->usage).c_str());
             }
-            if (pConditionalRenderingBegin->offset + 4 > buffer_state->createInfo.size) {
+            if (pConditionalRenderingBegin->offset + 4 > buffer_state->create_info.size) {
                 const LogObjectList objlist(commandBuffer, buffer_state->Handle());
                 skip |= LogError(
                     "VUID-VkConditionalRenderingBeginInfoEXT-offset-01983", objlist, conditional_loc.dot(Field::offset),
                     "(%" PRIu64 ") + 4 bytes is not less than the size of pConditionalRenderingBegin->buffer (%" PRIu64 ").",
-                    pConditionalRenderingBegin->offset, buffer_state->createInfo.size);
+                    pConditionalRenderingBegin->offset, buffer_state->create_info.size);
             }
         }
     }
@@ -1733,7 +1733,7 @@ bool CoreChecks::PreCallValidateCmdBindShadingRateImageNV(VkCommandBuffer comman
     }
 
     const auto *image_state = view_state->image_state.get();
-    auto usage = image_state->createInfo.usage;
+    auto usage = image_state->create_info.usage;
     if (!(usage & VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV)) {
         const LogObjectList objlist(commandBuffer, imageView);
         skip |= LogError("VUID-vkCmdBindShadingRateImageNV-imageView-02061", objlist, error_obj.location,

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -363,7 +363,7 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                 for (const auto attachment : (*cb_state.active_attachments)) {
                     if (attachment && attachment->create_info.subresourceRange.aspectMask &
                                           (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)) {
-                        if ((attachment->image_state->createInfo.flags &
+                        if ((attachment->image_state->create_info.flags &
                              VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
                             const LogObjectList objlist(cb_state.Handle(), frag_spirv_state->handle());
                             skip |=
@@ -853,7 +853,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         bool pgq_active = false;
         for (const auto& active_query : cb_state.activeQueries) {
             auto query_pool_state = Get<vvl::QueryPool>(active_query.pool);
-            if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+            if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
                 pgq_active = true;
                 break;
             }

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -156,7 +156,7 @@ static inline bool IsExtentAllZeroes(const VkExtent3D &extent) {
 VkExtent3D CoreChecks::GetScaledItg(const vvl::CommandBuffer &cb_state, const vvl::Image &image_state) const {
     // Default to (0, 0, 0) granularity in case we can't find the real granularity for the physical device.
     VkExtent3D granularity = {0, 0, 0};
-    const VkFormat image_format = image_state.createInfo.format;
+    const VkFormat image_format = image_state.create_info.format;
     const auto pool = cb_state.command_pool;
     if (pool) {
         granularity = physical_device_state->queue_family_properties[pool->queueFamilyIndex].minImageTransferGranularity;
@@ -275,11 +275,11 @@ template <typename HandleT>
 bool CoreChecks::ValidateImageMipLevel(const HandleT handle, const vvl::Image &image_state, uint32_t mip_level,
                                        const Location &subresource_loc) const {
     bool skip = false;
-    if (mip_level >= image_state.createInfo.mipLevels) {
+    if (mip_level >= image_state.create_info.mipLevels) {
         const LogObjectList objlist(handle, image_state.Handle());
         skip |= LogError(vvl::GetImageMipLevelVUID(subresource_loc), objlist, subresource_loc.dot(Field::mipLevel),
                          "is %" PRIu32 ", but provided %s has %" PRIu32 " mip levels.", mip_level,
-                         FormatHandle(image_state).c_str(), image_state.createInfo.mipLevels);
+                         FormatHandle(image_state).c_str(), image_state.create_info.mipLevels);
     }
     return skip;
 }
@@ -287,13 +287,13 @@ template <typename HandleT>
 bool CoreChecks::ValidateImageArrayLayerRange(const HandleT handle, const vvl::Image &image_state, const uint32_t base_layer,
                                               const uint32_t layer_count, const Location &subresource_loc) const {
     bool skip = false;
-    if (base_layer >= image_state.createInfo.arrayLayers || layer_count > image_state.createInfo.arrayLayers ||
-        (base_layer + layer_count) > image_state.createInfo.arrayLayers) {
+    if (base_layer >= image_state.create_info.arrayLayers || layer_count > image_state.create_info.arrayLayers ||
+        (base_layer + layer_count) > image_state.create_info.arrayLayers) {
         if (layer_count != VK_REMAINING_ARRAY_LAYERS) {
             const LogObjectList objlist(handle, image_state.Handle());
             skip |= LogError(vvl::GetImageArrayLayerRangeVUID(subresource_loc), objlist, subresource_loc.dot(Field::baseArrayLayer),
                              "is %" PRIu32 " and layerCount is %" PRIu32 ", but provided %s has %" PRIu32 " array layers.",
-                             base_layer, layer_count, FormatHandle(image_state).c_str(), image_state.createInfo.arrayLayers);
+                             base_layer, layer_count, FormatHandle(image_state).c_str(), image_state.create_info.arrayLayers);
         }
     }
     return skip;
@@ -350,7 +350,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
         const Location subresource_loc = region_loc.dot(Field::imageSubresource);
         const RegionType region = pRegions[i];
         const VkImageAspectFlags region_aspect_mask = region.imageSubresource.aspectMask;
-        if (image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
+        if (image_state.create_info.imageType == VK_IMAGE_TYPE_1D) {
             if ((region.imageOffset.y != 0) || (region.imageExtent.height != 1)) {
                 const LogObjectList objlist(handle, image_state.Handle());
                 skip |= LogError(GetCopyBufferImageVUID(region_loc, vvl::CopyError::Image1D_07979), objlist, region_loc,
@@ -361,7 +361,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
             }
         }
 
-        if ((image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) || (image_state.createInfo.imageType == VK_IMAGE_TYPE_2D)) {
+        if ((image_state.create_info.imageType == VK_IMAGE_TYPE_1D) || (image_state.create_info.imageType == VK_IMAGE_TYPE_2D)) {
             if ((region.imageOffset.z != 0) || (region.imageExtent.depth != 1)) {
                 const LogObjectList objlist(handle, image_state.Handle());
                 skip |= LogError(GetCopyBufferImageVUID(region_loc, vvl::CopyError::Image1D_07980), objlist, region_loc,
@@ -372,7 +372,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
             }
         }
 
-        if (image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
+        if (image_state.create_info.imageType == VK_IMAGE_TYPE_3D) {
             if ((0 != region.imageSubresource.baseArrayLayer) || (1 != region.imageSubresource.layerCount)) {
                 const LogObjectList objlist(handle, image_state.Handle());
                 skip |= LogError(GetCopyBufferImageVUID(region_loc, vvl::CopyError::Image3D_07983), objlist, subresource_loc,
@@ -469,7 +469,7 @@ bool CoreChecks::ValidateHeterogeneousCopyData(const HandleT handle, uint32_t re
                              region.imageOffset.z, (region.imageOffset.z + region.imageExtent.depth), adjusted_image_extent.depth);
         }
 
-        const VkFormat image_format = image_state.createInfo.format;
+        const VkFormat image_format = image_state.create_info.format;
         // image subresource aspect bit must match format
         if (!VerifyAspectsPresent(region_aspect_mask, image_format)) {
             const LogObjectList objlist(handle, image_state.Handle());
@@ -607,7 +607,7 @@ bool CoreChecks::ValidateBufferImageCopyData(const vvl::CommandBuffer &cb_state,
                                              const vvl::Image &image_state, const Location &loc) const {
     bool skip = false;
 
-    const VkFormat image_format = image_state.createInfo.format;
+    const VkFormat image_format = image_state.create_info.format;
 
     skip |= ValidateHeterogeneousCopyData(cb_state.VkHandle(), regionCount, pRegions, image_state, loc);
 
@@ -684,8 +684,8 @@ bool CoreChecks::ValidateCmdCopyBufferBounds(VkCommandBuffer cb, const vvl::Buff
     const bool is_2 = loc.function == Func::vkCmdCopyBuffer2 || loc.function == Func::vkCmdCopyBuffer2KHR;
     const char *vuid;
 
-    VkDeviceSize src_buffer_size = src_buffer_state.createInfo.size;
-    VkDeviceSize dst_buffer_size = dst_buffer_state.createInfo.size;
+    VkDeviceSize src_buffer_size = src_buffer_state.create_info.size;
+    VkDeviceSize dst_buffer_size = dst_buffer_state.create_info.size;
     const bool are_buffers_sparse = src_buffer_state.sparse || dst_buffer_state.sparse;
 
     const LogObjectList src_objlist(cb, dst_buffer_state.Handle());
@@ -817,7 +817,7 @@ bool CoreChecks::ValidateCopyBufferImageTransferGranularityRequirements(const vv
     skip |= CheckItgOffset(objlist, region->imageOffset, granularity, region_loc.dot(Field::imageOffset), vuid);
     VkExtent3D subresource_extent = image_state.GetEffectiveSubresourceExtent(region->imageSubresource);
     skip |= CheckItgExtent(objlist, region->imageExtent, region->imageOffset, granularity, subresource_extent,
-                           image_state.createInfo.imageType, region_loc.dot(Field::imageExtent), vuid);
+                           image_state.create_info.imageType, region_loc.dot(Field::imageExtent), vuid);
     return skip;
 }
 
@@ -874,7 +874,7 @@ bool CoreChecks::ValidateCopyImageTransferGranularityRequirements(const vvl::Com
         const VkExtent3D subresource_extent = src_image_state.GetEffectiveSubresourceExtent(region->srcSubresource);
         vuid = is_2 ? "VUID-VkCopyImageInfo2-srcOffset-01783" : "VUID-vkCmdCopyImage-srcOffset-01783";
         skip |= CheckItgExtent(objlist, extent, region->srcOffset, granularity, subresource_extent,
-                               src_image_state.createInfo.imageType, region_loc.dot(Field::extent), vuid);
+                               src_image_state.create_info.imageType, region_loc.dot(Field::extent), vuid);
     }
 
     {
@@ -885,11 +885,11 @@ bool CoreChecks::ValidateCopyImageTransferGranularityRequirements(const vvl::Com
         skip |= CheckItgOffset(objlist, region->dstOffset, granularity, region_loc.dot(Field::dstOffset), vuid);
         // Adjust dest extent, if necessary
         const VkExtent3D dest_effective_extent =
-            GetAdjustedDestImageExtent(src_image_state.createInfo.format, dst_image_state.createInfo.format, extent);
+            GetAdjustedDestImageExtent(src_image_state.create_info.format, dst_image_state.create_info.format, extent);
         const VkExtent3D subresource_extent = dst_image_state.GetEffectiveSubresourceExtent(region->dstSubresource);
         vuid = is_2 ? "VUID-VkCopyImageInfo2-dstOffset-01784" : "VUID-vkCmdCopyImage-dstOffset-01784";
         skip |= CheckItgExtent(objlist, dest_effective_extent, region->dstOffset, granularity, subresource_extent,
-                               dst_image_state.createInfo.imageType, region_loc.dot(Field::extent), vuid);
+                               dst_image_state.create_info.imageType, region_loc.dot(Field::extent), vuid);
     }
     return skip;
 }
@@ -910,25 +910,25 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         // For comp<->uncomp copies, the copy extent for the dest image must be adjusted
         const VkExtent3D src_copy_extent = region.extent;
         const VkExtent3D dst_copy_extent =
-            GetAdjustedDestImageExtent(src_image_state.createInfo.format, dst_image_state.createInfo.format, region.extent);
+            GetAdjustedDestImageExtent(src_image_state.create_info.format, dst_image_state.create_info.format, region.extent);
 
         bool slice_override = false;
         uint32_t depth_slices = 0;
 
         // Special case for copying between a 1D/2D array and a 3D image
         // TBD: This seems like the only way to reconcile 3 mutually-exclusive VU checks for 2D/3D copies. Heads up.
-        if ((VK_IMAGE_TYPE_3D == src_image_state.createInfo.imageType) &&
-            (VK_IMAGE_TYPE_3D != dst_image_state.createInfo.imageType)) {
+        if ((VK_IMAGE_TYPE_3D == src_image_state.create_info.imageType) &&
+            (VK_IMAGE_TYPE_3D != dst_image_state.create_info.imageType)) {
             depth_slices = region.dstSubresource.layerCount;  // Slice count from 2D subresource
             slice_override = (depth_slices != 1);
-        } else if ((VK_IMAGE_TYPE_3D == dst_image_state.createInfo.imageType) &&
-                   (VK_IMAGE_TYPE_3D != src_image_state.createInfo.imageType)) {
+        } else if ((VK_IMAGE_TYPE_3D == dst_image_state.create_info.imageType) &&
+                   (VK_IMAGE_TYPE_3D != src_image_state.create_info.imageType)) {
             depth_slices = region.srcSubresource.layerCount;  // Slice count from 2D subresource
             slice_override = (depth_slices != 1);
         }
 
         // Do all checks on source image
-        if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
+        if (src_image_state.create_info.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.srcOffset.y) || (1 != src_copy_extent.height)) {
                 const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::SrcImage1D_00146), objlist, region_loc,
@@ -939,8 +939,8 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             }
         }
 
-        if (((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) ||
-             ((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
+        if (((src_image_state.create_info.imageType == VK_IMAGE_TYPE_1D) ||
+             ((src_image_state.create_info.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
             ((0 != region.srcOffset.z) || (1 != src_copy_extent.depth))) {
             const LogObjectList objlist(handle, src_image_state.Handle());
             const char *image_type = is_host ? "1D or 2D" : "1D";
@@ -951,7 +951,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                              region.srcOffset.z, src_copy_extent.depth, image_type);
         }
 
-        if ((src_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.srcOffset.z) && (!is_host)) {
+        if ((src_image_state.create_info.imageType == VK_IMAGE_TYPE_2D) && (0 != region.srcOffset.z) && (!is_host)) {
             const LogObjectList objlist(handle, src_image_state.Handle());
             vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-01787" : "VUID-vkCmdCopyImage-srcImage-01787";
             skip |= LogError(vuid, objlist, region_loc, "srcOffset.z is %" PRId32 ". For 2D images the z-offset must be 0.",
@@ -959,7 +959,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         }
 
         {  // Used to be compressed checks, now apply to all
-            const VkExtent3D block_size = vkuFormatTexelBlockExtent(src_image_state.createInfo.format);
+            const VkExtent3D block_size = vkuFormatTexelBlockExtent(src_image_state.create_info.format);
             if (SafeModulo(region.srcOffset.x, block_size.width) != 0) {
                 const LogObjectList objlist(handle, src_image_state.Handle());
                 skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::SrcOffset_07278), objlist, region_loc,
@@ -1027,7 +1027,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         }
 
         // Do all checks on dest image
-        if (dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) {
+        if (dst_image_state.create_info.imageType == VK_IMAGE_TYPE_1D) {
             if ((0 != region.dstOffset.y) || (1 != dst_copy_extent.height)) {
                 const LogObjectList objlist(handle, dst_image_state.Handle());
                 skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::DstImage1D_00152), objlist, region_loc,
@@ -1038,8 +1038,8 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
             }
         }
 
-        if (((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_1D) ||
-             ((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
+        if (((dst_image_state.create_info.imageType == VK_IMAGE_TYPE_1D) ||
+             ((dst_image_state.create_info.imageType == VK_IMAGE_TYPE_2D) && is_host)) &&
             ((0 != region.dstOffset.z) || (1 != dst_copy_extent.depth))) {
             const LogObjectList objlist(handle, dst_image_state.Handle());
             const char *image_type = is_host ? "1D or 2D" : "1D";
@@ -1050,7 +1050,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                              region.dstOffset.z, dst_copy_extent.depth, image_type);
         }
 
-        if ((dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_2D) && (0 != region.dstOffset.z) && !(is_host)) {
+        if ((dst_image_state.create_info.imageType == VK_IMAGE_TYPE_2D) && (0 != region.dstOffset.z) && !(is_host)) {
             const LogObjectList objlist(handle, dst_image_state.Handle());
             vuid = is_2 ? "VUID-VkCopyImageInfo2-dstImage-01788" : "VUID-vkCmdCopyImage-dstImage-01788";
             skip |= LogError(vuid, objlist, region_loc, "dstOffset.z is %" PRId32 ". For 2D images the z-offset must be 0.",
@@ -1059,7 +1059,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
 
         // Handle difference between Maintenance 1
         if (IsExtEnabled(device_extensions.vk_khr_maintenance1) || is_host) {
-            if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
+            if (src_image_state.create_info.imageType == VK_IMAGE_TYPE_3D) {
                 const LogObjectList objlist(handle, src_image_state.Handle());
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::SrcImage3D_04443), objlist, region_loc,
@@ -1069,7 +1069,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                                      region.srcSubresource.baseArrayLayer, region.srcSubresource.layerCount);
                 }
             }
-            if (dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
+            if (dst_image_state.create_info.imageType == VK_IMAGE_TYPE_3D) {
                 const LogObjectList objlist(handle, dst_image_state.Handle());
                 if ((0 != region.dstSubresource.baseArrayLayer) || (1 != region.dstSubresource.layerCount)) {
                     skip |= LogError(GetCopyImageVUID(region_loc, vvl::CopyError::DstImage3D_04444), objlist, region_loc,
@@ -1080,8 +1080,8 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
                 }
             }
         } else {  // Pre maint 1
-            if (src_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D ||
-                dst_image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) {
+            if (src_image_state.create_info.imageType == VK_IMAGE_TYPE_3D ||
+                dst_image_state.create_info.imageType == VK_IMAGE_TYPE_3D) {
                 if ((0 != region.srcSubresource.baseArrayLayer) || (1 != region.srcSubresource.layerCount)) {
                     const LogObjectList objlist(handle, src_image_state.Handle());
                     vuid = is_2 ? "VUID-VkCopyImageInfo2-apiVersion-07932" : "VUID-vkCmdCopyImage-apiVersion-07932";
@@ -1108,7 +1108,7 @@ bool CoreChecks::ValidateImageCopyData(const HandleT handle, const uint32_t regi
         }
 
         {
-            const VkExtent3D block_size = vkuFormatTexelBlockExtent(dst_image_state.createInfo.format);
+            const VkExtent3D block_size = vkuFormatTexelBlockExtent(dst_image_state.create_info.format);
             //  image offsets x must be multiple of block width
             if (SafeModulo(region.dstOffset.x, block_size.width) != 0) {
                 const LogObjectList objlist(handle, src_image_state.Handle());
@@ -1208,12 +1208,12 @@ bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image &src_i
     const bool is_2 = loc.function == Func::vkCmdCopyImage2 || loc.function == Func::vkCmdCopyImage2KHR;
     const bool is_host = loc.function == Func::vkCopyImageToImageEXT;
 
-    const VkFormat src_format = src_image_state.createInfo.format;
-    const VkFormat dst_format = dst_image_state.createInfo.format;
+    const VkFormat src_format = src_image_state.create_info.format;
+    const VkFormat dst_format = dst_image_state.create_info.format;
     const VkImage src_image = src_image_state.VkHandle();
     const VkImage dst_image = dst_image_state.VkHandle();
-    const bool src_is_3d = (VK_IMAGE_TYPE_3D == src_image_state.createInfo.imageType);
-    const bool dst_is_3d = (VK_IMAGE_TYPE_3D == dst_image_state.createInfo.imageType);
+    const bool src_is_3d = (VK_IMAGE_TYPE_3D == src_image_state.create_info.imageType);
+    const bool dst_is_3d = (VK_IMAGE_TYPE_3D == dst_image_state.create_info.imageType);
 
     const LogObjectList src_objlist(handle, src_image);
     const LogObjectList dst_objlist(handle, dst_image);
@@ -1365,11 +1365,11 @@ bool CoreChecks::ValidateCopyImageCommon(HandleT handle, const vvl::Image &src_i
     skip |= ValidateMemoryIsBoundToImage(dst_objlist, dst_image_state, loc.dot(Field::dstImage),
                                          GetCopyImageVUID(loc, vvl::CopyError::DstImageContiguous_07966).c_str());
 
-    if (src_image_state.createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (src_image_state.create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         skip |= LogError(GetCopyImageVUID(loc, vvl::CopyError::SrcImageSubsampled_07969), src_objlist, loc.dot(Field::srcImage),
                          "was created with flags including VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
     }
-    if (dst_image_state.createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (dst_image_state.create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         skip |= LogError(GetCopyImageVUID(loc, vvl::CopyError::DstImageSubsampled_07969), dst_objlist, loc.dot(Field::dstImage),
                          "was created with flags including VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
     }
@@ -1389,10 +1389,10 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         return skip;
     }
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
-    const VkFormat src_format = src_image_state->createInfo.format;
-    const VkFormat dst_format = dst_image_state->createInfo.format;
-    const VkImageType src_image_type = src_image_state->createInfo.imageType;
-    const VkImageType dst_image_type = dst_image_state->createInfo.imageType;
+    const VkFormat src_format = src_image_state->create_info.format;
+    const VkFormat dst_format = dst_image_state->create_info.format;
+    const VkImageType src_image_type = src_image_state->create_info.imageType;
+    const VkImageType dst_image_type = dst_image_state->create_info.imageType;
     const bool src_is_2d = (VK_IMAGE_TYPE_2D == src_image_type);
     const bool src_is_3d = (VK_IMAGE_TYPE_3D == src_image_type);
     const bool dst_is_2d = (VK_IMAGE_TYPE_2D == dst_image_type);
@@ -1447,20 +1447,20 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                 uint32_t dst_slices = (dst_is_3d ? dst_copy_extent.depth : dst_subresource.layerCount);
                 if (src_slices == VK_REMAINING_ARRAY_LAYERS || dst_slices == VK_REMAINING_ARRAY_LAYERS) {
                     if (src_slices != VK_REMAINING_ARRAY_LAYERS) {
-                        if (src_slices != (dst_image_state->createInfo.arrayLayers - dst_subresource.baseArrayLayer)) {
+                        if (src_slices != (dst_image_state->create_info.arrayLayers - dst_subresource.baseArrayLayer)) {
                             vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-08794" : "VUID-vkCmdCopyImage-srcImage-08794";
                             skip |= LogError(vuid, dst_objlist, src_subresource_loc.dot(Field::layerCount),
                                              "(%" PRIu32 ") does not match dstImage arrayLayers (%" PRIu32
                                              ") minus baseArrayLayer (%" PRIu32 ").",
-                                             src_slices, dst_image_state->createInfo.arrayLayers, dst_subresource.baseArrayLayer);
+                                             src_slices, dst_image_state->create_info.arrayLayers, dst_subresource.baseArrayLayer);
                         }
                     } else if (dst_slices != VK_REMAINING_ARRAY_LAYERS) {
-                        if (dst_slices != (src_image_state->createInfo.arrayLayers - src_subresource.baseArrayLayer)) {
+                        if (dst_slices != (src_image_state->create_info.arrayLayers - src_subresource.baseArrayLayer)) {
                             vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-08794" : "VUID-vkCmdCopyImage-srcImage-08794";
                             skip |= LogError(vuid, src_objlist, dst_subresource_loc.dot(Field::layerCount),
                                              "(%" PRIu32 ") does not match srcImage arrayLayers (%" PRIu32
                                              ") minus baseArrayLayer (%" PRIu32 ").",
-                                             dst_slices, src_image_state->createInfo.arrayLayers, src_subresource.baseArrayLayer);
+                                             dst_slices, src_image_state->create_info.arrayLayers, src_subresource.baseArrayLayer);
                         }
                     }
                 } else if (src_slices != dst_slices) {
@@ -1693,7 +1693,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
         skip |=
             ValidateImageUsageFlags(commandBuffer, *dst_image_state, VK_IMAGE_USAGE_TRANSFER_DST_BIT, false, vuid, dst_image_loc);
     } else {
-        auto src_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(src_image_state->createInfo.pNext);
+        auto src_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(src_image_state->create_info.pNext);
         if (src_separate_stencil && has_stencil_aspect &&
             ((src_separate_stencil->stencilUsage & VK_IMAGE_USAGE_TRANSFER_SRC_BIT) == 0)) {
             vuid = is_2 ? "VUID-VkCopyImageInfo2-aspect-06664" : "VUID-vkCmdCopyImage-aspect-06664";
@@ -1708,7 +1708,7 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
                                             src_image_loc);
         }
 
-        auto dst_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(dst_image_state->createInfo.pNext);
+        auto dst_separate_stencil = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(dst_image_state->create_info.pNext);
         if (dst_separate_stencil && has_stencil_aspect &&
             ((dst_separate_stencil->stencilUsage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0)) {
             vuid = is_2 ? "VUID-VkCopyImageInfo2-aspect-06665" : "VUID-vkCmdCopyImage-aspect-06665";
@@ -1725,11 +1725,11 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
     }
 
     // Source and dest image sample counts must match
-    if (src_image_state->createInfo.samples != dst_image_state->createInfo.samples) {
+    if (src_image_state->create_info.samples != dst_image_state->create_info.samples) {
         vuid = is_2 ? "VUID-VkCopyImageInfo2-srcImage-00136" : "VUID-vkCmdCopyImage-srcImage-00136";
         skip |= LogError(vuid, all_objlist, src_image_loc, "was created with (%s) but the dstImage was created with (%s).",
-                         string_VkSampleCountFlagBits(src_image_state->createInfo.samples),
-                         string_VkSampleCountFlagBits(dst_image_state->createInfo.samples));
+                         string_VkSampleCountFlagBits(src_image_state->create_info.samples),
+                         string_VkSampleCountFlagBits(dst_image_state->create_info.samples));
     }
 
     vuid = is_2 ? "VUID-vkCmdCopyImage2-commandBuffer-01825" : "VUID-vkCmdCopyImage-commandBuffer-01825";
@@ -1916,7 +1916,7 @@ template <typename HandleT, typename RegionType>
 bool CoreChecks::ValidateImageBounds(const HandleT handle, const vvl::Image &image_state, const uint32_t regionCount,
                                      const RegionType *pRegions, const Location &loc, const char *vuid, bool is_src) const {
     bool skip = false;
-    const VkImageCreateInfo *image_info = &(image_state.createInfo);
+    const VkImageCreateInfo *image_info = &(image_state.create_info);
 
     for (uint32_t i = 0; i < regionCount; i++) {
         const Location region_loc = loc.dot(Field::pRegions, i);
@@ -1963,13 +1963,13 @@ bool CoreChecks::ValidateBufferBounds(VkCommandBuffer cb, const vvl::Image &imag
                                       const char *vuid) const {
     bool skip = false;
 
-    const VkDeviceSize buffer_size = buff_state.createInfo.size;
+    const VkDeviceSize buffer_size = buff_state.create_info.size;
 
     for (uint32_t i = 0; i < regionCount; i++) {
         const Location region_loc = loc.dot(Field::pRegions, i);
         const RegionType region = pRegions[i];
         const VkDeviceSize buffer_copy_size =
-            GetBufferSizeFromCopyImage(region, image_state.createInfo.format, image_state.createInfo.arrayLayers);
+            GetBufferSizeFromCopyImage(region, image_state.create_info.format, image_state.create_info.arrayLayers);
         // This blocks against invalid VkBufferCopyImage that already have been caught elsewhere
         if (buffer_copy_size != 0) {
             const VkDeviceSize max_buffer_copy = buffer_copy_size + region.bufferOffset;
@@ -1991,10 +1991,10 @@ template <typename HandleT>
 bool CoreChecks::ValidateImageSampleCount(const HandleT handle, const vvl::Image &image_state, VkSampleCountFlagBits sample_count,
                                           const Location &loc, const std::string &vuid) const {
     bool skip = false;
-    if (image_state.createInfo.samples != sample_count) {
+    if (image_state.create_info.samples != sample_count) {
         const LogObjectList objlist(handle, image_state.Handle());
         skip |= LogError(vuid, objlist, loc, "%s was created with a sample count of %s but must be %s.",
-                         FormatHandle(image_state).c_str(), string_VkSampleCountFlagBits(image_state.createInfo.samples),
+                         FormatHandle(image_state).c_str(), string_VkSampleCountFlagBits(image_state.create_info.samples),
                          string_VkSampleCountFlagBits(sample_count));
     }
     return skip;
@@ -2009,10 +2009,10 @@ bool CoreChecks::ValidateImageBufferCopyMemoryOverlap(const vvl::CommandBuffer &
 
     for (uint32_t i = 0; i < regionCount; ++i) {
         const RegionType &region = pRegions[i];
-        auto texel_size = vkuFormatTexelSizeWithAspect(image_state.createInfo.format,
+        auto texel_size = vkuFormatTexelSizeWithAspect(image_state.create_info.format,
                                                        static_cast<VkImageAspectFlagBits>(region.imageSubresource.aspectMask));
         VkDeviceSize image_offset;
-        if (image_state.createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
+        if (image_state.create_info.tiling == VK_IMAGE_TILING_LINEAR) {
             // Can only know actual offset for linearly tiled images
             VkImageSubresource isr = {};
             isr.arrayLayer = region.imageSubresource.baseArrayLayer;
@@ -2020,8 +2020,8 @@ bool CoreChecks::ValidateImageBufferCopyMemoryOverlap(const vvl::CommandBuffer &
             isr.mipLevel = region.imageSubresource.mipLevel;
             VkSubresourceLayout srl = {};
             DispatchGetImageSubresourceLayout(device, image_state.VkHandle(), &isr, &srl);
-            if (image_state.createInfo.arrayLayers == 1) srl.arrayPitch = 0;
-            if (image_state.createInfo.imageType != VK_IMAGE_TYPE_3D) srl.depthPitch = 0;
+            if (image_state.create_info.arrayLayers == 1) srl.arrayPitch = 0;
+            if (image_state.create_info.imageType != VK_IMAGE_TYPE_3D) srl.depthPitch = 0;
             image_offset = (region.imageSubresource.baseArrayLayer * srl.arrayPitch) +
                            static_cast<VkDeviceSize>((region.imageOffset.x * texel_size)) + (region.imageOffset.y * srl.rowPitch) +
                            (region.imageOffset.z * srl.depthPitch) + srl.offset;
@@ -2078,7 +2078,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
     VkQueueFlags queue_flags = physical_device_state->queue_family_properties[pool->queueFamilyIndex].queueFlags;
 
     if (0 == (queue_flags & (VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT))) {
-        const LogObjectList objlist(cb_state.createInfo.commandPool, commandBuffer, srcImage, dstBuffer);
+        const LogObjectList objlist(cb_state.allocate_info.commandPool, commandBuffer, srcImage, dstBuffer);
         vuid = is_2 ? "VUID-vkCmdCopyImageToBuffer2-commandBuffer-cmdpool" : "VUID-vkCmdCopyImageToBuffer-commandBuffer-cmdpool";
         skip |= LogError(vuid, objlist, loc, "command buffer allocated from a pool with queue type %s.",
                          string_VkQueueFlags(queue_flags).c_str());
@@ -2110,7 +2110,7 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
     skip |= ValidateUnprotectedBuffer(cb_state, *dst_buffer_state, dst_buffer_loc, vuid);
 
     // Validation for VK_EXT_fragment_density_map
-    if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (src_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         const LogObjectList objlist(commandBuffer, srcImage, dstBuffer);
         vuid = is_2 ? "VUID-VkCopyImageToBufferInfo2-srcImage-07969" : "VUID-vkCmdCopyImageToBuffer-srcImage-07969";
         skip |= LogError(vuid, objlist, src_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
@@ -2257,7 +2257,7 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
     skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
 
     // Validation for VK_EXT_fragment_density_map
-    if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (dst_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         const LogObjectList objlist(commandBuffer, srcBuffer, dstImage);
         vuid = is_2 ? "VUID-VkCopyBufferToImageInfo2-dstImage-07969" : "VUID-vkCmdCopyBufferToImage-dstImage-07969";
         skip |= LogError(vuid, objlist, dst_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
@@ -2372,7 +2372,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
                                         const Location &loc) const {
     bool skip = false;
     if (has_stencil) {
-        const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.createInfo.pNext);
+        const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext);
         if (image_stencil_struct != nullptr) {
             if ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
                 LogObjectList objlist(device, image_state.Handle());
@@ -2384,7 +2384,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
                     "included in VkImageStencilUsageCreateInfo::stencilUsage used to create image");
             }
         } else {
-            if ((image_state.createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
+            if ((image_state.create_info.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
                 LogObjectList objlist(device, image_state.Handle());
                 skip |= LogError(
                     vuid_09111, objlist, loc,
@@ -2396,7 +2396,7 @@ bool CoreChecks::UsageHostTransferCheck(VkDevice device, const vvl::Image &image
         }
     }
     if (has_non_stencil) {
-        if ((image_state.createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
+        if ((image_state.create_info.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
             LogObjectList objlist(device, image_state.Handle());
             skip |= LogError(
                 vuid_09113, objlist, loc,
@@ -2464,7 +2464,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
         skip |= LogError(vuid, objlist, image_loc, "is a sparse image with no memory bound");
     }
 
-    if (image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         const char *vuid =
             from_image ? "VUID-VkCopyImageToMemoryInfoEXT-srcImage-07969" : "VUID-VkCopyMemoryToImageInfoEXT-dstImage-07969";
         const LogObjectList objlist(device, image);
@@ -2549,12 +2549,12 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(VkDevice device, InfoPointer info
         // Image and host memory can't overlap unless the image memory is mapped
         if (state->mapped_range.size != 0) {
             const uint64_t mapped_size = (state->mapped_range.size == VK_WHOLE_SIZE)
-                                             ? state->alloc_info.allocationSize
+                                             ? state->allocate_info.allocationSize
                                              : (state->mapped_range.offset + state->mapped_range.size);
             const void *mapped_end = static_cast<char *>(state->p_driver_data) + mapped_size;
             for (uint32_t i = 0; i < regionCount; i++) {
                 const auto region = info_ptr->pRegions[i];
-                auto element_size = vkuFormatElementSize(image_state->createInfo.format);
+                auto element_size = vkuFormatElementSize(image_state->create_info.format);
                 uint64_t copy_size;
                 if (region.memoryRowLength != 0 && region.memoryImageHeight != 0) {
                     copy_size = ((region.memoryRowLength * region.memoryImageHeight) * element_size);
@@ -2585,8 +2585,8 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(VkDevice device, const vvl::Im
                                                   const vvl::Image &dst_image_state, const Location &loc) const {
     bool skip = false;
     std::stringstream mismatch_stream{};
-    const VkImageCreateInfo src_info = src_image_state.createInfo;
-    const VkImageCreateInfo dst_info = dst_image_state.createInfo;
+    const VkImageCreateInfo &src_info = src_image_state.create_info;
+    const VkImageCreateInfo &dst_info = dst_image_state.create_info;
 
     if (src_info.flags != dst_info.flags) {
         mismatch_stream << "srcImage flags = " << string_VkImageCreateFlags(src_info.flags)
@@ -2704,14 +2704,14 @@ bool CoreChecks::ValidateMemcpyExtents(VkDevice device, const VkImageCopy2 regio
         skip |= LogError(vuid, objlist, region_loc.dot(field), "is (%s) but flags contains VK_HOST_IMAGE_COPY_MEMCPY_EXT.",
                          string_VkOffset3D(offset).c_str());
     }
-    if (!IsExtentEqual(region.extent, image_state.createInfo.extent)) {
+    if (!IsExtentEqual(region.extent, image_state.create_info.extent)) {
         const char *vuid =
             is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-09115" : "VUID-VkCopyImageToImageInfoEXT-dstImage-09115";
         const LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(Field::imageExtent),
                          "(%s) must match the image's subresource "
                          "extents (%s) when VkCopyImageToImageInfoEXT->flags contains VK_HOST_IMAGE_COPY_MEMCPY_EXT",
-                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(image_state.createInfo.extent).c_str());
+                         string_VkExtent3D(region.extent).c_str(), string_VkExtent3D(image_state.create_info.extent).c_str());
     }
     return skip;
 }
@@ -2720,7 +2720,7 @@ bool CoreChecks::ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region
                                             const Location &region_loc) const {
     bool skip = false;
     auto aspect_mask = is_src ? region.srcSubresource.aspectMask : region.dstSubresource.aspectMask;
-    if (vkuFormatPlaneCount(image_state.createInfo.format) == 2 &&
+    if (vkuFormatPlaneCount(image_state.create_info.format) == 2 &&
         (aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT)) {
         const char *vuid =
             is_src ? "VUID-VkCopyImageToImageInfoEXT-srcImage-07981" : "VUID-VkCopyImageToImageInfoEXT-dstImage-07981";
@@ -2728,9 +2728,9 @@ bool CoreChecks::ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region
         LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(field), "is %s but %s has 2-plane format (%s).",
                          string_VkImageAspectFlags(aspect_mask).c_str(), is_src ? "srcImage" : "dstImage",
-                         string_VkFormat(image_state.createInfo.format));
+                         string_VkFormat(image_state.create_info.format));
     }
-    if (vkuFormatPlaneCount(image_state.createInfo.format) == 3 &&
+    if (vkuFormatPlaneCount(image_state.create_info.format) == 3 &&
         (aspect_mask != VK_IMAGE_ASPECT_PLANE_0_BIT && aspect_mask != VK_IMAGE_ASPECT_PLANE_1_BIT &&
          aspect_mask != VK_IMAGE_ASPECT_PLANE_2_BIT)) {
         const char *vuid =
@@ -2739,7 +2739,7 @@ bool CoreChecks::ValidateHostCopyMultiplane(VkDevice device, VkImageCopy2 region
         LogObjectList objlist(device, image_state.Handle());
         skip |= LogError(vuid, objlist, region_loc.dot(field), "is %s but %s has 3-plane format (%s).",
                          string_VkImageAspectFlags(aspect_mask).c_str(), is_src ? "srcImage" : "dstImage",
-                         string_VkFormat(image_state.createInfo.format));
+                         string_VkFormat(image_state.create_info.format));
     }
     return skip;
 }
@@ -2752,8 +2752,8 @@ bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCop
     auto src_image_state = Get<vvl::Image>(info_ptr->srcImage);
     auto dst_image_state = Get<vvl::Image>(info_ptr->dstImage);
     // Formats are required to match, but check each image anyway
-    auto src_plane_count = vkuFormatPlaneCount(src_image_state->createInfo.format);
-    auto dst_plane_count = vkuFormatPlaneCount(dst_image_state->createInfo.format);
+    auto src_plane_count = vkuFormatPlaneCount(src_image_state->create_info.format);
+    auto dst_plane_count = vkuFormatPlaneCount(dst_image_state->create_info.format);
     bool check_multiplane = ((src_plane_count == 2 || src_plane_count == 3) || (dst_plane_count == 2 || dst_plane_count == 3));
     bool check_memcpy = (info_ptr->flags & VK_HOST_IMAGE_COPY_MEMCPY_EXT);
     auto regionCount = info_ptr->regionCount;
@@ -2876,21 +2876,21 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     skip |= ValidateUnprotectedImage(cb_state, *dst_image_state, dst_image_loc, vuid);
 
     // Validation for VK_EXT_fragment_density_map
-    if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (src_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
         skip |= LogError(vuid, src_objlist, src_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
     }
-    if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (dst_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2 ? "VUID-VkBlitImageInfo2-dstImage-02545" : "VUID-vkCmdBlitImage-dstImage-02545";
         skip |= LogError(vuid, dst_objlist, dst_image_loc, "was created with VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT.");
     }
 
     // TODO: Need to validate image layouts, which will include layout validation for shared presentable images
 
-    VkFormat src_format = src_image_state->createInfo.format;
-    VkFormat dst_format = dst_image_state->createInfo.format;
-    VkImageType src_type = src_image_state->createInfo.imageType;
-    VkImageType dst_type = dst_image_state->createInfo.imageType;
+    VkFormat src_format = src_image_state->create_info.format;
+    VkFormat dst_format = dst_image_state->create_info.format;
+    VkImageType src_type = src_image_state->create_info.imageType;
+    VkImageType dst_type = dst_image_state->create_info.imageType;
 
     if (VK_FILTER_LINEAR == filter) {
         vuid = is_2 ? "VUID-VkBlitImageInfo2-filter-02001" : "VUID-vkCmdBlitImage-filter-02001";
@@ -3009,20 +3009,20 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
 
         if (src_subresource.layerCount == VK_REMAINING_ARRAY_LAYERS || dst_subresource.layerCount == VK_REMAINING_ARRAY_LAYERS) {
             if (src_subresource.layerCount != VK_REMAINING_ARRAY_LAYERS) {
-                if (src_subresource.layerCount != (dst_image_state->createInfo.arrayLayers - dst_subresource.baseArrayLayer)) {
+                if (src_subresource.layerCount != (dst_image_state->create_info.arrayLayers - dst_subresource.baseArrayLayer)) {
                     vuid = is_2 ? "VUID-VkImageBlit2-layerCount-08801" : "VUID-VkImageBlit-layerCount-08801";
                     skip |= LogError(
                         vuid, dst_objlist, src_subresource_loc.dot(Field::layerCount),
                         "(%" PRIu32 ") does not match dstImage arrayLayers (%" PRIu32 ") minus baseArrayLayer (%" PRIu32 ").",
-                        src_subresource.layerCount, dst_image_state->createInfo.arrayLayers, dst_subresource.baseArrayLayer);
+                        src_subresource.layerCount, dst_image_state->create_info.arrayLayers, dst_subresource.baseArrayLayer);
                 }
             } else if (dst_subresource.layerCount != VK_REMAINING_ARRAY_LAYERS) {
-                if (dst_subresource.layerCount != (src_image_state->createInfo.arrayLayers - src_subresource.baseArrayLayer)) {
+                if (dst_subresource.layerCount != (src_image_state->create_info.arrayLayers - src_subresource.baseArrayLayer)) {
                     vuid = is_2 ? "VUID-VkImageBlit2-layerCount-08801" : "VUID-VkImageBlit-layerCount-08801";
                     skip |= LogError(
                         vuid, src_objlist, dst_subresource_loc.dot(Field::layerCount),
                         "(%" PRIu32 ") does not match srcImage arrayLayers (%" PRIu32 ") minus baseArrayLayer (%" PRIu32 ").",
-                        dst_subresource.layerCount, src_image_state->createInfo.arrayLayers, src_subresource.baseArrayLayer);
+                        dst_subresource.layerCount, src_image_state->create_info.arrayLayers, src_subresource.baseArrayLayer);
                 }
             }
         } else if (src_subresource.layerCount != dst_subresource.layerCount) {
@@ -3181,7 +3181,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
         // must not overlap in memory
         if (srcImage == dstImage) {
             for (uint32_t j = 0; j < regionCount; j++) {
-                if (RegionIntersectsBlit(&region, &pRegions[j], src_image_state->createInfo.imageType,
+                if (RegionIntersectsBlit(&region, &pRegions[j], src_image_state->create_info.imageType,
                                          vkuFormatIsMultiplane(src_format))) {
                     vuid = is_2 ? "VUID-VkBlitImageInfo2-pRegions-00217" : "VUID-vkCmdBlitImage-pRegions-00217";
                     skip |=
@@ -3297,13 +3297,13 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         ValidateImageFormatFeatureFlags(commandBuffer, *dst_image_state, VK_FORMAT_FEATURE_TRANSFER_DST_BIT, dst_image_loc, vuid);
 
     // Validation for VK_EXT_fragment_density_map
-    if (src_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (src_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
         skip |= LogError(vuid, src_objlist, src_image_loc,
                          "must not have been created with flags containing "
                          "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT");
     }
-    if (dst_image_state->createInfo.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
+    if (dst_image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-02546" : "VUID-vkCmdResolveImage-dstImage-02546";
         skip |= LogError(vuid, dst_objlist, dst_image_loc,
                          "must not have been created with flags containing "
@@ -3349,20 +3349,20 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
 
         if (src_subresource.layerCount == VK_REMAINING_ARRAY_LAYERS || dst_subresource.layerCount == VK_REMAINING_ARRAY_LAYERS) {
             if (src_subresource.layerCount != VK_REMAINING_ARRAY_LAYERS) {
-                if (src_subresource.layerCount != (dst_image_state->createInfo.arrayLayers - dst_subresource.baseArrayLayer)) {
+                if (src_subresource.layerCount != (dst_image_state->create_info.arrayLayers - dst_subresource.baseArrayLayer)) {
                     vuid = is_2 ? "VUID-VkImageResolve2-layerCount-08804" : "VUID-VkImageResolve-layerCount-08804";
                     skip |= LogError(
                         vuid, dst_objlist, src_subresource_loc.dot(Field::layerCount),
                         "(%" PRIu32 ") does not match dstImage arrayLayers (%" PRIu32 ") minus baseArrayLayer (%" PRIu32 ").",
-                        src_subresource.layerCount, dst_image_state->createInfo.arrayLayers, dst_subresource.baseArrayLayer);
+                        src_subresource.layerCount, dst_image_state->create_info.arrayLayers, dst_subresource.baseArrayLayer);
                 }
             } else if (dst_subresource.layerCount != VK_REMAINING_ARRAY_LAYERS) {
-                if (dst_subresource.layerCount != (src_image_state->createInfo.arrayLayers - src_subresource.baseArrayLayer)) {
+                if (dst_subresource.layerCount != (src_image_state->create_info.arrayLayers - src_subresource.baseArrayLayer)) {
                     vuid = is_2 ? "VUID-VkImageResolve2-layerCount-08804" : "VUID-VkImageResolve-layerCount-08804";
                     skip |= LogError(
                         vuid, src_objlist, dst_subresource_loc.dot(Field::layerCount),
                         "(%" PRIu32 ") does not match srcImage arrayLayers (%" PRIu32 ") minus baseArrayLayer (%" PRIu32 ").",
-                        dst_subresource.layerCount, src_image_state->createInfo.arrayLayers, src_subresource.baseArrayLayer);
+                        dst_subresource.layerCount, src_image_state->create_info.arrayLayers, src_subresource.baseArrayLayer);
                 }
             }
         } else if (src_subresource.layerCount != dst_subresource.layerCount) {
@@ -3381,8 +3381,8 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
                              string_VkImageAspectFlags(dst_subresource.aspectMask).c_str());
         }
 
-        const VkImageType src_image_type = src_image_state->createInfo.imageType;
-        const VkImageType dst_image_type = dst_image_state->createInfo.imageType;
+        const VkImageType src_image_type = src_image_state->create_info.imageType;
+        const VkImageType dst_image_type = dst_image_state->create_info.imageType;
 
         if (VK_IMAGE_TYPE_3D == dst_image_type) {
             if (src_subresource.layerCount != 1) {
@@ -3436,7 +3436,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         VkExtent3D subresource_extent = src_image_state->GetEffectiveSubresourceExtent(src_subresource);
         // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
         // developer
-        if (src_subresource.mipLevel < src_image_state->createInfo.mipLevels) {
+        if (src_subresource.mipLevel < src_image_state->create_info.mipLevels) {
             uint32_t extent_check = ExceedsBounds(&(region.srcOffset), &(region.extent), &subresource_extent);
             if ((extent_check & kXBit) != 0) {
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-srcOffset-00269" : "VUID-vkCmdResolveImage-srcOffset-00269";
@@ -3467,7 +3467,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         subresource_extent = dst_image_state->GetEffectiveSubresourceExtent(dst_subresource);
         // MipLevel bound is checked already and adding extra errors with a "subresource extent of zero" is confusing to
         // developer
-        if (dst_subresource.mipLevel < dst_image_state->createInfo.mipLevels) {
+        if (dst_subresource.mipLevel < dst_image_state->create_info.mipLevels) {
             uint32_t extent_check = ExceedsBounds(&(region.dstOffset), &(region.extent), &subresource_extent);
             if ((extent_check & kXBit) != 0) {
                 vuid = is_2 ? "VUID-VkResolveImageInfo2-dstOffset-00274" : "VUID-vkCmdResolveImage-dstOffset-00274";
@@ -3495,19 +3495,20 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
         }
     }
 
-    if (src_image_state->createInfo.format != dst_image_state->createInfo.format) {
+    if (src_image_state->create_info.format != dst_image_state->create_info.format) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-01386" : "VUID-vkCmdResolveImage-srcImage-01386";
-        skip |= LogError(vuid, all_objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
-                         string_VkFormat(src_image_state->createInfo.format), string_VkFormat(dst_image_state->createInfo.format));
+        skip |=
+            LogError(vuid, all_objlist, src_image_loc, "was created with format %s but dstImage format is %s.",
+                     string_VkFormat(src_image_state->create_info.format), string_VkFormat(dst_image_state->create_info.format));
     }
-    if (src_image_state->createInfo.samples == VK_SAMPLE_COUNT_1_BIT) {
+    if (src_image_state->create_info.samples == VK_SAMPLE_COUNT_1_BIT) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-srcImage-00257" : "VUID-vkCmdResolveImage-srcImage-00257";
         skip |= LogError(vuid, src_objlist, src_image_loc, "was created with sample count VK_SAMPLE_COUNT_1_BIT.");
     }
-    if (dst_image_state->createInfo.samples != VK_SAMPLE_COUNT_1_BIT) {
+    if (dst_image_state->create_info.samples != VK_SAMPLE_COUNT_1_BIT) {
         vuid = is_2 ? "VUID-VkResolveImageInfo2-dstImage-00259" : "VUID-vkCmdResolveImage-dstImage-00259";
         skip |= LogError(vuid, dst_objlist, dst_image_loc, "was created with sample count (%s) (not VK_SAMPLE_COUNT_1_BIT).",
-                         string_VkSampleCountFlagBits(dst_image_state->createInfo.samples));
+                         string_VkSampleCountFlagBits(dst_image_state->create_info.samples));
     }
     return skip;
 }

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -344,7 +344,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                                      offset, set_idx, binding_index, j);
 
                                 } else if (buffer_state && (bound_range != VK_WHOLE_SIZE) &&
-                                           ((offset + bound_range + bound_offset) > buffer_state->createInfo.size)) {
+                                           ((offset + bound_range + bound_offset) > buffer_state->create_info.size)) {
                                     const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx],
                                                                 buffer_descriptor->GetBuffer());
                                     const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-01979"
@@ -354,7 +354,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                                                  "is %" PRIu32 ", which when added to the buffer descriptor's range (%" PRIu64
                                                  ") and offset (%" PRIu64 ") is greater than the size of the buffer (%" PRIu64
                                                  ") in descriptorSet #%" PRIu32 " binding #%" PRIu32 " descriptor[%" PRIu32 "].",
-                                                 offset, bound_range, bound_offset, buffer_state->createInfo.size, set_idx,
+                                                 offset, bound_range, bound_offset, buffer_state->create_info.size, set_idx,
                                                  binding_index, j);
                                 }
                             }
@@ -366,7 +366,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
                     total_dynamic_descriptors += set_dynamic_descriptor_count;
                 }
             }
-            if (descriptor_set->GetPoolState()->createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) {
+            if (descriptor_set->GetPoolState()->create_info.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT) {
                 const LogObjectList objlist(cb_state.Handle(), pDescriptorSets[set_idx], descriptor_set->GetPoolState()->Handle());
                 const char *vuid = is_2 ? "VUID-VkBindDescriptorSetsInfoKHR-pDescriptorSets-04616"
                                         : "VUID-vkCmdBindDescriptorSets-pDescriptorSets-04616";
@@ -713,8 +713,8 @@ bool CoreChecks::PreCallValidateCreateDescriptorSetLayout(VkDevice device, const
             binding_info.pImmutableSamplers) {
             for (uint32_t j = 0; j < binding_info.descriptorCount; j++) {
                 auto sampler_state = Get<vvl::Sampler>(binding_info.pImmutableSamplers[j]);
-                if (sampler_state && (sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
-                                      sampler_state->createInfo.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)) {
+                if (sampler_state && (sampler_state->create_info.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
+                                      sampler_state->create_info.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT)) {
                     skip |= LogError("VUID-VkDescriptorSetLayoutBinding-pImmutableSamplers-04009", device,
                                      binding_loc.dot(Field::pImmutableSamplers, j),
                                      "(%s) presented as immutable has a custom border color.",
@@ -989,23 +989,23 @@ bool CoreChecks::ValidateCopyUpdate(const VkCopyDescriptorSet &update, const Loc
 
     const auto &src_pool = *src_set.GetPoolState();
     const auto &dst_pool = *dst_set.GetPoolState();
-    if ((src_pool.createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT) &&
-        !(dst_pool.createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
+    if ((src_pool.create_info.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT) &&
+        !(dst_pool.create_info.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
         const LogObjectList objlist(update.srcSet, update.dstSet, src_pool.Handle(), dst_pool.Handle());
         skip |= LogError("VUID-VkCopyDescriptorSet-srcSet-01920", objlist, copy_loc.dot(Field::srcSet),
                          "descriptor pool was created with %s, but dstSet descriptor pool was created with %s.",
-                         string_VkDescriptorPoolCreateFlags(src_pool.createInfo.flags).c_str(),
-                         string_VkDescriptorPoolCreateFlags(dst_pool.createInfo.flags).c_str());
+                         string_VkDescriptorPoolCreateFlags(src_pool.create_info.flags).c_str(),
+                         string_VkDescriptorPoolCreateFlags(dst_pool.create_info.flags).c_str());
     }
 
-    if (!(src_pool.createInfo.flags &
+    if (!(src_pool.create_info.flags &
           (VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT | VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT)) &&
-        (dst_pool.createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
+        (dst_pool.create_info.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
         const LogObjectList objlist(update.srcSet, update.dstSet, src_pool.Handle(), dst_pool.Handle());
         skip |= LogError("VUID-VkCopyDescriptorSet-srcSet-04887", objlist, copy_loc.dot(Field::srcSet),
                          "descriptor pool was created with %s, but dstSet descriptor pool was created with %s.",
-                         string_VkDescriptorPoolCreateFlags(src_pool.createInfo.flags).c_str(),
-                         string_VkDescriptorPoolCreateFlags(dst_pool.createInfo.flags).c_str());
+                         string_VkDescriptorPoolCreateFlags(src_pool.create_info.flags).c_str(),
+                         string_VkDescriptorPoolCreateFlags(dst_pool.create_info.flags).c_str());
     }
 
     if (src_type == VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT && ((update.srcArrayElement % 4) != 0)) {
@@ -1117,11 +1117,11 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     assert(image_node);
 
     const auto image_view_usage_info = vku::FindStructInPNextChain<VkImageViewUsageCreateInfo>(iv_state->create_info.pNext);
-    const auto stencil_usage_info = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_node->createInfo.pNext);
+    const auto stencil_usage_info = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_node->create_info.pNext);
     if (image_view_usage_info) {
         usage = image_view_usage_info->usage;
     } else {
-        usage = image_node->createInfo.usage;
+        usage = image_node->create_info.usage;
     }
     if (stencil_usage_info) {
         const bool stencil_aspect = (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) > 0;
@@ -1141,7 +1141,7 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
     const LogObjectList objlist(iv_state->Handle(), image_node->Handle());
     // KHR_maintenance1 allows rendering into 2D or 2DArray views which slice a 3D image,
     // but not binding them to descriptor sets.
-    if (iv_state->IsDepthSliced() && image_node->createInfo.imageType == VK_IMAGE_TYPE_3D) {
+    if (iv_state->IsDepthSliced() && image_node->create_info.imageType == VK_IMAGE_TYPE_3D) {
         // VK_EXT_image_2d_view_of_3d allows use of VIEW_TYPE_2D in descriptor
         if (iv_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
             skip |= LogError("VUID-VkDescriptorImageInfo-imageView-06712", objlist, image_info_loc.dot(Field::imageView),
@@ -1169,10 +1169,10 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
                                  string_VkDescriptorType(type));
             }
 
-            if (!(image_node->createInfo.flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT)) {
+            if (!(image_node->create_info.flags & VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT)) {
                 skip |= LogError("VUID-VkDescriptorImageInfo-imageView-07796", objlist, image_info_loc.dot(Field::imageView),
                                  "is VK_IMAGE_VIEW_TYPE_2D, the image is VK_IMAGE_VIEW_TYPE_3D, but the image was created with %s.",
-                                 string_VkImageCreateFlags(image_node->createInfo.flags).c_str());
+                                 string_VkImageCreateFlags(image_node->create_info.flags).c_str());
             }
         }
     }
@@ -1198,12 +1198,12 @@ bool CoreChecks::ValidateImageUpdate(VkImageView image_view, VkImageLayout image
         }
     }
 
-    if (vkuFormatIsDepthOrStencil(image_node->createInfo.format)) {
+    if (vkuFormatIsDepthOrStencil(image_node->create_info.format)) {
         if (aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) {
             if (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) {
                 skip |= LogError("VUID-VkDescriptorImageInfo-imageView-01976", objlist, image_info_loc.dot(Field::imageView),
                                  "use layout %s and the image format (%s), but it has both STENCIL and DEPTH aspects set",
-                                 string_VkImageLayout(image_layout), string_VkFormat(image_node->createInfo.format));
+                                 string_VkImageLayout(image_layout), string_VkFormat(image_node->create_info.format));
             }
         }
     }
@@ -1374,14 +1374,14 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
         if (acceleration_structure_khr) {
             for (uint32_t j = 0; j < acceleration_structure_khr->accelerationStructureCount; ++j) {
                 auto as_state = Get<vvl::AccelerationStructureKHR>(acceleration_structure_khr->pAccelerationStructures[j]);
-                if (as_state && (as_state->create_infoKHR.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR &&
-                                 (as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
-                                  as_state->create_infoKHR.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR))) {
+                if (as_state && (as_state->create_info.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR &&
+                                 (as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR &&
+                                  as_state->create_info.type != VK_ACCELERATION_STRUCTURE_TYPE_GENERIC_KHR))) {
                     const LogObjectList objlist(dst_set, as_state->Handle());
                     skip |= LogError(
                         "VUID-VkWriteDescriptorSetAccelerationStructureKHR-pAccelerationStructures-03579", objlist,
                         write_loc.pNext(Struct::VkWriteDescriptorSetAccelerationStructureKHR, Field::pAccelerationStructures, j),
-                        "was created with %s.", string_VkAccelerationStructureTypeKHR(as_state->create_infoKHR.type));
+                        "was created with %s.", string_VkAccelerationStructureTypeKHR(as_state->create_info.type));
                 }
             }
         }
@@ -1391,13 +1391,13 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
         if (acceleration_structure_nv) {
             for (uint32_t j = 0; j < acceleration_structure_nv->accelerationStructureCount; ++j) {
                 auto as_state = Get<vvl::AccelerationStructureNV>(acceleration_structure_nv->pAccelerationStructures[j]);
-                if (as_state && (as_state->create_infoNV.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV &&
-                                 as_state->create_infoNV.info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV)) {
+                if (as_state && (as_state->create_info.sType == VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV &&
+                                 as_state->create_info.info.type != VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV)) {
                     const LogObjectList objlist(dst_set, as_state->Handle());
                     skip |= LogError(
                         "VUID-VkWriteDescriptorSetAccelerationStructureNV-pAccelerationStructures-03748", objlist,
                         write_loc.pNext(Struct::VkWriteDescriptorSetAccelerationStructureKHR, Field::pAccelerationStructures, j),
-                        "was created with %s.", string_VkAccelerationStructureTypeKHR(as_state->create_infoNV.info.type));
+                        "was created with %s.", string_VkAccelerationStructureTypeKHR(as_state->create_info.info.type));
                 }
             }
         }
@@ -1580,20 +1580,20 @@ bool CoreChecks::ValidateBufferUpdate(const VkDescriptorBufferInfo &buffer_info,
                                           "VUID-VkWriteDescriptorSet-descriptorType-00329");
     skip |= ValidateBufferUsage(buffer_state, type, buffer_info_loc.dot(Field::buffer));
 
-    if (buffer_info.offset >= buffer_state.createInfo.size) {
+    if (buffer_info.offset >= buffer_state.create_info.size) {
         skip |= LogError("VUID-VkDescriptorBufferInfo-offset-00340", buffer_info.buffer, buffer_info_loc.dot(Field::offset),
                          "(%" PRIu64 ") is greater than or equal to buffer size (%" PRIu64 ").", buffer_info.offset,
-                         buffer_state.createInfo.size);
+                         buffer_state.create_info.size);
     }
     if (buffer_info.range != VK_WHOLE_SIZE) {
         if (buffer_info.range == 0) {
             skip |= LogError("VUID-VkDescriptorBufferInfo-range-00341", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                              "is not VK_WHOLE_SIZE and is zero.");
         }
-        if (buffer_info.range > (buffer_state.createInfo.size - buffer_info.offset)) {
+        if (buffer_info.range > (buffer_state.create_info.size - buffer_info.offset)) {
             skip |= LogError("VUID-VkDescriptorBufferInfo-range-00342", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                              "(%" PRIu64 ") is larger than buffer size (%" PRIu64 ") + offset (%" PRIu64 ").", buffer_info.range,
-                             buffer_state.createInfo.size, buffer_info.offset);
+                             buffer_state.create_info.size, buffer_info.offset);
         }
     }
 
@@ -1604,12 +1604,12 @@ bool CoreChecks::ValidateBufferUpdate(const VkDescriptorBufferInfo &buffer_info,
                 LogError("VUID-VkWriteDescriptorSet-descriptorType-00332", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                          "(%" PRIu64 ") is greater than maxUniformBufferRange (%" PRIu32 ") for descriptorType %s.",
                          buffer_info.range, max_ub_range, string_VkDescriptorType(type));
-        } else if (buffer_info.range == VK_WHOLE_SIZE && (buffer_state.createInfo.size - buffer_info.offset) > max_ub_range) {
+        } else if (buffer_info.range == VK_WHOLE_SIZE && (buffer_state.create_info.size - buffer_info.offset) > max_ub_range) {
             skip |=
                 LogError("VUID-VkWriteDescriptorSet-descriptorType-00332", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                          "is VK_WHOLE_SIZE, but the effective range [size (%" PRIu64 ") - offset (%" PRIu64 ") = %" PRIu64
                          "] is greater than maxUniformBufferRange (%" PRIu32 ") for descriptorType %s.",
-                         buffer_state.createInfo.size, buffer_info.offset, buffer_state.createInfo.size - buffer_info.offset,
+                         buffer_state.create_info.size, buffer_info.offset, buffer_state.create_info.size - buffer_info.offset,
                          max_ub_range, string_VkDescriptorType(type));
         }
     } else if (VK_DESCRIPTOR_TYPE_STORAGE_BUFFER == type || VK_DESCRIPTOR_TYPE_STORAGE_BUFFER_DYNAMIC == type) {
@@ -1619,12 +1619,12 @@ bool CoreChecks::ValidateBufferUpdate(const VkDescriptorBufferInfo &buffer_info,
                 LogError("VUID-VkWriteDescriptorSet-descriptorType-00333", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                          "(%" PRIu64 ") is greater than maxStorageBufferRange (%" PRIu32 ") for descriptorType %s.",
                          buffer_info.range, max_sb_range, string_VkDescriptorType(type));
-        } else if (buffer_info.range == VK_WHOLE_SIZE && (buffer_state.createInfo.size - buffer_info.offset) > max_sb_range) {
+        } else if (buffer_info.range == VK_WHOLE_SIZE && (buffer_state.create_info.size - buffer_info.offset) > max_sb_range) {
             skip |=
                 LogError("VUID-VkWriteDescriptorSet-descriptorType-00333", buffer_info.buffer, buffer_info_loc.dot(Field::range),
                          "is VK_WHOLE_SIZE, but the effective range [size (%" PRIu64 ") - offset (%" PRIu64 ") = %" PRIu64
                          "] is greater than maxStorageBufferRange (%" PRIu32 ") for descriptorType %s.",
-                         buffer_state.createInfo.size, buffer_info.offset, buffer_state.createInfo.size - buffer_info.offset,
+                         buffer_state.create_info.size, buffer_info.offset, buffer_state.create_info.size - buffer_info.offset,
                          max_sb_range, string_VkDescriptorType(type));
         }
     }
@@ -1961,15 +1961,15 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                     }
                 }
                 // If there is an immutable sampler then |sampler| isn't used, so the following VU does not apply.
-                if (sampler && !desc.IsImmutableSampler() && vkuFormatIsMultiplane(image_state->createInfo.format)) {
+                if (sampler && !desc.IsImmutableSampler() && vkuFormatIsMultiplane(image_state->create_info.format)) {
                     // multiplane formats must be created with mutable format bit
-                    const VkFormat image_format = image_state->createInfo.format;
-                    if (0 == (image_state->createInfo.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
+                    const VkFormat image_format = image_state->create_info.format;
+                    if (0 == (image_state->create_info.flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT)) {
                         const LogObjectList objlist(update.dstSet, image_state->Handle());
                         skip |= LogError("VUID-VkDescriptorImageInfo-sampler-01564", objlist, write_loc,
                                          "combined image sampler is a multi-planar format %s and was created with %s.",
                                          string_VkFormat(image_format),
-                                         string_VkImageCreateFlags(image_state->createInfo.flags).c_str());
+                                         string_VkImageCreateFlags(image_state->create_info.flags).c_str());
                     }
                     const VkImageAspectFlags image_aspect = iv_state->create_info.subresourceRange.aspectMask;
                     if (!IsValidPlaneAspect(image_format, image_aspect)) {
@@ -1985,7 +1985,7 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
                 if (sampler_state) {
                     if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
                         if ((VK_FALSE == enabled_features.mutableComparisonSamplers) &&
-                            (VK_FALSE != sampler_state->createInfo.compareEnable)) {
+                            (VK_FALSE != sampler_state->create_info.compareEnable)) {
                             skip |= LogError("VUID-VkDescriptorImageInfo-mutableComparisonSamplers-04450", device, write_loc,
                                              "(portability error): sampler comparison not available.");
                         }
@@ -2620,10 +2620,10 @@ bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice
     auto buffer_state = Get<vvl::Buffer>(pInfo->buffer);
 
     if (buffer_state) {
-        if (!(buffer_state->createInfo.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
+        if (!(buffer_state->create_info.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
             skip |= LogError("VUID-VkBufferCaptureDescriptorDataInfoEXT-buffer-08075", pInfo->buffer,
                              error_obj.location.dot(Field::pInfo).dot(Field::buffer), "was created with %s.",
-                             string_VkBufferCreateFlags(buffer_state->createInfo.flags).c_str());
+                             string_VkBufferCreateFlags(buffer_state->create_info.flags).c_str());
         }
     }
 
@@ -2652,10 +2652,10 @@ bool CoreChecks::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice 
     auto image_state = Get<vvl::Image>(pInfo->image);
 
     if (image_state) {
-        if (!(image_state->createInfo.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
+        if (!(image_state->create_info.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
             skip |= LogError("VUID-VkImageCaptureDescriptorDataInfoEXT-image-08079", pInfo->image,
                              error_obj.location.dot(Field::pInfo).dot(Field::image), "is %s.",
-                             string_VkImageCreateFlags(image_state->createInfo.flags).c_str());
+                             string_VkImageCreateFlags(image_state->create_info.flags).c_str());
         }
     }
 
@@ -2716,10 +2716,10 @@ bool CoreChecks::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEXT(VkDevic
     auto sampler_state = Get<vvl::Sampler>(pInfo->sampler);
 
     if (sampler_state) {
-        if (!(sampler_state->createInfo.flags & VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
+        if (!(sampler_state->create_info.flags & VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
             skip |= LogError("VUID-VkSamplerCaptureDescriptorDataInfoEXT-sampler-08087", pInfo->sampler,
                              error_obj.location.dot(Field::pInfo).dot(Field::sampler), "is %s.",
-                             string_VkSamplerCreateFlags(sampler_state->createInfo.flags).c_str());
+                             string_VkSamplerCreateFlags(sampler_state->create_info.flags).c_str());
         }
     }
 
@@ -2749,12 +2749,12 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
         auto acceleration_structure_state = Get<vvl::AccelerationStructureKHR>(pInfo->accelerationStructure);
 
         if (acceleration_structure_state) {
-            if (!(acceleration_structure_state->create_infoKHR.createFlags &
+            if (!(acceleration_structure_state->create_info.createFlags &
                   VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
                 skip |= LogError(
                     "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructure-08091",
                     pInfo->accelerationStructure, error_obj.location, "pInfo->accelerationStructure was %s.",
-                    string_VkAccelerationStructureCreateFlagsKHR(acceleration_structure_state->create_infoKHR.createFlags).c_str());
+                    string_VkAccelerationStructureCreateFlagsKHR(acceleration_structure_state->create_info.createFlags).c_str());
             }
         }
 
@@ -2769,12 +2769,12 @@ bool CoreChecks::PreCallValidateGetAccelerationStructureOpaqueCaptureDescriptorD
         auto acceleration_structure_state = Get<vvl::AccelerationStructureNV>(pInfo->accelerationStructureNV);
 
         if (acceleration_structure_state) {
-            if (!(acceleration_structure_state->create_infoNV.info.flags &
+            if (!(acceleration_structure_state->create_info.info.flags &
                   VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
                 skip |= LogError(
                     "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructureNV-08092",
                     pInfo->accelerationStructureNV, error_obj.location, "pInfo->accelerationStructure was %s.",
-                    string_VkAccelerationStructureCreateFlagsKHR(acceleration_structure_state->create_infoNV.info.flags).c_str());
+                    string_VkAccelerationStructureCreateFlagsKHR(acceleration_structure_state->create_info.info.flags).c_str());
             }
         }
 
@@ -2820,10 +2820,10 @@ bool CoreChecks::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoE
             {{{"VUID-VkDescriptorAddressInfoEXT-range-08045",
                [&address_info](vvl::Buffer *const buffer_state, std::string *out_error_msg) {
                    if (address_info->range >
-                       buffer_state->createInfo.size - (address_info->address - buffer_state->deviceAddress)) {
+                       buffer_state->create_info.size - (address_info->address - buffer_state->deviceAddress)) {
                        if (out_error_msg) {
                            const sparse_container::range<VkDeviceAddress> buffer_address_range{
-                               buffer_state->deviceAddress, buffer_state->deviceAddress + buffer_state->createInfo.size};
+                               buffer_state->deviceAddress, buffer_state->deviceAddress + buffer_state->create_info.size};
                            *out_error_msg += "buffer has range " + string_range_hex(buffer_address_range);
                        }
                        return false;
@@ -2931,7 +2931,7 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
         } else {
             const auto image_view_state = Get<vvl::ImageView>(combined_image_sampler->imageView);
             if (image_view_state && image_view_state->samplerConversion != VK_NULL_HANDLE) {
-                auto image_info = image_view_state->image_state->createInfo;
+                auto image_info = image_view_state->image_state->create_info;
                 VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
                 image_format_info.type = image_info.imageType;
                 image_format_info.format = image_info.format;
@@ -2957,7 +2957,7 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
 
         if (combined_image_sampler->sampler != VK_NULL_HANDLE) {
             const auto sampler_state = Get<vvl::Sampler>(combined_image_sampler->sampler);
-            if (sampler_state && (0 != (sampler_state->createInfo.flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT))) {
+            if (sampler_state && (0 != (sampler_state->create_info.flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT))) {
                 size = phys_dev_ext_props.descriptor_buffer_density_props.combinedImageSamplerDensityMapDescriptorSize;
                 struct_name = Struct::VkPhysicalDeviceDescriptorBufferDensityMapPropertiesEXT;
                 field_name = Field::combinedImageSamplerDensityMapDescriptorSize;
@@ -3297,20 +3297,20 @@ bool CoreChecks::PreCallValidateAllocateDescriptorSets(VkDevice device, const Vk
                              FormatHandle(pAllocateInfo->pSetLayouts[i]).c_str());
         }
         if (layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT &&
-            !(pool_state->createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
+            !(pool_state->create_info.flags & VK_DESCRIPTOR_POOL_CREATE_UPDATE_AFTER_BIND_BIT)) {
             const LogObjectList objlist(pAllocateInfo->descriptorPool, pAllocateInfo->pSetLayouts[i]);
             skip |= LogError("VUID-VkDescriptorSetAllocateInfo-pSetLayouts-03044", objlist, set_layout_loc,
                              "was created with %s but the descriptorPool was created with %s",
                              string_VkDescriptorSetLayoutCreateFlags(layout->GetCreateFlags()).c_str(),
-                             string_VkDescriptorPoolCreateFlags(pool_state->createInfo.flags).c_str());
+                             string_VkDescriptorPoolCreateFlags(pool_state->create_info.flags).c_str());
         }
         if (layout->GetCreateFlags() & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT &&
-            !(pool_state->createInfo.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT)) {
+            !(pool_state->create_info.flags & VK_DESCRIPTOR_POOL_CREATE_HOST_ONLY_BIT_EXT)) {
             const LogObjectList objlist(pAllocateInfo->descriptorPool, pAllocateInfo->pSetLayouts[i]);
             skip |= LogError("VUID-VkDescriptorSetAllocateInfo-pSetLayouts-04610", objlist, set_layout_loc,
                              "was created with %s but the descriptorPool was created with %s",
                              string_VkDescriptorSetLayoutCreateFlags(layout->GetCreateFlags()).c_str(),
-                             string_VkDescriptorPoolCreateFlags(pool_state->createInfo.flags).c_str());
+                             string_VkDescriptorPoolCreateFlags(pool_state->create_info.flags).c_str());
         }
     }
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance1)) {
@@ -3437,11 +3437,11 @@ bool CoreChecks::PreCallValidateFreeDescriptorSets(VkDevice device, VkDescriptor
         }
     }
     auto pool_state = Get<vvl::DescriptorPool>(descriptorPool);
-    if (pool_state && !(VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT & pool_state->createInfo.flags)) {
+    if (pool_state && !(VK_DESCRIPTOR_POOL_CREATE_FREE_DESCRIPTOR_SET_BIT & pool_state->create_info.flags)) {
         // Can't Free from a NON_FREE pool
         skip |= LogError("VUID-vkFreeDescriptorSets-descriptorPool-00312", descriptorPool,
                          error_obj.location.dot(Field::descriptorPool), "with a pool created with %s.",
-                         string_VkDescriptorPoolCreateFlags(pool_state->createInfo.flags).c_str());
+                         string_VkDescriptorPoolCreateFlags(pool_state->create_info.flags).c_str());
     }
     return skip;
 }
@@ -4405,8 +4405,8 @@ bool CoreChecks::PreCallValidateCreatePipelineLayout(VkDevice device, const VkPi
                     (binding->pImmutableSamplers != nullptr)) {
                     for (uint32_t sampler_idx = 0; sampler_idx < binding->descriptorCount; sampler_idx++) {
                         auto state = Get<vvl::Sampler>(binding->pImmutableSamplers[sampler_idx]);
-                        if (state && (state->createInfo.flags & (VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT |
-                                                                 VK_SAMPLER_CREATE_SUBSAMPLED_COARSE_RECONSTRUCTION_BIT_EXT))) {
+                        if (state && (state->create_info.flags & (VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT |
+                                                                  VK_SAMPLER_CREATE_SUBSAMPLED_COARSE_RECONSTRUCTION_BIT_EXT))) {
                             sum_subsampled_samplers++;
                         }
                     }

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -84,7 +84,7 @@ bool CoreChecks::ValidatePhysicalDeviceQueueFamilies(uint32_t queue_family_count
 bool CoreChecks::GetPhysicalDeviceImageFormatProperties(vvl::Image &image_state, const char *vuid_string,
                                                         const Location &loc) const {
     bool skip = false;
-    const auto image_create_info = image_state.createInfo;
+    const auto image_create_info = image_state.create_info;
     VkResult image_properties_result = VK_SUCCESS;
     Func command = Func::vkGetPhysicalDeviceImageFormatProperties;
     if (image_create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -49,7 +49,7 @@ bool CoreChecks::VerifyBoundMemoryIsDeviceVisible(const vvl::DeviceMemory *mem_s
                                                   const char *vuid) const {
     bool result = false;
     if (mem_state) {
-        if ((phys_dev_mem_props.memoryTypes[mem_state->alloc_info.memoryTypeIndex].propertyFlags &
+        if ((phys_dev_mem_props.memoryTypes[mem_state->allocate_info.memoryTypeIndex].propertyFlags &
              VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT) == 0) {
             result |= LogError(vuid, objlist, loc, "(%s) used with memory that is not device visible.",
                                FormatHandle(typed_handle).c_str());
@@ -104,8 +104,8 @@ bool CoreChecks::ValidateAccelStructsMemoryDoNotOverlap(const Location &function
     const vvl::Buffer &buffer_a = *accel_struct_a.buffer_state;
     const vvl::Buffer &buffer_b = *accel_struct_b.buffer_state;
 
-    const sparse_container::range<VkDeviceSize> range_a(accel_struct_a.create_infoKHR.offset, accel_struct_a.create_infoKHR.size);
-    const sparse_container::range<VkDeviceSize> range_b(accel_struct_b.create_infoKHR.offset, accel_struct_b.create_infoKHR.size);
+    const sparse_container::range<VkDeviceSize> range_a(accel_struct_a.create_info.offset, accel_struct_a.create_info.size);
+    const sparse_container::range<VkDeviceSize> range_b(accel_struct_b.create_info.offset, accel_struct_b.create_info.size);
 
     if (const auto [memory, overlap_range] = buffer_a.GetResourceMemoryOverlap(range_a, &buffer_b, range_b);
         memory != VK_NULL_HANDLE) {
@@ -130,7 +130,7 @@ bool CoreChecks::ValidateAccelStructBufferMemoryIsHostVisible(const vvl::Acceler
     if (!result) {
         const auto mem_state = accel_struct.buffer_state->MemState();
         if (mem_state) {
-            if ((phys_dev_mem_props.memoryTypes[mem_state->alloc_info.memoryTypeIndex].propertyFlags &
+            if ((phys_dev_mem_props.memoryTypes[mem_state->allocate_info.memoryTypeIndex].propertyFlags &
                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
                 const LogObjectList objlist(accel_struct.Handle(), accel_struct.buffer_state->Handle(), mem_state->Handle());
                 result |=
@@ -248,9 +248,9 @@ bool CoreChecks::IsZeroAllocationSizeAllowed(const VkMemoryAllocateInfo *pAlloca
 
 bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Buffer &buffer, VkExternalMemoryHandleTypeFlagBits handle_type) const {
     VkPhysicalDeviceExternalBufferInfo info = vku::InitStructHelper();
-    info.flags = buffer.createInfo.flags;
+    info.flags = buffer.create_info.flags;
     // TODO - Add VkBufferUsageFlags2CreateInfoKHR support
-    info.usage = buffer.createInfo.usage;
+    info.usage = buffer.create_info.usage;
     info.handleType = handle_type;
     VkExternalBufferProperties properties = vku::InitStructHelper();
     DispatchGetPhysicalDeviceExternalBufferProperties(physical_device, &info, &properties);
@@ -261,15 +261,15 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExter
     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
     external_info.handleType = handle_type;
     VkPhysicalDeviceImageFormatInfo2 info = vku::InitStructHelper(&external_info);
-    info.format = image.createInfo.format;
-    info.type = image.createInfo.imageType;
-    info.tiling = image.createInfo.tiling;
-    info.usage = image.createInfo.usage;
-    info.flags = image.createInfo.flags;
+    info.format = image.create_info.format;
+    info.type = image.create_info.imageType;
+    info.tiling = image.create_info.tiling;
+    info.usage = image.create_info.usage;
+    info.flags = image.create_info.flags;
 
     VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
     VkImageFormatProperties2 properties = vku::InitStructHelper(&external_properties);
-    if (image.createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+    if (image.create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         if (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) {
             if (DispatchGetPhysicalDeviceImageFormatProperties2KHR(physical_device, &info, &properties) != VK_SUCCESS) {
                 return false;
@@ -281,9 +281,9 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExter
         }
     } else {
         VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
-        drm_format_modifier.sharingMode = image.createInfo.sharingMode;
-        drm_format_modifier.queueFamilyIndexCount = image.createInfo.queueFamilyIndexCount;
-        drm_format_modifier.pQueueFamilyIndices = image.createInfo.pQueueFamilyIndices;
+        drm_format_modifier.sharingMode = image.create_info.sharingMode;
+        drm_format_modifier.queueFamilyIndexCount = image.create_info.queueFamilyIndexCount;
+        drm_format_modifier.pQueueFamilyIndices = image.create_info.pQueueFamilyIndices;
         vvl::PnextChainScopedAdd scoped_add_drm_fmt_mod(&info, &drm_format_modifier);
 
         VkImageDrmFormatModifierPropertiesEXT drm_format_properties = vku::InitStructHelper();
@@ -414,7 +414,7 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                      pAllocateInfo->allocationSize, image_loc.Fields().c_str(),
                                      FormatHandle(dedicated_image).c_str(), image_state->requirements[0].size);
                 }
-                if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
+                if ((image_state->create_info.flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
                     skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01434", objlist, image_loc,
                                      "(%s): was created with VK_IMAGE_CREATE_SPARSE_BINDING_BIT.",
                                      FormatHandle(dedicated_image).c_str());
@@ -433,7 +433,7 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                  pAllocateInfo->allocationSize, buffer_loc.Fields().c_str(), FormatHandle(dedicated_buffer).c_str(),
                                  buffer_state->requirements.size);
             }
-            if ((buffer_state->createInfo.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0) {
+            if ((buffer_state->create_info.flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0) {
                 skip |=
                     LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01436", objlist, buffer_loc,
                              "(%s) was created with VK_BUFFER_CREATE_SPARSE_BINDING_BIT.", FormatHandle(dedicated_buffer).c_str());
@@ -635,7 +635,7 @@ bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle
                                            VkDeviceSize memoryOffset, const Location &loc) const {
     bool skip = false;
 
-    if (memoryOffset >= mem_info.alloc_info.allocationSize) {
+    if (memoryOffset >= mem_info.allocate_info.allocationSize) {
         const bool bind_2 = (loc.function != Func::vkBindBufferMemory) && (loc.function != Func::vkBindImageMemory);
         const char *vuid = nullptr;
         if (typed_handle.type == kVulkanObjectTypeBuffer) {
@@ -653,7 +653,7 @@ bool CoreChecks::ValidateInsertMemoryRange(const VulkanTypedHandle &typed_handle
                          "attempting to bind %s to %s, memoryOffset (%" PRIu64
                          ") must be less than the memory allocation size (%" PRIu64 ").",
                          FormatHandle(mem_info.Handle()).c_str(), FormatHandle(typed_handle).c_str(), memoryOffset,
-                         mem_info.alloc_info.allocationSize);
+                         mem_info.allocate_info.allocationSize);
     }
 
     return skip;
@@ -672,10 +672,10 @@ bool CoreChecks::ValidateInsertBufferMemoryRange(VkBuffer buffer, const vvl::Dev
 bool CoreChecks::ValidateMemoryTypes(const vvl::DeviceMemory &mem_info, const uint32_t memory_type_bits,
                                      const Location &resource_loc, const char *vuid) const {
     bool skip = false;
-    if (((1 << mem_info.alloc_info.memoryTypeIndex) & memory_type_bits) == 0) {
+    if (((1 << mem_info.allocate_info.memoryTypeIndex) & memory_type_bits) == 0) {
         skip |= LogError(vuid, mem_info.Handle(), resource_loc,
                          "require memoryTypeBits (0x%x) but %s was allocated with memoryTypeIndex (%" PRIu32 ").", memory_type_bits,
-                         FormatHandle(mem_info.Handle()).c_str(), mem_info.alloc_info.memoryTypeIndex);
+                         FormatHandle(mem_info.Handle()).c_str(), mem_info.allocate_info.memoryTypeIndex);
     }
     return skip;
 }
@@ -733,7 +733,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         // because they require buffer information.
         if (mem_info->IsExport()) {
             VkPhysicalDeviceExternalBufferInfo external_info = vku::InitStructHelper();
-            external_info.flags = buffer_state->createInfo.flags;
+            external_info.flags = buffer_state->create_info.flags;
             // TODO: for now, there is no VkBufferUsageFlags2KHR flag that exceeds 32-bit but should be revisited later
             external_info.usage = VkBufferUsageFlags(buffer_state->usage);
             VkExternalBufferProperties external_properties = vku::InitStructHelper();
@@ -792,15 +792,15 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
         skip |= ValidateMemoryTypes(*mem_info, buffer_state->requirements.memoryTypeBits, loc.dot(Field::buffer), mem_type_vuid);
 
         // Validate memory requirements size
-        if (buffer_state->requirements.size > (mem_info->alloc_info.allocationSize - memoryOffset)) {
+        if (buffer_state->requirements.size > (mem_info->allocate_info.allocationSize - memoryOffset)) {
             const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-size-01037" : "VUID-vkBindBufferMemory-size-01037";
             const LogObjectList objlist(buffer, memory);
             skip |= LogError(vuid, objlist, loc,
                              "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
                              " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                              ", returned from a call to vkGetBufferMemoryRequirements with buffer.",
-                             mem_info->alloc_info.allocationSize, memoryOffset, mem_info->alloc_info.allocationSize - memoryOffset,
-                             buffer_state->requirements.size);
+                             mem_info->allocate_info.allocationSize, memoryOffset,
+                             mem_info->allocate_info.allocationSize - memoryOffset, buffer_state->requirements.size);
         }
 
         // Validate dedicated allocation
@@ -816,7 +816,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
                              memoryOffset);
         }
 
-        auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->alloc_info.pNext);
+        auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->allocate_info.pNext);
         if (enabled_features.bufferDeviceAddress && (buffer_state->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) &&
             (!chained_flags_struct || !(chained_flags_struct->flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT))) {
             const LogObjectList objlist(buffer, memory);
@@ -827,7 +827,7 @@ bool CoreChecks::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory memory
                              "memory must have been allocated with the VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT bit set.");
         }
         const VkMemoryAllocateFlags memory_allocate_flags = chained_flags_struct ? chained_flags_struct->flags : 0;
-        if (buffer_state->createInfo.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) {
+        if (buffer_state->create_info.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) {
             if (!(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)) {
                 const char *vuid = bind_buffer_mem_2 ? "VUID-VkBindBufferMemoryInfo-descriptorBufferCaptureReplay-08112"
                                                      : "VUID-vkBindBufferMemory-descriptorBufferCaptureReplay-08112";
@@ -974,8 +974,8 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, con
     skip |= ValidateGetImageMemoryRequirementsANDROID(pInfo->image, image_loc);
 
     auto image_state = Get<vvl::Image>(pInfo->image);
-    const VkFormat image_format = image_state->createInfo.format;
-    const VkImageTiling image_tiling = image_state->createInfo.tiling;
+    const VkFormat image_format = image_state->create_info.format;
+    const VkImageTiling image_tiling = image_state->create_info.tiling;
     const auto *image_plane_info = vku::FindStructInPNextChain<VkImagePlaneMemoryRequirementsInfo>(pInfo->pNext);
     if (!image_plane_info && image_state->disjoint) {
         if (vkuFormatIsMultiplane(image_format)) {
@@ -985,7 +985,7 @@ bool CoreChecks::PreCallValidateGetImageMemoryRequirements2(VkDevice device, con
                              "VkImagePlaneMemoryRequirementsInfo struct",
                              FormatHandle(pInfo->image).c_str(), string_VkFormat(image_format));
         }
-        if (image_state->createInfo.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+        if (image_state->create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
             skip |= LogError("VUID-VkImageMemoryRequirementsInfo2-image-02279", pInfo->image, image_loc,
                              "(%s) was created with VK_IMAGE_CREATE_DISJOINT_BIT and has tiling of "
                              "VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT, "
@@ -1047,7 +1047,7 @@ bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory &mem_info, VkDeviceSi
     const Location loc(offset_loc.function);
     const VkDeviceMemory memory = mem_info.VkHandle();
 
-    const uint32_t memoryTypeIndex = mem_info.alloc_info.memoryTypeIndex;
+    const uint32_t memoryTypeIndex = mem_info.allocate_info.memoryTypeIndex;
     const VkMemoryPropertyFlags propertyFlags = phys_dev_mem_props.memoryTypes[memoryTypeIndex].propertyFlags;
     if ((propertyFlags & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) == 0) {
         skip |= LogError(map2 ? "VUID-VkMemoryMapInfoKHR-memory-07962" : "VUID-vkMapMemory-memory-00682", memory, loc,
@@ -1072,7 +1072,7 @@ bool CoreChecks::ValidateMapMemory(const vvl::DeviceMemory &mem_info, VkDeviceSi
     }
 
     // Validate offset is not over allocation size
-    const VkDeviceSize allocationSize = mem_info.alloc_info.allocationSize;
+    const VkDeviceSize allocationSize = mem_info.allocate_info.allocationSize;
     if (offset >= allocationSize) {
         skip |= LogError(map2 ? "VUID-VkMemoryMapInfoKHR-offset-07959" : "VUID-vkMapMemory-offset-00679", memory, offset_loc,
                          "0x%" PRIx64 " is larger than the total array size 0x%" PRIx64, offset, allocationSize);
@@ -1258,7 +1258,7 @@ bool CoreChecks::ValidateMemoryIsMapped(uint32_t memoryRangeCount, const VkMappe
                              pMemoryRanges[i].offset, mem_info->mapped_range.offset);
             }
             const uint64_t data_end = (mem_info->mapped_range.size == VK_WHOLE_SIZE)
-                                          ? mem_info->alloc_info.allocationSize
+                                          ? mem_info->allocate_info.allocationSize
                                           : (mem_info->mapped_range.offset + mem_info->mapped_range.size);
             if ((data_end < (pMemoryRanges[i].offset + pMemoryRanges[i].size))) {
                 skip |= LogError("VUID-VkMappedMemoryRange-size-00685", pMemoryRanges[i].memory, memory_range_loc,
@@ -1290,7 +1290,7 @@ bool CoreChecks::ValidateMappedMemoryRangeDeviceLimits(uint32_t mem_range_count,
         if (!mem_info) {
             continue;
         }
-        const auto allocation_size = mem_info->alloc_info.allocationSize;
+        const auto allocation_size = mem_info->allocate_info.allocationSize;
         if (size == VK_WHOLE_SIZE) {
             const auto mapping_offset = mem_info->mapped_range.offset;
             const auto mapping_size = mem_info->mapped_range.size;
@@ -1340,7 +1340,7 @@ bool CoreChecks::PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDev
     auto mem_info = Get<vvl::DeviceMemory>(memory);
 
     if (mem_info) {
-        if ((phys_dev_mem_props.memoryTypes[mem_info->alloc_info.memoryTypeIndex].propertyFlags &
+        if ((phys_dev_mem_props.memoryTypes[mem_info->allocate_info.memoryTypeIndex].propertyFlags &
              VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) == 0) {
             skip |= LogError("VUID-vkGetDeviceMemoryCommitment-memory-00690", memory, error_obj.location,
                              "Querying commitment for memory without "
@@ -1409,9 +1409,9 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     }
 
                     if (mem_info) {
-                        safe_VkMemoryAllocateInfo alloc_info = mem_info->alloc_info;
+                        const VkMemoryAllocateInfo &allocate_info = mem_info->allocate_info;
                         // Validate memory requirements size
-                        if (mem_req.size > alloc_info.allocationSize - bind_info.memoryOffset) {
+                        if (mem_req.size > allocate_info.allocationSize - bind_info.memoryOffset) {
                             const char *vuid =
                                 bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-pNext-01617" : "VUID-vkBindImageMemory-size-01049";
                             const LogObjectList objlist(bind_info.image, bind_info.memory);
@@ -1419,8 +1419,8 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                              "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
                                              " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                                              ", returned from a call to vkGetImageMemoryRequirements with image.",
-                                             alloc_info.allocationSize, bind_info.memoryOffset,
-                                             alloc_info.allocationSize - bind_info.memoryOffset, mem_req.size);
+                                             allocate_info.allocationSize, bind_info.memoryOffset,
+                                             allocate_info.allocationSize - bind_info.memoryOffset, mem_req.size);
                         }
 
                         // Validate memory type used
@@ -1465,18 +1465,18 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     }
 
                     if (mem_info) {
-                        safe_VkMemoryAllocateInfo alloc_info = mem_info->alloc_info;
+                        const VkMemoryAllocateInfo &allocate_info = mem_info->allocate_info;
 
                         // Validate memory requirements size
-                        if (disjoint_mem_req.size > alloc_info.allocationSize - bind_info.memoryOffset) {
+                        if (disjoint_mem_req.size > allocate_info.allocationSize - bind_info.memoryOffset) {
                             const LogObjectList objlist(bind_info.image, bind_info.memory);
                             skip |= LogError(
                                 "VUID-VkBindImageMemoryInfo-pNext-01621", objlist, loc,
                                 "allocationSize (%" PRIu64 ") minus memoryOffset (%" PRIu64 ") is %" PRIu64
                                 " but must be at least as large as VkMemoryRequirements::size value %" PRIu64
                                 ", returned from a call to vkGetImageMemoryRequirements with disjoint image for aspect plane %s.",
-                                alloc_info.allocationSize, bind_info.memoryOffset,
-                                alloc_info.allocationSize - bind_info.memoryOffset, disjoint_mem_req.size,
+                                allocate_info.allocationSize, bind_info.memoryOffset,
+                                allocate_info.allocationSize - bind_info.memoryOffset, disjoint_mem_req.size,
                                 string_VkImageAspectFlagBits(aspect));
                         }
 
@@ -1547,9 +1547,9 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     }
                 }
 
-                auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->alloc_info.pNext);
+                auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->allocate_info.pNext);
                 const VkMemoryAllocateFlags memory_allocate_flags = chained_flags_struct ? chained_flags_struct->flags : 0;
-                if ((image_state->createInfo.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
+                if ((image_state->create_info.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
                     !(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)) {
                     const char *vuid = bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-descriptorBufferCaptureReplay-08113"
                                                         : "VUID-vkBindImageMemory-descriptorBufferCaptureReplay-08113";
@@ -1560,7 +1560,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                      "VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT.",
                                      string_VkMemoryAllocateFlags(memory_allocate_flags).c_str());
                 }
-                if ((image_state->createInfo.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
+                if ((image_state->create_info.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
                     !(memory_allocate_flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)) {
                     const char *vuid =
                         bind_image_mem_2 ? "VUID-VkBindImageMemoryInfo-image-09202" : "VUID-vkBindImageMemory-image-09202";
@@ -1575,16 +1575,16 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 // Validate export memory handles
                 if (mem_info->IsExport()) {
                     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
-                    drm_format_modifier.sharingMode = image_state->createInfo.sharingMode;
-                    drm_format_modifier.queueFamilyIndexCount = image_state->createInfo.queueFamilyIndexCount;
-                    drm_format_modifier.pQueueFamilyIndices = image_state->createInfo.pQueueFamilyIndices;
+                    drm_format_modifier.sharingMode = image_state->create_info.sharingMode;
+                    drm_format_modifier.queueFamilyIndexCount = image_state->create_info.queueFamilyIndexCount;
+                    drm_format_modifier.pQueueFamilyIndices = image_state->create_info.pQueueFamilyIndices;
                     VkPhysicalDeviceExternalImageFormatInfo external_info = vku::InitStructHelper();
                     VkPhysicalDeviceImageFormatInfo2 image_info = vku::InitStructHelper(&external_info);
-                    image_info.format = image_state->createInfo.format;
-                    image_info.type = image_state->createInfo.imageType;
-                    image_info.tiling = image_state->createInfo.tiling;
-                    image_info.usage = image_state->createInfo.usage;
-                    image_info.flags = image_state->createInfo.flags;
+                    image_info.format = image_state->create_info.format;
+                    image_info.type = image_state->create_info.imageType;
+                    image_info.tiling = image_state->create_info.tiling;
+                    image_info.usage = image_state->create_info.usage;
+                    image_info.flags = image_state->create_info.flags;
                     VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
                     VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
                     bool export_supported = true;
@@ -1592,7 +1592,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                     auto validate_export_handle_types = [&](VkExternalMemoryHandleTypeFlagBits flag) {
                         external_info.handleType = flag;
                         external_info.pNext = NULL;
-                        if (image_state->createInfo.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+                        if (image_state->create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
                             VkImageDrmFormatModifierPropertiesEXT drm_modifier_properties = vku::InitStructHelper();
                             auto result =
                                 DispatchGetImageDrmFormatModifierPropertiesEXT(device, bind_info.image, &drm_modifier_properties);
@@ -1756,7 +1756,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                                          swapchain_state->images.size());
                     }
                     if (IsExtEnabled(device_extensions.vk_ext_swapchain_maintenance1) &&
-                        (swapchain_state->createInfo.flags & VK_SWAPCHAIN_CREATE_DEFERRED_MEMORY_ALLOCATION_BIT_EXT)) {
+                        (swapchain_state->create_info.flags & VK_SWAPCHAIN_CREATE_DEFERRED_MEMORY_ALLOCATION_BIT_EXT)) {
                         if (swapchain_state->images[swapchain_info->imageIndex].acquired == false) {
                             const LogObjectList objlist(bind_info.image, bind_info.memory);
                             skip |= LogError("VUID-VkBindImageMemorySwapchainInfoKHR-swapchain-07756", objlist,
@@ -1782,7 +1782,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
 
             const auto bind_image_memory_device_group_info = vku::FindStructInPNextChain<VkBindImageMemoryDeviceGroupInfo>(bind_info.pNext);
             if (bind_image_memory_device_group_info && bind_image_memory_device_group_info->splitInstanceBindRegionCount != 0) {
-                if (!(image_state->createInfo.flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
+                if (!(image_state->create_info.flags & VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT)) {
                     const LogObjectList objlist(bind_info.image, bind_info.memory);
                     skip |= LogError("VUID-VkBindImageMemoryInfo-pNext-01627", objlist,
                                      loc.pNext(Struct::VkBindImageMemoryDeviceGroupInfo, Field::splitInstanceBindRegionCount),
@@ -1818,9 +1818,9 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                 }
 
                 // Make sure planeAspect is only a single, valid plane
-                const VkFormat image_format = image_state->createInfo.format;
+                const VkFormat image_format = image_state->create_info.format;
                 const VkImageAspectFlags aspect = plane_info->planeAspect;
-                const VkImageTiling image_tiling = image_state->createInfo.tiling;
+                const VkImageTiling image_tiling = image_state->create_info.tiling;
 
                 if ((image_tiling == VK_IMAGE_TILING_LINEAR) || (image_tiling == VK_IMAGE_TILING_OPTIMAL)) {
                     if (vkuFormatIsMultiplane(image_format) && !IsOnlyOneValidPlaneAspect(image_format, aspect)) {
@@ -1873,7 +1873,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
     for (auto &resource : resources_bound) {
         auto image_state = Get<vvl::Image>(resource.first);
         if (image_state->disjoint == true && !is_drm) {
-            uint32_t total_planes = vkuFormatPlaneCount(image_state->createInfo.format);
+            uint32_t total_planes = vkuFormatPlaneCount(image_state->create_info.format);
             for (uint32_t i = 0; i < total_planes; i++) {
                 if (resource.second[i] == vvl::kU32Max) {
                     skip |= LogError("VUID-vkBindImageMemory2-pBindInfos-02858", resource.first, error_obj.location,
@@ -1954,12 +1954,12 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const 
     bool skip = false;
     auto mem_state = Get<vvl::DeviceMemory>(bind.memory);
     if (mem_state) {
-        if (!((uint32_t(1) << mem_state->alloc_info.memoryTypeIndex) & requirements.memoryTypeBits)) {
+        if (!((uint32_t(1) << mem_state->allocate_info.memoryTypeIndex) & requirements.memoryTypeBits)) {
             const LogObjectList objlist(bind.memory, resource_handle);
             skip |= LogError("VUID-VkSparseMemoryBind-memory-01096", objlist, loc.dot(Field::memory),
                              "has a type index (%" PRIu32 ") that is not among the allowed types mask (0x%" PRIX32
                              ") for this resource.",
-                             mem_state->alloc_info.memoryTypeIndex, requirements.memoryTypeBits);
+                             mem_state->allocate_info.memoryTypeIndex, requirements.memoryTypeBits);
         }
 
         if (SafeModulo(bind.memoryOffset, requirements.alignment) != 0) {
@@ -1969,26 +1969,26 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const 
                              requirements.alignment);
         }
 
-        if (phys_dev_mem_props.memoryTypes[mem_state->alloc_info.memoryTypeIndex].propertyFlags &
+        if (phys_dev_mem_props.memoryTypes[mem_state->allocate_info.memoryTypeIndex].propertyFlags &
             VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) {
             const LogObjectList objlist(bind.memory, resource_handle);
             skip |= LogError("VUID-VkSparseMemoryBind-memory-01097", objlist, loc.dot(Field::memory),
                              "type has VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT bit set.");
         }
 
-        if (bind.memoryOffset >= mem_state->alloc_info.allocationSize) {
+        if (bind.memoryOffset >= mem_state->allocate_info.allocationSize) {
             const LogObjectList objlist(bind.memory, resource_handle);
             skip |= LogError("VUID-VkSparseMemoryBind-memoryOffset-01101", objlist, loc.dot(Field::memoryOffset),
                              "(%" PRIu64 ") must be less than the size of memory (%" PRIu64 ")", bind.memoryOffset,
-                             mem_state->alloc_info.allocationSize);
+                             mem_state->allocate_info.allocationSize);
         }
 
-        if ((mem_state->alloc_info.allocationSize - bind.memoryOffset) < bind.size) {
+        if ((mem_state->allocate_info.allocationSize - bind.memoryOffset) < bind.size) {
             const LogObjectList objlist(bind.memory, resource_handle);
             skip |= LogError("VUID-VkSparseMemoryBind-size-01102", objlist, loc.dot(Field::size),
                              "(%" PRIu64 ") must be less than or equal to the size of memory (%" PRIu64
                              ") minus memoryOffset (%" PRIu64 ").",
-                             bind.size, mem_state->alloc_info.allocationSize, bind.memoryOffset);
+                             bind.size, mem_state->allocate_info.allocationSize, bind.memoryOffset);
         }
 
         if (mem_state->IsExport()) {
@@ -2041,21 +2041,21 @@ bool CoreChecks::ValidateSparseMemoryBind(const VkSparseMemoryBind &bind, const 
 bool CoreChecks::ValidateImageSubresourceSparseImageMemoryBind(vvl::Image const &image_state, VkImageSubresource const &subresource,
                                                                const Location &bind_loc, const Location &subresource_loc) const {
     bool skip = false;
-    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.createInfo.format, subresource.aspectMask,
+    skip |= ValidateImageAspectMask(image_state.VkHandle(), image_state.create_info.format, subresource.aspectMask,
                                     image_state.disjoint, bind_loc, "VUID-VkSparseImageMemoryBindInfo-subresource-01106");
 
-    if (subresource.mipLevel >= image_state.createInfo.mipLevels) {
+    if (subresource.mipLevel >= image_state.create_info.mipLevels) {
         skip |=
             LogError("VUID-VkSparseImageMemoryBindInfo-subresource-01722", image_state.Handle(),
                      subresource_loc.dot(Field::mipLevel), "(%" PRIu32 ") is not less than mipLevels (%" PRIu32 ") of %s.image.",
-                     subresource.mipLevel, image_state.createInfo.mipLevels, bind_loc.Fields().c_str());
+                     subresource.mipLevel, image_state.create_info.mipLevels, bind_loc.Fields().c_str());
     }
 
-    if (subresource.arrayLayer >= image_state.createInfo.arrayLayers) {
+    if (subresource.arrayLayer >= image_state.create_info.arrayLayers) {
         skip |= LogError("VUID-VkSparseImageMemoryBindInfo-subresource-01723", image_state.Handle(),
                          subresource_loc.dot(Field::arrayLayer),
                          "(%" PRIu32 ") is not less than arrayLayers (%" PRIu32 ") of %s.image.", subresource.arrayLayer,
-                         image_state.createInfo.arrayLayers, bind_loc.Fields().c_str());
+                         image_state.create_info.arrayLayers, bind_loc.Fields().c_str());
     }
 
     return skip;
@@ -2070,10 +2070,10 @@ bool CoreChecks::ValidateSparseImageMemoryBind(vvl::Image const *image_state, Vk
     if (mem_state) {
         // TODO: The closest one should be VUID-VkSparseImageMemoryBind-memory-01105 instead of the mentioned
         // one. We also need to check memory_bind.memory
-        if (bind.memoryOffset >= mem_state->alloc_info.allocationSize) {
+        if (bind.memoryOffset >= mem_state->allocate_info.allocationSize) {
             skip |= LogError("VUID-VkSparseMemoryBind-memoryOffset-01101", bind.memory, bind_loc.dot(Field::memoryOffset),
                              "(%" PRIu64 ") is not less than the size (%" PRIu64 ") of memory.", bind.memoryOffset,
-                             mem_state->alloc_info.allocationSize);
+                             mem_state->allocate_info.allocationSize);
         }
 
         if (mem_state->IsExport()) {
@@ -2194,7 +2194,7 @@ bool CoreChecks::PreCallValidateGetBufferDeviceAddress(VkDevice device, const Vk
     auto buffer_state = Get<vvl::Buffer>(pInfo->buffer);
     if (buffer_state) {
         const Location info_loc = error_obj.location.dot(Field::pInfo);
-        if (!(buffer_state->createInfo.flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
+        if (!(buffer_state->create_info.flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT)) {
             skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, info_loc.dot(Field::buffer),
                                                   "VUID-VkBufferDeviceAddressInfo-buffer-02600");
         }
@@ -2258,7 +2258,7 @@ bool CoreChecks::PreCallValidateGetDeviceMemoryOpaqueCaptureAddress(VkDevice dev
 
     auto mem_info = Get<vvl::DeviceMemory>(pInfo->memory);
     if (mem_info) {
-        auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->alloc_info.pNext);
+        auto chained_flags_struct = vku::FindStructInPNextChain<VkMemoryAllocateFlagsInfo>(mem_info->allocate_info.pNext);
         if (!chained_flags_struct || !(chained_flags_struct->flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT)) {
             skip |= LogError("VUID-VkDeviceMemoryOpaqueCaptureAddressInfo-memory-03336", objlst, error_obj.location,
                              "memory must have been allocated with VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT.");

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -138,13 +138,13 @@ bool CoreChecks::ValidateMeshShaderStage(const vvl::CommandBuffer &cb_state, con
     }
     for (const auto &query : cb_state.activeQueries) {
         const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
-        if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
+        if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
             skip |= LogError(vuid.xfb_queries_07074, cb_state.Handle(), loc, "Query with type %s is active.",
-                             string_VkQueryType(query_pool_state->createInfo.queryType));
+                             string_VkQueryType(query_pool_state->create_info.queryType));
         }
-        if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+        if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
             skip |= LogError(vuid.pg_queries_07075, cb_state.Handle(), loc, "Query with type %s is active.",
-                             string_VkQueryType(query_pool_state->createInfo.queryType));
+                             string_VkQueryType(query_pool_state->create_info.queryType));
         }
     }
     return skip;
@@ -319,14 +319,14 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, V
         skip |= ValidateCmdDrawStrideWithBuffer(cb_state, "VUID-vkCmdDrawIndirect-drawCount-00488", stride,
                                                 Struct::VkDrawIndirectCommand, sizeof(VkDrawIndirectCommand), drawCount, offset,
                                                 *buffer_state, error_obj.location);
-    } else if ((drawCount == 1) && (offset + sizeof(VkDrawIndirectCommand)) > buffer_state->createInfo.size) {
+    } else if ((drawCount == 1) && (offset + sizeof(VkDrawIndirectCommand)) > buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer);
         skip |= LogError("VUID-vkCmdDrawIndirect-drawCount-00487", objlist, error_obj.location.dot(Field::drawCount),
                          "is 1 and (offset + sizeof(VkDrawIndirectCommand)) (%" PRIu64
                          ") is not less than "
                          "or equal to the size of buffer (%" PRIu64 ").",
-                         (offset + sizeof(VkDrawIndirectCommand)), buffer_state->createInfo.size);
+                         (offset + sizeof(VkDrawIndirectCommand)), buffer_state->create_info.size);
     }
     // TODO: If the drawIndirectFirstInstance feature is not enabled, all the firstInstance members of the
     // VkDrawIndirectCommand structures accessed by this command must be 0, which will require access to the contents of 'buffer'.
@@ -368,14 +368,14 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBu
     } else if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawIndexedIndirect-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
                          error_obj.location.dot(Field::offset), "(%" PRIu64 ") must be a multiple of 4.", offset);
-    } else if ((drawCount == 1) && (offset + sizeof(VkDrawIndexedIndirectCommand)) > buffer_state->createInfo.size) {
+    } else if ((drawCount == 1) && (offset + sizeof(VkDrawIndexedIndirectCommand)) > buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer);
         skip |= LogError("VUID-vkCmdDrawIndexedIndirect-drawCount-00539", objlist, error_obj.location.dot(Field::drawCount),
                          "is 1 and (offset + sizeof(VkDrawIndexedIndirectCommand)) (%" PRIu64
                          ") is not less than "
                          "or equal to the size of buffer (%" PRIu64 ").",
-                         (offset + sizeof(VkDrawIndexedIndirectCommand)), buffer_state->createInfo.size);
+                         (offset + sizeof(VkDrawIndexedIndirectCommand)), buffer_state->create_info.size);
     }
     // TODO: If the drawIndirectFirstInstance feature is not enabled, all the firstInstance members of the
     // VkDrawIndexedIndirectCommand structures accessed by this command must be 0, which will require access to the contents of
@@ -506,13 +506,13 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffe
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-02710", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
                          error_obj.location.dot(Field::offset), "(%" PRIu64 ") must be a multiple of 4.", offset);
     }
-    if ((offset + sizeof(VkDispatchIndirectCommand)) > buffer_state->createInfo.size) {
+    if ((offset + sizeof(VkDispatchIndirectCommand)) > buffer_state->create_info.size) {
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-00407", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
                          error_obj.location,
                          "The (offset + sizeof(VkDrawIndexedIndirectCommand)) (%" PRIu64
                          ")  is greater than the "
                          "size of the buffer (%" PRIu64 ").",
-                         offset + sizeof(VkDispatchIndirectCommand), buffer_state->createInfo.size);
+                         offset + sizeof(VkDispatchIndirectCommand), buffer_state->create_info.size);
     }
     return skip;
 }
@@ -777,40 +777,40 @@ bool CoreChecks::PreCallValidateCmdTraceRaysNV(VkCommandBuffer commandBuffer, Vk
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, error_obj.location);
     auto callable_shader_buffer_state = Get<vvl::Buffer>(callableShaderBindingTableBuffer);
-    if (callable_shader_buffer_state && callableShaderBindingOffset >= callable_shader_buffer_state->createInfo.size) {
+    if (callable_shader_buffer_state && callableShaderBindingOffset >= callable_shader_buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
         objlist.add(callableShaderBindingTableBuffer);
         skip |= LogError("VUID-vkCmdTraceRaysNV-callableShaderBindingOffset-02461", objlist,
                          error_obj.location.dot(Field::callableShaderBindingOffset),
                          "%" PRIu64 " must be less than the size of callableShaderBindingTableBuffer %" PRIu64 " .",
-                         callableShaderBindingOffset, callable_shader_buffer_state->createInfo.size);
+                         callableShaderBindingOffset, callable_shader_buffer_state->create_info.size);
     }
     auto hit_shader_buffer_state = Get<vvl::Buffer>(hitShaderBindingTableBuffer);
-    if (hit_shader_buffer_state && hitShaderBindingOffset >= hit_shader_buffer_state->createInfo.size) {
+    if (hit_shader_buffer_state && hitShaderBindingOffset >= hit_shader_buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
         objlist.add(hitShaderBindingTableBuffer);
         skip |= LogError("VUID-vkCmdTraceRaysNV-hitShaderBindingOffset-02459", objlist,
                          error_obj.location.dot(Field::hitShaderBindingOffset),
                          "%" PRIu64 " must be less than the size of hitShaderBindingTableBuffer %" PRIu64 " .",
-                         hitShaderBindingOffset, hit_shader_buffer_state->createInfo.size);
+                         hitShaderBindingOffset, hit_shader_buffer_state->create_info.size);
     }
     auto miss_shader_buffer_state = Get<vvl::Buffer>(missShaderBindingTableBuffer);
-    if (miss_shader_buffer_state && missShaderBindingOffset >= miss_shader_buffer_state->createInfo.size) {
+    if (miss_shader_buffer_state && missShaderBindingOffset >= miss_shader_buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
         objlist.add(missShaderBindingTableBuffer);
         skip |= LogError("VUID-vkCmdTraceRaysNV-missShaderBindingOffset-02457", objlist,
                          error_obj.location.dot(Field::missShaderBindingOffset),
                          "%" PRIu64 " must be less than the size of missShaderBindingTableBuffer %" PRIu64 " .",
-                         missShaderBindingOffset, miss_shader_buffer_state->createInfo.size);
+                         missShaderBindingOffset, miss_shader_buffer_state->create_info.size);
     }
     auto raygen_shader_buffer_state = Get<vvl::Buffer>(raygenShaderBindingTableBuffer);
-    if (raygenShaderBindingOffset >= raygen_shader_buffer_state->createInfo.size) {
+    if (raygenShaderBindingOffset >= raygen_shader_buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
         objlist.add(raygenShaderBindingTableBuffer);
         skip |= LogError("VUID-vkCmdTraceRaysNV-raygenShaderBindingOffset-02455", objlist,
                          error_obj.location.dot(Field::raygenShaderBindingOffset),
                          "%" PRIu64 " must be less than the size of raygenShaderBindingTableBuffer %" PRIu64 " .",
-                         raygenShaderBindingOffset, raygen_shader_buffer_state->createInfo.size);
+                         raygenShaderBindingOffset, raygen_shader_buffer_state->create_info.size);
     }
     return skip;
 }
@@ -1277,13 +1277,13 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
                 error_obj.location.dot(Field::stride),
                 "(0x%" PRIxLEAST32 "), is not a multiple of 4 or smaller than sizeof (VkDrawMeshTasksIndirectCommandNV).", stride);
         }
-    } else if (drawCount == 1 && ((offset + sizeof(VkDrawMeshTasksIndirectCommandNV)) > buffer_state.get()->createInfo.size)) {
+    } else if (drawCount == 1 && ((offset + sizeof(VkDrawMeshTasksIndirectCommandNV)) > buffer_state.get()->create_info.size)) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer);
         skip |=
             LogError("VUID-vkCmdDrawMeshTasksIndirectNV-drawCount-02156", objlist, error_obj.location,
                      "(offset + sizeof(VkDrawMeshTasksIndirectNV)) (%" PRIu64 ") is greater than the size of buffer (%" PRIu64 ").",
-                     offset + sizeof(VkDrawMeshTasksIndirectCommandNV), buffer_state->createInfo.size);
+                     offset + sizeof(VkDrawMeshTasksIndirectCommandNV), buffer_state->create_info.size);
     }
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDrawMeshTasksIndirectNV-offset-02710", cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
@@ -1419,14 +1419,14 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
             cb_state, "VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-07090", stride, Struct::VkDrawMeshTasksIndirectCommandEXT,
             sizeof(VkDrawMeshTasksIndirectCommandEXT), drawCount, offset, *buffer_state, error_obj.location);
     }
-    if ((drawCount == 1) && (offset + sizeof(VkDrawMeshTasksIndirectCommandEXT)) > buffer_state->createInfo.size) {
+    if ((drawCount == 1) && (offset + sizeof(VkDrawMeshTasksIndirectCommandEXT)) > buffer_state->create_info.size) {
         LogObjectList objlist = cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS);
         objlist.add(buffer);
         skip |= LogError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-07089", objlist, error_obj.location.dot(Field::drawCount),
                          "is 1 and (offset + sizeof(vkCmdDrawMeshTasksIndirectEXT)) (%" PRIu64
                          ") is not less than "
                          "or equal to the size of buffer (%" PRIu64 ").",
-                         (offset + sizeof(VkDrawMeshTasksIndirectCommandEXT)), buffer_state->createInfo.size);
+                         (offset + sizeof(VkDrawMeshTasksIndirectCommandEXT)), buffer_state->create_info.size);
     }
     // TODO: vkMapMemory() and check the contents of buffer at offset
     // issue #4547 (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4547)
@@ -1761,7 +1761,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                                               VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) != 0) {
             for (const auto &query : cb_state.activeQueries) {
                 const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
-                if (query_pool_state->createInfo.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
+                if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
                     const LogObjectList objlist(cb_state.Handle(), query.pool);
                     skip |= LogError(vuid.mesh_shader_queries_07073, objlist, loc,
                                      "Query (slot %" PRIu32 ") with type VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT is active.",
@@ -1842,10 +1842,10 @@ bool CoreChecks::ValidateIndirectCountCmd(const vvl::CommandBuffer &cb_state, co
                                           vuid.indirect_count_contiguous_memory_02714);
     skip |= ValidateBufferUsageFlags(objlist, count_buffer_state, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, true,
                                      vuid.indirect_count_buffer_bit_02715, loc.dot(Field::countBuffer));
-    if (count_buffer_offset + sizeof(uint32_t) > count_buffer_state.createInfo.size) {
+    if (count_buffer_offset + sizeof(uint32_t) > count_buffer_state.create_info.size) {
         skip |= LogError(vuid.indirect_count_offset_04129, objlist, loc,
                          "countBufferOffset (%" PRIu64 ") + sizeof(uint32_t) is greater than the buffer size of %" PRIu64 ".",
-                         count_buffer_offset, count_buffer_state.createInfo.size);
+                         count_buffer_offset, count_buffer_state.create_info.size);
     }
     return skip;
 }

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -47,7 +47,7 @@ bool CoreChecks::PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGe
                                                const ErrorObject &error_obj) const {
     bool skip = false;
     if (const auto memory_state = Get<vvl::DeviceMemory>(pGetFdInfo->memory)) {
-        const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->alloc_info.pNext);
+        const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->allocate_info.pNext);
         if (!export_info) {
             skip |= LogError("VUID-VkMemoryGetFdInfoKHR-handleType-00671", pGetFdInfo->memory,
                              error_obj.location.dot(Field::pGetFdInfo).dot(Field::memory),
@@ -193,7 +193,7 @@ bool CoreChecks::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device, const V
                                                         HANDLE *pHandle, const ErrorObject &error_obj) const {
     bool skip = false;
     if (const auto memory_state = Get<vvl::DeviceMemory>(pGetWin32HandleInfo->memory)) {
-        const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->alloc_info.pNext);
+        const auto export_info = vku::FindStructInPNextChain<VkExportMemoryAllocateInfo>(memory_state->allocate_info.pNext);
         if (!export_info) {
             skip |= LogError("VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00662", pGetWin32HandleInfo->memory,
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::memory),
@@ -402,7 +402,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "VkImageCreateInfo structure",
                                 FormatHandle(metal_texture_ptr->image).c_str());
                         }
-                        auto format_plane_count = vkuFormatPlaneCount(image_info->createInfo.format);
+                        auto format_plane_count = vkuFormatPlaneCount(image_info->create_info.format);
                         auto image_plane = metal_texture_ptr->plane;
                         if (!(format_plane_count > 1) && (image_plane != VK_IMAGE_ASPECT_PLANE_0_BIT)) {
                             skip |= LogError(
@@ -411,7 +411,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "%s, and plane = %s, but image was created with format %s, which is not multiplaner and plane is "
                                 "required to be VK_IMAGE_ASPECT_PLANE_0_BIT",
                                 FormatHandle(metal_texture_ptr->image).c_str(), string_VkImageAspectFlags(image_plane).c_str(),
-                                string_VkFormat(image_info->createInfo.format));
+                                string_VkFormat(image_info->create_info.format));
                         }
                         if ((format_plane_count == 2) && (image_plane == VK_IMAGE_ASPECT_PLANE_2_BIT)) {
                             skip |= LogError(
@@ -421,7 +421,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                 "cannot"
                                 "be VK_IMAGE_ASPECT_PLANE_2_BIT",
                                 FormatHandle(metal_texture_ptr->image).c_str(), string_VkImageAspectFlags(image_plane).c_str(),
-                                string_VkFormat(image_info->createInfo.format));
+                                string_VkFormat(image_info->create_info.format));
                         }
                     }
                 }

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -409,7 +409,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     if (swapchain_create_info != nullptr) {
         if (swapchain_create_info->swapchain != VK_NULL_HANDLE) {
             auto swapchain_state = Get<vvl::Swapchain>(swapchain_create_info->swapchain);
-            const VkSwapchainCreateFlagsKHR swapchain_flags = swapchain_state->createInfo.flags;
+            const VkSwapchainCreateFlagsKHR swapchain_flags = swapchain_state->create_info.flags;
 
             // Validate rest of Swapchain Image create check that require swapchain state
             const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
@@ -436,27 +436,27 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             if (pCreateInfo->imageType != VK_IMAGE_TYPE_2D) {
                 skip |= LogError(vuid, device, create_info_loc.dot(Field::imageType), "must be VK_IMAGE_TYPE_2D.");
             }
-            if (pCreateInfo->format != swapchain_state->createInfo.imageFormat) {
+            if (pCreateInfo->format != swapchain_state->create_info.imageFormat) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with format %s which doesn't match pCreateInfo->format %s.",
-                                 string_VkFormat(swapchain_state->createInfo.imageFormat), string_VkFormat(pCreateInfo->format));
+                                 string_VkFormat(swapchain_state->create_info.imageFormat), string_VkFormat(pCreateInfo->format));
             }
-            if (pCreateInfo->extent.width != swapchain_state->createInfo.imageExtent.width ||
-                pCreateInfo->extent.height != swapchain_state->createInfo.imageExtent.height || pCreateInfo->extent.depth != 1u) {
+            if (pCreateInfo->extent.width != swapchain_state->create_info.imageExtent.width ||
+                pCreateInfo->extent.height != swapchain_state->create_info.imageExtent.height || pCreateInfo->extent.depth != 1u) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with extent (%" PRIu32 ", %" PRIu32
                                  ", 1) which doesn't match pCreateInfo->extent (%" PRIu32 ", %" PRIu32 ", %" PRIu32 ").",
-                                 swapchain_state->createInfo.imageExtent.width, swapchain_state->createInfo.imageExtent.height,
+                                 swapchain_state->create_info.imageExtent.width, swapchain_state->create_info.imageExtent.height,
                                  pCreateInfo->extent.width, pCreateInfo->extent.height, pCreateInfo->extent.depth);
             }
             if (pCreateInfo->mipLevels != 1u) {
                 skip |= LogError(vuid, device, create_info_loc.dot(Field::mipLevels), "must be 1.");
             }
-            if (pCreateInfo->arrayLayers != swapchain_state->createInfo.imageArrayLayers) {
+            if (pCreateInfo->arrayLayers != swapchain_state->create_info.imageArrayLayers) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with imageArrayLayers %" PRIu32
                                  " which doesn't match pCreateInfo->arrayLayers %" PRIu32 ".",
-                                 swapchain_state->createInfo.imageArrayLayers, pCreateInfo->arrayLayers);
+                                 swapchain_state->create_info.imageArrayLayers, pCreateInfo->arrayLayers);
             }
             if (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT) {
                 skip |= LogError(vuid, device, create_info_loc.dot(Field::samples), "must be VK_SAMPLE_COUNT_1_BIT.");
@@ -464,28 +464,28 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
             if (pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
                 skip |= LogError(vuid, device, create_info_loc.dot(Field::tiling), "must be VK_IMAGE_TILING_OPTIMAL.");
             }
-            if (pCreateInfo->usage != swapchain_state->createInfo.imageUsage) {
+            if (pCreateInfo->usage != swapchain_state->create_info.imageUsage) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with imageUsage %s which doesn't match pCreateInfo->usage %s.",
-                                 string_VkImageUsageFlags(swapchain_state->createInfo.imageUsage).c_str(),
+                                 string_VkImageUsageFlags(swapchain_state->create_info.imageUsage).c_str(),
                                  string_VkImageUsageFlags(pCreateInfo->usage).c_str());
             }
-            if (pCreateInfo->sharingMode != swapchain_state->createInfo.imageSharingMode) {
+            if (pCreateInfo->sharingMode != swapchain_state->create_info.imageSharingMode) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with imageSharingMode %s which doesn't match pCreateInfo->sharingMode %s.",
-                                 string_VkSharingMode(swapchain_state->createInfo.imageSharingMode),
+                                 string_VkSharingMode(swapchain_state->create_info.imageSharingMode),
                                  string_VkSharingMode(pCreateInfo->sharingMode));
             }
-            if (pCreateInfo->queueFamilyIndexCount != swapchain_state->createInfo.queueFamilyIndexCount) {
+            if (pCreateInfo->queueFamilyIndexCount != swapchain_state->create_info.queueFamilyIndexCount) {
                 skip |= LogError(vuid, device, create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain),
                                  "was created with queueFamilyIndexCount %" PRIu32
                                  " which doesn't match pCreateInfo->queueFamilyIndexCount %" PRIu32 ".",
-                                 swapchain_state->createInfo.queueFamilyIndexCount, pCreateInfo->queueFamilyIndexCount);
+                                 swapchain_state->create_info.queueFamilyIndexCount, pCreateInfo->queueFamilyIndexCount);
             } else {
                 for (uint32_t i = 0; i < pCreateInfo->queueFamilyIndexCount; ++i) {
                     bool found = false;
                     for (uint32_t j = 0; j < pCreateInfo->queueFamilyIndexCount; ++j) {
-                        if (i != j && pCreateInfo->pQueueFamilyIndices[j] == swapchain_state->createInfo.pQueueFamilyIndices[i]) {
+                        if (i != j && pCreateInfo->pQueueFamilyIndices[j] == swapchain_state->create_info.pQueueFamilyIndices[i]) {
                             found = true;
                             break;
                         }
@@ -846,12 +846,12 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
     skip |= ValidateUnprotectedImage(cb_state, image_state, image_loc, "VUID-vkCmdClearColorImage-commandBuffer-01806");
     for (uint32_t i = 0; i < rangeCount; ++i) {
         const Location range_loc = error_obj.location.dot(Field::pRanges, i);
-        skip |= ValidateCmdClearColorSubresourceRange(image_state.createInfo, pRanges[i], objlist, range_loc);
+        skip |= ValidateCmdClearColorSubresourceRange(image_state.create_info, pRanges[i], objlist, range_loc);
         skip |= ValidateClearImageSubresourceRange(objlist, pRanges[i], range_loc);
         skip |= VerifyClearImageLayout(cb_state, image_state, pRanges[i], imageLayout, range_loc);
     }
 
-    const VkFormat format = image_state.createInfo.format;
+    const VkFormat format = image_state.create_info.format;
     if (vkuFormatIsDepthOrStencil(format)) {
         skip |=
             LogError("VUID-vkCmdClearColorImage-image-00007", objlist, image_loc,
@@ -861,10 +861,10 @@ bool CoreChecks::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuffer
                          "(%s) was created with a compressed format (%s).", FormatHandle(image).c_str(), string_VkFormat(format));
     }
 
-    if (!(image_state.createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
+    if (!(image_state.create_info.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT)) {
         skip |= LogError("VUID-vkCmdClearColorImage-image-00002", objlist, image_loc,
                          "(%s) was created with usage %s (missing VK_IMAGE_USAGE_TRANSFER_DST_BIT).", FormatHandle(image).c_str(),
-                         string_VkImageUsageFlags(image_state.createInfo.usage).c_str());
+                         string_VkImageUsageFlags(image_state.create_info.usage).c_str());
     }
 
     // Tests for "Formats requiring sampler Y’CBCR conversion for VK_IMAGE_ASPECT_COLOR_BIT image views"
@@ -921,7 +921,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     const auto &image_state = *image_state_ptr;
     const Location image_loc = error_obj.location.dot(Field::image);
 
-    const VkFormat image_format = image_state.createInfo.format;
+    const VkFormat image_format = image_state.create_info.format;
     const LogObjectList objlist(commandBuffer, image);
     skip |= ValidateMemoryIsBoundToImage(objlist, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-image-00010");
     skip |= ValidateCmd(cb_state, error_obj.location);
@@ -933,10 +933,10 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
     skip |= ValidateProtectedImage(cb_state, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-commandBuffer-01807");
     skip |= ValidateUnprotectedImage(cb_state, image_state, image_loc, "VUID-vkCmdClearDepthStencilImage-commandBuffer-01808");
 
-    const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.createInfo.pNext);
+    const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext);
     for (uint32_t i = 0; i < rangeCount; ++i) {
         const Location range_loc = error_obj.location.dot(Field::pRanges, i);
-        skip |= ValidateCmdClearDepthSubresourceRange(image_state.createInfo, pRanges[i], objlist, range_loc);
+        skip |= ValidateCmdClearDepthSubresourceRange(image_state.create_info, pRanges[i], objlist, range_loc);
         skip |= VerifyClearImageLayout(cb_state, image_state, pRanges[i], imageLayout, range_loc);
         // Image aspect must be depth or stencil or both
         VkImageAspectFlags valid_aspects = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -952,7 +952,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
                                  "doesn't have a depth component.",
                                  string_VkFormat(image_format));
             }
-            if ((image_state.createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
+            if ((image_state.create_info.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
                 skip |= LogError(
                     "VUID-vkCmdClearDepthStencilImage-pRanges-02660", objlist, range_loc.dot(Field::aspectMask),
                     "includes VK_IMAGE_ASPECT_DEPTH_BIT, but the image was not created with VK_IMAGE_USAGE_TRANSFER_DST_BIT.");
@@ -973,7 +973,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
                                      "image was created with VkImageStencilUsageCreateInfo::stencilUsage = %s.",
                                      string_VkImageUsageFlags(image_stencil_struct->stencilUsage).c_str());
                 }
-            } else if ((image_state.createInfo.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
+            } else if ((image_state.create_info.usage & VK_IMAGE_USAGE_TRANSFER_DST_BIT) == 0) {
                 skip |= LogError("VUID-vkCmdClearDepthStencilImage-pRanges-02659", objlist, range_loc.dot(Field::aspectMask),
                                  "includes VK_IMAGE_ASPECT_STENCIL_BIT and "
                                  "image was not created with VkImageStencilUsageCreateInfo, but was created with "
@@ -987,7 +987,7 @@ bool CoreChecks::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer comman
             LogError("VUID-vkCmdClearDepthStencilImage-image-00014", objlist, image_loc,
                      "(%s) doesn't have a depth/stencil format (%s).", FormatHandle(image).c_str(), string_VkFormat(image_format));
     }
-    if (VK_IMAGE_USAGE_TRANSFER_DST_BIT != (VK_IMAGE_USAGE_TRANSFER_DST_BIT & image_state.createInfo.usage)) {
+    if (VK_IMAGE_USAGE_TRANSFER_DST_BIT != (VK_IMAGE_USAGE_TRANSFER_DST_BIT & image_state.create_info.usage)) {
         skip |= LogError("VUID-vkCmdClearDepthStencilImage-pRanges-02659", objlist, image_loc,
                          "(%s) was not created with the "
                          "VK_IMAGE_USAGE_TRANSFER_DST_BIT set.",
@@ -1071,7 +1071,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         if (cb_state.activeRenderPass->UsesDynamicRendering()) {
             layer_count = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.layerCount;
         } else {
-            layer_count = cb_state.activeFramebuffer.get()->createInfo.layers;
+            layer_count = cb_state.activeFramebuffer.get()->create_info.layers;
         }
         skip |= ValidateClearAttachmentExtent(cb_state, render_area, layer_count, rectCount, pRects, error_obj.location);
     }
@@ -1115,7 +1115,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
             view_mask = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.viewMask;
             external_format_resolve = cb_state.HasExternalFormatResolveAttachment();
         } else {
-            const auto *renderpass_create_info = cb_state.activeRenderPass->createInfo.ptr();
+            const auto *renderpass_create_info = cb_state.activeRenderPass->create_info.ptr();
             const auto *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
             const auto *framebuffer = cb_state.activeFramebuffer.get();
 
@@ -1123,7 +1123,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                 if (framebuffer && (clear_desc->colorAttachment != VK_ATTACHMENT_UNUSED) &&
                     (clear_desc->colorAttachment < subpass_desc->colorAttachmentCount)) {
                     if (subpass_desc->pColorAttachments[clear_desc->colorAttachment].attachment <
-                        framebuffer->createInfo.attachmentCount) {
+                        framebuffer->create_info.attachmentCount) {
                         color_view_state = cb_state.GetActiveAttachmentImageViewState(
                             subpass_desc->pColorAttachments[clear_desc->colorAttachment].attachment);
 
@@ -1290,7 +1290,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
             }
         }
     } else if (cb_state.activeRenderPass->use_dynamic_rendering == false) {
-        const VkRenderPassCreateInfo2 *renderpass_create_info = cb_state.activeRenderPass->createInfo.ptr();
+        const VkRenderPassCreateInfo2 *renderpass_create_info = cb_state.activeRenderPass->create_info.ptr();
         const VkSubpassDescription2 *subpass_desc = &renderpass_create_info->pSubpasses[cb_state.GetActiveSubpass()];
 
         for (uint32_t attachment_index = 0; attachment_index < attachmentCount; attachment_index++) {
@@ -1319,7 +1319,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
                     bool skip = false;
 
                     if (fb && prim_cb->IsPrimary()) {
-                        skip |= ValidateClearAttachmentExtent(secondary, render_area, fb->createInfo.layers, rectCount,
+                        skip |= ValidateClearAttachmentExtent(secondary, render_area, fb->create_info.layers, rectCount,
                                                               clear_rect_copy->data(), record_obj.location);
                     }
                     return skip;
@@ -1337,15 +1337,15 @@ bool CoreChecks::ValidateImageUsageFlags(VkCommandBuffer cb, vvl::Image const &i
     LogObjectList objlist(cb, image_state.Handle());
     bool correct_usage = false;
     if (strict) {
-        correct_usage = ((image_state.createInfo.usage & desired) == desired);
+        correct_usage = ((image_state.create_info.usage & desired) == desired);
     } else {
-        correct_usage = ((image_state.createInfo.usage & desired) != 0);
+        correct_usage = ((image_state.create_info.usage & desired) != 0);
     }
 
     if (!correct_usage) {
-        skip |= LogError(vuid, objlist, image_loc, "(%s) was created with %s but requires %s.",
-                         FormatHandle(image_state.Handle()).c_str(), string_VkImageUsageFlags(image_state.createInfo.usage).c_str(),
-                         string_VkImageUsageFlags(desired).c_str());
+        skip |= LogError(
+            vuid, objlist, image_loc, "(%s) was created with %s but requires %s.", FormatHandle(image_state.Handle()).c_str(),
+            string_VkImageUsageFlags(image_state.create_info.usage).c_str(), string_VkImageUsageFlags(desired).c_str());
     }
     return skip;
 }
@@ -1369,8 +1369,8 @@ bool CoreChecks::ValidateImageFormatFeatureFlags(VkCommandBuffer cb, vvl::Image 
             skip |= LogError(vuid, objlist, image_loc,
                              "(%s) was created with format %s and tiling %s which have VkFormatFeatureFlags2 (%s) which in turn is "
                              "missing the required feature %s.",
-                             FormatHandle(image_state).c_str(), string_VkFormat(image_state.createInfo.format),
-                             string_VkImageTiling(image_state.createInfo.tiling),
+                             FormatHandle(image_state).c_str(), string_VkFormat(image_state.create_info.format),
+                             string_VkImageTiling(image_state.create_info.tiling),
                              string_VkFormatFeatureFlags2(image_format_features).c_str(),
                              string_VkFormatFeatureFlags2(desired).c_str());
         }
@@ -1525,8 +1525,8 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image
                                                          const Location &loc) const {
     const bool is_khr_maintenance1 = IsExtEnabled(device_extensions.vk_khr_maintenance1);
     const bool is_2d_compatible =
-        image_state.createInfo.flags & (VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT);
-    const bool is_image_slicable = (image_state.createInfo.imageType == VK_IMAGE_TYPE_3D) && is_2d_compatible;
+        image_state.create_info.flags & (VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT);
+    const bool is_image_slicable = (image_state.create_info.imageType == VK_IMAGE_TYPE_3D) && is_2d_compatible;
     const bool is_3_d_to_2_d_map = is_khr_maintenance1 && is_image_slicable && is_imageview_2d_type;
 
     uint32_t image_layer_count;
@@ -1536,7 +1536,7 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image
         const auto extent = image_state.GetEffectiveSubresourceExtent(layers);
         image_layer_count = extent.depth;
     } else {
-        image_layer_count = image_state.createInfo.arrayLayers;
+        image_layer_count = image_state.create_info.arrayLayers;
     }
 
     const auto image_layer_count_var_name = is_3_d_to_2_d_map ? "extent.depth" : "arrayLayers";
@@ -1549,7 +1549,7 @@ bool CoreChecks::ValidateCreateImageViewSubresourceRange(const vvl::Image &image
     subresource_range_error_codes.layer_count_err = is_3_d_to_2_d_map ? "VUID-VkImageViewCreateInfo-subresourceRange-02725"
                                                                       : "VUID-VkImageViewCreateInfo-subresourceRange-06725";
 
-    return ValidateImageSubresourceRange(image_state.createInfo.mipLevels, image_layer_count, subresourceRange,
+    return ValidateImageSubresourceRange(image_state.create_info.mipLevels, image_layer_count, subresourceRange,
                                          image_layer_count_var_name, image_state.VkHandle(), subresource_range_error_codes,
                                          loc.dot(Field::subresourceRange));
 }
@@ -1593,7 +1593,7 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image &image_state, 
     bool skip = false;
 
     VkFormatFeatureFlags2KHR tiling_features = 0;
-    const VkImageTiling image_tiling = image_state.createInfo.tiling;
+    const VkImageTiling image_tiling = image_state.create_info.tiling;
 
     if (image_state.HasAHBFormat()) {
         // AHB image view and image share same feature sets
@@ -1698,7 +1698,7 @@ bool CoreChecks::ValidateImageViewFormatFeatures(const vvl::Image &image_state, 
         }
     }
 
-    if (image_state.createInfo.flags & VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) {
+    if (image_state.create_info.flags & VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) {
         if ((image_usage & VK_IMAGE_USAGE_VIDEO_DECODE_DST_BIT_KHR) &&
             !(tiling_features & VK_FORMAT_FEATURE_VIDEO_DECODE_OUTPUT_BIT_KHR)) {
             skip |= LogError("VUID-VkImageViewCreateInfo-image-08333", image_state.Handle(), create_info_loc.dot(Field::format),
@@ -1799,19 +1799,20 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         pCreateInfo->subresourceRange, create_info_loc);
 
     const auto normalized_subresource_range = image_state.NormalizeSubresourceRange(pCreateInfo->subresourceRange);
-    const VkImageCreateFlags image_flags = image_state.createInfo.flags;
-    const VkFormat image_format = image_state.createInfo.format;
+    const VkImageCreateFlags image_flags = image_state.create_info.flags;
+    const VkFormat image_format = image_state.create_info.format;
     const VkFormat view_format = pCreateInfo->format;
     const VkImageAspectFlags aspect_mask = pCreateInfo->subresourceRange.aspectMask;
-    const VkImageType image_type = image_state.createInfo.imageType;
+    const VkImageType image_type = image_state.create_info.imageType;
     const VkImageViewType view_type = pCreateInfo->viewType;
     const uint32_t layer_count = pCreateInfo->subresourceRange.layerCount;
 
     // If there's a chained VkImageViewUsageCreateInfo struct, modify image_usage to match
-    VkImageUsageFlags image_usage = image_state.createInfo.usage;
+    VkImageUsageFlags image_usage = image_state.create_info.usage;
     if (const auto chained_ivuci_struct = vku::FindStructInPNextChain<VkImageViewUsageCreateInfo>(pCreateInfo->pNext); chained_ivuci_struct) {
         if (IsExtEnabled(device_extensions.vk_khr_maintenance2)) {
-            const auto image_stencil_struct = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.createInfo.pNext);
+            const auto image_stencil_struct =
+                vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(image_state.create_info.pNext);
             if (image_stencil_struct == nullptr) {
                 if ((image_usage | chained_ivuci_struct->usage) != image_usage) {
                     skip |=
@@ -1866,7 +1867,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
                              create_info_loc.dot(Field::viewType), "is (%s).", string_VkImageViewType(view_type));
         }
 
-        const uint32_t effective_mip_levels = ResolveRemainingLevels(image_state.createInfo, pCreateInfo->subresourceRange);
+        const uint32_t effective_mip_levels = ResolveRemainingLevels(image_state.create_info, pCreateInfo->subresourceRange);
         if (effective_mip_levels != 1) {
             skip |= LogError("VUID-VkImageViewSlicedCreateInfoEXT-None-07870", pCreateInfo->image, create_info_loc,
                              "Image view references %" PRIu32 " mip levels.", effective_mip_levels);
@@ -1900,7 +1901,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     }
 
     // If image used VkImageFormatListCreateInfo need to make sure a format from list is used
-    if (const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.createInfo.pNext);
+    if (const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(image_state.create_info.pNext);
         format_list_info && (format_list_info->viewFormatCount > 0)) {
         bool found_format = false;
         for (uint32_t i = 0; i < format_list_info->viewFormatCount; i++) {
@@ -1964,11 +1965,11 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         }
     }
 
-    if (image_state.createInfo.samples != VK_SAMPLE_COUNT_1_BIT && view_type != VK_IMAGE_VIEW_TYPE_2D &&
+    if (image_state.create_info.samples != VK_SAMPLE_COUNT_1_BIT && view_type != VK_IMAGE_VIEW_TYPE_2D &&
         view_type != VK_IMAGE_VIEW_TYPE_2D_ARRAY) {
         skip |= LogError("VUID-VkImageViewCreateInfo-image-04972", pCreateInfo->image, create_info_loc.dot(Field::image),
                          "was created with sample count %s, but pCreateInfo->viewType is %s.",
-                         string_VkSampleCountFlagBits(image_state.createInfo.samples), string_VkImageViewType(view_type));
+                         string_VkSampleCountFlagBits(image_state.create_info.samples), string_VkImageViewType(view_type));
     }
 
     // Validate correct image aspect bits for desired formats and format consistency
@@ -2107,7 +2108,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     }
 
     if (layer_count == VK_REMAINING_ARRAY_LAYERS) {
-        const uint32_t remaining_layers = image_state.createInfo.arrayLayers - pCreateInfo->subresourceRange.baseArrayLayer;
+        const uint32_t remaining_layers = image_state.create_info.arrayLayers - pCreateInfo->subresourceRange.baseArrayLayer;
         if (view_type == VK_IMAGE_VIEW_TYPE_CUBE && remaining_layers != 6) {
             skip |= LogError("VUID-VkImageViewCreateInfo-viewType-02962", pCreateInfo->image,
                              create_info_loc.dot(Field::subresourceRange).dot(Field::layerCount),
@@ -2241,7 +2242,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
         // Ensure ImageView's format has the same number of bits and components as Image's format if format reinterpretation is
         // disabled
         if (!enabled_features.imageViewFormatReinterpretation &&
-            !FormatsEqualComponentBits(pCreateInfo->format, image_state.createInfo.format)) {
+            !FormatsEqualComponentBits(pCreateInfo->format, image_state.create_info.format)) {
             skip |=
                 LogError("VUID-VkImageViewCreateInfo-imageViewFormatReinterpretation-04466", pCreateInfo->image, create_info_loc,
                          "(portability error): ImageView format must have"
@@ -2317,16 +2318,16 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     skip |= ValidateImageViewSampleWeightQCOM(*pCreateInfo, image_state, create_info_loc);
 
     // If Chroma subsampled format ( _420_ or _422_ )
-    if (vkuFormatIsXChromaSubsampled(view_format) && (SafeModulo(image_state.createInfo.extent.width, 2) != 0)) {
+    if (vkuFormatIsXChromaSubsampled(view_format) && (SafeModulo(image_state.create_info.extent.width, 2) != 0)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-format-04714", device, create_info_loc.dot(Field::format),
                          "(%s) is X Chroma Subsampled (has _422 or _420 suffix) so the image width (%" PRIu32
                          ") must be a multiple of 2.",
-                         string_VkFormat(view_format), image_state.createInfo.extent.width);
+                         string_VkFormat(view_format), image_state.create_info.extent.width);
     }
-    if (vkuFormatIsYChromaSubsampled(view_format) && (SafeModulo(image_state.createInfo.extent.height, 2) != 0)) {
+    if (vkuFormatIsYChromaSubsampled(view_format) && (SafeModulo(image_state.create_info.extent.height, 2) != 0)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-format-04715", device, create_info_loc.dot(Field::format),
                          "(%s) is Y Chroma Subsampled (has _420 suffix) so the image height (%" PRIu32 ") must be a multiple of 2.",
-                         string_VkFormat(view_format), image_state.createInfo.extent.height);
+                         string_VkFormat(view_format), image_state.create_info.extent.height);
     }
 
     return skip;
@@ -2358,25 +2359,25 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     }
 
     // mipLevel must be less than the mipLevels specified in VkImageCreateInfo when the image was created
-    if (subresource.mipLevel >= image_state.createInfo.mipLevels) {
+    if (subresource.mipLevel >= image_state.create_info.mipLevels) {
         const char *vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2KHR-mipLevel-01716" : "VUID-vkGetImageSubresourceLayout-mipLevel-01716";
         skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::mipLevel),
-                         "(%" PRIu32 ") must be less than %" PRIu32 ".", subresource.mipLevel, image_state.createInfo.mipLevels);
+                         "(%" PRIu32 ") must be less than %" PRIu32 ".", subresource.mipLevel, image_state.create_info.mipLevels);
     }
 
     // arrayLayer must be less than the arrayLayers specified in VkImageCreateInfo when the image was created
-    if (subresource.arrayLayer >= image_state.createInfo.arrayLayers) {
+    if (subresource.arrayLayer >= image_state.create_info.arrayLayers) {
         const char *vuid =
             is_2 ? "VUID-vkGetImageSubresourceLayout2KHR-arrayLayer-01717" : "VUID-vkGetImageSubresourceLayout-arrayLayer-01717";
         skip |=
             LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::arrayLayer),
-                     "(%" PRIu32 ") must be less than %" PRIu32 ".", subresource.arrayLayer, image_state.createInfo.arrayLayers);
+                     "(%" PRIu32 ") must be less than %" PRIu32 ".", subresource.arrayLayer, image_state.create_info.arrayLayers);
     }
 
-    const VkFormat image_format = image_state.createInfo.format;
+    const VkFormat image_format = image_state.create_info.format;
     const bool tiling_linear_optimal =
-        image_state.createInfo.tiling == VK_IMAGE_TILING_LINEAR || image_state.createInfo.tiling == VK_IMAGE_TILING_OPTIMAL;
+        image_state.create_info.tiling == VK_IMAGE_TILING_LINEAR || image_state.create_info.tiling == VK_IMAGE_TILING_OPTIMAL;
     if (vkuFormatIsColor(image_format) && !vkuFormatIsMultiplane(image_format) && (aspect_mask != VK_IMAGE_ASPECT_COLOR_BIT) &&
         tiling_linear_optimal) {
         const char *vuid =
@@ -2413,14 +2414,14 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
     }
 
     // subresource's aspect must be compatible with image's format.
-    if (image_state.createInfo.tiling == VK_IMAGE_TILING_LINEAR) {
+    if (image_state.create_info.tiling == VK_IMAGE_TILING_LINEAR) {
         if (vkuFormatIsMultiplane(image_format) && !IsOnlyOneValidPlaneAspect(image_format, aspect_mask)) {
             const char *vuid =
                 is_2 ? "VUID-vkGetImageSubresourceLayout2KHR-tiling-08717" : "VUID-vkGetImageSubresourceLayout-tiling-08717";
             skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask), "(%s) is invalid for format %s.",
                              string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_format));
         }
-    } else if (image_state.createInfo.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+    } else if (image_state.create_info.tiling == VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
         if ((aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_0_BIT_EXT) && (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_1_BIT_EXT) &&
             (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_2_BIT_EXT) && (aspect_mask != VK_IMAGE_ASPECT_MEMORY_PLANE_3_BIT_EXT)) {
             const char *vuid =
@@ -2436,10 +2437,10 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
 
             VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
             VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
-            DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_state.createInfo.format, &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_state.create_info.format, &fmt_props_2);
             std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties{fmt_drm_props.drmFormatModifierCount};
             fmt_drm_props.pDrmFormatModifierProperties = drm_properties.data();
-            DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_state.createInfo.format, &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2(physical_device, image_state.create_info.format, &fmt_props_2);
 
             uint32_t max_plane_count = 0u;
 
@@ -2469,7 +2470,7 @@ bool CoreChecks::ValidateGetImageSubresourceLayout(const vvl::Image &image_state
                 skip |= LogError(vuid, image_state.Handle(), subresource_loc.dot(Field::aspectMask),
                                  "is %s for image format %s, but drmFormatModifierPlaneCount is %" PRIu32
                                  " (drmFormatModifier = %" PRIu64 ").",
-                                 string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_state.createInfo.format),
+                                 string_VkImageAspectFlags(aspect_mask).c_str(), string_VkFormat(image_state.create_info.format),
                                  max_plane_count, drm_format_properties.drmFormatModifier);
             }
         }
@@ -2493,10 +2494,10 @@ bool CoreChecks::PreCallValidateGetImageSubresourceLayout(VkDevice device, VkIma
     auto image_state = Get<vvl::Image>(image);
     if (pSubresource && pLayout && image_state) {
         skip |= ValidateGetImageSubresourceLayout(*image_state, *pSubresource, error_obj.location.dot(Field::pSubresource));
-        if ((image_state->createInfo.tiling != VK_IMAGE_TILING_LINEAR) &&
-            (image_state->createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)) {
+        if ((image_state->create_info.tiling != VK_IMAGE_TILING_LINEAR) &&
+            (image_state->create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT)) {
             skip |= LogError("VUID-vkGetImageSubresourceLayout-image-07790", image, error_obj.location,
-                             "image was created with tiling %s.", string_VkImageTiling(image_state->createInfo.tiling));
+                             "image was created with tiling %s.", string_VkImageTiling(image_state->create_info.tiling));
         }
     }
     return skip;
@@ -2528,10 +2529,10 @@ bool CoreChecks::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(VkDevice 
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     if (image_state) {
-        if (image_state->createInfo.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
+        if (image_state->create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
             skip |=
                 LogError("VUID-vkGetImageDrmFormatModifierPropertiesEXT-image-02272", image, error_obj.location.dot(Field::image),
-                         "was created with tiling %s.", string_VkImageTiling(image_state->createInfo.tiling));
+                         "was created with tiling %s.", string_VkImageTiling(image_state->create_info.tiling));
         }
     }
     return skip;
@@ -2553,20 +2554,20 @@ bool CoreChecks::PreCallValidateTransitionImageLayoutEXT(VkDevice device, uint32
         const Location transition_loc = error_obj.location.dot(Field::pTransitions, i);
         const auto &transition = pTransitions[i];
         const auto image_state = Get<vvl::Image>(transition.image);
-        const auto image_format = image_state->createInfo.format;
+        const auto image_format = image_state->create_info.format;
         const auto aspect_mask = transition.subresourceRange.aspectMask;
         const bool has_depth_mask = (aspect_mask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0;
         const bool has_stencil_mask = (aspect_mask & VK_IMAGE_ASPECT_STENCIL_BIT) != 0;
 
-        if ((image_state->createInfo.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
+        if ((image_state->create_info.usage & VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT) == 0) {
             const LogObjectList objlist(device, image_state->Handle());
             skip |= LogError("VUID-VkHostImageLayoutTransitionInfoEXT-image-09055", objlist, transition_loc.dot(Field::image),
                              "was created with usage (%s) which does not contain "
                              "VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT.",
-                             string_VkImageUsageFlags(image_state->createInfo.usage).c_str());
+                             string_VkImageUsageFlags(image_state->create_info.usage).c_str());
         }
 
-        skip |= ValidateImageSubresourceRange(image_state->createInfo.mipLevels, image_state->createInfo.arrayLayers,
+        skip |= ValidateImageSubresourceRange(image_state->create_info.mipLevels, image_state->create_info.arrayLayers,
                                               transition.subresourceRange, "arrayLayers", image_state->VkHandle(),
                                               TransitionImageLayoutVUIDs, transition_loc.dot(Field::subresourceRange));
         skip |=
@@ -2719,9 +2720,9 @@ bool CoreChecks::ValidateImageViewSampleWeightQCOM(const VkImageViewCreateInfo &
     }
 
     const VkImageAspectFlags aspect_mask = create_info.subresourceRange.aspectMask;
-    const VkImageType image_type = image_state.createInfo.imageType;
-    const VkImageUsageFlags image_usage = image_state.createInfo.usage;
-    const VkExtent3D image_extent = image_state.createInfo.extent;
+    const VkImageType image_type = image_state.create_info.imageType;
+    const VkImageUsageFlags image_usage = image_state.create_info.usage;
+    const VkExtent3D image_extent = image_state.create_info.extent;
     const uint32_t layer_count = create_info.subresourceRange.layerCount;
 
     if ((enabled_features.textureSampleWeighted == VK_FALSE)) {

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1066,7 +1066,7 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                                   ? cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.renderArea
                                   : cb_state.active_render_pass_begin_info.renderArea;
 
-    if (cb_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY) {
+    if (cb_state.IsPrimary()) {
         uint32_t layer_count = 0;
         if (cb_state.activeRenderPass->UsesDynamicRendering()) {
             layer_count = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info.layerCount;
@@ -1252,7 +1252,7 @@ void CoreChecks::PreCallRecordCmdClearAttachments(VkCommandBuffer commandBuffer,
         return;
     }
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
-    if (!cb_state.activeRenderPass || (cb_state.createInfo.level != VK_COMMAND_BUFFER_LEVEL_SECONDARY)) {
+    if (!cb_state.activeRenderPass || cb_state.IsPrimary()) {
         return;
     }
     std::shared_ptr<std::vector<VkClearRect>> clear_rect_copy;

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -440,7 +440,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer &cb_state, V
 
         const auto &qfp = physical_device_state->queue_family_properties[pool->queueFamilyIndex];
         if (0 == (qfp.queueFlags & required_mask)) {
-            const LogObjectList objlist(cb_state.Handle(), cb_state.createInfo.commandPool);
+            const LogObjectList objlist(cb_state.Handle(), cb_state.allocate_info.commandPool);
             const char *vuid = kVUIDUndefined;
             switch (loc.function) {
                 case Func::vkCmdBindDescriptorSets:
@@ -486,7 +486,7 @@ bool CoreChecks::ValidatePipelineBindPoint(const vvl::CommandBuffer &cb_state, V
                     break;
             }
             skip |= LogError(vuid, objlist, loc, "%s was allocated from %s that does not support bindpoint %s.",
-                             FormatHandle(cb_state.Handle()).c_str(), FormatHandle(cb_state.createInfo.commandPool).c_str(),
+                             FormatHandle(cb_state.Handle()).c_str(), FormatHandle(cb_state.allocate_info.commandPool).c_str(),
                              string_VkPipelineBindPoint(bind_point));
         }
     }
@@ -587,8 +587,8 @@ bool CoreChecks::ValidateShaderStageMaxResources(VkShaderStageFlagBits stage, co
             total_resources += rp_state->dynamic_pipeline_rendering_create_info.colorAttachmentCount;
         } else {
             // "For the fragment shader stage the framebuffer color attachments also count against this limit"
-            if (pipeline.Subpass() < rp_state->createInfo.subpassCount) {
-                total_resources += rp_state->createInfo.pSubpasses[pipeline.Subpass()].colorAttachmentCount;
+            if (pipeline.Subpass() < rp_state->create_info.subpassCount) {
+                total_resources += rp_state->create_info.pSubpasses[pipeline.Subpass()].colorAttachmentCount;
             }
         }
     }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -59,12 +59,12 @@ bool CoreChecks::ValidateGraphicsPipeline(const vvl::Pipeline &pipeline, const L
         // Ensure the subpass index is valid. If not, then ValidateGraphicsPipelineShaderState
         // produces nonsense errors that confuse users. Other layers should already
         // emit errors for renderpass being invalid.
-        subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
-        if (subpass >= rp_state->createInfo.subpassCount) {
+        subpass_desc = &rp_state->create_info.pSubpasses[subpass];
+        if (subpass >= rp_state->create_info.subpassCount) {
             skip |=
                 LogError("VUID-VkGraphicsPipelineCreateInfo-renderPass-06046", rp_state->Handle(),
                          create_info_loc.dot(Field::subpass), "(%" PRIu32 ") is out of range for this renderpass (0..%" PRIu32 ").",
-                         subpass, rp_state->createInfo.subpassCount - 1);
+                         subpass, rp_state->create_info.subpassCount - 1);
             subpass_desc = nullptr;
         }
 
@@ -214,7 +214,7 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
         const bool ignore_color_blend_state =
             raster_state_ci->rasterizerDiscardEnable ||
             (pipeline.rendering_create_info ? (pipeline.rendering_create_info->colorAttachmentCount == 0)
-                                            : (render_pass->createInfo.pSubpasses[subpass].colorAttachmentCount == 0));
+                                            : (render_pass->create_info.pSubpasses[subpass].colorAttachmentCount == 0));
         const auto *color_blend_state = pipeline.ColorBlendState();
         if (!enabled_features.constantAlphaColorBlendFactors && !ignore_color_blend_state && color_blend_state) {
             const auto attachments = color_blend_state->pAttachments;
@@ -1189,13 +1189,13 @@ bool CoreChecks::ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline &pipeli
 
     if (!rp_state->UsesDynamicRendering()) {
         const auto subpass = pipeline.Subpass();
-        const auto *subpass_desc = &rp_state->createInfo.pSubpasses[subpass];
+        const auto *subpass_desc = &rp_state->create_info.pSubpasses[subpass];
 
         for (uint32_t i = 0; i < pipeline.Attachments().size() && i < subpass_desc->colorAttachmentCount; ++i) {
             const auto attachment = subpass_desc->pColorAttachments[i].attachment;
             if (attachment == VK_ATTACHMENT_UNUSED) continue;
 
-            const auto attachment_desc = rp_state->createInfo.pAttachments[attachment];
+            const auto attachment_desc = rp_state->create_info.pAttachments[attachment];
             VkFormatFeatureFlags2KHR format_features = GetPotentialFormatFeatures(attachment_desc.format);
 
             const auto *raster_state = pipeline.RasterizationState();
@@ -1236,7 +1236,7 @@ bool CoreChecks::ValidateGraphicsPipelineExternalFormatResolve(const vvl::Pipeli
         if (attachment == VK_ATTACHMENT_UNUSED) {
             return false;
         }
-        const uint64_t external_format = GetExternalFormat(rp_state->createInfo.pAttachments[attachment].pNext);
+        const uint64_t external_format = GetExternalFormat(rp_state->create_info.pAttachments[attachment].pNext);
         if (external_format == 0) {
             return false;
         }
@@ -1891,7 +1891,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
             for (uint32_t i = 0; i < subpass_desc->colorAttachmentCount; i++) {
                 const auto attachment = subpass_desc->pColorAttachments[i].attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
-                    samples |= static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
+                    samples |= static_cast<uint32_t>(rp_state->create_info.pAttachments[attachment].samples);
                 }
             }
         };
@@ -1908,7 +1908,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                 if (subpass_desc->pDepthStencilAttachment &&
                     subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                     const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
-                    subpass_num_samples |= static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
+                    subpass_num_samples |= static_cast<uint32_t>(rp_state->create_info.pAttachments[attachment].samples);
                 }
 
                 // subpass_num_samples is 0 when the subpass has no attachments or if all attachments are VK_ATTACHMENT_UNUSED.
@@ -1926,14 +1926,14 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                     if (subpass_desc->pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) {
                         max_sample_count =
                             std::max(max_sample_count,
-                                     rp_state->createInfo.pAttachments[subpass_desc->pColorAttachments[i].attachment].samples);
+                                     rp_state->create_info.pAttachments[subpass_desc->pColorAttachments[i].attachment].samples);
                     }
                 }
                 if (subpass_desc->pDepthStencilAttachment &&
                     subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                     max_sample_count =
                         std::max(max_sample_count,
-                                 rp_state->createInfo.pAttachments[subpass_desc->pDepthStencilAttachment->attachment].samples);
+                                 rp_state->create_info.pAttachments[subpass_desc->pDepthStencilAttachment->attachment].samples);
                 }
                 const auto raster_state = pipeline.RasterizationState();
                 if ((raster_state && raster_state->rasterizerDiscardEnable == VK_FALSE) &&
@@ -1955,7 +1955,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                     subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                     const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
                     const uint32_t subpass_depth_samples =
-                        static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
+                        static_cast<uint32_t>(rp_state->create_info.pAttachments[attachment].samples);
                     const auto ds_state = pipeline.DepthStencilState();
                     if (ds_state) {
                         const bool ds_test_enabled = (ds_state->depthTestEnable == VK_TRUE) ||
@@ -2014,7 +2014,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                 if (subpass_desc->pDepthStencilAttachment &&
                     subpass_desc->pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                     const auto attachment = subpass_desc->pDepthStencilAttachment->attachment;
-                    subpass_depth_samples = static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
+                    subpass_depth_samples = static_cast<uint32_t>(rp_state->create_info.pAttachments[attachment].samples);
                 }
 
                 if (multisample_state && IsPowerOfTwo(subpass_color_samples) &&
@@ -2090,7 +2090,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                 const auto &color_attachment_ref =
                     subpass_desc->pColorAttachments[coverage_to_color_state->coverageToColorLocation];
                 if (color_attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
-                    const auto &color_attachment = rp_state->createInfo.pAttachments[color_attachment_ref.attachment];
+                    const auto &color_attachment = rp_state->create_info.pAttachments[color_attachment_ref.attachment];
 
                     switch (color_attachment.format) {
                         case VK_FORMAT_R8_UINT:
@@ -2175,7 +2175,7 @@ bool CoreChecks::ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline &p
                 const auto attachment = subpass_desc->pInputAttachments[i].attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
                     subpass_input_attachment_samples |=
-                        static_cast<uint32_t>(rp_state->createInfo.pAttachments[attachment].samples);
+                        static_cast<uint32_t>(rp_state->create_info.pAttachments[attachment].samples);
                 }
             }
 
@@ -2994,7 +2994,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
         bool primitives_generated_query = false;
         for (const auto &query : cb_state.activeQueries) {
             auto query_pool_state = Get<vvl::QueryPool>(query.pool);
-            if (query_pool_state && query_pool_state->createInfo.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+            if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
                 primitives_generated_query = true;
                 break;
             }
@@ -3152,7 +3152,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
                 // TODO: Mirror the below VUs but using dynamic rendering
                 const auto dynamic_rendering_info = cb_state.activeRenderPass->dynamic_rendering_begin_rendering_info;
             } else {
-                const auto render_pass_info = cb_state.activeRenderPass->createInfo.ptr();
+                const auto render_pass_info = cb_state.activeRenderPass->create_info.ptr();
                 const VkSubpassDescription2 *subpass_desc = &render_pass_info->pSubpasses[cb_state.GetActiveSubpass()];
                 uint32_t i;
                 unsigned subpass_num_samples = 0;
@@ -3538,7 +3538,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                          cb_state.GetActiveSubpass());
     }
     const safe_VkAttachmentReference2 *ds_attachment =
-        cb_state.activeRenderPass->createInfo.pSubpasses[cb_state.GetActiveSubpass()].pDepthStencilAttachment;
+        cb_state.activeRenderPass->create_info.pSubpasses[cb_state.GetActiveSubpass()].pDepthStencilAttachment;
     if (ds_attachment != nullptr) {
         // Check if depth stencil attachment was created with sample location compatible bit
         if (pipeline.SampleLocationEnabled() == VK_TRUE) {
@@ -3548,7 +3548,7 @@ bool CoreChecks::ValidatePipelineRenderpassDraw(const LastBound &last_bound_stat
                 if (imageview_state != nullptr) {
                     const auto *image_state = imageview_state->image_state.get();
                     if (image_state != nullptr) {
-                        if ((image_state->createInfo.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
+                        if ((image_state->create_info.flags & VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT) == 0) {
                             const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), cb_state.activeRenderPass->Handle());
                             skip |= LogError(vuid.sample_location_02689, objlist, loc,
                                              "sampleLocationsEnable is true for the pipeline, but the subpass (%u) depth "
@@ -3947,7 +3947,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 continue;
             }
             auto color_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-            auto color_image_samples = Get<vvl::Image>(color_view_state->create_info.image)->createInfo.samples;
+            auto color_image_samples = Get<vvl::Image>(color_view_state->create_info.image)->create_info.samples;
 
             if (p_attachment_sample_count_info &&
                 (color_image_samples != p_attachment_sample_count_info->pColorAttachmentSamples[i])) {
@@ -3963,7 +3963,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         if (rendering_info.pDepthAttachment != nullptr) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-            auto depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->createInfo.samples;
+            auto depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->create_info.samples;
 
             if (p_attachment_sample_count_info) {
                 if (depth_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
@@ -3980,7 +3980,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         if (rendering_info.pStencilAttachment != nullptr) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-            auto stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->createInfo.samples;
+            auto stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->create_info.samples;
 
             if (p_attachment_sample_count_info) {
                 if (stencil_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
@@ -4002,7 +4002,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
                 continue;
             }
             auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-            auto samples = Get<vvl::Image>(view_state->create_info.image)->createInfo.samples;
+            auto samples = Get<vvl::Image>(view_state->create_info.image)->create_info.samples;
 
             if (samples != rasterization_samples) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
@@ -4016,7 +4016,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         if ((rendering_info.pDepthAttachment != nullptr) && (rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE)) {
             const auto &depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-            const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->createInfo.samples;
+            const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->create_info.samples;
             if (depth_image_samples != rasterization_samples) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07286, objlist, loc,
@@ -4029,7 +4029,7 @@ bool CoreChecks::ValidatePipelineDynamicRenderpassDraw(const LastBound &last_bou
 
         if ((rendering_info.pStencilAttachment != nullptr) && (rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE)) {
             const auto &stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-            const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->createInfo.samples;
+            const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->create_info.samples;
             if (stencil_image_samples != rasterization_samples) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline->Handle(), cb_state.activeRenderPass->Handle());
                 skip |= LogError(vuid.dynamic_rendering_07287, objlist, loc,

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -594,7 +594,7 @@ bool CoreChecks::ValidatePrimaryCommandBufferState(
     // Track in-use for resources off of primary and any secondary CBs
     bool skip = false;
 
-    if (cb_state.createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
+    if (cb_state.IsSeconary()) {
         const auto &vuid = GetQueueSubmitVUID(loc, SubmitError::kSecondaryCmdInSubmit);
         skip |= LogError(vuid, cb_state.Handle(), loc, "Command buffer %s must be allocated with VK_COMMAND_BUFFER_LEVEL_PRIMARY.",
                          FormatHandle(cb_state).c_str());

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -504,19 +504,19 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::Comm
             switch (state_object->Type()) {
                 case kVulkanObjectTypeImage: {
                     auto image_state = static_cast<const vvl::Image *>(state_object.get());
-                    if (image_state && image_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
+                    if (image_state && image_state->create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                         skip |= ValidImageBufferQueue(cb_state, image_state->Handle(), queue_state->queueFamilyIndex,
-                                                      image_state->createInfo.queueFamilyIndexCount,
-                                                      image_state->createInfo.pQueueFamilyIndices, loc);
+                                                      image_state->create_info.queueFamilyIndexCount,
+                                                      image_state->create_info.pQueueFamilyIndices, loc);
                     }
                     break;
                 }
                 case kVulkanObjectTypeBuffer: {
                     auto buffer_state = static_cast<const vvl::Buffer *>(state_object.get());
-                    if (buffer_state && buffer_state->createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) {
+                    if (buffer_state && buffer_state->create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
                         skip |= ValidImageBufferQueue(cb_state, buffer_state->Handle(), queue_state->queueFamilyIndex,
-                                                      buffer_state->createInfo.queueFamilyIndexCount,
-                                                      buffer_state->createInfo.pQueueFamilyIndices, loc);
+                                                      buffer_state->create_info.queueFamilyIndexCount,
+                                                      buffer_state->create_info.pQueueFamilyIndices, loc);
                     }
                     break;
                 }
@@ -712,7 +712,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 if (!image_state->sparse_residency) {
                     skip |=
                         LogError("VUID-VkSparseImageMemoryBindInfo-image-02901", image_bind.image, bind_loc.dot(Field::image),
-                                 "was created with flags %s.", string_VkImageCreateFlags(image_state->createInfo.flags).c_str());
+                                 "was created with flags %s.", string_VkImageCreateFlags(image_state->create_info.flags).c_str());
                 }
 
                 for (uint32_t image_bind_idx = 0; image_bind_idx < image_bind.bindCount; ++image_bind_idx) {

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -644,7 +644,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
 
     const auto &rp_state = pipeline.RenderPassState();
     if (rp_state && !rp_state->UsesDynamicRendering()) {
-        const auto rpci = rp_state->createInfo.ptr();
+        const auto rpci = rp_state->create_info.ptr();
         if (subpass_index < rpci->subpassCount) {
             const auto subpass = rpci->pSubpasses[subpass_index];
             for (uint32_t i = 0; i < subpass.colorAttachmentCount; ++i) {

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -84,140 +84,140 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
     uint32_t linked_binary_index = invalid;
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
-        const VkShaderCreateInfoEXT& createInfo = pCreateInfos[i];
-        if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
-            createInfo.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
+        const VkShaderCreateInfoEXT& create_info = pCreateInfos[i];
+        if (create_info.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+            create_info.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) {
             if (enabled_features.tessellationShader == VK_FALSE) {
                 skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08419", device, create_info_loc.dot(Field::stage),
                                  "is %s, but the tessellationShader feature was not enabled.",
-                                 string_VkShaderStageFlagBits(createInfo.stage));
+                                 string_VkShaderStageFlagBits(create_info.stage));
             }
-        } else if (createInfo.stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
+        } else if (create_info.stage == VK_SHADER_STAGE_GEOMETRY_BIT) {
             if (enabled_features.geometryShader == VK_FALSE) {
                 skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08420", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_GEOMETRY_BIT, but the geometryShader feature was not enabled.");
             }
-        } else if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_EXT) {
+        } else if (create_info.stage == VK_SHADER_STAGE_TASK_BIT_EXT) {
             if (enabled_features.taskShader == VK_FALSE) {
                 skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08421", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_TASK_BIT_EXT, but the taskShader feature was not enabled.");
             }
-        } else if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
+        } else if (create_info.stage == VK_SHADER_STAGE_MESH_BIT_EXT) {
             if (enabled_features.meshShader == VK_FALSE) {
                 skip |= LogError("VUID-VkShaderCreateInfoEXT-stage-08422", device, create_info_loc.dot(Field::stage),
                                  "is VK_SHADER_STAGE_MESH_BIT_EXT, but the meshShader feature was not enabled.");
             }
         }
 
-        if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0 &&
+        if ((create_info.flags & VK_SHADER_CREATE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_EXT) != 0 &&
             enabled_features.attachmentFragmentShadingRate == VK_FALSE) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08487", device, create_info_loc.dot(Field::flags),
                              "is %s, but the attachmentFragmentShadingRate feature was not enabled.",
-                             string_VkShaderCreateFlagsEXT(createInfo.flags).c_str());
+                             string_VkShaderCreateFlagsEXT(create_info.flags).c_str());
         }
-        if ((createInfo.flags & VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT) != 0 &&
+        if ((create_info.flags & VK_SHADER_CREATE_FRAGMENT_DENSITY_MAP_ATTACHMENT_BIT_EXT) != 0 &&
             enabled_features.fragmentDensityMap == VK_FALSE) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-flags-08489", device, create_info_loc.dot(Field::flags),
                              "is %s, but the fragmentDensityMap feature was not enabled.",
-                             string_VkShaderCreateFlagsEXT(createInfo.flags).c_str());
+                             string_VkShaderCreateFlagsEXT(create_info.flags).c_str());
         }
 
-        if ((createInfo.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
-            const auto nextStage = FindNextStage(createInfoCount, pCreateInfos, createInfo.stage);
-            if (nextStage != 0 && createInfo.nextStage != nextStage) {
-                skip |=
-                    LogError("VUID-vkCreateShadersEXT-pCreateInfos-08409", device, create_info_loc.dot(Field::flags),
-                             "is %s, but nextStage (%s) does not equal the "
-                             "logically next stage (%s) which also has the VK_SHADER_CREATE_LINK_STAGE_BIT_EXT bit.",
-                             string_VkShaderCreateFlagsEXT(createInfo.flags).c_str(),
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str(), string_VkShaderStageFlags(nextStage).c_str());
+        if ((create_info.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
+            const auto nextStage = FindNextStage(createInfoCount, pCreateInfos, create_info.stage);
+            if (nextStage != 0 && create_info.nextStage != nextStage) {
+                skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08409", device, create_info_loc.dot(Field::flags),
+                                 "is %s, but nextStage (%s) does not equal the "
+                                 "logically next stage (%s) which also has the VK_SHADER_CREATE_LINK_STAGE_BIT_EXT bit.",
+                                 string_VkShaderCreateFlagsEXT(create_info.flags).c_str(),
+                                 string_VkShaderStageFlags(create_info.nextStage).c_str(),
+                                 string_VkShaderStageFlags(nextStage).c_str());
             }
             for (uint32_t j = i; j < createInfoCount; ++j) {
-                if (i != j && createInfo.stage == pCreateInfos[j].stage) {
+                if (i != j && create_info.stage == pCreateInfos[j].stage) {
                     skip |= LogError("VUID-vkCreateShadersEXT-pCreateInfos-08410", device, create_info_loc,
                                      "and pCreateInfos[%" PRIu32
                                      "] both contain VK_SHADER_CREATE_LINK_STAGE_BIT_EXT and have the stage %s.",
-                                     j, string_VkShaderStageFlagBits(createInfo.stage));
+                                     j, string_VkShaderStageFlagBits(create_info.stage));
                 }
             }
 
             linked_stage = i;
-            if ((createInfo.stage & VK_SHADER_STAGE_VERTEX_BIT) != 0) {
+            if ((create_info.stage & VK_SHADER_STAGE_VERTEX_BIT) != 0) {
                 linked_vert_stage = i;
-            } else if ((createInfo.stage & VK_SHADER_STAGE_TASK_BIT_EXT) != 0) {
+            } else if ((create_info.stage & VK_SHADER_STAGE_TASK_BIT_EXT) != 0) {
                 linked_task_mesh_stage = i;
                 linked_task_stage = i;
-            } else if ((createInfo.stage & VK_SHADER_STAGE_MESH_BIT_EXT) != 0) {
+            } else if ((create_info.stage & VK_SHADER_STAGE_MESH_BIT_EXT) != 0) {
                 linked_task_mesh_stage = i;
-                if ((createInfo.flags & VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT) != 0) {
+                if ((create_info.flags & VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT) != 0) {
                     linked_mesh_no_task_stage = i;
                 }
             }
-            if (createInfo.codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
+            if (create_info.codeType == VK_SHADER_CODE_TYPE_SPIRV_EXT) {
                 linked_spirv_index = i;
-            } else if (createInfo.codeType == VK_SHADER_CODE_TYPE_BINARY_EXT) {
+            } else if (create_info.codeType == VK_SHADER_CODE_TYPE_BINARY_EXT) {
                 linked_binary_index = i;
             }
-        } else if ((createInfo.stage & (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
-                                        VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT |
-                                        VK_SHADER_STAGE_FRAGMENT_BIT)) != 0) {
+        } else if ((create_info.stage & (VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT |
+                                         VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT |
+                                         VK_SHADER_STAGE_FRAGMENT_BIT)) != 0) {
             non_linked_graphics_stage = i;
-        } else if ((createInfo.stage & (VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT)) != 0) {
+        } else if ((create_info.stage & (VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT)) != 0) {
             non_linked_task_mesh_stage = i;
         }
 
         if (enabled_features.tessellationShader == VK_FALSE &&
-            (createInfo.nextStage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
-             createInfo.nextStage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) {
+            (create_info.nextStage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT ||
+             create_info.nextStage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT)) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08428", device, create_info_loc.dot(Field::nextStage),
                              "is %s, but tessellationShader feature was not enabled.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if (enabled_features.geometryShader == VK_FALSE && createInfo.nextStage == VK_SHADER_STAGE_GEOMETRY_BIT) {
+        if (enabled_features.geometryShader == VK_FALSE && create_info.nextStage == VK_SHADER_STAGE_GEOMETRY_BIT) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08429", device, create_info_loc.dot(Field::nextStage),
                              "is VK_SHADER_STAGE_GEOMETRY_BIT, but tessellationShader feature was not enabled.");
         }
-        if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT &&
-            (createInfo.nextStage & ~VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) > 0) {
+        if (create_info.stage == VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT &&
+            (create_info.nextStage & ~VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT) > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08430", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, but nextStage is %s.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if (createInfo.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT &&
-            (createInfo.nextStage & ~(VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) > 0) {
+        if (create_info.stage == VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT &&
+            (create_info.nextStage & ~(VK_SHADER_STAGE_GEOMETRY_BIT | VK_SHADER_STAGE_FRAGMENT_BIT)) > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08431", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, but nextStage is %s.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if (createInfo.stage == VK_SHADER_STAGE_GEOMETRY_BIT && (createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
+        if (create_info.stage == VK_SHADER_STAGE_GEOMETRY_BIT && (create_info.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08433", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_GEOMETRY_BIT, but nextStage is %s.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if ((createInfo.stage == VK_SHADER_STAGE_FRAGMENT_BIT || createInfo.stage == VK_SHADER_STAGE_COMPUTE_BIT) &&
-            createInfo.nextStage > 0) {
+        if ((create_info.stage == VK_SHADER_STAGE_FRAGMENT_BIT || create_info.stage == VK_SHADER_STAGE_COMPUTE_BIT) &&
+            create_info.nextStage > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08434", device, create_info_loc.dot(Field::stage),
-                             "is %s, but nextStage is %s.", string_VkShaderStageFlagBits(createInfo.stage),
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             "is %s, but nextStage is %s.", string_VkShaderStageFlagBits(create_info.stage),
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if (createInfo.stage == VK_SHADER_STAGE_TASK_BIT_EXT && (createInfo.nextStage & ~VK_SHADER_STAGE_MESH_BIT_EXT) > 0) {
+        if (create_info.stage == VK_SHADER_STAGE_TASK_BIT_EXT && (create_info.nextStage & ~VK_SHADER_STAGE_MESH_BIT_EXT) > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08435", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_TASK_BIT_EXT, but nextStage is %s.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
-        if (createInfo.stage == VK_SHADER_STAGE_MESH_BIT_EXT && (createInfo.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
+        if (create_info.stage == VK_SHADER_STAGE_MESH_BIT_EXT && (create_info.nextStage & ~VK_SHADER_STAGE_FRAGMENT_BIT) > 0) {
             skip |= LogError("VUID-VkShaderCreateInfoEXT-nextStage-08436", device, create_info_loc.dot(Field::stage),
                              "is VK_SHADER_STAGE_MESH_BIT_EXT, but nextStage is %s.",
-                             string_VkShaderStageFlags(createInfo.nextStage).c_str());
+                             string_VkShaderStageFlags(create_info.nextStage).c_str());
         }
 
-        if ((createInfo.flags & VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) != 0 &&
+        if ((create_info.flags & VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT) != 0 &&
             enabled_features.subgroupSizeControl == VK_FALSE) {
             skip |= LogError(
                 "VUID-VkShaderCreateInfoEXT-flags-09404", device, create_info_loc.dot(Field::flags),
                 "contains VK_SHADER_CREATE_ALLOW_VARYING_SUBGROUP_SIZE_BIT_EXT, but subgroupSizeControl feature is not enabled.");
         }
-        if ((createInfo.flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0 &&
+        if ((create_info.flags & VK_SHADER_CREATE_REQUIRE_FULL_SUBGROUPS_BIT_EXT) != 0 &&
             enabled_features.computeFullSubgroups == VK_FALSE) {
             skip |= LogError(
                 "VUID-VkShaderCreateInfoEXT-flags-09405", device, create_info_loc.dot(Field::flags),

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -49,7 +49,7 @@ bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module &module_state
         if (!variable.input_attachment_index_read[i]) {
             continue;
         }
-        const auto rpci = rp_state->createInfo.ptr();
+        const auto rpci = rp_state->create_info.ptr();
         const uint32_t subpass = pipeline.Subpass();
         const auto subpass_description = rpci->pSubpasses[subpass];
         const auto input_attachments = subpass_description.pInputAttachments;
@@ -825,7 +825,7 @@ bool CoreChecks::ValidateShaderResolveQCOM(const spirv::Module &module_state, Vk
     // then the fragment shader must not enable the SPIRV SampleRateShading capability.
     if (stage == VK_SHADER_STAGE_FRAGMENT_BIT && module_state.HasCapability(spv::CapabilitySampleRateShading)) {
         const auto &rp_state = pipeline.RenderPassState();
-        auto subpass_flags = (!rp_state) ? 0 : rp_state->createInfo.pSubpasses[pipeline.Subpass()].flags;
+        auto subpass_flags = (!rp_state) ? 0 : rp_state->create_info.pSubpasses[pipeline.Subpass()].flags;
         if ((subpass_flags & VK_SUBPASS_DESCRIPTION_FRAGMENT_REGION_BIT_QCOM) != 0) {
             const LogObjectList objlist(module_state.handle(), rp_state->Handle());
             skip |= LogError("VUID-RuntimeSpirv-SampleRateShading-06378", objlist, loc,

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -78,13 +78,13 @@ bool CoreChecks::IsVideoFormatSupported(VkFormat format, VkImageUsageFlags image
 
 bool CoreChecks::IsBufferCompatibleWithVideoProfile(const vvl::Buffer &buffer_state,
                                                     const std::shared_ptr<const vvl::VideoProfileDesc> &video_profile) const {
-    return (buffer_state.createInfo.flags & VK_BUFFER_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) ||
+    return (buffer_state.create_info.flags & VK_BUFFER_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) ||
            buffer_state.supported_video_profiles.find(video_profile) != buffer_state.supported_video_profiles.end();
 }
 
 bool CoreChecks::IsImageCompatibleWithVideoProfile(const vvl::Image &image_state,
                                                    const std::shared_ptr<const vvl::VideoProfileDesc> &video_profile) const {
-    return (image_state.createInfo.flags & VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) ||
+    return (image_state.create_info.flags & VK_IMAGE_CREATE_VIDEO_PROFILE_INDEPENDENT_BIT_KHR) ||
            image_state.supported_video_profiles.find(video_profile) != image_state.supported_video_profiles.end();
 }
 
@@ -122,16 +122,16 @@ bool CoreChecks::ValidateVideoInlineQueryInfo(const vvl::QueryPool &query_pool_s
                                               const Location &loc) const {
     bool skip = false;
 
-    if (query_info.firstQuery >= query_pool_state.createInfo.queryCount) {
+    if (query_info.firstQuery >= query_pool_state.create_info.queryCount) {
         skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08372", query_pool_state.Handle(), loc.dot(Field::firstQuery),
                          "(%u) is greater than or equal to the number of queries (%u) in %s.", query_info.firstQuery,
-                         query_pool_state.createInfo.queryCount, FormatHandle(query_pool_state).c_str());
+                         query_pool_state.create_info.queryCount, FormatHandle(query_pool_state).c_str());
     }
 
-    if (query_info.firstQuery + query_info.queryCount > query_pool_state.createInfo.queryCount) {
+    if (query_info.firstQuery + query_info.queryCount > query_pool_state.create_info.queryCount) {
         skip |= LogError("VUID-VkVideoInlineQueryInfoKHR-queryPool-08373", query_pool_state.Handle(), loc.dot(Field::firstQuery),
                          "(%u) plus queryCount (%u) is greater than the number of queries (%u) in %s.", query_info.firstQuery,
-                         query_info.queryCount, query_pool_state.createInfo.queryCount, FormatHandle(query_pool_state).c_str());
+                         query_info.queryCount, query_pool_state.create_info.queryCount, FormatHandle(query_pool_state).c_str());
     }
 
     return skip;
@@ -2639,7 +2639,7 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
             if (mem_binding_info != nullptr) {
                 auto mem_state = Get<vvl::DeviceMemory>(bind_info.memory);
                 if (mem_state) {
-                    if (((1 << mem_state->alloc_info.memoryTypeIndex) & mem_binding_info->requirements.memoryTypeBits) == 0) {
+                    if (((1 << mem_state->allocate_info.memoryTypeIndex) & mem_binding_info->requirements.memoryTypeBits) == 0) {
                         const LogObjectList objlist(videoSession, mem_state->Handle());
                         skip |=
                             LogError("VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-07198", objlist, error_obj.location,
@@ -2647,24 +2647,24 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
                                      "with index %u of %s are not compatible with the memory type index (%u) of "
                                      "%s specified in pBindSessionMemoryInfos[%u].memory.",
                                      mem_binding_info->requirements.memoryTypeBits, bind_info.memoryBindIndex,
-                                     FormatHandle(videoSession).c_str(), mem_state->alloc_info.memoryTypeIndex,
+                                     FormatHandle(videoSession).c_str(), mem_state->allocate_info.memoryTypeIndex,
                                      FormatHandle(*mem_state).c_str(), i);
                     }
 
-                    if (bind_info.memoryOffset >= mem_state->alloc_info.allocationSize) {
+                    if (bind_info.memoryOffset >= mem_state->allocate_info.allocationSize) {
                         const LogObjectList objlist(videoSession, mem_state->Handle());
                         skip |= LogError("VUID-VkBindVideoSessionMemoryInfoKHR-memoryOffset-07201", objlist,
                                          error_obj.location.dot(Field::pBindSessionMemoryInfos, i).dot(Field::memoryOffset),
                                          "(%" PRIuLEAST64 ") must be less than the size (%" PRIuLEAST64 ") of %s.",
-                                         bind_info.memoryOffset, mem_state->alloc_info.allocationSize,
+                                         bind_info.memoryOffset, mem_state->allocate_info.allocationSize,
                                          FormatHandle(*mem_state).c_str());
-                    } else if (bind_info.memoryOffset + bind_info.memorySize > mem_state->alloc_info.allocationSize) {
+                    } else if (bind_info.memoryOffset + bind_info.memorySize > mem_state->allocate_info.allocationSize) {
                         const LogObjectList objlist(videoSession, mem_state->Handle());
                         skip |= LogError("VUID-VkBindVideoSessionMemoryInfoKHR-memorySize-07202", objlist,
                                          error_obj.location.dot(Field::pBindSessionMemoryInfos, i).dot(Field::memoryOffset),
                                          "(%" PRIuLEAST64 ") + memory size (%" PRIuLEAST64
                                          ") must be less than or equal to the size (%" PRIuLEAST64 ") of %s.",
-                                         bind_info.memoryOffset, bind_info.memorySize, mem_state->alloc_info.allocationSize,
+                                         bind_info.memoryOffset, bind_info.memorySize, mem_state->allocate_info.allocationSize,
                                          FormatHandle(*mem_state).c_str());
                     }
                 }
@@ -3748,11 +3748,12 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                          FormatHandle(pDecodeInfo->srcBuffer).c_str(), FormatHandle(*vs_state).c_str());
     }
 
-    if (pDecodeInfo->srcBufferOffset >= buffer_state->createInfo.size) {
+    if (pDecodeInfo->srcBufferOffset >= buffer_state->create_info.size) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
-        skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBufferOffset-07166", objlist, decode_info_loc.dot(Field::srcBufferOffset),
-                         "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
-                         pDecodeInfo->srcBufferOffset, buffer_state->createInfo.size, FormatHandle(pDecodeInfo->srcBuffer).c_str());
+        skip |=
+            LogError("VUID-VkVideoDecodeInfoKHR-srcBufferOffset-07166", objlist, decode_info_loc.dot(Field::srcBufferOffset),
+                     "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
+                     pDecodeInfo->srcBufferOffset, buffer_state->create_info.size, FormatHandle(pDecodeInfo->srcBuffer).c_str());
     }
 
     if (!IsIntegerMultipleOf(pDecodeInfo->srcBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
@@ -3764,12 +3765,12 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                          FormatHandle(*vs_state).c_str());
     }
 
-    if (pDecodeInfo->srcBufferOffset + pDecodeInfo->srcBufferRange > buffer_state->createInfo.size) {
+    if (pDecodeInfo->srcBufferOffset + pDecodeInfo->srcBufferRange > buffer_state->create_info.size) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
         skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBufferRange-07167", objlist, decode_info_loc.dot(Field::srcBufferOffset),
                          "(%" PRIu64 ") plus pDecodeInfo->srcBufferRange (%" PRIu64
                          ") must be less than or equal to the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
-                         pDecodeInfo->srcBufferOffset, pDecodeInfo->srcBufferRange, buffer_state->createInfo.size,
+                         pDecodeInfo->srcBufferOffset, pDecodeInfo->srcBufferRange, buffer_state->create_info.size,
                          FormatHandle(pDecodeInfo->srcBuffer).c_str());
     }
 
@@ -3979,7 +3980,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
             skip |= LogError("VUID-vkCmdDecodeVideoKHR-opCount-07134", commandBuffer, error_obj.location,
                              "not enough activatable queries for query type %s "
                              "with opCount %u, active query index %u, and last activatable query index %u.",
-                             string_VkQueryType(query_pool_state->createInfo.queryType), op_count, query.active_query_index,
+                             string_VkQueryType(query_pool_state->create_info.queryType), op_count, query.active_query_index,
                              query.last_activatable_query_index);
         }
     }
@@ -3999,13 +4000,13 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
                                      "(%u) is not equal to opCount (%u).", inline_query_info->queryCount, op_count);
                 }
 
-                if (query_pool_state->createInfo.queryType != VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR) {
+                if (query_pool_state->create_info.queryType != VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);
                     skip |= LogError("VUID-vkCmdDecodeVideoKHR-queryType-08367", objlist,
                                      decode_info_loc.pNext(Struct::VkVideoInlineQueryInfoKHR, Field::queryPool),
                                      "(%s) has query type (%s) but must be VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR.",
                                      FormatHandle(*query_pool_state).c_str(),
-                                     string_VkQueryType(query_pool_state->createInfo.queryType));
+                                     string_VkQueryType(query_pool_state->create_info.queryType));
                 }
 
                 if (vs_state->profile != query_pool_state->supported_video_profile) {
@@ -4162,7 +4163,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                                           "VUID-vkCmdEncodeVideoKHR-commandBuffer-08203", where);
     }
 
-    if ((buffer_state->createInfo.usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
+    if ((buffer_state->create_info.usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
         skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBuffer-08236", objlist, encode_info_loc.dot(Field::dstBuffer),
                          "(%s) was not created with "
@@ -4178,11 +4179,12 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                          FormatHandle(pEncodeInfo->dstBuffer).c_str(), FormatHandle(*vs_state).c_str());
     }
 
-    if (pEncodeInfo->dstBufferOffset >= buffer_state->createInfo.size) {
+    if (pEncodeInfo->dstBufferOffset >= buffer_state->create_info.size) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
-        skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBufferOffset-08237", objlist, encode_info_loc.dot(Field::dstBufferOffset),
-                         "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
-                         pEncodeInfo->dstBufferOffset, buffer_state->createInfo.size, FormatHandle(pEncodeInfo->dstBuffer).c_str());
+        skip |=
+            LogError("VUID-VkVideoEncodeInfoKHR-dstBufferOffset-08237", objlist, encode_info_loc.dot(Field::dstBufferOffset),
+                     "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
+                     pEncodeInfo->dstBufferOffset, buffer_state->create_info.size, FormatHandle(pEncodeInfo->dstBuffer).c_str());
     }
 
     if (!IsIntegerMultipleOf(pEncodeInfo->dstBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
@@ -4194,12 +4196,12 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                          FormatHandle(*vs_state).c_str());
     }
 
-    if (pEncodeInfo->dstBufferOffset + pEncodeInfo->dstBufferRange > buffer_state->createInfo.size) {
+    if (pEncodeInfo->dstBufferOffset + pEncodeInfo->dstBufferRange > buffer_state->create_info.size) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
         skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBufferRange-08238", objlist, encode_info_loc.dot(Field::dstBufferOffset),
                          "(%" PRIu64 ") plus pEncodeInfo->dstBufferRange (%" PRIu64
                          ") must be less than or equal to the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
-                         pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange, buffer_state->createInfo.size,
+                         pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange, buffer_state->create_info.size,
                          FormatHandle(pEncodeInfo->dstBuffer).c_str());
     }
 
@@ -4389,7 +4391,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
             skip |= LogError("VUID-vkCmdEncodeVideoKHR-opCount-07174", commandBuffer, error_obj.location,
                              "not enough activatable queries for query type %s "
                              "with opCount %u, active query index %u, and last activatable query index %u.",
-                             string_VkQueryType(query_pool_state->createInfo.queryType), op_count, query.active_query_index,
+                             string_VkQueryType(query_pool_state->create_info.queryType), op_count, query.active_query_index,
                              query.last_activatable_query_index);
         }
     }
@@ -4409,15 +4411,15 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                                      "(%u) is not equal to opCount (%u).", inline_query_info->queryCount, op_count);
                 }
 
-                if (query_pool_state->createInfo.queryType != VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
-                    query_pool_state->createInfo.queryType != VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR) {
+                if (query_pool_state->create_info.queryType != VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
+                    query_pool_state->create_info.queryType != VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR) {
                     const LogObjectList objlist(commandBuffer, inline_query_info->queryPool);
                     skip |= LogError("VUID-vkCmdEncodeVideoKHR-queryType-08362", objlist,
                                      encode_info_loc.pNext(Struct::VkVideoInlineQueryInfoKHR, Field::queryPool),
                                      "(%s) has query type (%s) but must be VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR or "
                                      "VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR.",
                                      FormatHandle(*query_pool_state).c_str(),
-                                     string_VkQueryType(query_pool_state->createInfo.queryType));
+                                     string_VkQueryType(query_pool_state->create_info.queryType));
                 }
 
                 if (vs_state->profile != query_pool_state->supported_video_profile) {

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -578,8 +578,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
             if (color_feedback_loop || depth_feedback_loop || stencil_feedback_loop) {
                 bool dependency_found = false;
-                for (uint32_t i = 0; i < cb_state.activeRenderPass->createInfo.dependencyCount; ++i) {
-                    const auto &dep = cb_state.activeRenderPass->createInfo.pDependencies[i];
+                for (uint32_t i = 0; i < cb_state.activeRenderPass->create_info.dependencyCount; ++i) {
+                    const auto &dep = cb_state.activeRenderPass->create_info.pDependencies[i];
                     if ((dep.dependencyFlags & VK_DEPENDENCY_FEEDBACK_LOOP_BIT_EXT) != 0 &&
                         dep.srcSubpass == cb_state.GetActiveSubpass() &&
                         dep.dstSubpass == cb_state.GetActiveSubpass()) {
@@ -681,8 +681,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         }
 
         // TODO: Validate 04015 for DescriptorClass::PlainSampler
-        if ((sampler_state->createInfo.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
-             sampler_state->createInfo.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) &&
+        if ((sampler_state->create_info.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
+             sampler_state->create_info.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) &&
             (sampler_state->customCreateInfo.format == VK_FORMAT_UNDEFINED)) {
             if (image_view_format == VK_FORMAT_B4G4R4A4_UNORM_PACK16 || image_view_format == VK_FORMAT_B5G6R5_UNORM_PACK16 ||
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
@@ -697,11 +697,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
-        const VkFilter sampler_mag_filter = sampler_state->createInfo.magFilter;
-        const VkFilter sampler_min_filter = sampler_state->createInfo.minFilter;
-        const bool sampler_compare_enable = sampler_state->createInfo.compareEnable == VK_TRUE;
+        const VkFilter sampler_mag_filter = sampler_state->create_info.magFilter;
+        const VkFilter sampler_min_filter = sampler_state->create_info.minFilter;
+        const bool sampler_compare_enable = sampler_state->create_info.compareEnable == VK_TRUE;
         const auto sampler_reduction =
-            vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(sampler_state->createInfo.pNext);
+            vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(sampler_state->create_info.pNext);
         // The VU is wording is a bit misleading, if there is no VkSamplerReductionModeCreateInfo we still need to check for linear
         // tiling feature
         const bool is_weighted_average =
@@ -719,7 +719,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                           FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
-            if (sampler_state->createInfo.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
+            if (sampler_state->create_info.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
@@ -747,7 +747,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                           string_VkSamplerReductionMode(sampler_reduction->reductionMode),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
-            if (sampler_state->createInfo.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
+            if (sampler_state->create_info.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_09599, objlist, loc,
@@ -775,7 +775,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
 
             if (IsExtEnabled(dev_state.device_extensions.vk_ext_filter_cubic)) {
-                const auto reduction_mode_info = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(sampler_state->createInfo.pNext);
+                const auto reduction_mode_info =
+                    vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(sampler_state->create_info.pNext);
                 if (reduction_mode_info &&
                     (reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MIN ||
                      reduction_mode_info->reductionMode == VK_SAMPLER_REDUCTION_MODE_MAX) &&
@@ -823,19 +824,19 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             }
         }
         const auto image_state = image_view_state->image_state.get();
-        if ((image_state->createInfo.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) &&
-            (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
-             sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
-             sampler_state->createInfo.addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)) {
+        if ((image_state->create_info.flags & VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV) &&
+            (sampler_state->create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
+             sampler_state->create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE ||
+             sampler_state->create_info.addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)) {
             std::string address_mode_letter =
-                (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)   ? "U"
-                : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ? "V"
-                                                                                                    : "W";
-            VkSamplerAddressMode address_mode = (sampler_state->createInfo.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                                                    ? sampler_state->createInfo.addressModeU
-                                                : (sampler_state->createInfo.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
-                                                    ? sampler_state->createInfo.addressModeV
-                                                    : sampler_state->createInfo.addressModeW;
+                (sampler_state->create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)   ? "U"
+                : (sampler_state->create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ? "V"
+                                                                                                     : "W";
+            VkSamplerAddressMode address_mode = (sampler_state->create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+                                                    ? sampler_state->create_info.addressModeU
+                                                : (sampler_state->create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE)
+                                                    ? sampler_state->create_info.addressModeV
+                                                    : sampler_state->create_info.addressModeW;
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, sampler_state->Handle(), image_state->Handle(), image_view_state->Handle());
             return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
@@ -843,7 +844,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                       ") image (%s) in image view (%s) is created with flag "
                                       "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
                                       "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
-                                      "createInfo.addressMode%s set to %s.",
+                                      "pCreateInfo->addressMode%s set to %s.",
                                       FormatHandle(set).c_str(), binding, index, FormatHandle(image_state->Handle()).c_str(),
                                       FormatHandle(image_view_state->Handle()).c_str(),
                                       FormatHandle(sampler_state->Handle()).c_str(), address_mode_letter.c_str(),
@@ -852,7 +853,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
         // UnnormalizedCoordinates sampler validations
         // only check if sampled as could have a texelFetch on a combined image sampler
-        if (sampler_state->createInfo.unnormalizedCoordinates && variable->info.is_sampler_sampled) {
+        if (sampler_state->create_info.unnormalizedCoordinates && variable->info.is_sampler_sampled) {
             // If ImageView is used by a unnormalizedCoordinates sampler, it needs to check ImageView type
             if (image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_3D || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_CUBE ||
                 image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_1D_ARRAY || image_view_ci.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY ||
@@ -1042,11 +1043,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             FormatHandle(set).c_str(), binding, index, string_VkFormat(buffer_view_format), variable->image_sampled_type_width);
     }
 
-    const VkFormatFeatureFlags2 buf_format_features = buffer_view_state->buf_format_features;
+    const VkFormatFeatureFlags2 buffer_format_features = buffer_view_state->buffer_format_features;
 
     // Verify VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT
     if ((variable->info.is_atomic_operation) && (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) &&
-        !(buf_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
+        !(buffer_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
         return dev_state.LogError(vuids.bufferview_atomic_07888, objlist, loc,
@@ -1054,7 +1055,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                   ") has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
                                   "(supported features: %s).",
                                   FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
-                                  string_VkFormat(buffer_view_format), string_VkFormatFeatureFlags2(buf_format_features).c_str());
+                                  string_VkFormat(buffer_view_format),
+                                  string_VkFormatFeatureFlags2(buffer_format_features).c_str());
     }
 
     // When KHR_format_feature_flags2 is supported, the read/write without
@@ -1063,7 +1065,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     if (dev_state.has_format_feature2) {
         if (descriptor_type == VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER) {
             if ((variable->info.is_read_without_format) &&
-                !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
+                !(buffer_format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR)) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_read_without_format_07030, objlist, loc,
@@ -1073,11 +1075,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                           "(supported features: %s).",
                                           FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
                                           string_VkFormat(buffer_view_format),
-                                          string_VkFormatFeatureFlags2(buf_format_features).c_str());
+                                          string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
 
             if ((variable->info.is_write_without_format) &&
-                !(buf_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
+                !(buffer_format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR)) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_write_without_format_07029, objlist, loc,
@@ -1087,7 +1089,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                           "(supported features: %s).",
                                           FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
                                           string_VkFormat(buffer_view_format),
-                                          string_VkFormatFeatureFlags2(buf_format_features).c_str());
+                                          string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
         }
     }

--- a/layers/gpu_validation/gpu_descriptor_set.cpp
+++ b/layers/gpu_validation/gpu_descriptor_set.cpp
@@ -164,7 +164,7 @@ static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {
         return glsl::DescriptorState(DescriptorClass::GeneralBuffer, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
     }
     return glsl::DescriptorState(DescriptorClass::GeneralBuffer, buffer_state->id,
-                                 static_cast<uint32_t>(buffer_state->createInfo.size));
+                                 static_cast<uint32_t>(buffer_state->create_info.size));
 }
 
 static glsl::DescriptorState GetInData(const vvl::TexelDescriptor &desc) {
@@ -214,7 +214,7 @@ static glsl::DescriptorState GetInData(const vvl::MutableDescriptor &desc) {
             if (!buffer_state) {
                 return glsl::DescriptorState(desc_class, glsl::kDebugInputBindlessSkipId, vvl::kU32Max);
             }
-            return glsl::DescriptorState(desc_class, buffer_state->id, static_cast<uint32_t>(buffer_state->createInfo.size));
+            return glsl::DescriptorState(desc_class, buffer_state->id, static_cast<uint32_t>(buffer_state->create_info.size));
         }
         case DescriptorClass::TexelBuffer: {
             auto buffer_view_state = std::static_pointer_cast<const BufferView>(desc.GetSharedBufferViewState());

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -572,7 +572,7 @@ void gpuav::Validator::TransitionAttachmentRefLayout(vvl::CommandBuffer &cb_stat
 
 void gpuav::Validator::TransitionSubpassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state,
                                                 const int subpass_index) {
-    auto const &subpass = render_pass_state.createInfo.pSubpasses[subpass_index];
+    auto const &subpass = render_pass_state.create_info.pSubpasses[subpass_index];
     for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
         TransitionAttachmentRefLayout(cb_state, subpass.pInputAttachments[j]);
     }
@@ -589,7 +589,7 @@ void gpuav::Validator::TransitionSubpassLayouts(vvl::CommandBuffer &cb_state, co
 // 2. Transition from initialLayout to layout used in subpass 0
 void gpuav::Validator::TransitionBeginRenderPassLayouts(vvl::CommandBuffer &cb_state, const vvl::RenderPass &render_pass_state) {
     // First record expected initialLayout as a potential initial layout usage.
-    auto const rpci = render_pass_state.createInfo.ptr();
+    auto const rpci = render_pass_state.create_info.ptr();
     for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {
         auto *view_state = cb_state.GetActiveAttachmentImageViewState(i);
         if (view_state) {
@@ -620,7 +620,7 @@ void gpuav::Validator::TransitionFinalSubpassLayouts(vvl::CommandBuffer &cb_stat
         return;
     }
 
-    const VkRenderPassCreateInfo2 *render_pass_info = render_pass_state->createInfo.ptr();
+    const VkRenderPassCreateInfo2 *render_pass_info = render_pass_state->create_info.ptr();
     for (uint32_t i = 0; i < render_pass_info->attachmentCount; ++i) {
         auto *view_state = cb_state.GetActiveAttachmentImageViewState(i);
         if (view_state) {

--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -82,7 +82,7 @@ void gpuav::Validator::PreCallRecordCmdBuildAccelerationStructureNV(VkCommandBuf
 
     std::vector<uint64_t> current_valid_handles;
     ForEach<vvl::AccelerationStructureNV>([&current_valid_handles](const vvl::AccelerationStructureNV &as_state) {
-        if (as_state.built && as_state.create_infoNV.info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV) {
+        if (as_state.built && as_state.create_info.info.type == VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_NV) {
             current_valid_handles.push_back(as_state.opaque_handle);
         }
     });

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -897,33 +897,33 @@ void gpu_tracker::Validator::PreCallRecordDestroyPipeline(VkDevice device, VkPip
 }
 
 template <typename CreateInfo>
-VkShaderModule GetShaderModule(const CreateInfo &createInfo, VkShaderStageFlagBits stage) {
-    for (uint32_t i = 0; i < createInfo.stageCount; ++i) {
-        if (createInfo.pStages[i].stage == stage) {
-            return createInfo.pStages[i].module;
+VkShaderModule GetShaderModule(const CreateInfo &create_info, VkShaderStageFlagBits stage) {
+    for (uint32_t i = 0; i < create_info.stageCount; ++i) {
+        if (create_info.pStages[i].stage == stage) {
+            return create_info.pStages[i].module;
         }
     }
     return {};
 }
 
 template <>
-VkShaderModule GetShaderModule(const VkComputePipelineCreateInfo &createInfo, VkShaderStageFlagBits) {
-    return createInfo.stage.module;
+VkShaderModule GetShaderModule(const VkComputePipelineCreateInfo &create_info, VkShaderStageFlagBits) {
+    return create_info.stage.module;
 }
 
 template <typename SafeType>
-void SetShaderModule(SafeType &createInfo, const safe_VkPipelineShaderStageCreateInfo &stage_info, VkShaderModule shader_module,
+void SetShaderModule(SafeType &create_info, const safe_VkPipelineShaderStageCreateInfo &stage_info, VkShaderModule shader_module,
                      uint32_t stage_ci_index) {
-    createInfo.pStages[stage_ci_index] = stage_info;
-    createInfo.pStages[stage_ci_index].module = shader_module;
+    create_info.pStages[stage_ci_index] = stage_info;
+    create_info.pStages[stage_ci_index].module = shader_module;
 }
 
 template <>
-void SetShaderModule(safe_VkComputePipelineCreateInfo &createInfo, const safe_VkPipelineShaderStageCreateInfo &stage_info,
+void SetShaderModule(safe_VkComputePipelineCreateInfo &create_info, const safe_VkPipelineShaderStageCreateInfo &stage_info,
                      VkShaderModule shader_module, uint32_t stage_ci_index) {
     assert(stage_ci_index == 0);
-    createInfo.stage = stage_info;
-    createInfo.stage.module = shader_module;
+    create_info.stage = stage_info;
+    create_info.stage.module = shader_module;
 }
 
 template <typename CreateInfo, typename StageInfo>

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -720,7 +720,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndire
         }
         auto buffer_state = Get<vvl::Buffer>(indirect_buffer);
         uint32_t max_count;
-        uint64_t bufsize = buffer_state->createInfo.size;
+        uint64_t bufsize = buffer_state->create_info.size;
         uint64_t first_command_bytes = struct_size + indirect_offset;
         if (first_command_bytes > bufsize) {
             max_count = 0;

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  * Modifications Copyright (C) 2022 RasterGrid Kft.
  *
@@ -54,12 +54,12 @@ static bool GetMetalExport(const VkBufferViewCreateInfo *info) {
 
 namespace vvl {
 
-Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo)
-    : Bindable(buff, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
+Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+    : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
       createInfo(*safe_create_info.ptr()),
-      requirements(GetMemoryRequirements(dev_data, buff)),
+      requirements(GetMemoryRequirements(dev_data, handle)),
       usage(GetBufferUsageFlags(createInfo)),
       supported_video_profiles(dev_data->video_profile_cache_.Get(
           dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
@@ -73,9 +73,9 @@ Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCr
     }
 }
 
-BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
+BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *ci,
                        VkFormatFeatureFlags2KHR buf_ff)
-    : StateObject(bv, kVulkanObjectTypeBufferView),
+    : StateObject(handle, kVulkanObjectTypeBufferView),
       create_info(*ci),
       buffer_state(bf),
 #ifdef VK_USE_PLATFORM_METAL_EXT

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -58,9 +58,9 @@ Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBuffer
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
-      createInfo(*safe_create_info.ptr()),
+      create_info(*safe_create_info.ptr()),
       requirements(GetMemoryRequirements(dev_data, handle)),
-      usage(GetBufferUsageFlags(createInfo)),
+      usage(GetBufferUsageFlags(create_info)),
       supported_video_profiles(dev_data->video_profile_cache_.Get(
           dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
@@ -73,15 +73,16 @@ Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBuffer
     }
 }
 
-BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *ci,
-                       VkFormatFeatureFlags2KHR buf_ff)
+BufferView::BufferView(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *pCreateInfo,
+                       VkFormatFeatureFlags2KHR format_features)
     : StateObject(handle, kVulkanObjectTypeBufferView),
-      create_info(*ci),
+      safe_create_info(pCreateInfo),
+      create_info(*safe_create_info.ptr()),
       buffer_state(bf),
 #ifdef VK_USE_PLATFORM_METAL_EXT
-      metal_bufferview_export(GetMetalExport(ci)),
+      metal_bufferview_export(GetMetalExport(pCreateInfo)),
 #endif
-      buf_format_features(buf_ff) {
+      buffer_format_features(format_features) {
 }
 
 }  // namespace vvl

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -39,7 +39,7 @@ class Buffer : public Bindable {
 
     unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
-    Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo);
+    Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
 
     Buffer(Buffer const &rh_obj) = delete;
 
@@ -81,7 +81,7 @@ class BufferView : public StateObject {
     // both as a buffer (ex OpLoad) or image (ex OpImageWrite)
     const VkFormatFeatureFlags2KHR buf_format_features;
 
-    BufferView(const std::shared_ptr<Buffer> &bf, VkBufferView bv, const VkBufferViewCreateInfo *ci,
+    BufferView(const std::shared_ptr<Buffer> &bf, VkBufferView handle, const VkBufferViewCreateInfo *ci,
                VkFormatFeatureFlags2KHR buf_ff);
 
     void LinkChildNodes() override {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -926,12 +926,11 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     // Set updated state here in case implicit reset occurs above
     state = CbState::Recording;
     beginInfo = *pBeginInfo;
-    if (beginInfo.pInheritanceInfo && (createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY)) {
+    if (beginInfo.pInheritanceInfo && IsSeconary()) {
         inheritanceInfo = *(beginInfo.pInheritanceInfo);
         beginInfo.pInheritanceInfo = &inheritanceInfo;
         // If we are a secondary command-buffer and inheriting.  Update the items we should inherit.
-        if ((createInfo.level != VK_COMMAND_BUFFER_LEVEL_PRIMARY) &&
-            (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
+        if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
             if (beginInfo.pInheritanceInfo->renderPass) {
                 activeRenderPass = dev_data->Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
                 SetActiveSubpass(beginInfo.pInheritanceInfo->subpass);

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -41,9 +41,9 @@ static ShaderObjectStage inline ConvertToShaderObjectStage(VkShaderStageFlagBits
 
 namespace vvl {
 
-CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo,
+CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
                          VkQueueFlags flags)
-    : StateObject(cp, kVulkanObjectTypeCommandPool),
+    : StateObject(handle, kVulkanObjectTypeCommandPool),
       dev_data(dev),
       createFlags(pCreateInfo->flags),
       queueFamilyIndex(pCreateInfo->queueFamilyIndex),
@@ -89,9 +89,9 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
     active_subpass_sample_count_ = std::nullopt;
 }
 
-CommandBuffer::CommandBuffer(ValidationStateTracker *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+CommandBuffer::CommandBuffer(ValidationStateTracker *dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
                              const vvl::CommandPool *pool)
-    : RefcountedStateObject(cb, kVulkanObjectTypeCommandBuffer),
+    : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       createInfo(*pCreateInfo),
       command_pool(pool),
       dev_data(dev),

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -616,6 +616,7 @@ class CommandBuffer : public RefcountedStateObject {
     void BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state);
 
     bool IsPrimary() const { return createInfo.level == VK_COMMAND_BUFFER_LEVEL_PRIMARY; }
+    bool IsSeconary() const { return createInfo.level == VK_COMMAND_BUFFER_LEVEL_SECONDARY; }
     void BeginLabel(const char *label_name);
     void EndLabel();
     int LabelStackDepth() const { return label_stack_depth_; }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -72,8 +72,8 @@ class Event : public StateObject {
     // Queue that signaled this event. It's null if event was signaled from the host
     VkQueue signaling_queue = VK_NULL_HANDLE;
 
-    Event(VkEvent event_, const VkEventCreateInfo *pCreateInfo)
-        : StateObject(event_, kVulkanObjectTypeEvent),
+    Event(VkEvent handle, const VkEventCreateInfo *pCreateInfo)
+        : StateObject(handle, kVulkanObjectTypeEvent),
           write_in_use(0),
 #ifdef VK_USE_PLATFORM_METAL_EXT
           metal_event_export(GetMetalExport(pCreateInfo)),
@@ -103,7 +103,7 @@ class CommandPool : public StateObject {
     // Cmd buffers allocated from this pool
     vvl::unordered_map<VkCommandBuffer, CommandBuffer *> commandBuffers;
 
-    CommandPool(ValidationStateTracker *dev, VkCommandPool cp, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
+    CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
     VkCommandPool VkHandle() const { return handle_.Cast<VkCommandPool>(); }
@@ -464,7 +464,7 @@ class CommandBuffer : public RefcountedStateObject {
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(ValidationStateTracker *, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+    CommandBuffer(ValidationStateTracker *, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
                   const vvl::CommandPool *cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -36,9 +36,9 @@ static vvl::DescriptorPool::TypeCountMap GetMaxTypeCounts(const VkDescriptorPool
     return counts;
 }
 
-vvl::DescriptorPool::DescriptorPool(ValidationStateTracker *dev, const VkDescriptorPool pool,
-                                             const VkDescriptorPoolCreateInfo *pCreateInfo)
-    : StateObject(pool, kVulkanObjectTypeDescriptorPool),
+vvl::DescriptorPool::DescriptorPool(ValidationStateTracker *dev, const VkDescriptorPool handle,
+                                    const VkDescriptorPoolCreateInfo *pCreateInfo)
+    : StateObject(handle, kVulkanObjectTypeDescriptorPool),
       maxSets(pCreateInfo->maxSets),
       createInfo(pCreateInfo),
       maxDescriptorTypeCount(GetMaxTypeCounts(pCreateInfo)),
@@ -372,15 +372,15 @@ bool vvl::DescriptorSetLayout::IsCompatible(DescriptorSetLayout const *rh_ds_lay
 // The DescriptorSetLayout stores the per handle data for a descriptor set layout, and references the common defintion for the
 // handle invariant portion
 vvl::DescriptorSetLayout::DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info,
-                                                          const VkDescriptorSetLayout layout)
-    : StateObject(layout, kVulkanObjectTypeDescriptorSetLayout), layout_id_(GetCanonicalId(p_create_info)) {}
+                                              const VkDescriptorSetLayout handle)
+    : StateObject(handle, kVulkanObjectTypeDescriptorSetLayout), layout_id_(GetCanonicalId(p_create_info)) {}
 
 void vvl::AllocateDescriptorSetsData::Init(uint32_t count) { layout_nodes.resize(count); }
 
-vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool_state,
-                                              const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,
-                                              vvl::DescriptorSet::StateTracker *state_data)
-    : StateObject(set, kVulkanObjectTypeDescriptorSet),
+vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool *pool_state,
+                                  const std::shared_ptr<DescriptorSetLayout const> &layout, uint32_t variable_count,
+                                  vvl::DescriptorSet::StateTracker *state_data)
+    : StateObject(handle, kVulkanObjectTypeDescriptorSet),
       some_update_(false),
       pool_state_(pool_state),
       layout_(layout),

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -47,7 +47,7 @@ struct AllocateDescriptorSetsData;
 
 class DescriptorPool : public StateObject {
   public:
-    DescriptorPool(ValidationStateTracker *dev, const VkDescriptorPool pool, const VkDescriptorPoolCreateInfo *pCreateInfo);
+    DescriptorPool(ValidationStateTracker *dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo);
     ~DescriptorPool() { Destroy(); }
 
     VkDescriptorPool VkHandle() const { return handle_.Cast<VkDescriptorPool>(); };
@@ -96,8 +96,8 @@ class DescriptorUpdateTemplate : public StateObject {
   public:
     const safe_VkDescriptorUpdateTemplateCreateInfo create_info;
 
-    DescriptorUpdateTemplate(VkDescriptorUpdateTemplate update_template, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : StateObject(update_template, kVulkanObjectTypeDescriptorUpdateTemplate), create_info(pCreateInfo) {}
+    DescriptorUpdateTemplate(VkDescriptorUpdateTemplate handle, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
+        : StateObject(handle, kVulkanObjectTypeDescriptorUpdateTemplate), create_info(pCreateInfo) {}
 
     VkDescriptorUpdateTemplate VkHandle() const { return handle_.Cast<VkDescriptorUpdateTemplate>(); };
 };
@@ -239,7 +239,7 @@ using DescriptorSetLayoutId = DescriptorSetLayoutDict::Id;
 class DescriptorSetLayout : public StateObject {
   public:
     // Constructors and destructor
-    DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *p_create_info, const VkDescriptorSetLayout layout);
+    DescriptorSetLayout(const VkDescriptorSetLayoutCreateInfo *pCreateInfo, const VkDescriptorSetLayout handle);
     virtual ~DescriptorSetLayout() { Destroy(); }
 
     bool HasBinding(const uint32_t binding) const { return layout_id_->HasBinding(binding); }
@@ -755,7 +755,7 @@ class DescriptorSet : public StateObject {
     using ConstBindingIterator = BindingVector::const_iterator;
     using StateTracker = ValidationStateTracker;
 
-    DescriptorSet(const VkDescriptorSet, vvl::DescriptorPool *, const std::shared_ptr<DescriptorSetLayout const> &,
+    DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool *, const std::shared_ptr<DescriptorSetLayout const> &,
                   uint32_t variable_count, StateTracker *state_data);
     void LinkChildNodes() override;
     void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) override;

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -77,8 +77,10 @@ class DescriptorPool : public StateObject {
         return available_sets_;
     }
 
+    const safe_VkDescriptorPoolCreateInfo safe_create_info;
+    const VkDescriptorPoolCreateInfo &create_info;
+
     const uint32_t maxSets;  // Max descriptor sets allowed in this pool
-    const safe_VkDescriptorPoolCreateInfo createInfo;
     using TypeCountMap = vvl::unordered_map<uint32_t, uint32_t>;
     const TypeCountMap maxDescriptorTypeCount;  // Max # of descriptors of each type in this pool
 
@@ -94,10 +96,13 @@ class DescriptorPool : public StateObject {
 
 class DescriptorUpdateTemplate : public StateObject {
   public:
-    const safe_VkDescriptorUpdateTemplateCreateInfo create_info;
+    const safe_VkDescriptorUpdateTemplateCreateInfo safe_create_info;
+    const VkDescriptorUpdateTemplateCreateInfo &create_info;
 
     DescriptorUpdateTemplate(VkDescriptorUpdateTemplate handle, const VkDescriptorUpdateTemplateCreateInfo *pCreateInfo)
-        : StateObject(handle, kVulkanObjectTypeDescriptorUpdateTemplate), create_info(pCreateInfo) {}
+        : StateObject(handle, kVulkanObjectTypeDescriptorUpdateTemplate),
+          safe_create_info(pCreateInfo),
+          create_info(*safe_create_info.ptr()) {}
 
     VkDescriptorUpdateTemplate VkHandle() const { return handle_.Cast<VkDescriptorUpdateTemplate>(); };
 };

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -86,19 +86,20 @@ static bool GetMetalExport(const VkMemoryAllocateInfo *info) {
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 namespace vvl {
-DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *p_alloc_info, uint64_t fake_address,
+DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *pAllocateInfo, uint64_t fake_address,
                            const VkMemoryType &memory_type, const VkMemoryHeap &memory_heap,
                            std::optional<DedicatedBinding> &&dedicated_binding, uint32_t physical_device_count)
     : StateObject(handle, kVulkanObjectTypeDeviceMemory),
-      alloc_info(p_alloc_info),
-      export_handle_types(GetExportHandleTypes(p_alloc_info)),
-      import_handle_type(GetImportHandleType(p_alloc_info)),
+      safe_allocate_info(pAllocateInfo),
+      allocate_info(*safe_allocate_info.ptr()),
+      export_handle_types(GetExportHandleTypes(pAllocateInfo)),
+      import_handle_type(GetImportHandleType(pAllocateInfo)),
       unprotected((memory_type.propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) == 0),
-      multi_instance(IsMultiInstance(p_alloc_info, memory_heap, physical_device_count)),
+      multi_instance(IsMultiInstance(pAllocateInfo, memory_heap, physical_device_count)),
       dedicated(std::move(dedicated_binding)),
       mapped_range{},
 #ifdef VK_USE_PLATFORM_METAL_EXT
-      metal_buffer_export(GetMetalExport(p_alloc_info)),
+      metal_buffer_export(GetMetalExport(pAllocateInfo)),
 #endif  // VK_USE_PLATFORM_METAL_EXT
       p_driver_data(nullptr),
       fake_base_address(fake_address) {

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -86,10 +86,10 @@ static bool GetMetalExport(const VkMemoryAllocateInfo *info) {
 #endif  // VK_USE_PLATFORM_METAL_EXT
 
 namespace vvl {
-DeviceMemory::DeviceMemory(VkDeviceMemory memory, const VkMemoryAllocateInfo *p_alloc_info, uint64_t fake_address,
+DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *p_alloc_info, uint64_t fake_address,
                            const VkMemoryType &memory_type, const VkMemoryHeap &memory_heap,
                            std::optional<DedicatedBinding> &&dedicated_binding, uint32_t physical_device_count)
-    : StateObject(memory, kVulkanObjectTypeDeviceMemory),
+    : StateObject(handle, kVulkanObjectTypeDeviceMemory),
       alloc_info(p_alloc_info),
       export_handle_types(GetExportHandleTypes(p_alloc_info)),
       import_handle_type(GetImportHandleType(p_alloc_info)),

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -46,7 +46,9 @@ struct DedicatedBinding {
 // Data struct for tracking memory object
 class DeviceMemory : public StateObject {
   public:
-    const safe_VkMemoryAllocateInfo alloc_info;
+    const safe_VkMemoryAllocateInfo safe_allocate_info;
+    const VkMemoryAllocateInfo &allocate_info;
+
     const VkExternalMemoryHandleTypeFlags export_handle_types;  // from VkExportMemoryAllocateInfo::handleTypes
     const std::optional<VkExternalMemoryHandleTypeFlagBits> import_handle_type;
     const bool unprotected;     // can't be used for protected memory
@@ -60,7 +62,7 @@ class DeviceMemory : public StateObject {
     void *p_driver_data;                   // Pointer to application's actual memory
     const VkDeviceSize fake_base_address;  // To allow a unified view of allocations, useful to Synchronization Validation
 
-    DeviceMemory(VkDeviceMemory memory, const VkMemoryAllocateInfo *p_alloc_info, uint64_t fake_address,
+    DeviceMemory(VkDeviceMemory memory, const VkMemoryAllocateInfo *pAllocateInfo, uint64_t fake_address,
                  const VkMemoryType &memory_type, const VkMemoryHeap &memory_heap,
                  std::optional<DedicatedBinding> &&dedicated_binding, uint32_t physical_device_count);
 

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -212,8 +212,12 @@ class BindableMultiplanarMemoryTracker : public BindableMemoryTracker {
 class Bindable : public StateObject {
   public:
     template <typename Handle>
-    Bindable(Handle h, VulkanObjectType t, bool is_sparse, bool is_unprotected, VkExternalMemoryHandleTypeFlags handle_types)
-        : StateObject(h, t), external_memory_handle_types(handle_types), sparse(is_sparse), unprotected(is_unprotected),
+    Bindable(Handle handle, VulkanObjectType type, bool is_sparse, bool is_unprotected,
+             VkExternalMemoryHandleTypeFlags handle_types)
+        : StateObject(handle, type),
+          external_memory_handle_types(handle_types),
+          sparse(is_sparse),
+          unprotected(is_unprotected),
           memory_tracker_(nullptr) {}
 
     virtual ~Bindable() {

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -50,8 +50,8 @@ class PhysicalDevice : public StateObject {
     // Surfaceless Query extension needs 'global' surface_state data
     SurfacelessQueryState surfaceless_query_state{};
 
-    PhysicalDevice(VkPhysicalDevice phys_dev)
-        : StateObject(phys_dev, kVulkanObjectTypePhysicalDevice), queue_family_properties(GetQueueFamilyProps(phys_dev)) {}
+    PhysicalDevice(VkPhysicalDevice handle)
+        : StateObject(handle, kVulkanObjectTypePhysicalDevice), queue_family_properties(GetQueueFamilyProps(handle)) {}
 
     VkPhysicalDevice VkHandle() const { return handle_.Cast<VkPhysicalDevice>(); }
 
@@ -70,8 +70,8 @@ class DisplayMode : public StateObject {
   public:
     const VkPhysicalDevice physical_device;
 
-    DisplayMode(VkDisplayModeKHR dm, VkPhysicalDevice phys_dev)
-        : StateObject(dm, kVulkanObjectTypeDisplayModeKHR), physical_device(phys_dev) {}
+    DisplayMode(VkDisplayModeKHR handle, VkPhysicalDevice phys_dev)
+        : StateObject(handle, kVulkanObjectTypeDisplayModeKHR), physical_device(phys_dev) {}
 
     VkDisplayModeKHR VkHandle() const { return handle_.Cast<VkDisplayModeKHR>(); }
 };

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -56,8 +56,8 @@ class Fence : public RefcountedStateObject {
         kExternalPermanent,
     };
     // Default constructor
-    Fence(ValidationStateTracker &dev, VkFence f, const VkFenceCreateInfo *pCreateInfo)
-        : RefcountedStateObject(f, kVulkanObjectTypeFence),
+    Fence(ValidationStateTracker &dev, VkFence handle, const VkFenceCreateInfo *pCreateInfo)
+        : RefcountedStateObject(handle, kVulkanObjectTypeFence),
           flags(pCreateInfo->flags),
           exportHandleTypes(GetExportHandleTypes(pCreateInfo)),
           state_((pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? kRetired : kUnsignaled),

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -405,9 +405,9 @@ static bool GetMetalExport(const VkImageViewCreateInfo *info) {
 
 namespace vvl {
 
-ImageView::ImageView(const std::shared_ptr<vvl::Image> &im, VkImageView iv, const VkImageViewCreateInfo *ci,
+ImageView::ImageView(const std::shared_ptr<vvl::Image> &im, VkImageView handle, const VkImageViewCreateInfo *ci,
                      VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props)
-    : StateObject(iv, kVulkanObjectTypeImageView),
+    : StateObject(handle, kVulkanObjectTypeImageView),
       safe_create_info(ci),
       create_info(*safe_create_info.ptr()),
       normalized_subresource_range(::NormalizeSubresourceRange(im->createInfo, *ci)),
@@ -529,8 +529,8 @@ static safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR 
 
 namespace vvl {
 
-Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain)
-    : StateObject(swapchain, kVulkanObjectTypeSwapchainKHR),
+Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
+    : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
       createInfo(pCreateInfo),
       images(),
       exclusive_full_screen_access(false),

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -176,7 +176,7 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
-      createInfo(*safe_create_info.ptr()),
+      create_info(*safe_create_info.ptr()),
       shared_presentable(false),
       layout_locked(false),
       ahb_format(GetExternalFormat(pCreateInfo->pNext)),
@@ -219,7 +219,7 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
-      createInfo(*safe_create_info.ptr()),
+      create_info(*safe_create_info.ptr()),
       shared_presentable(false),
       layout_locked(false),
       ahb_format(GetExternalFormat(pCreateInfo->pNext)),
@@ -273,45 +273,45 @@ void Image::NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool un
     }
 }
 
-bool Image::IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const {
-    bool is_equal = (createInfo.sType == other_createInfo.sType) && (createInfo.flags == other_createInfo.flags);
-    is_equal = is_equal && IsImageTypeEqual(other_createInfo) && IsFormatEqual(other_createInfo);
-    is_equal = is_equal && IsMipLevelsEqual(other_createInfo) && IsArrayLayersEqual(other_createInfo);
-    is_equal = is_equal && IsUsageEqual(other_createInfo) && IsInitialLayoutEqual(other_createInfo);
-    is_equal = is_equal && IsExtentEqual(other_createInfo) && IsTilingEqual(other_createInfo);
-    is_equal = is_equal && IsSamplesEqual(other_createInfo) && IsSharingModeEqual(other_createInfo);
+bool Image::IsCreateInfoEqual(const VkImageCreateInfo &other_create_info) const {
+    bool is_equal = (create_info.sType == other_create_info.sType) && (create_info.flags == other_create_info.flags);
+    is_equal = is_equal && IsImageTypeEqual(other_create_info) && IsFormatEqual(other_create_info);
+    is_equal = is_equal && IsMipLevelsEqual(other_create_info) && IsArrayLayersEqual(other_create_info);
+    is_equal = is_equal && IsUsageEqual(other_create_info) && IsInitialLayoutEqual(other_create_info);
+    is_equal = is_equal && IsExtentEqual(other_create_info) && IsTilingEqual(other_create_info);
+    is_equal = is_equal && IsSamplesEqual(other_create_info) && IsSharingModeEqual(other_create_info);
     return is_equal &&
-           ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) ? IsQueueFamilyIndicesEqual(other_createInfo) : true);
+           ((create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) ? IsQueueFamilyIndicesEqual(other_create_info) : true);
 }
 
 // Check image compatibility rules for VK_NV_dedicated_allocation_image_aliasing
-bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_createInfo) const {
-    bool is_compatible = (createInfo.sType == other_createInfo.sType) && (createInfo.flags == other_createInfo.flags);
-    is_compatible = is_compatible && IsImageTypeEqual(other_createInfo) && IsFormatEqual(other_createInfo);
-    is_compatible = is_compatible && IsMipLevelsEqual(other_createInfo);
-    is_compatible = is_compatible && IsUsageEqual(other_createInfo) && IsInitialLayoutEqual(other_createInfo);
-    is_compatible = is_compatible && IsSamplesEqual(other_createInfo) && IsSharingModeEqual(other_createInfo);
+bool Image::IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_create_info) const {
+    bool is_compatible = (create_info.sType == other_create_info.sType) && (create_info.flags == other_create_info.flags);
+    is_compatible = is_compatible && IsImageTypeEqual(other_create_info) && IsFormatEqual(other_create_info);
+    is_compatible = is_compatible && IsMipLevelsEqual(other_create_info);
+    is_compatible = is_compatible && IsUsageEqual(other_create_info) && IsInitialLayoutEqual(other_create_info);
+    is_compatible = is_compatible && IsSamplesEqual(other_create_info) && IsSharingModeEqual(other_create_info);
     is_compatible = is_compatible &&
-                    ((createInfo.sharingMode == VK_SHARING_MODE_CONCURRENT) ? IsQueueFamilyIndicesEqual(other_createInfo) : true);
-    is_compatible = is_compatible && IsTilingEqual(other_createInfo);
+                    ((create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) ? IsQueueFamilyIndicesEqual(other_create_info) : true);
+    is_compatible = is_compatible && IsTilingEqual(other_create_info);
 
-    is_compatible = is_compatible && createInfo.extent.width <= other_createInfo.extent.width &&
-                    createInfo.extent.height <= other_createInfo.extent.height &&
-                    createInfo.extent.depth <= other_createInfo.extent.depth &&
-                    createInfo.arrayLayers <= other_createInfo.arrayLayers;
+    is_compatible = is_compatible && create_info.extent.width <= other_create_info.extent.width &&
+                    create_info.extent.height <= other_create_info.extent.height &&
+                    create_info.extent.depth <= other_create_info.extent.depth &&
+                    create_info.arrayLayers <= other_create_info.arrayLayers;
     return is_compatible;
 }
 
 bool Image::IsCompatibleAliasing(const Image *other_image_state) const {
     if (!IsSwapchainImage() && !other_image_state->IsSwapchainImage() &&
-        !(createInfo.flags & other_image_state->createInfo.flags & VK_IMAGE_CREATE_ALIAS_BIT)) {
+        !(create_info.flags & other_image_state->create_info.flags & VK_IMAGE_CREATE_ALIAS_BIT)) {
         return false;
     }
     const auto binding = Binding();
     const auto other_binding = other_image_state->Binding();
     if ((create_from_swapchain == VK_NULL_HANDLE) && binding && other_binding &&
         (binding->memory_state == other_binding->memory_state) && (binding->memory_offset == other_binding->memory_offset) &&
-        IsCreateInfoEqual(other_image_state->createInfo)) {
+        IsCreateInfoEqual(other_image_state->create_info)) {
         return true;
     }
     if (bind_swapchain && (bind_swapchain == other_image_state->bind_swapchain) &&
@@ -347,7 +347,7 @@ void Image::SetInitialLayoutMap() {
         layout_map = std::make_shared<GlobalImageLayoutRangeMap>(subresource_encoder.SubresourceCount());
         auto range_gen = subresource_adapter::RangeGenerator(subresource_encoder);
         for (; range_gen->non_empty(); ++range_gen) {
-            layout_map->insert(layout_map->end(), std::make_pair(*range_gen, createInfo.initialLayout));
+            layout_map->insert(layout_map->end(), std::make_pair(*range_gen, create_info.initialLayout));
         }
     }
     // And store in the object
@@ -380,7 +380,7 @@ static VkSamplerYcbcrConversion GetSamplerConversion(const VkImageViewCreateInfo
 
 static VkImageUsageFlags GetInheritedUsage(const VkImageViewCreateInfo *ci, const vvl::Image &image_state) {
     auto usage_create_info = vku::FindStructInPNextChain<VkImageViewUsageCreateInfo>(ci->pNext);
-    return (usage_create_info) ? usage_create_info->usage : image_state.createInfo.usage;
+    return (usage_create_info) ? usage_create_info->usage : image_state.create_info.usage;
 }
 
 static float GetImageViewMinLod(const VkImageViewCreateInfo *ci) {
@@ -410,9 +410,9 @@ ImageView::ImageView(const std::shared_ptr<vvl::Image> &im, VkImageView handle, 
     : StateObject(handle, kVulkanObjectTypeImageView),
       safe_create_info(ci),
       create_info(*safe_create_info.ptr()),
-      normalized_subresource_range(::NormalizeSubresourceRange(im->createInfo, *ci)),
+      normalized_subresource_range(::NormalizeSubresourceRange(im->create_info, *ci)),
       range_generator(im->subresource_encoder, normalized_subresource_range),
-      samples(im->createInfo.samples),
+      samples(im->create_info.samples),
       // When the image has a external format the views format must be VK_FORMAT_UNDEFINED and it is required to use a sampler
       // Ycbcr conversion. Thus we can't extract any meaningful information from the format parameter. As a Sampler Ycbcr
       // conversion must be used the shader type is always float.
@@ -427,7 +427,7 @@ ImageView::ImageView(const std::shared_ptr<vvl::Image> &im, VkImageView handle, 
       metal_imageview_export(GetMetalExport(ci)),
 #endif
       image_state(im),
-      is_depth_sliced(::IsDepthSliced(im->createInfo, *ci)) {
+      is_depth_sliced(::IsDepthSliced(im->create_info, *ci)) {
 }
 
 void ImageView::Destroy() {
@@ -440,7 +440,7 @@ void ImageView::Destroy() {
 
 uint32_t ImageView::GetAttachmentLayerCount() const {
     if (create_info.subresourceRange.layerCount == VK_REMAINING_ARRAY_LAYERS && !IsDepthSliced()) {
-        return image_state->createInfo.arrayLayers;
+        return image_state->create_info.arrayLayers;
     }
     return create_info.subresourceRange.layerCount;
 }
@@ -531,7 +531,8 @@ namespace vvl {
 
 Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
     : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
-      createInfo(pCreateInfo),
+      safe_create_info(pCreateInfo),
+      create_info(*safe_create_info.ptr()),
       images(),
       exclusive_full_screen_access(false),
       shared_presentable(VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR == pCreateInfo->presentMode ||

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -278,7 +278,7 @@ class ImageView : public StateObject {
     std::shared_ptr<vvl::Image> image_state;
     const bool is_depth_sliced;
 
-    ImageView(const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
+    ImageView(const std::shared_ptr<vvl::Image> &image_state, VkImageView handle, const VkImageViewCreateInfo *ci,
               VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     ImageView(const ImageView &rh_obj) = delete;
     VkImageView VkHandle() const { return handle_.Cast<VkImageView>(); }
@@ -332,7 +332,7 @@ class Swapchain : public StateObject {
     ValidationStateTracker *dev_data;
     uint32_t acquired_images = 0;
 
-    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
+    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
         if (!Destroyed()) {
@@ -392,7 +392,7 @@ namespace vvl {
 //    vvl::Surface -> nothing
 class Surface : public StateObject {
   public:
-    Surface(VkSurfaceKHR s) : StateObject(s, kVulkanObjectTypeSurfaceKHR) {}
+    Surface(VkSurfaceKHR handle) : StateObject(handle, kVulkanObjectTypeSurfaceKHR) {}
 
     ~Surface() {
         if (!Destroyed()) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -88,7 +88,7 @@ namespace vvl {
 class Image : public Bindable {
   public:
     const safe_VkImageCreateInfo safe_create_info;
-    const VkImageCreateInfo &createInfo;
+    const VkImageCreateInfo &create_info;
     bool shared_presentable;                   // True for a front-buffered swapchain image
     bool layout_locked;                        // A front-buffered image that has been presented can never have layout transitioned
     const uint64_t ahb_format;                 // External Android format, if provided
@@ -126,9 +126,9 @@ class Image : public Bindable {
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
-    Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
+    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
           VkFormatFeatureFlags2KHR features);
-    Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
     Image(Image const &rh_obj) = delete;
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -140,49 +140,51 @@ class Image : public Bindable {
     bool IsCompatibleAliasing(const Image *other_image_state) const;
 
     // returns true if this image could be using the same memory as another image
-    bool HasAliasFlag() const { return 0 != (createInfo.flags & VK_IMAGE_CREATE_ALIAS_BIT); }
+    bool HasAliasFlag() const { return 0 != (create_info.flags & VK_IMAGE_CREATE_ALIAS_BIT); }
     bool CanAlias() const { return HasAliasFlag() || bind_swapchain; }
 
-    bool IsCreateInfoEqual(const VkImageCreateInfo &other_createInfo) const;
-    bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_createInfo) const;
+    bool IsCreateInfoEqual(const VkImageCreateInfo &other_create_info) const;
+    bool IsCreateInfoDedicatedAllocationImageAliasingCompatible(const VkImageCreateInfo &other_create_info) const;
 
     bool IsSwapchainImage() const { return create_from_swapchain != VK_NULL_HANDLE; }
 
-    inline bool IsImageTypeEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.imageType == other_createInfo.imageType;
+    inline bool IsImageTypeEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.imageType == other_create_info.imageType;
     }
-    inline bool IsFormatEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.format == other_createInfo.format;
+    inline bool IsFormatEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.format == other_create_info.format;
     }
-    inline bool IsMipLevelsEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.mipLevels == other_createInfo.mipLevels;
+    inline bool IsMipLevelsEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.mipLevels == other_create_info.mipLevels;
     }
-    inline bool IsUsageEqual(const VkImageCreateInfo &other_createInfo) const { return createInfo.usage == other_createInfo.usage; }
-    inline bool IsSamplesEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.samples == other_createInfo.samples;
+    inline bool IsUsageEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.usage == other_create_info.usage;
     }
-    inline bool IsTilingEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.tiling == other_createInfo.tiling;
+    inline bool IsSamplesEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.samples == other_create_info.samples;
     }
-    inline bool IsArrayLayersEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.arrayLayers == other_createInfo.arrayLayers;
+    inline bool IsTilingEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.tiling == other_create_info.tiling;
     }
-    inline bool IsInitialLayoutEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.initialLayout == other_createInfo.initialLayout;
+    inline bool IsArrayLayersEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.arrayLayers == other_create_info.arrayLayers;
     }
-    inline bool IsSharingModeEqual(const VkImageCreateInfo &other_createInfo) const {
-        return createInfo.sharingMode == other_createInfo.sharingMode;
+    inline bool IsInitialLayoutEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.initialLayout == other_create_info.initialLayout;
     }
-    inline bool IsExtentEqual(const VkImageCreateInfo &other_createInfo) const {
-        return (createInfo.extent.width == other_createInfo.extent.width) &&
-               (createInfo.extent.height == other_createInfo.extent.height) &&
-               (createInfo.extent.depth == other_createInfo.extent.depth);
+    inline bool IsSharingModeEqual(const VkImageCreateInfo &other_create_info) const {
+        return create_info.sharingMode == other_create_info.sharingMode;
     }
-    inline bool IsQueueFamilyIndicesEqual(const VkImageCreateInfo &other_createInfo) const {
-        return (createInfo.queueFamilyIndexCount == other_createInfo.queueFamilyIndexCount) &&
-               (createInfo.queueFamilyIndexCount == 0 ||
-                memcmp(createInfo.pQueueFamilyIndices, other_createInfo.pQueueFamilyIndices,
-                       createInfo.queueFamilyIndexCount * sizeof(createInfo.pQueueFamilyIndices[0])) == 0);
+    inline bool IsExtentEqual(const VkImageCreateInfo &other_create_info) const {
+        return (create_info.extent.width == other_create_info.extent.width) &&
+               (create_info.extent.height == other_create_info.extent.height) &&
+               (create_info.extent.depth == other_create_info.extent.depth);
+    }
+    inline bool IsQueueFamilyIndicesEqual(const VkImageCreateInfo &other_create_info) const {
+        return (create_info.queueFamilyIndexCount == other_create_info.queueFamilyIndexCount) &&
+               (create_info.queueFamilyIndexCount == 0 ||
+                memcmp(create_info.pQueueFamilyIndices, other_create_info.pQueueFamilyIndices,
+                       create_info.queueFamilyIndexCount * sizeof(create_info.pQueueFamilyIndices[0])) == 0);
     }
 
     ~Image() {
@@ -197,21 +199,21 @@ class Image : public Bindable {
 
     // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceLayers &sub) const {
-        return GetEffectiveExtent(createInfo, sub.aspectMask, sub.mipLevel);
+        return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
     }
 
     // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresource &sub) const {
-        return GetEffectiveExtent(createInfo, sub.aspectMask, sub.mipLevel);
+        return GetEffectiveExtent(create_info, sub.aspectMask, sub.mipLevel);
     }
 
     // Returns the effective extent of the provided subresource, adjusted for mip level and array depth.
     VkExtent3D GetEffectiveSubresourceExtent(const VkImageSubresourceRange &range) const {
-        return GetEffectiveExtent(createInfo, range.aspectMask, range.baseMipLevel);
+        return GetEffectiveExtent(create_info, range.aspectMask, range.baseMipLevel);
     }
 
     VkImageSubresourceRange NormalizeSubresourceRange(const VkImageSubresourceRange &range) const {
-        return ::NormalizeSubresourceRange(createInfo, range);
+        return ::NormalizeSubresourceRange(create_info, range);
     }
 
     void SetInitialLayoutMap();
@@ -263,6 +265,7 @@ class ImageView : public StateObject {
   public:
     const safe_VkImageViewCreateInfo safe_create_info;
     const VkImageViewCreateInfo &create_info;
+
     const VkImageSubresourceRange normalized_subresource_range;
     const image_layout_map::RangeGenerator range_generator;
     const VkSampleCountFlagBits samples;
@@ -318,7 +321,9 @@ struct SwapchainImage {
 //    However, only 1 swapchain for each surface can be !retired.
 class Swapchain : public StateObject {
   public:
-    const safe_VkSwapchainCreateInfoKHR createInfo;
+    const safe_VkSwapchainCreateInfoKHR safe_create_info;
+    const VkSwapchainCreateInfoKHR &create_info;
+
     std::vector<VkPresentModeKHR> present_modes;
     std::vector<SwapchainImage> images;
     bool retired = false;

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2023 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -194,8 +194,9 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
     return set_layouts;
 }
 
-PipelineLayout::PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout l, const VkPipelineLayoutCreateInfo *pCreateInfo)
-    : StateObject(l, kVulkanObjectTypePipelineLayout),
+PipelineLayout::PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle,
+                               const VkPipelineLayoutCreateInfo *pCreateInfo)
+    : StateObject(handle, kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
       push_constant_ranges(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),
       set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)),

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -78,7 +78,7 @@ class PipelineLayout : public StateObject {
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
 
-    PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout l, const VkPipelineLayoutCreateInfo *pCreateInfo);
+    PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
     PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts);
     template <typename Container>

--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -34,10 +34,10 @@ class VideoProfileDesc;
 
 class QueryPool : public StateObject {
   public:
-    QueryPool(VkQueryPool qp, const VkQueryPoolCreateInfo *pCreateInfo, uint32_t index_count, uint32_t perf_queue_family_index,
+    QueryPool(VkQueryPool handle, const VkQueryPoolCreateInfo *pCreateInfo, uint32_t index_count, uint32_t perf_queue_family_index,
               uint32_t n_perf_pass, bool has_cb, bool has_rb, std::shared_ptr<const vvl::VideoProfileDesc> &&supp_video_profile,
               VkVideoEncodeFeedbackFlagsKHR enabled_video_encode_feedback_flags)
-        : StateObject(qp, kVulkanObjectTypeQueryPool),
+        : StateObject(handle, kVulkanObjectTypeQueryPool),
           createInfo(*pCreateInfo),
           has_perf_scope_command_buffer(has_cb),
           has_perf_scope_render_pass(has_rb),

--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -38,7 +38,8 @@ class QueryPool : public StateObject {
               uint32_t n_perf_pass, bool has_cb, bool has_rb, std::shared_ptr<const vvl::VideoProfileDesc> &&supp_video_profile,
               VkVideoEncodeFeedbackFlagsKHR enabled_video_encode_feedback_flags)
         : StateObject(handle, kVulkanObjectTypeQueryPool),
-          createInfo(*pCreateInfo),
+          safe_create_info(pCreateInfo),
+          create_info(*safe_create_info.ptr()),
           has_perf_scope_command_buffer(has_cb),
           has_perf_scope_render_pass(has_rb),
           n_performance_passes(n_perf_pass),
@@ -79,7 +80,8 @@ class QueryPool : public StateObject {
         return QUERYSTATE_UNKNOWN;
     }
 
-    const VkQueryPoolCreateInfo createInfo;
+    const safe_VkQueryPoolCreateInfo safe_create_info;
+    const VkQueryPoolCreateInfo &create_info;
 
     const bool has_perf_scope_command_buffer;
     const bool has_perf_scope_render_pass;

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -78,9 +78,9 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
 
 class Queue: public StateObject {
   public:
-    Queue(ValidationStateTracker &dev_data, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
-                const VkQueueFamilyProperties &queueFamilyProperties)
-        : StateObject(q, kVulkanObjectTypeQueue),
+    Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
+          const VkQueueFamilyProperties &queueFamilyProperties)
+        : StateObject(handle, kVulkanObjectTypeQueue),
           queueFamilyIndex(index),
           flags(flags),
           queueFamilyProperties(queueFamilyProperties),

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -25,14 +25,16 @@ namespace vvl {
 
 class AccelerationStructureNV : public Bindable {
   public:
-    AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci)
-        : Bindable(as, kVulkanObjectTypeAccelerationStructureNV, false, false, 0),
-          create_infoNV(ci),
-          memory_requirements(GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV)),
+    AccelerationStructureNV(VkDevice device, VkAccelerationStructureNV handle,
+                            const VkAccelerationStructureCreateInfoNV *pCreateInfo)
+        : Bindable(handle, kVulkanObjectTypeAccelerationStructureNV, false, false, 0),
+          safe_create_info(pCreateInfo),
+          create_info(*safe_create_info.ptr()),
+          memory_requirements(GetMemReqs(device, handle, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV)),
           build_scratch_memory_requirements(
-              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV)),
+              GetMemReqs(device, handle, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV)),
           update_scratch_memory_requirements(
-              GetMemReqs(device, as, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)),
+              GetMemReqs(device, handle, VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_UPDATE_SCRATCH_NV)),
           tracker_(&memory_requirements) {
         Bindable::SetMemoryTracker(&tracker_);
     }
@@ -45,7 +47,9 @@ class AccelerationStructureNV : public Bindable {
         build_info.initialize(pInfo);
     };
 
-    const safe_VkAccelerationStructureCreateInfoNV create_infoNV = {};
+    const safe_VkAccelerationStructureCreateInfoNV safe_create_info;
+    const VkAccelerationStructureCreateInfoNV &create_info;
+
     safe_VkAccelerationStructureInfoNV build_info;
     const VkMemoryRequirements memory_requirements;
     const VkMemoryRequirements build_scratch_memory_requirements;
@@ -71,9 +75,12 @@ class AccelerationStructureNV : public Bindable {
 
 class AccelerationStructureKHR : public StateObject {
   public:
-    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *ci,
+    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
                              std::shared_ptr<Buffer> &&buf_state)
-        : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR), create_infoKHR(ci), buffer_state(buf_state) {}
+        : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR),
+          safe_create_info(pCreateInfo),
+          create_info(*safe_create_info.ptr()),
+          buffer_state(buf_state) {}
     AccelerationStructureKHR(const AccelerationStructureKHR &rh_obj) = delete;
 
     virtual ~AccelerationStructureKHR() {
@@ -110,7 +117,9 @@ class AccelerationStructureKHR : public StateObject {
         }
     }
 
-    const safe_VkAccelerationStructureCreateInfoKHR create_infoKHR{};
+    const safe_VkAccelerationStructureCreateInfoKHR safe_create_info;
+    const VkAccelerationStructureCreateInfoKHR &create_info;
+
     safe_VkAccelerationStructureBuildGeometryInfoKHR build_info_khr{};
     bool built = false;
     uint64_t opaque_handle = 0;

--- a/layers/state_tracker/ray_tracing_state.h
+++ b/layers/state_tracker/ray_tracing_state.h
@@ -71,9 +71,9 @@ class AccelerationStructureNV : public Bindable {
 
 class AccelerationStructureKHR : public StateObject {
   public:
-    AccelerationStructureKHR(VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci,
+    AccelerationStructureKHR(VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *ci,
                              std::shared_ptr<Buffer> &&buf_state)
-        : StateObject(as, kVulkanObjectTypeAccelerationStructureKHR), create_infoKHR(ci), buffer_state(buf_state) {}
+        : StateObject(handle, kVulkanObjectTypeAccelerationStructureKHR), create_infoKHR(ci), buffer_state(buf_state) {}
     AccelerationStructureKHR(const AccelerationStructureKHR &rh_obj) = delete;
 
     virtual ~AccelerationStructureKHR() {

--- a/layers/state_tracker/render_pass_state.cpp
+++ b/layers/state_tracker/render_pass_state.cpp
@@ -269,8 +269,8 @@ static void InitRenderPassState(vvl::RenderPass *render_pass) {
 
 namespace vvl {
 
-RenderPass::RenderPass(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo)
-    : StateObject(rp, kVulkanObjectTypeRenderPass),
+RenderPass::RenderPass(VkRenderPass handle, VkRenderPassCreateInfo2 const *pCreateInfo)
+    : StateObject(handle, kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
       has_multiview_enabled(false),
@@ -283,8 +283,8 @@ static safe_VkRenderPassCreateInfo2 ConvertCreateInfo(const VkRenderPassCreateIn
     return create_info_2;
 }
 
-RenderPass::RenderPass(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo)
-    : StateObject(rp, kVulkanObjectTypeRenderPass),
+RenderPass::RenderPass(VkRenderPass handle, VkRenderPassCreateInfo const *pCreateInfo)
+    : StateObject(handle, kVulkanObjectTypeRenderPass),
       use_dynamic_rendering(false),
       use_dynamic_rendering_inherited(false),
       has_multiview_enabled(false),
@@ -406,9 +406,9 @@ RenderPass::RenderPass(VkCommandBufferInheritanceRenderingInfo const *pInheritan
       has_multiview_enabled(false),
       inheritance_rendering_info(pInheritanceRenderingInfo) {}
 
-Framebuffer::Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
+Framebuffer::Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
                          std::vector<std::shared_ptr<vvl::ImageView>> &&attachments)
-    : StateObject(fb, kVulkanObjectTypeFramebuffer),
+    : StateObject(handle, kVulkanObjectTypeFramebuffer),
       createInfo(pCreateInfo),
       rp_state(rpstate),
       attachments_view_state(std::move(attachments)) {}

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -87,7 +87,7 @@ class RenderPass : public StateObject {
     const safe_VkRenderingInfo dynamic_rendering_begin_rendering_info;
     const safe_VkPipelineRenderingCreateInfo dynamic_pipeline_rendering_create_info;
     const safe_VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info;
-    const safe_VkRenderPassCreateInfo2 createInfo;
+    const safe_VkRenderPassCreateInfo2 create_info;
     using SubpassVec = std::vector<uint32_t>;
     using SelfDepVec = std::vector<SubpassVec>;
     const std::vector<SubpassVec> self_dependencies;
@@ -126,7 +126,8 @@ class RenderPass : public StateObject {
 
 class Framebuffer : public StateObject {
   public:
-    const safe_VkFramebufferCreateInfo createInfo;
+    const safe_VkFramebufferCreateInfo safe_create_info;
+    const VkFramebufferCreateInfo &create_info;
     std::shared_ptr<const RenderPass> rp_state;
     std::vector<std::shared_ptr<vvl::ImageView>> attachments_view_state;
 

--- a/layers/state_tracker/render_pass_state.h
+++ b/layers/state_tracker/render_pass_state.h
@@ -104,8 +104,8 @@ class RenderPass : public StateObject {
     using TransitionVec = std::vector<std::vector<AttachmentTransition>>;
     const TransitionVec subpass_transitions;
 
-    RenderPass(VkRenderPass rp, VkRenderPassCreateInfo2 const *pCreateInfo);
-    RenderPass(VkRenderPass rp, VkRenderPassCreateInfo const *pCreateInfo);
+    RenderPass(VkRenderPass handle, VkRenderPassCreateInfo2 const *pCreateInfo);
+    RenderPass(VkRenderPass handle, VkRenderPassCreateInfo const *pCreateInfo);
 
     RenderPass(VkPipelineRenderingCreateInfo const *pPipelineRenderingCreateInfo, bool rasterization_enabled);
     RenderPass(VkRenderingInfo const *pRenderingInfo, bool rasterization_enabled);
@@ -130,7 +130,7 @@ class Framebuffer : public StateObject {
     std::shared_ptr<const RenderPass> rp_state;
     std::vector<std::shared_ptr<vvl::ImageView>> attachments_view_state;
 
-    Framebuffer(VkFramebuffer fb, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
+    Framebuffer(VkFramebuffer handle, const VkFramebufferCreateInfo *pCreateInfo, std::shared_ptr<RenderPass> &&rpstate,
                 std::vector<std::shared_ptr<vvl::ImageView>> &&attachments);
     void LinkChildNodes() override;
 

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -59,26 +59,29 @@ namespace vvl {
 
 class Sampler : public StateObject {
   public:
-    const safe_VkSamplerCreateInfo createInfo;
+    const safe_VkSamplerCreateInfo safe_create_info;
+    const VkSamplerCreateInfo &create_info;
+
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
-    Sampler(const VkSampler handle, const VkSamplerCreateInfo *pci)
+    Sampler(const VkSampler handle, const VkSamplerCreateInfo *pCreateInfo)
         : StateObject(handle, kVulkanObjectTypeSampler),
-          createInfo(pci),
-          samplerConversion(GetConversion(pci)),
-          customCreateInfo(GetCustomCreateInfo(pci)) {}
+          safe_create_info(pCreateInfo),
+          create_info(*safe_create_info.ptr()),
+          samplerConversion(GetConversion(pCreateInfo)),
+          customCreateInfo(GetCustomCreateInfo(pCreateInfo)) {}
 
     VkSampler VkHandle() const { return handle_.Cast<VkSampler>(); }
 
   private:
-    static inline VkSamplerYcbcrConversion GetConversion(const VkSamplerCreateInfo *pci) {
-        auto *conversionInfo = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pci->pNext);
+    static inline VkSamplerYcbcrConversion GetConversion(const VkSamplerCreateInfo *pCreateInfo) {
+        auto *conversionInfo = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
         return conversionInfo ? conversionInfo->conversion : VK_NULL_HANDLE;
     }
-    static inline VkSamplerCustomBorderColorCreateInfoEXT GetCustomCreateInfo(const VkSamplerCreateInfo *pci) {
+    static inline VkSamplerCustomBorderColorCreateInfoEXT GetCustomCreateInfo(const VkSamplerCreateInfo *pCreateInfo) {
         VkSamplerCustomBorderColorCreateInfoEXT result{};
-        auto cbci = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(pci->pNext);
+        auto cbci = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(pCreateInfo->pNext);
         if (cbci) result = *cbci;
         return result;
     }

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -63,8 +63,8 @@ class Sampler : public StateObject {
     const VkSamplerYcbcrConversion samplerConversion;
     const VkSamplerCustomBorderColorCreateInfoEXT customCreateInfo;
 
-    Sampler(const VkSampler s, const VkSamplerCreateInfo *pci)
-        : StateObject(s, kVulkanObjectTypeSampler),
+    Sampler(const VkSampler handle, const VkSamplerCreateInfo *pci)
+        : StateObject(handle, kVulkanObjectTypeSampler),
           createInfo(pci),
           samplerConversion(GetConversion(pci)),
           customCreateInfo(GetCustomCreateInfo(pci)) {}
@@ -91,9 +91,9 @@ class SamplerYcbcrConversion : public StateObject {
     const VkFilter chromaFilter;
     const uint64_t external_format;
 
-    SamplerYcbcrConversion(VkSamplerYcbcrConversion ycbcr, const VkSamplerYcbcrConversionCreateInfo *info,
+    SamplerYcbcrConversion(VkSamplerYcbcrConversion handle, const VkSamplerYcbcrConversionCreateInfo *info,
                            VkFormatFeatureFlags2KHR features)
-        : StateObject(ycbcr, kVulkanObjectTypeSamplerYcbcrConversion),
+        : StateObject(handle, kVulkanObjectTypeSamplerYcbcrConversion),
           format_features(features),
           format(info->format),
           chromaFilter(info->chromaFilter),

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -121,12 +121,12 @@ class Semaphore : public RefcountedStateObject {
         return export_info ? export_info->handleTypes : 0;
     }
 
-    Semaphore(ValidationStateTracker &dev, VkSemaphore sem, const VkSemaphoreCreateInfo *pCreateInfo)
-        : Semaphore(dev, sem, vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext), pCreateInfo) {}
+    Semaphore(ValidationStateTracker &dev, VkSemaphore handle, const VkSemaphoreCreateInfo *pCreateInfo)
+        : Semaphore(dev, handle, vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext), pCreateInfo) {}
 
-    Semaphore(ValidationStateTracker &dev, VkSemaphore sem, const VkSemaphoreTypeCreateInfo *type_create_info,
-                    const VkSemaphoreCreateInfo *pCreateInfo)
-        : RefcountedStateObject(sem, kVulkanObjectTypeSemaphore),
+    Semaphore(ValidationStateTracker &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
+              const VkSemaphoreCreateInfo *pCreateInfo)
+        : RefcountedStateObject(handle, kVulkanObjectTypeSemaphore),
 #ifdef VK_USE_PLATFORM_METAL_EXT
           metal_semaphore_export(GetMetalExport(pCreateInfo)),
 #endif  // VK_USE_PLATFORM_METAL_EXT

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -687,8 +687,8 @@ struct Module {
 // Represents a VkShaderModule handle
 namespace vvl {
 struct ShaderModule : public StateObject {
-    ShaderModule(VkShaderModule shader_module, std::shared_ptr<spirv::Module> &spirv_module, uint32_t unique_shader_id)
-        : StateObject(shader_module, kVulkanObjectTypeShaderModule), spirv(spirv_module), gpu_validation_shader_id(unique_shader_id) {
+    ShaderModule(VkShaderModule handle, std::shared_ptr<spirv::Module> &spirv_module, uint32_t unique_shader_id)
+        : StateObject(handle, kVulkanObjectTypeShaderModule), spirv(spirv_module), gpu_validation_shader_id(unique_shader_id) {
         spirv->handle_ = handle_;
     }
 

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -28,10 +28,10 @@ static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_d
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
+ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                            uint32_t unique_shader_id)
-    : StateObject(shader_object, kVulkanObjectTypeShaderEXT),
+    : StateObject(handle, kVulkanObjectTypeShaderEXT),
       create_info(&create_info),
       spirv(spirv_module),
       entrypoint(spirv ? spirv->FindEntrypoint(create_info.pName, create_info.stage) : nullptr),
@@ -43,7 +43,7 @@ ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreat
       set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)) {
     if ((create_info.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {
         for (uint32_t i = 0; i < createInfoCount; ++i) {
-            if (pShaders[i] != shader_object) {
+            if (pShaders[i] != handle) {
                 linked_shaders.push_back(pShaders[i]);
             }
         }

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -28,11 +28,12 @@ static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_d
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT handle,
+ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                            uint32_t unique_shader_id)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),
-      create_info(&create_info),
+      safe_create_info(&create_info_i),
+      create_info(*safe_create_info.ptr()),
       spirv(spirv_module),
       entrypoint(spirv ? spirv->FindEntrypoint(create_info.pName, create_info.stage) : nullptr),
       gpu_validation_shader_id(unique_shader_id),

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -33,7 +33,9 @@ struct ShaderObject : public StateObject {
                  std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                  uint32_t unique_shader_id = 0);
 
-    const safe_VkShaderCreateInfoEXT create_info;
+    const safe_VkShaderCreateInfoEXT safe_create_info;
+    const VkShaderCreateInfoEXT &create_info;
+
     std::shared_ptr<const spirv::Module> spirv;
     std::shared_ptr<const spirv::EntryPoint> entrypoint;
     std::vector<VkShaderEXT> linked_shaders;

--- a/layers/state_tracker/state_object.h
+++ b/layers/state_tracker/state_object.h
@@ -133,7 +133,7 @@ class RefcountedStateObject : public StateObject {
 
   public:
     template <typename Handle>
-    RefcountedStateObject(Handle h, VulkanObjectType t) : StateObject(h, t), in_use_(0) {}
+    RefcountedStateObject(Handle handle, VulkanObjectType type) : StateObject(handle, type), in_use_(0) {}
 
     void BeginUse() { in_use_.fetch_add(1); }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -213,15 +213,15 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
     return format_features;
 }
 
-std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
+std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, img, pCreateInfo, features);
+    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, features);
 }
 
-std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
+std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
@@ -367,8 +367,8 @@ struct BufferAddressInfillUpdateOps {
     const Mapped &insert_value;
 };
 
-std::shared_ptr<vvl::Buffer> ValidationStateTracker::CreateBufferState(VkBuffer buf, const VkBufferCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::Buffer>(this, buf, pCreateInfo);
+std::shared_ptr<vvl::Buffer> ValidationStateTracker::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo *pCreateInfo) {
+    return std::make_shared<vvl::Buffer>(this, handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
@@ -406,10 +406,11 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
     Add(std::move(buffer_state));
 }
 
-std::shared_ptr<vvl::BufferView> ValidationStateTracker::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf,
-                                                                               VkBufferView bv, const VkBufferViewCreateInfo *ci,
-                                                                               VkFormatFeatureFlags2KHR buf_ff) {
-    return std::make_shared<vvl::BufferView>(bf, bv, ci, buf_ff);
+std::shared_ptr<vvl::BufferView> ValidationStateTracker::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &buffer,
+                                                                               VkBufferView handle,
+                                                                               const VkBufferViewCreateInfo *pCreateInfo,
+                                                                               VkFormatFeatureFlags2KHR format_features) {
+    return std::make_shared<vvl::BufferView>(buffer, handle, pCreateInfo, format_features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo *pCreateInfo,
@@ -435,9 +436,9 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
 }
 
 std::shared_ptr<vvl::ImageView> ValidationStateTracker::CreateImageViewState(
-    const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci, VkFormatFeatureFlags2KHR ff,
-    const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props) {
-    return std::make_shared<vvl::ImageView>(image_state, iv, ci, ff, cubic_props);
+    const std::shared_ptr<vvl::Image> &image_state, VkImageView handle, const VkImageViewCreateInfo *pCreateInfo,
+    VkFormatFeatureFlags2KHR format_features, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props) {
+    return std::make_shared<vvl::ImageView>(image_state, handle, pCreateInfo, format_features, cubic_props);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
@@ -695,9 +696,9 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     device_state->CreateDevice(pCreateInfo, record_obj.location);
 }
 
-std::shared_ptr<vvl::Queue> ValidationStateTracker::CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
-                                                                 const VkQueueFamilyProperties &queueFamilyProperties) {
-    return std::make_shared<vvl::Queue>(*this, q, index, flags, queueFamilyProperties);
+std::shared_ptr<vvl::Queue> ValidationStateTracker::CreateQueue(VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
+                                                                const VkQueueFamilyProperties &queueFamilyProperties) {
+    return std::make_shared<vvl::Queue>(*this, handle, index, flags, queueFamilyProperties);
 }
 
 void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
@@ -1757,10 +1758,10 @@ void ValidationStateTracker::PreCallRecordFreeCommandBuffers(VkDevice device, Vk
     }
 }
 
-std::shared_ptr<vvl::CommandPool> ValidationStateTracker::CreateCommandPoolState(VkCommandPool command_pool,
+std::shared_ptr<vvl::CommandPool> ValidationStateTracker::CreateCommandPoolState(VkCommandPool handle,
                                                                                  const VkCommandPoolCreateInfo *pCreateInfo) {
     auto queue_flags = physical_device_state->queue_family_properties[pCreateInfo->queueFamilyIndex].queueFlags;
-    return std::make_shared<vvl::CommandPool>(this, command_pool, pCreateInfo, queue_flags);
+    return std::make_shared<vvl::CommandPool>(this, handle, pCreateInfo, queue_flags);
 }
 
 void ValidationStateTracker::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
@@ -1862,8 +1863,8 @@ void ValidationStateTracker::PostCallRecordCreateFence(VkDevice device, const Vk
 }
 
 std::shared_ptr<vvl::PipelineCache> ValidationStateTracker::CreatePipelineCacheState(
-    VkPipelineCache pipeline_cache, const VkPipelineCacheCreateInfo *pCreateInfo) const {
-    return std::make_shared<vvl::PipelineCache>(pipeline_cache, pCreateInfo);
+    VkPipelineCache handle, const VkPipelineCacheCreateInfo *pCreateInfo) const {
+    return std::make_shared<vvl::PipelineCache>(handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo *pCreateInfo,
@@ -2074,8 +2075,8 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesKHR(VkDevice
     crtpl_state->pipe_state.clear();
 }
 
-std::shared_ptr<vvl::Sampler> ValidationStateTracker::CreateSamplerState(VkSampler s, const VkSamplerCreateInfo *ci) {
-    return std::make_shared<vvl::Sampler>(s, ci);
+std::shared_ptr<vvl::Sampler> ValidationStateTracker::CreateSamplerState(VkSampler handle, const VkSamplerCreateInfo *pCreateInfo) {
+    return std::make_shared<vvl::Sampler>(handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
@@ -2113,14 +2114,14 @@ void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device,
 }
 
 std::shared_ptr<vvl::DescriptorPool> ValidationStateTracker::CreateDescriptorPoolState(
-    VkDescriptorPool pool, const VkDescriptorPoolCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::DescriptorPool>(this, pool, pCreateInfo);
+    VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo) {
+    return std::make_shared<vvl::DescriptorPool>(this, handle, pCreateInfo);
 }
 
 std::shared_ptr<vvl::DescriptorSet> ValidationStateTracker::CreateDescriptorSet(
-    VkDescriptorSet set, vvl::DescriptorPool *pool, const std::shared_ptr<vvl::DescriptorSetLayout const> &layout,
+    VkDescriptorSet handle, vvl::DescriptorPool *pool, const std::shared_ptr<vvl::DescriptorSetLayout const> &layout,
     uint32_t variable_count) {
-    return std::make_shared<vvl::DescriptorSet>(set, pool, layout, variable_count, this);
+    return std::make_shared<vvl::DescriptorSet>(handle, pool, layout, variable_count, this);
 }
 
 void ValidationStateTracker::PostCallRecordCreateDescriptorPool(VkDevice device, const VkDescriptorPoolCreateInfo *pCreateInfo,
@@ -2402,8 +2403,8 @@ void ValidationStateTracker::PostCallRecordCmdSetViewportShadingRatePaletteNV(Vk
 }
 
 std::shared_ptr<vvl::AccelerationStructureNV> ValidationStateTracker::CreateAccelerationStructureState(
-    VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV *ci) {
-    return std::make_shared<vvl::AccelerationStructureNV>(device, as, ci);
+    VkAccelerationStructureNV handle, const VkAccelerationStructureCreateInfoNV *pCreateInfo) {
+    return std::make_shared<vvl::AccelerationStructureNV>(device, handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevice device,
@@ -2416,8 +2417,9 @@ void ValidationStateTracker::PostCallRecordCreateAccelerationStructureNV(VkDevic
 }
 
 std::shared_ptr<vvl::AccelerationStructureKHR> ValidationStateTracker::CreateAccelerationStructureState(
-    VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR *ci, std::shared_ptr<vvl::Buffer> &&buf_state) {
-    return std::make_shared<vvl::AccelerationStructureKHR>(as, ci, std::move(buf_state));
+    VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR *pCreateInfo,
+    std::shared_ptr<vvl::Buffer> &&buf_state) {
+    return std::make_shared<vvl::AccelerationStructureKHR>(handle, pCreateInfo, std::move(buf_state));
 }
 
 void ValidationStateTracker::PostCallRecordCreateAccelerationStructureKHR(VkDevice device,
@@ -3841,8 +3843,8 @@ void ValidationStateTracker::PostCallRecordAcquireNextImage2KHR(VkDevice device,
                                 pAcquireInfo->fence, pImageIndex, record_obj.location.function);
 }
 
-std::shared_ptr<vvl::PhysicalDevice> ValidationStateTracker::CreatePhysicalDeviceState(VkPhysicalDevice phys_dev) {
-    return std::make_shared<vvl::PhysicalDevice>(phys_dev);
+std::shared_ptr<vvl::PhysicalDevice> ValidationStateTracker::CreatePhysicalDeviceState(VkPhysicalDevice handle) {
+    return std::make_shared<vvl::PhysicalDevice>(handle);
 }
 
 void ValidationStateTracker::PostCallRecordCreateInstance(const VkInstanceCreateInfo *pCreateInfo,
@@ -5632,20 +5634,20 @@ void ValidationStateTracker::PostCallRecordGetBufferDeviceAddressEXT(VkDevice de
     PostCallRecordGetBufferDeviceAddress(device, pInfo, record_obj);
 }
 
-std::shared_ptr<vvl::Swapchain> ValidationStateTracker::CreateSwapchainState(const VkSwapchainCreateInfoKHR *create_info,
-                                                                             VkSwapchainKHR swapchain) {
-    return std::make_shared<vvl::Swapchain>(this, create_info, swapchain);
+std::shared_ptr<vvl::Swapchain> ValidationStateTracker::CreateSwapchainState(const VkSwapchainCreateInfoKHR *pCreateInfo,
+                                                                             VkSwapchainKHR handle) {
+    return std::make_shared<vvl::Swapchain>(this, pCreateInfo, handle);
 }
 
-std::shared_ptr<vvl::CommandBuffer> ValidationStateTracker::CreateCmdBufferState(VkCommandBuffer cb,
-                                                                                 const VkCommandBufferAllocateInfo *create_info,
+std::shared_ptr<vvl::CommandBuffer> ValidationStateTracker::CreateCmdBufferState(VkCommandBuffer handle,
+                                                                                 const VkCommandBufferAllocateInfo *pAllocateInfo,
                                                                                  const vvl::CommandPool *pool) {
-    return std::make_shared<vvl::CommandBuffer>(this, cb, create_info, pool);
+    return std::make_shared<vvl::CommandBuffer>(this, handle, pAllocateInfo, pool);
 }
 
 std::shared_ptr<vvl::DeviceMemory> ValidationStateTracker::CreateDeviceMemoryState(
-    VkDeviceMemory mem, const VkMemoryAllocateInfo *p_alloc_info, uint64_t fake_address, const VkMemoryType &memory_type,
+    VkDeviceMemory handle, const VkMemoryAllocateInfo *pAllocateInfo, uint64_t fake_address, const VkMemoryType &memory_type,
     const VkMemoryHeap &memory_heap, std::optional<vvl::DedicatedBinding> &&dedicated_binding, uint32_t physical_device_count) {
-    return std::make_shared<vvl::DeviceMemory>(mem, p_alloc_info, fake_address, memory_type, memory_heap,
+    return std::make_shared<vvl::DeviceMemory>(handle, pAllocateInfo, fake_address, memory_type, memory_heap,
                                                std::move(dedicated_binding), physical_device_count);
 }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -451,7 +451,7 @@ class ValidationStateTracker : public ValidationObject {
 
     // State update functions
     // Gets/Enumerations
-    virtual std::shared_ptr<vvl::PhysicalDevice> CreatePhysicalDeviceState(VkPhysicalDevice phys_dev);
+    virtual std::shared_ptr<vvl::PhysicalDevice> CreatePhysicalDeviceState(VkPhysicalDevice handle);
     void PostCallRecordCreateInstance(const VkInstanceCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                       VkInstance* pInstance, const RecordObject& record_obj) override;
     void PostCallRecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(
@@ -467,7 +467,7 @@ class ValidationStateTracker : public ValidationObject {
                                                             VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                             const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::Queue> CreateQueue(VkQueue queue, uint32_t queue_family_index, VkDeviceQueueCreateFlags flags,
+    virtual std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t queue_family_index, VkDeviceQueueCreateFlags flags,
                                                     const VkQueueFamilyProperties& queueFamilyProperties);
 
     void PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
@@ -608,7 +608,7 @@ class ValidationStateTracker : public ValidationObject {
                                     const RecordObject& record_obj) override;
 
     virtual std::shared_ptr<vvl::AccelerationStructureNV> CreateAccelerationStructureState(
-        VkAccelerationStructureNV as, const VkAccelerationStructureCreateInfoNV* pCreateInfo);
+        VkAccelerationStructureNV handle, const VkAccelerationStructureCreateInfoNV* pCreateInfo);
     void PostCallRecordCreateAccelerationStructureNV(VkDevice device, const VkAccelerationStructureCreateInfoNV* pCreateInfo,
                                                      const VkAllocationCallbacks* pAllocator,
                                                      VkAccelerationStructureNV* pAccelerationStructure,
@@ -618,7 +618,7 @@ class ValidationStateTracker : public ValidationObject {
                                                      const RecordObject& record_obj) override;
 
     virtual std::shared_ptr<vvl::AccelerationStructureKHR> CreateAccelerationStructureState(
-        VkAccelerationStructureKHR as, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
+        VkAccelerationStructureKHR handle, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
         std::shared_ptr<vvl::Buffer>&& buf_state);
     void PostCallRecordCreateAccelerationStructureKHR(VkDevice device, const VkAccelerationStructureCreateInfoKHR* pCreateInfo,
                                                       const VkAllocationCallbacks* pAllocator,
@@ -645,21 +645,21 @@ class ValidationStateTracker : public ValidationObject {
                                                       const VkAllocationCallbacks* pAllocator,
                                                       const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::Buffer> CreateBufferState(VkBuffer buf, const VkBufferCreateInfo* pCreateInfo);
+    virtual std::shared_ptr<vvl::Buffer> CreateBufferState(VkBuffer handle, const VkBufferCreateInfo* pCreateInfo);
     void PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
                                     VkBuffer* pBuffer, const RecordObject& record_obj) override;
     void PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks* pAllocator,
                                     const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::BufferView> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& bf, VkBufferView bv,
-                                                                   const VkBufferViewCreateInfo* ci,
-                                                                   VkFormatFeatureFlags2KHR buf_ff);
+    virtual std::shared_ptr<vvl::BufferView> CreateBufferViewState(const std::shared_ptr<vvl::Buffer>& buffer, VkBufferView handle,
+                                                                   const VkBufferViewCreateInfo* pCreateInfo,
+                                                                   VkFormatFeatureFlags2KHR format_features);
     void PostCallRecordCreateBufferView(VkDevice device, const VkBufferViewCreateInfo* pCreateInfo,
                                         const VkAllocationCallbacks* pAllocator, VkBufferView* pView,
                                         const RecordObject& record_obj) override;
     void PreCallRecordDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks* pAllocator,
                                         const RecordObject& record_obj) override;
-    virtual std::shared_ptr<vvl::CommandPool> CreateCommandPoolState(VkCommandPool command_pool,
+    virtual std::shared_ptr<vvl::CommandPool> CreateCommandPoolState(VkCommandPool handle,
                                                                      const VkCommandPoolCreateInfo* pCreateInfo);
     void PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkCommandPool* pCommandPool,
@@ -674,9 +674,9 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyEvent(VkDevice device, VkEvent event, const VkAllocationCallbacks* pAllocator,
                                    const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::DescriptorPool> CreateDescriptorPoolState(VkDescriptorPool pool,
+    virtual std::shared_ptr<vvl::DescriptorPool> CreateDescriptorPoolState(VkDescriptorPool handle,
                                                                            const VkDescriptorPoolCreateInfo* pCreateInfo);
-    virtual std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet, vvl::DescriptorPool*,
+    virtual std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet handle, vvl::DescriptorPool*,
                                                                     const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
                                                                     uint32_t variable_count);
 
@@ -737,7 +737,7 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyFramebuffer(VkDevice device, VkFramebuffer framebuffer, const VkAllocationCallbacks* pAllocator,
                                          const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::PipelineCache> CreatePipelineCacheState(VkPipelineCache pipeline_cache,
+    virtual std::shared_ptr<vvl::PipelineCache> CreatePipelineCacheState(VkPipelineCache handle,
                                                                          const VkPipelineCacheCreateInfo* pCreateInfo) const;
     void PostCallRecordCreatePipelineCache(VkDevice device, const VkPipelineCacheCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkPipelineCache* pPipelineCache,
@@ -760,9 +760,9 @@ class ValidationStateTracker : public ValidationObject {
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
                                                const RecordObject& record_obj, void* cgpl_state) override;
 
-    virtual std::shared_ptr<vvl::Image> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo,
+    virtual std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                          VkFormatFeatureFlags2KHR features);
-    virtual std::shared_ptr<vvl::Image> CreateImageState(VkImage img, const VkImageCreateInfo* pCreateInfo,
+    virtual std::shared_ptr<vvl::Image> CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                          VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                          VkFormatFeatureFlags2KHR features);
     void PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo* pCreateInfo, const VkAllocationCallbacks* pAllocator,
@@ -770,8 +770,9 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
                                    const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::ImageView> CreateImageViewState(const std::shared_ptr<vvl::Image>& image_state, VkImageView iv,
-                                                                 const VkImageViewCreateInfo* ci, VkFormatFeatureFlags2KHR ff,
+    virtual std::shared_ptr<vvl::ImageView> CreateImageViewState(const std::shared_ptr<vvl::Image>& image_state, VkImageView handle,
+                                                                 const VkImageViewCreateInfo* pCreateInfo,
+                                                                 VkFormatFeatureFlags2KHR format_features,
                                                                  const VkFilterCubicImageViewImageFormatPropertiesEXT& cubic_props);
     void PostCallRecordCreateImageView(VkDevice device, const VkImageViewCreateInfo* pCreateInfo,
                                        const VkAllocationCallbacks* pAllocator, VkImageView* pView,
@@ -854,7 +855,7 @@ class ValidationStateTracker : public ValidationObject {
                                                        const VkAllocationCallbacks* pAllocator,
                                                        const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::Sampler> CreateSamplerState(VkSampler s, const VkSamplerCreateInfo* ci);
+    virtual std::shared_ptr<vvl::Sampler> CreateSamplerState(VkSampler handle, const VkSamplerCreateInfo* pCreateInfo);
     void PostCallRecordCreateSampler(VkDevice device, const VkSamplerCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkSampler* pSampler,
                                      const RecordObject& record_obj) override;
@@ -942,8 +943,8 @@ class ValidationStateTracker : public ValidationObject {
                                                const RecordObject& record_obj) override;
     void PostCallRecordReleaseProfilingLockKHR(VkDevice device, const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer cb,
-                                                                     const VkCommandBufferAllocateInfo* create_info,
+    virtual std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
+                                                                     const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                                      const vvl::CommandPool* pool);
     // Allocate/Free
     void PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo* pCreateInfo,
@@ -973,11 +974,9 @@ class ValidationStateTracker : public ValidationObject {
                                                          VkDescriptorUpdateTemplate descriptorUpdateTemplate, const void* pData,
                                                          const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::DeviceMemory> CreateDeviceMemoryState(VkDeviceMemory mem, const VkMemoryAllocateInfo* p_alloc_info,
-                                                                       uint64_t fake_address, const VkMemoryType& memory_type,
-                                                                       const VkMemoryHeap& memory_heap,
-                                                                       std::optional<vvl::DedicatedBinding>&& dedicated_binding,
-                                                                       uint32_t physical_device_count);
+    virtual std::shared_ptr<vvl::DeviceMemory> CreateDeviceMemoryState(
+        VkDeviceMemory handle, const VkMemoryAllocateInfo* pAllocateInfo, uint64_t fake_address, const VkMemoryType& memory_type,
+        const VkMemoryHeap& memory_heap, std::optional<vvl::DedicatedBinding>&& dedicated_binding, uint32_t physical_device_count);
 
     // Memory mapping
     void PostCallRecordMapMemory(VkDevice device, VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, VkFlags flags,
@@ -1444,8 +1443,8 @@ class ValidationStateTracker : public ValidationObject {
                                                     const vvl::DescriptorUpdateTemplate* template_state, const void* pData);
     void RecordAcquireNextImageState(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,
                                      VkFence fence, uint32_t* pImageIndex, vvl::Func command);
-    virtual std::shared_ptr<vvl::Swapchain> CreateSwapchainState(const VkSwapchainCreateInfoKHR* create_info,
-                                                                 VkSwapchainKHR swapchain);
+    virtual std::shared_ptr<vvl::Swapchain> CreateSwapchainState(const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                                                 VkSwapchainKHR handle);
     void RecordCreateSwapchainState(VkResult result, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR* pSwapchain,
                                     std::shared_ptr<vvl::Surface>&& surface_state, vvl::Swapchain* old_swapchain_state);
     void RecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters(VkPhysicalDevice physicalDevice,

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -587,14 +587,14 @@ bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTrac
     return skip;
 }
 
-VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR vs, VkVideoSessionCreateInfoKHR const *pCreateInfo,
-                           std::shared_ptr<const VideoProfileDesc> &&profile_desc)
-    : StateObject(vs, kVulkanObjectTypeVideoSessionKHR),
+VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle,
+                           VkVideoSessionCreateInfoKHR const *pCreateInfo, std::shared_ptr<const VideoProfileDesc> &&profile_desc)
+    : StateObject(handle, kVulkanObjectTypeVideoSessionKHR),
       create_info(pCreateInfo),
       profile(std::move(profile_desc)),
       memory_binding_count_queried(false),
       memory_bindings_queried(0),
-      memory_bindings_(GetMemoryBindings(dev_data, vs)),
+      memory_bindings_(GetMemoryBindings(dev_data, handle)),
       unbound_memory_binding_count_(static_cast<uint32_t>(memory_bindings_.size())),
       device_state_mutex_(),
       device_state_(pCreateInfo->maxDpbSlots) {}
@@ -654,11 +654,11 @@ bool VideoSession::ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_in
     }
 }
 
-VideoSessionParameters::VideoSessionParameters(VkVideoSessionParametersKHR vsp,
+VideoSessionParameters::VideoSessionParameters(VkVideoSessionParametersKHR handle,
                                                VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,
                                                std::shared_ptr<VideoSession> &&vsstate,
                                                std::shared_ptr<VideoSessionParameters> &&vsp_template)
-    : StateObject(vsp, kVulkanObjectTypeVideoSessionParametersKHR),
+    : StateObject(handle, kVulkanObjectTypeVideoSessionParametersKHR),
       create_info(pCreateInfo),
       vs_state(vsstate),
       mutex_(),

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -297,8 +297,8 @@ VkExtent3D VideoPictureResource::GetEffectiveImageExtent(const vvl::VideoSession
     extent.height = ((extent.height + gran.height - 1) / gran.height) * gran.height;
 
     // Clamp to mip level dimensions
-    extent.width = std::min(extent.width, image_state->createInfo.extent.width >> range.baseMipLevel);
-    extent.height = std::min(extent.height, image_state->createInfo.extent.height >> range.baseMipLevel);
+    extent.width = std::min(extent.width, image_state->create_info.extent.width >> range.baseMipLevel);
+    extent.height = std::min(extent.height, image_state->create_info.extent.height >> range.baseMipLevel);
 
     return extent;
 }
@@ -590,7 +590,8 @@ bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTrac
 VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle,
                            VkVideoSessionCreateInfoKHR const *pCreateInfo, std::shared_ptr<const VideoProfileDesc> &&profile_desc)
     : StateObject(handle, kVulkanObjectTypeVideoSessionKHR),
-      create_info(pCreateInfo),
+      safe_create_info(pCreateInfo),
+      create_info(*safe_create_info.ptr()),
       profile(std::move(profile_desc)),
       memory_binding_count_queried(false),
       memory_bindings_queried(0),
@@ -659,7 +660,8 @@ VideoSessionParameters::VideoSessionParameters(VkVideoSessionParametersKHR handl
                                                std::shared_ptr<VideoSession> &&vsstate,
                                                std::shared_ptr<VideoSessionParameters> &&vsp_template)
     : StateObject(handle, kVulkanObjectTypeVideoSessionParametersKHR),
-      create_info(pCreateInfo),
+      safe_create_info(pCreateInfo),
+      create_info(*safe_create_info.ptr()),
       vs_state(vsstate),
       mutex_(),
       data_(),

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -489,7 +489,7 @@ class VideoSession : public StateObject {
         VideoSessionDeviceState &state_;
     };
 
-    VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR vs, VkVideoSessionCreateInfoKHR const *pCreateInfo,
+    VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
     VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
@@ -673,7 +673,7 @@ class VideoSessionParameters : public StateObject {
     const safe_VkVideoSessionParametersCreateInfoKHR create_info;
     std::shared_ptr<const VideoSession> vs_state;
 
-    VideoSessionParameters(VkVideoSessionParametersKHR vsp, VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,
+    VideoSessionParameters(VkVideoSessionParametersKHR handle, VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,
                            std::shared_ptr<VideoSession> &&vsstate, std::shared_ptr<VideoSessionParameters> &&vsp_template);
 
     VkVideoSessionParametersKHR VkHandle() const { return handle_.Cast<VkVideoSessionParametersKHR>(); }

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -474,7 +474,8 @@ class VideoSession : public StateObject {
     };
     using MemoryBindingMap = unordered_map<uint32_t, MemoryBindingInfo>;
 
-    const safe_VkVideoSessionCreateInfoKHR create_info;
+    const safe_VkVideoSessionCreateInfoKHR safe_create_info;
+    const VkVideoSessionCreateInfoKHR &create_info;
     std::shared_ptr<const VideoProfileDesc> profile;
     bool memory_binding_count_queried;
     uint32_t memory_bindings_queried;
@@ -670,7 +671,8 @@ class VideoSessionParameters : public StateObject {
         const Data *data_;
     };
 
-    const safe_VkVideoSessionParametersCreateInfoKHR create_info;
+    const safe_VkVideoSessionParametersCreateInfoKHR safe_create_info;
+    const VkVideoSessionParametersCreateInfoKHR &create_info;
     std::shared_ptr<const VideoSession> vs_state;
 
     VideoSessionParameters(VkVideoSessionParametersKHR handle, VkVideoSessionParametersCreateInfoKHR const *pCreateInfo,

--- a/layers/sync/sync_op.cpp
+++ b/layers/sync/sync_op.cpp
@@ -452,7 +452,7 @@ void SyncOpBarriers::BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sy
         const auto &barrier = barriers[index];
         auto image = sync_state.Get<ImageState>(barrier.image);
         if (image) {
-            auto subresource_range = NormalizeSubresourceRange(image->createInfo, barrier.subresourceRange);
+            auto subresource_range = NormalizeSubresourceRange(image->create_info, barrier.subresourceRange);
             const SyncBarrier sync_barrier(barrier, src, dst);
             image_memory_barriers.emplace_back(image, index, sync_barrier, barrier.oldLayout, barrier.newLayout, subresource_range);
         } else {
@@ -472,7 +472,7 @@ void SyncOpBarriers::BarrierSet::MakeImageMemoryBarriers(const SyncValidator &sy
         auto dst = SyncExecScope::MakeDst(queue_flags, barrier.dstStageMask);
         auto image = sync_state.Get<ImageState>(barrier.image);
         if (image) {
-            auto subresource_range = NormalizeSubresourceRange(image->createInfo, barrier.subresourceRange);
+            auto subresource_range = NormalizeSubresourceRange(image->create_info, barrier.subresourceRange);
             const SyncBarrier sync_barrier(barrier, src, dst);
             image_memory_barriers.emplace_back(image, index, sync_barrier, barrier.oldLayout, barrier.newLayout, subresource_range);
         } else {

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -70,7 +70,7 @@ class UpdateStateResolveAction {
 
 void InitSubpassContexts(VkQueueFlags queue_flags, const vvl::RenderPass &rp_state, const AccessContext *external_context,
                          std::vector<AccessContext> &subpass_contexts) {
-    const auto &create_info = rp_state.createInfo;
+    const auto &create_info = rp_state.create_info;
     // Add this for all subpasses here so that they exsist during next subpass validation
     subpass_contexts.clear();
     subpass_contexts.reserve(create_info.subpassCount);
@@ -178,9 +178,9 @@ bool RenderPassAccessContext::ValidateLoadOperation(const SyncValidationInfo &va
                                                     const vvl::RenderPass &rp_state, const VkRect2D &render_area, uint32_t subpass,
                                                     const AttachmentViewGenVector &attachment_views, vvl::Func command) {
     bool skip = false;
-    const auto *attachment_ci = rp_state.createInfo.pAttachments;
+    const auto *attachment_ci = rp_state.create_info.pAttachments;
 
-    for (uint32_t i = 0; i < rp_state.createInfo.attachmentCount; i++) {
+    for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (subpass == rp_state.attachment_first_subpass[i]) {
             const auto &view_gen = attachment_views[i];
             if (!view_gen.IsValid()) continue;
@@ -250,9 +250,9 @@ bool RenderPassAccessContext::ValidateLoadOperation(const SyncValidationInfo &va
 // The latter is handled in layout transistion validation directly
 bool RenderPassAccessContext::ValidateStoreOperation(const SyncValidationInfo &val_info, vvl::Func command) const {
     bool skip = false;
-    const auto *attachment_ci = rp_state_->createInfo.pAttachments;
+    const auto *attachment_ci = rp_state_->create_info.pAttachments;
 
-    for (uint32_t i = 0; i < rp_state_->createInfo.attachmentCount; i++) {
+    for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
         if (current_subpass_ == rp_state_->attachment_last_subpass[i]) {
             const AttachmentViewGen &view_gen = attachment_views_[i];
             if (!view_gen.IsValid()) continue;
@@ -340,7 +340,7 @@ bool IsStencilAttachmentWriteable(const LastBound &last_bound_state, const VkFor
 template <typename Action>
 void ResolveOperation(Action &action, const vvl::RenderPass &rp_state, const AttachmentViewGenVector &attachment_views,
                       uint32_t subpass) {
-    const auto &rp_ci = rp_state.createInfo;
+    const auto &rp_ci = rp_state.create_info;
     const auto *attachment_ci = rp_ci.pAttachments;
     const auto &subpass_ci = rp_ci.pSubpasses[subpass];
 
@@ -414,9 +414,9 @@ void RenderPassAccessContext::UpdateAttachmentResolveAccess(const vvl::RenderPas
 void RenderPassAccessContext::UpdateAttachmentStoreAccess(const vvl::RenderPass &rp_state,
                                                           const AttachmentViewGenVector &attachment_views, uint32_t subpass,
                                                           const ResourceUsageTag tag, AccessContext &access_context) {
-    const auto *attachment_ci = rp_state.createInfo.pAttachments;
+    const auto *attachment_ci = rp_state.create_info.pAttachments;
 
-    for (uint32_t i = 0; i < rp_state.createInfo.attachmentCount; i++) {
+    for (uint32_t i = 0; i < rp_state.create_info.attachmentCount; i++) {
         if (rp_state.attachment_last_subpass[i] == subpass) {
             const auto &view_gen = attachment_views[i];
             if (!view_gen.IsValid()) continue;  // UNUSED
@@ -495,7 +495,7 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
         return skip;
     }
     const auto &list = pipe->fragmentShader_writable_output_location_list;
-    const auto &subpass = rp_state_->createInfo.pSubpasses[current_subpass_];
+    const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 
     const auto &current_context = CurrentContext();
     // Subpass's inputAttachment has been done in ValidateDispatchDrawDescriptorSet
@@ -585,7 +585,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
         return;
     }
     const auto &list = pipe->fragmentShader_writable_output_location_list;
-    const auto &subpass = rp_state_->createInfo.pSubpasses[current_subpass_];
+    const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 
     auto &current_context = CurrentContext();
     // Subpass's inputAttachment has been done in RecordDispatchDrawDescriptorSet
@@ -640,7 +640,7 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
 }
 
 uint32_t RenderPassAccessContext::GetAttachmentIndex(const VkClearAttachment &clear_attachment) const {
-    const auto &rpci = rp_state_->createInfo;
+    const auto &rpci = rp_state_->create_info;
     const auto &subpass = rpci.pSubpasses[GetCurrentSubpass()];
     uint32_t attachment_index = VK_ATTACHMENT_UNUSED;
 
@@ -835,10 +835,10 @@ void RenderPassAccessContext::RecordLayoutTransitions(const ResourceUsageTag tag
 }
 
 void RenderPassAccessContext::RecordLoadOperations(const ResourceUsageTag tag) {
-    const auto *attachment_ci = rp_state_->createInfo.pAttachments;
+    const auto *attachment_ci = rp_state_->create_info.pAttachments;
     auto &subpass_context = subpass_contexts_[current_subpass_];
 
-    for (uint32_t i = 0; i < rp_state_->createInfo.attachmentCount; i++) {
+    for (uint32_t i = 0; i < rp_state_->create_info.attachmentCount; i++) {
         if (rp_state_->attachment_first_subpass[i] == current_subpass_) {
             const AttachmentViewGen &view_gen = attachment_views_[i];
             if (!view_gen.IsValid()) continue;  // UNUSED

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -863,7 +863,7 @@ bool SyncValidator::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, 
             if (src_buffer) {
                 ResourceAccessRange src_range = MakeRange(
                     copy_region.bufferOffset,
-                    GetBufferSizeFromCopyImage(copy_region, dst_image->createInfo.format, dst_image->createInfo.arrayLayers));
+                    GetBufferSizeFromCopyImage(copy_region, dst_image->create_info.format, dst_image->create_info.arrayLayers));
                 hazard = context->DetectHazard(*src_buffer, SYNC_COPY_TRANSFER_READ, src_range);
                 if (hazard.IsHazard()) {
                     // PHASE1 TODO -- add tag information to log msg when useful.
@@ -934,7 +934,7 @@ void SyncValidator::RecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer, Vk
             if (src_buffer) {
                 ResourceAccessRange src_range = MakeRange(
                     copy_region.bufferOffset,
-                    GetBufferSizeFromCopyImage(copy_region, dst_image->createInfo.format, dst_image->createInfo.arrayLayers));
+                    GetBufferSizeFromCopyImage(copy_region, dst_image->create_info.format, dst_image->create_info.arrayLayers));
                 context->UpdateAccessState(*src_buffer, SYNC_COPY_TRANSFER_READ, SyncOrdering::kNonAttachment, src_range, tag);
             }
             context->UpdateAccessState(*dst_image, SYNC_COPY_TRANSFER_WRITE, SyncOrdering::kNonAttachment,
@@ -1000,7 +1000,7 @@ bool SyncValidator::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, 
             if (dst_mem) {
                 ResourceAccessRange dst_range = MakeRange(
                     copy_region.bufferOffset,
-                    GetBufferSizeFromCopyImage(copy_region, src_image->createInfo.format, src_image->createInfo.arrayLayers));
+                    GetBufferSizeFromCopyImage(copy_region, src_image->create_info.format, src_image->create_info.arrayLayers));
                 hazard = context->DetectHazard(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, dst_range);
                 if (hazard.IsHazard()) {
                     const LogObjectList objlist(commandBuffer, dstBuffer);
@@ -1063,7 +1063,7 @@ void SyncValidator::RecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, Vk
             if (dst_buffer) {
                 ResourceAccessRange dst_range = MakeRange(
                     copy_region.bufferOffset,
-                    GetBufferSizeFromCopyImage(copy_region, src_image->createInfo.format, src_image->createInfo.arrayLayers));
+                    GetBufferSizeFromCopyImage(copy_region, src_image->create_info.format, src_image->create_info.arrayLayers));
                 context->UpdateAccessState(*dst_buffer, SYNC_COPY_TRANSFER_WRITE, SyncOrdering::kNonAttachment, dst_range, tag);
             }
         }


### PR DESCRIPTION
This closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7707

> Note: no "logic" was modified, this is just a lot renaming for consistency and changing things to be a const ref of a safe_struct

We have `safe_Vk*CreateInfo` structs that are used to hold things like the pNext chains, but when using, people really just want a "normal" struct

We had zero consistency with this, and it lead to preventable bug 

This change unifies all `StateObject` classes to look like

```c++
const safe_VkBufferCreateInfo safe_create_info;
const VkBufferCreateInfo &create_info;

// when constructing
safe_create_info(pCreateInfo),
create_info(*safe_create_info.ptr()),
```

doing this ensures everyone trying to pNext look into a create info is rested assure it will work