### PR TITLE
tests: Cleanup vkt::Fence inits

### DIFF
--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -518,8 +518,7 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
     m_commandBuffer->QueueCommandBuffer(fence);
 
     VkPresentInfoKHR present = vku::InitStructHelper();

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -1211,11 +1211,8 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
                                                  });
     vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
-    VkEventCreateInfo event_create_info = vku::InitStructHelper();
-    vkt::Event event(*m_device, event_create_info);
+    vkt::Fence fence(*m_device);
+    vkt::Event event(*m_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAllocateCommandBuffers-pAllocateInfo::commandBufferCount-arraylength");
     {

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -199,8 +199,7 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
 
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_image_view.handle(), 100, 100);
-
-    vkt::Fence fence(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 100, 100, 1, &clear);

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -230,11 +230,8 @@ TEST_F(PositiveSyncObject, QueueSubmitSemaphoresAndLayoutTracking) {
 }
 
 TEST_F(PositiveSyncObject, ResetUnsignaledFence) {
-    vkt::Fence testFence;
-    VkFenceCreateInfo fenceInfo = vku::InitStructHelper();
-
     RETURN_IF_SKIP(Init());
-    testFence.init(*m_device, fenceInfo);
+    vkt::Fence testFence(*m_device);
     VkFence fences[1] = {testFence.handle()};
     VkResult result = vk::ResetFences(device(), 1, fences);
     ASSERT_EQ(VK_SUCCESS, result);
@@ -406,9 +403,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
 
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
@@ -491,9 +486,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
 
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
@@ -626,9 +619,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
 
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
@@ -713,9 +704,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAnd
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
-
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
+    vkt::Fence fence(*m_device);
 
     VkSemaphoreTypeCreateInfo semaphore_type_create_info = vku::InitStructHelper();
     semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
@@ -807,9 +796,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueWithSemaphoreAndOneFence) {
         "having a fence, followed by a WaitForFences call.");
 
     RETURN_IF_SKIP(Init());
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
@@ -885,8 +872,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueNullQueueSubmitWithFence) {
         "with NO SubmitInfos but with a fence, followed by a WaitForFences call.");
 
     RETURN_IF_SKIP(Init());
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
+    vkt::Fence fence(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -964,8 +950,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueOneFence) {
         "WaitForFences call.");
 
     RETURN_IF_SKIP(Init());
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
+    vkt::Fence fence(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
     pool_create_info.queueFamilyIndex = m_device->graphics_queue_node_index_;
@@ -1038,10 +1023,7 @@ TEST_F(PositiveSyncObject, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) {
     TEST_DESCRIPTION(
         "Two command buffers each in a separate SubmitInfo sent in a single QueueSubmit call followed by a WaitForFences call.");
     RETURN_IF_SKIP(Init());
-
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore semaphore(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
@@ -1142,8 +1124,7 @@ TEST_F(PositiveSyncObject, LongSemaphoreChain) {
         vk::QueueSubmit(m_default_queue->handle(), 1, &si, VK_NULL_HANDLE);
     }
 
-    VkFenceCreateInfo fci = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
-    vkt::Fence fence(*m_device, fci);
+    vkt::Fence fence(*m_device);
     VkSubmitInfo si = {VK_STRUCTURE_TYPE_SUBMIT_INFO, nullptr, 1, &semaphores.back(), &flags, 0, nullptr, 0, nullptr};
     vk::QueueSubmit(m_default_queue->handle(), 1, &si, fence.handle());
 
@@ -1772,9 +1753,7 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
 
     VkFenceCreateInfo fence_info = vku::InitStructHelper();
     fence_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-    vkt::Fence ts_fence;
-    ts_fence.init(*m_device, fence_info);
-    VkFence fence_handle = ts_fence.handle();
+    vkt::Fence ts_fence(*m_device, fence_info);
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
@@ -1810,8 +1789,8 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
     // Write a timestamp, and add a fence to be signalled.
     {
         submit_info.pCommandBuffers = &command_buffer[1];
-        vk::ResetFences(device(), 1, &fence_handle);
-        vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, fence_handle);
+        vk::ResetFences(device(), 1, &ts_fence.handle());
+        vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, ts_fence.handle());
     }
 
     // Reset query pool again.
@@ -1823,7 +1802,7 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
     // Finally, write a second timestamp, but before that, wait for the fence.
     {
         submit_info.pCommandBuffers = &command_buffer[1];
-        vk::WaitForFences(device(), 1, &fence_handle, true, kWaitTimeout);
+        vk::WaitForFences(device(), 1, &ts_fence.handle(), true, kWaitTimeout);
         vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
     }
 
@@ -1859,9 +1838,7 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
     RETURN_IF_SKIP(Init());
 
-    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_ci);
-    auto fence_handle = fence.handle();
+    vkt::Fence fence(*m_device);
 
     VkSemaphoreTypeCreateInfo timeline_ci = vku::InitStructHelper();
     timeline_ci.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE;
@@ -1891,9 +1868,9 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
     m_errorMonitor->SetBailout(&bailout);
 
     for (uint32_t i = 0; i < data.iterations; i++, signal_value++) {
-        vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, fence_handle);
+        vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, fence.handle());
         fence.wait(data.timeout);
-        vk::ResetFences(device(), 1, &fence_handle);
+        vk::ResetFences(device(), 1, &fence.handle());
     }
     m_errorMonitor->SetBailout(nullptr);
 
@@ -1911,9 +1888,7 @@ TEST_F(PositiveSyncObject, SubmitFenceButWaitIdle) {
     std::vector<VkImage> swapchainImages(image_count, VK_NULL_HANDLE);
     vk::GetSwapchainImagesKHR(m_device->handle(), m_swapchain, &image_count, swapchainImages.data());
 
-    VkFenceCreateInfo fence_create_info = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_create_info);
-
+    vkt::Fence fence(*m_device);
     vkt::Semaphore sem(*m_device);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -4590,9 +4590,7 @@ TEST_F(NegativeSyncVal, QSBufferCopyVsFence) {
         GTEST_SKIP() << "Test requires a valid queue object.";
     }
 
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
-    VkFence fence_handle = fence.handle();
+    vkt::Fence fence(*m_device);
     VkResult wait_result;
     vkt::CommandBuffer cbd;
     test.InitFromPool(cbd);
@@ -4609,7 +4607,7 @@ TEST_F(NegativeSyncVal, QSBufferCopyVsFence) {
     // Two copies *better* finish in a second...
     const uint64_t kFourSeconds = 1U << 30;
     // Copy A to B
-    test.Submit0(test.cba, VK_NULL_HANDLE, 0U, VK_NULL_HANDLE, fence_handle);
+    test.Submit0(test.cba, VK_NULL_HANDLE, 0U, VK_NULL_HANDLE, fence.handle());
     // Copy A to C
     test.Submit0(test.cbb);
     // Wait for A to B
@@ -5030,8 +5028,7 @@ TEST_F(NegativeSyncVal, QSPresentAcquire) {
     const VkQueue q = m_default_queue->handle();
     const VkDevice dev = m_device->handle();
 
-    VkFenceCreateInfo fence_ci = vku::InitStructHelper();
-    vkt::Fence fence(*m_device, fence_ci);
+    vkt::Fence fence(*m_device);
     VkFence h_fence = fence.handle();
 
     // Test stability requires that we wait on pending operations before returning starts the Vk*Obj destructors

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -563,8 +563,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
         const auto res = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fences[i].handle(), &image_i);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);
     }
-    vkt::Fence error_fence;
-    error_fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence error_fence(*m_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireNextImageKHR-surface-07783");
     uint32_t image_i;
@@ -689,8 +688,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
         const auto res = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fences[i].handle(), &image_i);
         ASSERT_TRUE(res == VK_SUCCESS || res == VK_SUBOPTIMAL_KHR);
     }
-    vkt::Fence error_fence;
-    error_fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence error_fence(*m_device);
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-vkAcquireNextImage2KHR-surface-07784");
     VkAcquireNextImageInfoKHR acquire_info = vku::InitStructHelper();
@@ -1626,9 +1624,8 @@ TEST_F(NegativeWsi, PresentIdWait) {
     auto images2 = GetSwapchainImages(swapchain2);
 
     uint32_t image_indices[2];
-    vkt::Fence fence, fence2;
-    fence.init(*m_device, vkt::Fence::create_info());
-    fence2.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
+    vkt::Fence fence2(*m_device);
     VkFence fence_handles[2];
     fence_handles[0] = fence.handle();
     fence_handles[1] = fence2.handle();
@@ -1706,8 +1703,7 @@ TEST_F(NegativeWsi, PresentIdWaitFeatures) {
     const auto images = GetSwapchainImages(m_swapchain);
 
     uint32_t image_index;
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), true, kWaitTimeout);
 
@@ -3219,8 +3215,7 @@ TEST_F(NegativeWsi, PresentInfoParameters) {
     RETURN_IF_SKIP(InitSwapchain());
 
     uint32_t image_index;
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), true, kWaitTimeout);
 
@@ -3246,8 +3241,7 @@ TEST_F(NegativeWsi, PresentRegionsKHR) {
     RETURN_IF_SKIP(InitSwapchain());
 
     uint32_t image_index;
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), true, kWaitTimeout);
 
@@ -3314,13 +3308,11 @@ TEST_F(PositiveWsi, UseDestroyedSwapchain) {
     swapchain_images.resize(swapchain_images_count);
     vk::GetSwapchainImagesKHR(device(), m_swapchain, &swapchain_images_count, swapchain_images.data());
 
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
-    VkFence fence_handle = fence.handle();
+    vkt::Fence fence(*m_device);
     uint32_t index;
-    vk::ResetFences(device(), 1, &fence_handle);
-    vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence_handle, &index);
-    vk::WaitForFences(device(), 1, &fence_handle, VK_TRUE, kWaitTimeout);
+    vk::ResetFences(device(), 1, &fence.handle());
+    vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &index);
+    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = swapchain_images[index];
@@ -3437,10 +3429,8 @@ TEST_F(NegativeWsi, PresentDuplicatedSwapchain) {
 
     auto images = GetSwapchainImages(m_swapchain);
 
-    vkt::Fence fence1;
-    fence1.init(*m_device, vkt::Fence::create_info());
-    vkt::Fence fence2;
-    fence2.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence1(*m_device);
+    vkt::Fence fence2(*m_device);
 
     VkSwapchainKHR swapchains[2] = {m_swapchain, m_swapchain};
     uint32_t image_indices[2];

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -373,13 +373,11 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
 
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
-    VkFence fence_handle = fence.handle();
+    vkt::Fence fence(*m_device);
 
     uint32_t image_index;
-    vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence_handle, &image_index);
-    vk::WaitForFences(device(), 1, &fence_handle, VK_TRUE, kWaitTimeout);
+    vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
+    vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
 
     m_commandBuffer->begin();
 
@@ -798,8 +796,7 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
     const auto images = GetSwapchainImages(m_swapchain);
 
     uint32_t image_index;
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), true, kWaitTimeout);
 
@@ -1367,8 +1364,7 @@ TEST_F(PositiveWsi, AcquireImageBeforeGettingSwapchainImages) {
     VkSwapchainKHR swapchain;
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &swapchain);
 
-    vkt::Fence fence;
-    fence.init(*m_device, vkt::Fence::create_info());
+    vkt::Fence fence(*m_device);
 
     uint32_t imageIndex;
     vk::AcquireNextImageKHR(device(), swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &imageIndex);


### PR DESCRIPTION
Small cleanup of creating `vkt::Fence` that use the default values