### PR TITLE
Consistent use of ValidationStateTracker

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -50,10 +50,11 @@ WriteLockGuard BestPractices::WriteLock() {
 std::shared_ptr<vvl::CommandBuffer> BestPractices::CreateCmdBufferState(VkCommandBuffer handle,
                                                                         const VkCommandBufferAllocateInfo* pCreateInfo,
                                                                         const vvl::CommandPool* pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<bp_state::CommandBuffer>(this, handle, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(
+        std::make_shared<bp_state::CommandBuffer>(*this, handle, pCreateInfo, pool));
 }
 
-bp_state::CommandBuffer::CommandBuffer(BestPractices* bp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+bp_state::CommandBuffer::CommandBuffer(BestPractices& bp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
                                        const vvl::CommandPool* pool)
     : vvl::CommandBuffer(bp, cb, pCreateInfo, pool) {}
 

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -184,5 +184,5 @@ bool BestPractices::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice devic
 
 std::shared_ptr<vvl::DescriptorPool> BestPractices::CreateDescriptorPoolState(VkDescriptorPool handle,
                                                                               const VkDescriptorPoolCreateInfo* pCreateInfo) {
-    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(this, handle, pCreateInfo));
+    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(*this, handle, pCreateInfo));
 }

--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -297,11 +297,11 @@ void BestPractices::ValidateImageInQueue(const vvl::Queue& qs, const vvl::Comman
 
 std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<bp_state::Image>(this, handle, pCreateInfo, features);
+    return std::make_shared<bp_state::Image>(*this, handle, pCreateInfo, features);
 }
 
 std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                             VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<bp_state::Image>(this, handle, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<bp_state::Image>(*this, handle, pCreateInfo, swapchain, swapchain_index, features);
 }

--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -174,8 +174,8 @@ void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std:
 
 void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std::shared_ptr<bp_state::Image>& state,
                                        IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level) {
-    funcs.push_back([this, command, state, usage, array_layer, mip_level](const ValidationStateTracker& vst, const vvl::Queue& qs,
-                                                                          const vvl::CommandBuffer& cbs) -> bool {
+    funcs.push_back([this, command, state, usage, array_layer, mip_level](
+                        const ValidationStateTracker& validator, const vvl::Queue& qs, const vvl::CommandBuffer& cbs) -> bool {
         ValidateImageInQueue(qs, cbs, command, *state, usage, array_layer, mip_level);
         return false;
     });

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -252,7 +252,7 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
     return result;
 }
 
-bp_state::Pipeline::Pipeline(const ValidationStateTracker* validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+bp_state::Pipeline::Pipeline(const ValidationStateTracker& validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
                              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache,
                              std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout,
                              CreateShaderModuleStates* csm_states)
@@ -265,7 +265,7 @@ std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(const 
                                                                           std::shared_ptr<const vvl::PipelineLayout>&& layout,
                                                                           CreateShaderModuleStates* csm_states) const {
     return std::static_pointer_cast<vvl::Pipeline>(std::make_shared<bp_state::Pipeline>(
-        this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), csm_states));
+        *this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), csm_states));
 }
 
 void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -252,11 +252,11 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
     return result;
 }
 
-bp_state::Pipeline::Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+bp_state::Pipeline::Pipeline(const ValidationStateTracker* validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
                              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache,
                              std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout,
                              CreateShaderModuleStates* csm_states)
-    : vvl::Pipeline(state_data, pCreateInfo, std::move(pipe_cache), std::move(rpstate), std::move(layout), csm_states),
+    : vvl::Pipeline(validator, pCreateInfo, std::move(pipe_cache), std::move(rpstate), std::move(layout), csm_states),
       access_framebuffer_attachments(GetAttachmentAccess(*this)) {}
 
 std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -31,15 +31,15 @@ class BestPractices;
 namespace bp_state {
 class Image : public vvl::Image {
   public:
-    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo,
+    Image(const ValidationStateTracker* validator, VkImage handle, const VkImageCreateInfo* pCreateInfo,
           VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, handle, pCreateInfo, features) {
+        : vvl::Image(validator, handle, pCreateInfo, features) {
         SetupUsages();
     }
 
-    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker* validator, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, handle, pCreateInfo, swapchain, swapchain_index, features) {
+        : vvl::Image(validator, handle, pCreateInfo, swapchain, swapchain_index, features) {
         SetupUsages();
     }
 
@@ -100,8 +100,8 @@ class PhysicalDevice : public vvl::PhysicalDevice {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
-        : vvl::Swapchain(dev_data, pCreateInfo, handle) {}
+    Swapchain(ValidationStateTracker* validator, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
+        : vvl::Swapchain(validator, pCreateInfo, handle) {}
 
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
 };
@@ -203,15 +203,15 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 class DescriptorPool : public vvl::DescriptorPool {
   public:
-    DescriptorPool(ValidationStateTracker* dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
-        : vvl::DescriptorPool(dev, handle, pCreateInfo) {}
+    DescriptorPool(ValidationStateTracker* validator, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
+        : vvl::DescriptorPool(validator, handle, pCreateInfo) {}
 
     uint32_t freed_count{0};
 };
 
 class Pipeline : public vvl::Pipeline {
   public:
-    Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    Pipeline(const ValidationStateTracker* validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache, std::shared_ptr<const vvl::RenderPass>&& rpstate,
              std::shared_ptr<const vvl::PipelineLayout>&& layout, CreateShaderModuleStates* csm_states);
 

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -31,13 +31,13 @@ class BestPractices;
 namespace bp_state {
 class Image : public vvl::Image {
   public:
-    Image(const ValidationStateTracker* validator, VkImage handle, const VkImageCreateInfo* pCreateInfo,
+    Image(const ValidationStateTracker& validator, VkImage handle, const VkImageCreateInfo* pCreateInfo,
           VkFormatFeatureFlags2KHR features)
         : vvl::Image(validator, handle, pCreateInfo, features) {
         SetupUsages();
     }
 
-    Image(const ValidationStateTracker* validator, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker& validator, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
         : vvl::Image(validator, handle, pCreateInfo, swapchain, swapchain_index, features) {
         SetupUsages();
@@ -100,7 +100,7 @@ class PhysicalDevice : public vvl::PhysicalDevice {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker* validator, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
+    Swapchain(ValidationStateTracker& validator, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
         : vvl::Swapchain(validator, pCreateInfo, handle) {}
 
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
@@ -189,7 +189,7 @@ struct CommandBufferStateNV {
 
 class CommandBuffer : public vvl::CommandBuffer {
   public:
-    CommandBuffer(BestPractices* bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CommandBuffer(BestPractices& bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
                   const vvl::CommandPool* pool);
 
     RenderPassState render_pass_state;
@@ -203,7 +203,7 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 class DescriptorPool : public vvl::DescriptorPool {
   public:
-    DescriptorPool(ValidationStateTracker* validator, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
+    DescriptorPool(ValidationStateTracker& validator, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
         : vvl::DescriptorPool(validator, handle, pCreateInfo) {}
 
     uint32_t freed_count{0};
@@ -211,7 +211,7 @@ class DescriptorPool : public vvl::DescriptorPool {
 
 class Pipeline : public vvl::Pipeline {
   public:
-    Pipeline(const ValidationStateTracker* validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    Pipeline(const ValidationStateTracker& validator, const VkGraphicsPipelineCreateInfo* pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache, std::shared_ptr<const vvl::RenderPass>&& rpstate,
              std::shared_ptr<const vvl::PipelineLayout>&& layout, CreateShaderModuleStates* csm_states);
 

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -399,7 +399,7 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
         barrier.dstQueueFamilyIndex == cb_state->command_pool->queueFamilyIndex) {
         auto image = Get<bp_state::Image>(barrier.image);
         auto subresource_range = barrier.subresourceRange;
-        cb_state->queue_submit_functions.push_back([image, subresource_range](const ValidationStateTracker& vst,
+        cb_state->queue_submit_functions.push_back([image, subresource_range](const ValidationStateTracker& validator,
                                                                               const vvl::Queue& qs,
                                                                               const vvl::CommandBuffer& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {

--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -386,5 +386,5 @@ void BestPractices::ManualPostCallRecordGetSwapchainImagesKHR(VkDevice device, V
 
 std::shared_ptr<vvl::Swapchain> BestPractices::CreateSwapchainState(const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                     VkSwapchainKHR handle) {
-    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(this, pCreateInfo, handle));
+    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(*this, pCreateInfo, handle));
 }

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1840,7 +1840,7 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 
         auto queue_submit_validation = [this, commandBuffer, src_buffer_state, dst_buffer_state, regionCount, src_ranges,
                                         dst_ranges, loc,
-                                        vuid](const ValidationStateTracker &device_data, const class vvl::Queue &queue_state,
+                                        vuid](const ValidationStateTracker &validator, const class vvl::Queue &queue_state,
                                               const vvl::CommandBuffer &cb_state) -> bool {
             bool skip = false;
             for (uint32_t i = 0; i < regionCount; ++i) {

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -756,9 +756,9 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
 bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, Func command,
                                     VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
     bool skip = false;
-    auto state_data = cb_state.dev_data;
+    auto validator = cb_state.validator;
 
-    auto query_pool_state = state_data->Get<vvl::QueryPool>(query_obj.pool);
+    auto query_pool_state = validator->Get<vvl::QueryPool>(query_obj.pool);
     const auto &query_pool_ci = query_pool_state->create_info;
 
     QueryState state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
@@ -793,12 +793,12 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
                                : unexpected_caller_vuid;
         assert(strcmp(vuid, unexpected_caller_vuid) != 0);
 
-        skip |= state_data->LogError(vuid, objlist, loc,
-                                     "%s and query %" PRIu32
-                                     ": query not reset. "
-                                     "After query pool creation, each query must be reset before it is used. "
-                                     "Queries must also be reset between uses.",
-                                     state_data->FormatHandle(query_obj.pool).c_str(), query_obj.slot);
+        skip |= validator->LogError(vuid, objlist, loc,
+                                    "%s and query %" PRIu32
+                                    ": query not reset. "
+                                    "After query pool creation, each query must be reset before it is used. "
+                                    "Queries must also be reset between uses.",
+                                    validator->FormatHandle(query_obj.pool).c_str(), query_obj.slot);
     }
 
     return skip;
@@ -806,8 +806,8 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
 
 bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, Func command,
                                           VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
-    auto state_data = cb_state.dev_data;
-    auto query_pool_state = state_data->Get<vvl::QueryPool>(query_obj.pool);
+    auto validator = cb_state.validator;
+    auto query_pool_state = validator->Get<vvl::QueryPool>(query_obj.pool);
     const auto &query_pool_ci = query_pool_state->create_info;
     const Location loc(command);
 
@@ -817,23 +817,23 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
 
     if (perfPass >= query_pool_state->n_performance_passes) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError("VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221", objlist, loc,
-                                     "Invalid counterPassIndex (%u, maximum allowed %u) value for query pool %s.", perfPass,
-                                     query_pool_state->n_performance_passes, state_data->FormatHandle(query_obj.pool).c_str());
+        skip |= validator->LogError("VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221", objlist, loc,
+                                    "Invalid counterPassIndex (%u, maximum allowed %u) value for query pool %s.", perfPass,
+                                    query_pool_state->n_performance_passes, validator->FormatHandle(query_obj.pool).c_str());
     }
 
     if (!cb_state.performance_lock_acquired || cb_state.performance_lock_released) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError("VUID-vkQueueSubmit-pCommandBuffers-03220", objlist, loc,
-                                     "Commandbuffer %s was submitted and contains a performance query but the"
-                                     "profiling lock was not held continuously throughout the recording of commands.",
-                                     state_data->FormatHandle(cb_state).c_str());
+        skip |= validator->LogError("VUID-vkQueueSubmit-pCommandBuffers-03220", objlist, loc,
+                                    "Commandbuffer %s was submitted and contains a performance query but the"
+                                    "profiling lock was not held continuously throughout the recording of commands.",
+                                    validator->FormatHandle(cb_state).c_str());
     }
 
     QueryState command_buffer_state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
     if (command_buffer_state == QUERYSTATE_RESET) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError(
+        skip |= validator->LogError(
             query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-02863" : "VUID-vkCmdBeginQuery-None-02863", objlist, loc,
             "VkQuery begin command recorded in a command buffer that, either directly or "
             "through secondary command buffers, also contains a vkCmdResetQueryPool command "
@@ -841,14 +841,14 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
     }
 
     if (firstPerfQueryPool != VK_NULL_HANDLE) {
-        if (firstPerfQueryPool != query_obj.pool && !state_data->enabled_features.performanceCounterMultipleQueryPools) {
+        if (firstPerfQueryPool != query_obj.pool && !validator->enabled_features.performanceCounterMultipleQueryPools) {
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-            skip |= state_data->LogError(
+            skip |= validator->LogError(
                 query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03226" : "VUID-vkCmdBeginQuery-queryPool-03226",
                 objlist, loc,
                 "Commandbuffer %s contains more than one performance query pool but "
                 "performanceCounterMultipleQueryPools is not enabled.",
-                state_data->FormatHandle(cb_state).c_str());
+                validator->FormatHandle(cb_state).c_str());
         }
     } else {
         firstPerfQueryPool = query_obj.pool;
@@ -886,8 +886,8 @@ void CoreChecks::EnqueueVerifyEndQuery(vvl::CommandBuffer &cb_state, const Query
                                                                   QueryMap *localQueryToStateMap) {
         if (!do_validate) return false;
         bool skip = false;
-        // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
-        auto query_pool_state = cb_state_arg.dev_data->Get<vvl::QueryPool>(query_obj.pool);
+        // NOTE: validator == this, but the compiler "Visual Studio 16" complains Get is ambiguous if validator isn't used
+        auto query_pool_state = cb_state_arg.validator->Get<vvl::QueryPool>(query_obj.pool);
         if (query_pool_state->has_perf_scope_command_buffer && (cb_state_arg.command_count - 1) != query_obj.end_command_index) {
             const LogObjectList objlist(cb_state_arg.Handle(), query_pool_state->Handle());
             const Location loc(command);
@@ -1058,15 +1058,15 @@ void CoreChecks::PreCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, V
                                                 vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                                 uint32_t perfPass, QueryMap *localQueryToStateMap) {
             if (!do_validate) return false;
-            const auto state_data = cb_state_arg.dev_data;
+            const auto validator = cb_state_arg.validator;
             bool skip = false;
             for (uint32_t i = 0; i < queryCount; i++) {
                 QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
                 if (state == QUERYSTATE_ENDED) {
                     const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
-                    skip |= state_data->LogError("VUID-vkCmdResetQueryPool-firstQuery-02862", objlist, record_obj.location,
-                                                 "Query index %" PRIu32 " was begun and reset in the same command buffer.",
-                                                 firstQuery + i);
+                    skip |= validator->LogError("VUID-vkCmdResetQueryPool-firstQuery-02862", objlist, record_obj.location,
+                                                "Query index %" PRIu32 " was begun and reset in the same command buffer.",
+                                                firstQuery + i);
                     break;
                 }
             }
@@ -1196,22 +1196,22 @@ void CoreChecks::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuf
                                             vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                             uint32_t perfPass, QueryMap *localQueryToStateMap) {
         if (!do_validate) return false;
-        const auto state_data = cb_state_arg.dev_data;
+        const auto validator = cb_state_arg.validator;
         bool skip = false;
         for (uint32_t i = 0; i < queryCount; i++) {
             QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
             QueryResultType result_type = GetQueryResultType(state, flags);
             if (result_type != QUERYRESULT_SOME_DATA && result_type != QUERYRESULT_UNKNOWN) {
                 const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
-                skip |= state_data->LogError("VUID-vkCmdCopyQueryPoolResults-None-08752", objlist, record_obj.location,
-                                             "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
-                                             state_data->FormatHandle(queryPool).c_str(), firstQuery + i,
-                                             string_QueryResultType(result_type));
+                skip |= validator->LogError("VUID-vkCmdCopyQueryPoolResults-None-08752", objlist, record_obj.location,
+                                            "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
+                                            validator->FormatHandle(queryPool).c_str(), firstQuery + i,
+                                            string_QueryResultType(result_type));
             }
         }
 
-        // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
-        auto query_pool_state = cb_state_arg.dev_data->Get<vvl::QueryPool>(queryPool);
+        // NOTE: validator == this, but the compiler "Visual Studio 16" complains Get is ambiguous if validator isn't used
+        auto query_pool_state = cb_state_arg.validator->Get<vvl::QueryPool>(queryPool);
         skip |= ValidateQueryPoolWasReset(*query_pool_state, firstQuery, queryCount, record_obj.location, localQueryToStateMap,
                                           perfPass);
 

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -91,12 +91,12 @@ bool CoreChecks::IsImageCompatibleWithVideoProfile(const vvl::Image &image_state
 void CoreChecks::EnqueueVerifyVideoSessionInitialized(vvl::CommandBuffer &cb_state, vvl::VideoSession &vs_state,
                                                       const Location &loc, const char *vuid) {
     cb_state.video_session_updates[vs_state.VkHandle()].emplace_back(
-        [loc, vuid](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
+        [loc, vuid](const ValidationStateTracker &validator, const vvl::VideoSession *vs_state,
                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
             bool skip = false;
             if (!dev_state.IsInitialized()) {
-                skip |= validator->LogError(vuid, vs_state->Handle(), loc, "Bound video session %s is uninitialized.",
-                                            validator->FormatHandle(*vs_state).c_str());
+                skip |= validator.LogError(vuid, vs_state->Handle(), loc, "Bound video session %s is uninitialized.",
+                                           validator.FormatHandle(*vs_state).c_str());
             }
             return skip;
         });
@@ -1403,8 +1403,8 @@ bool CoreChecks::ValidateVideoDecodeInfoAV1(const vvl::CommandBuffer &cb_state, 
             }
 
             if (decode_info.pSetupReferenceSlot != nullptr && decode_info.pSetupReferenceSlot->pPictureResource != nullptr) {
-                auto dst_resource = vvl::VideoPictureResource(this, decode_info.dstPictureResource);
-                auto setup_resource = vvl::VideoPictureResource(this, *decode_info.pSetupReferenceSlot->pPictureResource);
+                auto dst_resource = vvl::VideoPictureResource(*this, decode_info.dstPictureResource);
+                auto setup_resource = vvl::VideoPictureResource(*this, *decode_info.pSetupReferenceSlot->pPictureResource);
                 if (dst_resource == setup_resource) {
                     skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-09249", cb_state.Handle(),
                                      loc.pNext(Struct::VkVideoDecodeAV1PictureInfoKHR, Field::pStdPictureInfo),
@@ -3337,7 +3337,7 @@ bool CoreChecks::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer commandBu
             }
 
             if (slot.pPictureResource != nullptr) {
-                auto reference_resource = vvl::VideoPictureResource(this, *slot.pPictureResource);
+                auto reference_resource = vvl::VideoPictureResource(*this, *slot.pPictureResource);
                 skip |= ValidateVideoPictureResource(reference_resource, commandBuffer, *vs_state,
                                                      begin_info_loc.dot(Field::pReferenceSlots, i).dot(Field::pPictureResource),
                                                      "VUID-VkVideoBeginCodingInfoKHR-pPictureResource-07242",
@@ -3553,30 +3553,30 @@ void CoreChecks::PreCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuff
 
         for (uint32_t i = 0; i < pBeginInfo->referenceSlotCount; ++i) {
             if (pBeginInfo->pReferenceSlots[i].slotIndex >= 0) {
-                expected_slots.emplace_back(this, *vs_state->profile, pBeginInfo->pReferenceSlots[i], false);
+                expected_slots.emplace_back(*this, *vs_state->profile, pBeginInfo->pReferenceSlots[i], false);
             }
         }
 
         // Enqueue submission time validation of DPB slots
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [expected_slots, loc](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
+            [expected_slots, loc](const ValidationStateTracker &validator, const vvl::VideoSession *vs_state,
                                   vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                 if (!do_validate) return false;
                 bool skip = false;
                 for (const auto &slot : expected_slots) {
                     if (!dev_state.IsSlotActive(slot.index)) {
-                        skip |= validator->LogError("VUID-vkCmdBeginVideoCodingKHR-slotIndex-07239", vs_state->Handle(), loc,
-                                                    "DPB slot index %d is not active in %s.", slot.index,
-                                                    validator->FormatHandle(*vs_state).c_str());
+                        skip |= validator.LogError("VUID-vkCmdBeginVideoCodingKHR-slotIndex-07239", vs_state->Handle(), loc,
+                                                   "DPB slot index %d is not active in %s.", slot.index,
+                                                   validator.FormatHandle(*vs_state).c_str());
                     } else if (slot.resource && !dev_state.IsSlotPicture(slot.index, slot.resource)) {
-                        skip |= validator->LogError("VUID-vkCmdBeginVideoCodingKHR-pPictureResource-07265", vs_state->Handle(), loc,
-                                                    "DPB slot index %d of %s is not currently associated with the specified "
-                                                    "video picture resource: %s, layer %u, offset (%s), extent (%s).",
-                                                    slot.index, validator->FormatHandle(*vs_state).c_str(),
-                                                    validator->FormatHandle(slot.resource.image_state->Handle()).c_str(),
-                                                    slot.resource.range.baseArrayLayer,
-                                                    string_VkOffset2D(slot.resource.coded_offset).c_str(),
-                                                    string_VkExtent2D(slot.resource.coded_extent).c_str());
+                        skip |= validator.LogError("VUID-vkCmdBeginVideoCodingKHR-pPictureResource-07265", vs_state->Handle(), loc,
+                                                   "DPB slot index %d of %s is not currently associated with the specified "
+                                                   "video picture resource: %s, layer %u, offset (%s), extent (%s).",
+                                                   slot.index, validator.FormatHandle(*vs_state).c_str(),
+                                                   validator.FormatHandle(slot.resource.image_state->Handle()).c_str(),
+                                                   slot.resource.range.baseArrayLayer,
+                                                   string_VkOffset2D(slot.resource.coded_offset).c_str(),
+                                                   string_VkExtent2D(slot.resource.coded_extent).c_str());
                     }
                 }
                 return skip;
@@ -3588,7 +3588,7 @@ void CoreChecks::PreCallRecordCmdBeginVideoCodingKHR(VkCommandBuffer commandBuff
 
         // Enqueue submission time validation of rate control state
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [begin_info, loc](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
+            [begin_info, loc](const ValidationStateTracker &validator, const vvl::VideoSession *vs_state,
                               vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                 if (!do_validate) return false;
                 return dev_state.ValidateRateControlState(validator, vs_state, begin_info, loc);
@@ -3806,7 +3806,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
         }
 
         if (pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-            setup_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
+            setup_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
             if (setup_resource) {
                 skip |= ValidateVideoPictureResource(setup_resource, commandBuffer, *vs_state,
                                                      decode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource),
@@ -3828,7 +3828,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
         }
     }
 
-    auto dst_resource = vvl::VideoPictureResource(this, pDecodeInfo->dstPictureResource);
+    auto dst_resource = vvl::VideoPictureResource(*this, pDecodeInfo->dstPictureResource);
     skip |=
         ValidateVideoPictureResource(dst_resource, commandBuffer, *vs_state, decode_info_loc.dot(Field::dstPictureResource),
                                      "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07144", "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07145");
@@ -3928,7 +3928,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
             }
 
             if (pDecodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-                auto reference_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
+                auto reference_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
                 if (reference_resource) {
                     if (!unique_resources.emplace(reference_resource).second) {
                         resources_unique = false;
@@ -4065,25 +4065,25 @@ void CoreChecks::PreCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer, c
         std::vector<vvl::VideoReferenceSlot> reference_slots{};
         reference_slots.reserve(pDecodeInfo->referenceSlotCount);
         for (uint32_t i = 0; i < pDecodeInfo->referenceSlotCount; ++i) {
-            reference_slots.emplace_back(this, *vs_state->profile, pDecodeInfo->pReferenceSlots[i]);
+            reference_slots.emplace_back(*this, *vs_state->profile, pDecodeInfo->pReferenceSlots[i]);
         }
 
         // Enqueue submission time validation of picture kind (frame, top field, bottom field) for H.264
         cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
-            [reference_slots, loc](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
+            [reference_slots, loc](const ValidationStateTracker &validator, const vvl::VideoSession *vs_state,
                                    vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                 if (!do_validate) return false;
                 bool skip = false;
                 const auto log_picture_kind_error = [&](const vvl::VideoReferenceSlot &slot, const char *vuid,
                                                         const char *picture_kind) -> bool {
-                    return validator->LogError(vuid, vs_state->Handle(), loc,
-                                               "DPB slot index %d of %s does not currently contain a %s with the specified "
-                                               "video picture resource: %s, layer %u, offset (%s), extent (%s).",
-                                               slot.index, validator->FormatHandle(*vs_state).c_str(), picture_kind,
-                                               validator->FormatHandle(slot.resource.image_state->Handle()).c_str(),
-                                               slot.resource.range.baseArrayLayer,
-                                               string_VkOffset2D(slot.resource.coded_offset).c_str(),
-                                               string_VkExtent2D(slot.resource.coded_extent).c_str());
+                    return validator.LogError(vuid, vs_state->Handle(), loc,
+                                              "DPB slot index %d of %s does not currently contain a %s with the specified "
+                                              "video picture resource: %s, layer %u, offset (%s), extent (%s).",
+                                              slot.index, validator.FormatHandle(*vs_state).c_str(), picture_kind,
+                                              validator.FormatHandle(slot.resource.image_state->Handle()).c_str(),
+                                              slot.resource.range.baseArrayLayer,
+                                              string_VkOffset2D(slot.resource.coded_offset).c_str(),
+                                              string_VkExtent2D(slot.resource.coded_extent).c_str());
                 };
                 for (const auto &slot : reference_slots) {
                     if (slot.picture_id.IsFrame() &&
@@ -4237,7 +4237,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         }
 
         if (pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-            setup_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
+            setup_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
             if (setup_resource) {
                 skip |= ValidateVideoPictureResource(setup_resource, commandBuffer, *vs_state,
                                                      encode_info_loc.dot(Field::pSetupReferenceSlot).dot(Field::pPictureResource),
@@ -4260,7 +4260,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
         }
     }
 
-    auto src_resource = vvl::VideoPictureResource(this, pEncodeInfo->srcPictureResource);
+    auto src_resource = vvl::VideoPictureResource(*this, pEncodeInfo->srcPictureResource);
     skip |=
         ValidateVideoPictureResource(src_resource, commandBuffer, *vs_state, encode_info_loc.dot(Field::srcPictureResource),
                                      "VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08208", "VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08209");
@@ -4338,7 +4338,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
             }
 
             if (pEncodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-                auto reference_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
+                auto reference_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
                 if (reference_resource) {
                     if (!unique_resources.emplace(reference_resource).second) {
                         resources_unique = false;
@@ -4478,18 +4478,17 @@ void CoreChecks::PreCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer, c
             // so we only have to do submit-time validation if that's not the case
             cb_state->video_session_updates[vs_state->VkHandle()].emplace_back(
                 [vsp_state = cb_state->bound_video_session_parameters, loc](
-                    const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
+                    const ValidationStateTracker &validator, const vvl::VideoSession *vs_state,
                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (!do_validate) return false;
                     bool skip = false;
                     if (vsp_state->GetEncodeQualityLevel() != dev_state.GetEncodeQualityLevel()) {
                         const LogObjectList objlist(vs_state->Handle(), vsp_state->Handle());
-                        skip |=
-                            validator->LogError("VUID-vkCmdEncodeVideoKHR-None-08318", objlist, loc,
-                                                "The currently configured encode quality level (%u) for %s "
-                                                "does not match the encode quality level (%u) %s was created with.",
-                                                dev_state.GetEncodeQualityLevel(), validator->FormatHandle(*vs_state).c_str(),
-                                                vsp_state->GetEncodeQualityLevel(), validator->FormatHandle(*vsp_state).c_str());
+                        skip |= validator.LogError("VUID-vkCmdEncodeVideoKHR-None-08318", objlist, loc,
+                                                   "The currently configured encode quality level (%u) for %s "
+                                                   "does not match the encode quality level (%u) %s was created with.",
+                                                   dev_state.GetEncodeQualityLevel(), validator.FormatHandle(*vs_state).c_str(),
+                                                   vsp_state->GetEncodeQualityLevel(), validator.FormatHandle(*vsp_state).c_str());
                     }
                     return skip;
                 });

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -832,7 +832,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
     bool skip = false;
     auto queue_state = Get<vvl::Queue>(queue);
 
-    SemaphoreSubmitState sem_submit_state(this, queue,
+    SemaphoreSubmitState sem_submit_state(*this, queue,
                                           physical_device_state->queue_family_properties[queue_state->queueFamilyIndex].queueFlags);
 
     const Location present_info_loc = error_obj.location.dot(Struct::VkPresentInfoKHR, Field::pPresentInfo);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -48,7 +48,7 @@ typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRan
 // class.
 class CORE_CMD_BUFFER_STATE : public vvl::CommandBuffer {
   public:
-    CORE_CMD_BUFFER_STATE(ValidationStateTracker* validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CORE_CMD_BUFFER_STATE(ValidationStateTracker& validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
                           const vvl::CommandPool* cmd_pool)
         : vvl::CommandBuffer(validator, cb, pCreateInfo, cmd_pool) {}
 
@@ -2442,6 +2442,6 @@ class CoreChecks : public ValidationStateTracker {
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
     std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
                                                              const vvl::CommandPool* pool) override {
-        return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CORE_CMD_BUFFER_STATE>(this, cb, create_info, pool));
+        return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CORE_CMD_BUFFER_STATE>(*this, cb, create_info, pool));
     }
 };  // Class CoreChecks

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -48,9 +48,9 @@ typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRan
 // class.
 class CORE_CMD_BUFFER_STATE : public vvl::CommandBuffer {
   public:
-    CORE_CMD_BUFFER_STATE(ValidationStateTracker* dev_data, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CORE_CMD_BUFFER_STATE(ValidationStateTracker* validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
                           const vvl::CommandPool* cmd_pool)
-        : vvl::CommandBuffer(dev_data, cb, pCreateInfo, cmd_pool) {}
+        : vvl::CommandBuffer(validator, cb, pCreateInfo, cmd_pool) {}
 
     void RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
                           VkPipelineStageFlags2KHR src_stage_mask) override;
@@ -170,7 +170,7 @@ class CoreChecks : public ValidationStateTracker {
                                         const ImageBarrier& img_barrier,
                                         const vvl::CommandBuffer* primary_cb_state = nullptr) const;
 
-    static bool ValidateConcurrentBarrierAtSubmit(const Location& loc, const ValidationStateTracker& state_data,
+    static bool ValidateConcurrentBarrierAtSubmit(const Location& loc, const ValidationStateTracker& validator,
                                                   const vvl::Queue& queue_data, const vvl::CommandBuffer& cb_state,
                                                   const VulkanTypedHandle& typed_handle, uint32_t src_queue_family,
                                                   uint32_t dst_queue_family);

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -122,7 +122,7 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             auto &imgs_binding = static_cast<vvl::ImageSamplerBinding &>(binding);
             for (auto index : indices) {
                 auto &descriptor = imgs_binding.descriptors[index];
-                descriptor.UpdateDrawState(&validator, &cb_state);
+                descriptor.UpdateDrawState(validator, &cb_state);
             }
             skip |= ValidateDescriptors(binding_info, imgs_binding, indices);
             break;
@@ -131,7 +131,7 @@ bool vvl::DescriptorValidator::ValidateBinding(const DescriptorBindingInfo &bind
             auto &img_binding = static_cast<vvl::ImageBinding &>(binding);
             for (auto index : indices) {
                 auto &descriptor = img_binding.descriptors[index];
-                descriptor.UpdateDrawState(&validator, &cb_state);
+                descriptor.UpdateDrawState(validator, &cb_state);
             }
             skip |= ValidateDescriptors(binding_info, img_binding, indices);
             break;

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -44,7 +44,7 @@ class DescriptorValidator {
 
    template <typename T>
    std::string FormatHandle(T&& h) const {
-       return dev_state.FormatHandle(std::forward<T>(h));
+       return validator.FormatHandle(std::forward<T>(h));
     }
 
     bool ValidateBinding(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;
@@ -76,7 +76,7 @@ class DescriptorValidator {
     bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
                                    const vvl::Sampler* sampler_state) const;
 
-    ValidationStateTracker& dev_state;
+    ValidationStateTracker& validator;
     vvl::CommandBuffer& cb_state;
     vvl::DescriptorSet& descriptor_set;
     const uint32_t set_index;

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -416,7 +416,7 @@ void debug_printf::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer command
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
 void debug_printf::CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<debug_printf::Validator *>(validator);
+    auto *device_state = static_cast<debug_printf::Validator *>(&validator);
     if (has_draw_cmd || has_trace_rays_cmd || has_dispatch_cmd) {
         auto &gpu_buffer_list = buffer_infos;
         uint32_t draw_index = 0;
@@ -737,12 +737,13 @@ void debug_printf::Validator::AllocateDebugPrintfResources(const VkCommandBuffer
 std::shared_ptr<vvl::CommandBuffer> debug_printf::Validator::CreateCmdBufferState(VkCommandBuffer cb,
                                                                                   const VkCommandBufferAllocateInfo *pCreateInfo,
                                                                                   const vvl::CommandPool *pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<debug_printf::CommandBuffer>(this, cb, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(
+        std::make_shared<debug_printf::CommandBuffer>(*this, cb, pCreateInfo, pool));
 }
 
-debug_printf::CommandBuffer::CommandBuffer(debug_printf::Validator *dp, VkCommandBuffer cb,
+debug_printf::CommandBuffer::CommandBuffer(debug_printf::Validator &validator, VkCommandBuffer cb,
                                            const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool)
-    : gpu_tracker::CommandBuffer(dp, cb, pCreateInfo, pool) {}
+    : gpu_tracker::CommandBuffer(validator, cb, pCreateInfo, pool) {}
 
 debug_printf::CommandBuffer::~CommandBuffer() { Destroy(); }
 
@@ -757,7 +758,7 @@ void debug_printf::CommandBuffer::Reset() {
 }
 
 void debug_printf::CommandBuffer::ResetCBState() {
-    auto debug_printf = static_cast<debug_printf::Validator *>(validator);
+    auto debug_printf = static_cast<debug_printf::Validator *>(&validator);
     // Free the device memory and descriptor set(s) associated with a command buffer.
     if (debug_printf->aborted) {
         return;

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -416,7 +416,7 @@ void debug_printf::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer command
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
 void debug_printf::CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<debug_printf::Validator *>(dev_data);
+    auto *device_state = static_cast<debug_printf::Validator *>(validator);
     if (has_draw_cmd || has_trace_rays_cmd || has_dispatch_cmd) {
         auto &gpu_buffer_list = buffer_infos;
         uint32_t draw_index = 0;
@@ -757,7 +757,7 @@ void debug_printf::CommandBuffer::Reset() {
 }
 
 void debug_printf::CommandBuffer::ResetCBState() {
-    auto debug_printf = static_cast<debug_printf::Validator *>(dev_data);
+    auto debug_printf = static_cast<debug_printf::Validator *>(validator);
     // Free the device memory and descriptor set(s) associated with a command buffer.
     if (debug_printf->aborted) {
         return;

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -59,7 +59,8 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
   public:
     std::vector<BufferInfo> buffer_infos;
 
-    CommandBuffer(Validator* dp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info, const vvl::CommandPool* pool);
+    CommandBuffer(Validator& validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
+                  const vvl::CommandPool* pool);
     ~CommandBuffer();
 
     bool PreProcess() final { return !buffer_infos.empty(); }

--- a/layers/gpu_validation/gpu_descriptor_set.cpp
+++ b/layers/gpu_validation/gpu_descriptor_set.cpp
@@ -76,7 +76,7 @@ gpuav::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPo
 
 gpuav::DescriptorSet::~DescriptorSet() {
     Destroy();
-    Validator *gv_dev = static_cast<Validator *>(validator_);
+    Validator *gv_dev = static_cast<Validator *>(&validator_);
     vmaDestroyBuffer(gv_dev->vmaAllocator, layout_.buffer, layout_.allocation);
 }
 
@@ -86,7 +86,7 @@ VkDeviceAddress gpuav::DescriptorSet::GetLayoutState() {
         return layout_.device_addr;
     }
     uint32_t num_bindings = (GetBindingCount() > 0) ? GetLayout()->GetMaxBinding() + 1 : 0;
-    Validator *gv_dev = static_cast<Validator *>(validator_);
+    Validator *gv_dev = static_cast<Validator *>(&validator_);
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
     // 1 uvec2 to store num_bindings and 1 for each binding's data
     buffer_info.size = (1 + num_bindings) * sizeof(glsl::BindingLayout);
@@ -278,7 +278,7 @@ void FillBindingInData(const vvl::InlineUniformBinding &binding, glsl::Descripto
 
 std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetCurrentState() {
     auto guard = Lock();
-    Validator *gv_dev = static_cast<Validator *>(validator_);
+    Validator *gv_dev = static_cast<Validator *>(&validator_);
     uint32_t cur_version = current_version_.load();
     if (last_used_state_ && last_used_state_->version == cur_version) {
         return last_used_state_;
@@ -378,7 +378,7 @@ std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetCurrentSta
 
 std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetOutputState() {
     auto guard = Lock();
-    Validator *gv_dev = static_cast<Validator *>(validator_);
+    Validator *gv_dev = static_cast<Validator *>(&validator_);
     uint32_t cur_version = current_version_.load();
     if (output_state_) {
         return output_state_;

--- a/layers/gpu_validation/gpu_descriptor_set.cpp
+++ b/layers/gpu_validation/gpu_descriptor_set.cpp
@@ -76,7 +76,7 @@ gpuav::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPo
 
 gpuav::DescriptorSet::~DescriptorSet() {
     Destroy();
-    Validator *gv_dev = static_cast<Validator *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(validator_);
     vmaDestroyBuffer(gv_dev->vmaAllocator, layout_.buffer, layout_.allocation);
 }
 
@@ -86,7 +86,7 @@ VkDeviceAddress gpuav::DescriptorSet::GetLayoutState() {
         return layout_.device_addr;
     }
     uint32_t num_bindings = (GetBindingCount() > 0) ? GetLayout()->GetMaxBinding() + 1 : 0;
-    Validator *gv_dev = static_cast<Validator *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(validator_);
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
     // 1 uvec2 to store num_bindings and 1 for each binding's data
     buffer_info.size = (1 + num_bindings) * sizeof(glsl::BindingLayout);
@@ -278,7 +278,7 @@ void FillBindingInData(const vvl::InlineUniformBinding &binding, glsl::Descripto
 
 std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetCurrentState() {
     auto guard = Lock();
-    Validator *gv_dev = static_cast<Validator *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(validator_);
     uint32_t cur_version = current_version_.load();
     if (last_used_state_ && last_used_state_->version == cur_version) {
         return last_used_state_;
@@ -378,7 +378,7 @@ std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetCurrentSta
 
 std::shared_ptr<gpuav::DescriptorSet::State> gpuav::DescriptorSet::GetOutputState() {
     auto guard = Lock();
-    Validator *gv_dev = static_cast<Validator *>(state_data_);
+    Validator *gv_dev = static_cast<Validator *>(validator_);
     uint32_t cur_version = current_version_.load();
     if (output_state_) {
         return output_state_;

--- a/layers/gpu_validation/gpu_descriptor_set.h
+++ b/layers/gpu_validation/gpu_descriptor_set.h
@@ -30,7 +30,7 @@ class DescriptorSet : public vvl::DescriptorSet {
   public:
     DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool,
                   const std::shared_ptr<vvl::DescriptorSetLayout const> &layout, uint32_t variable_count,
-                  ValidationStateTracker *state_data);
+                  ValidationStateTracker *validator);
     virtual ~DescriptorSet();
     void Destroy() override { last_used_state_.reset(); };
     struct State {

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -40,7 +40,7 @@
 #include "generated/gpu_inst_shader_hash.h"
 
 std::shared_ptr<vvl::Buffer> gpuav::Validator::CreateBufferState(VkBuffer buf, const VkBufferCreateInfo *pCreateInfo) {
-    return std::make_shared<Buffer>(this, buf, pCreateInfo, *desc_heap);
+    return std::make_shared<Buffer>(*this, buf, pCreateInfo, *desc_heap);
 }
 
 std::shared_ptr<vvl::BufferView> gpuav::Validator::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv,
@@ -78,7 +78,7 @@ std::shared_ptr<vvl::DescriptorSet> gpuav::Validator::CreateDescriptorSet(
 std::shared_ptr<vvl::CommandBuffer> gpuav::Validator::CreateCmdBufferState(VkCommandBuffer cb,
                                                                            const VkCommandBufferAllocateInfo *pCreateInfo,
                                                                            const vvl::CommandPool *pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(this, cb, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(*this, cb, pCreateInfo, pool));
 }
 
 std::shared_ptr<vvl::Queue> gpuav::Validator::CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -26,7 +26,7 @@ class Validator;
 
 class Queue : public vvl::Queue {
   public:
-    Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
+    Queue(Validator &validator, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
           const VkQueueFamilyProperties &queueFamilyProperties);
     virtual ~Queue();
 
@@ -36,7 +36,7 @@ class Queue : public vvl::Queue {
     void SubmitBarrier(const Location &loc, uint64_t seq);
     void Retire(vvl::QueueSubmission &) override;
 
-    Validator &state_;
+    Validator &validator_;
     VkCommandPool barrier_command_pool_{VK_NULL_HANDLE};
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};
@@ -45,7 +45,8 @@ class Queue : public vvl::Queue {
 
 class CommandBuffer : public vvl::CommandBuffer {
   public:
-    CommandBuffer(Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool);
+    CommandBuffer(Validator &validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+                  const vvl::CommandPool *pool);
 
     virtual bool PreProcess() = 0;
     virtual void PostProcess(VkQueue queue, const Location &loc) = 0;

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -132,7 +132,7 @@ void gpuav::CommandBuffer::Reset() {
 }
 
 void gpuav::CommandBuffer::ResetCBState() {
-    auto gpuav = static_cast<Validator *>(dev_data);
+    auto gpuav = static_cast<Validator *>(validator);
     // Free the device memory and descriptor set(s) associated with a command buffer.
 
     for (auto &cmd_info : per_command_resources) {
@@ -159,7 +159,7 @@ bool gpuav::CommandBuffer::PreProcess() {
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
 void gpuav::CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<Validator *>(dev_data);
+    auto *device_state = static_cast<Validator *>(validator);
     uint32_t draw_index = 0;
     uint32_t compute_index = 0;
     uint32_t ray_trace_index = 0;

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -89,7 +89,8 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
     std::vector<AccelerationStructureBuildValidationInfo> as_validation_buffers;
     VkBuffer current_bindless_buffer = VK_NULL_HANDLE;
 
-    CommandBuffer(Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool);
+    CommandBuffer(Validator &validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+                  const vvl::CommandPool *pool);
     ~CommandBuffer();
 
     bool PreProcess() final;
@@ -99,14 +100,14 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
     void Reset() final;
 
   private:
-    Validator &state_;
+    Validator &validator_;
     void ResetCBState();
     void ProcessAccelerationStructure(VkQueue queue, const Location &loc);
 };
 
 class Queue : public gpu_tracker::Queue {
   public:
-    Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp);
+    Queue(Validator &validator, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp);
 
   protected:
     uint64_t PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
@@ -114,7 +115,7 @@ class Queue : public gpu_tracker::Queue {
 
 class Buffer : public vvl::Buffer {
   public:
-    Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);
+    Buffer(ValidationStateTracker &validator, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
     void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;

--- a/layers/layer_chassis_dispatch_manual.cpp
+++ b/layers/layer_chassis_dispatch_manual.cpp
@@ -156,10 +156,10 @@ VkResult DispatchCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipeli
             }
 
             auto& graphics_info = pCreateInfos[idx0];
-            auto state_info = dynamic_cast<ValidationStateTracker*>(layer_data);
+            auto validator = dynamic_cast<ValidationStateTracker *>(layer_data);
             PNextCopyState pnext_copy_state = {
-                [state_info, &graphics_info](VkBaseOutStructure *safe_struct, const VkBaseOutStructure *in_struct) -> bool {
-                    return vvl::Pipeline::PnextRenderingInfoCustomCopy(state_info, graphics_info, safe_struct, in_struct);
+                [validator, &graphics_info](VkBaseOutStructure *safe_struct, const VkBaseOutStructure *in_struct) -> bool {
+                    return vvl::Pipeline::PnextRenderingInfoCustomCopy(validator, graphics_info, safe_struct, in_struct);
                 }};
             local_pCreateInfos[idx0].initialize(&pCreateInfos[idx0], uses_color_attachment, uses_depthstencil_attachment, &pnext_copy_state);
 

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -26,9 +26,9 @@ static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCrea
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker *dev_data, VkBuffer buffer) {
+static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker *validator, VkBuffer buffer) {
     VkMemoryRequirements result{};
-    DispatchGetBufferMemoryRequirements(dev_data->device, buffer, &result);
+    DispatchGetBufferMemoryRequirements(validator->device, buffer, &result);
     return result;
 }
 
@@ -54,15 +54,15 @@ static bool GetMetalExport(const VkBufferViewCreateInfo *info) {
 
 namespace vvl {
 
-Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+Buffer::Buffer(ValidationStateTracker *validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
-      requirements(GetMemoryRequirements(dev_data, handle)),
+      requirements(GetMemoryRequirements(validator, handle)),
       usage(GetBufferUsageFlags(create_info)),
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      supported_video_profiles(validator->video_profile_cache_.Get(
+          validator->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
         tracker_.emplace<BindableSparseMemoryTracker>(&requirements,
                                                       (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) != 0);

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -26,9 +26,9 @@ static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCrea
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker *validator, VkBuffer buffer) {
+static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker &validator, VkBuffer buffer) {
     VkMemoryRequirements result{};
-    DispatchGetBufferMemoryRequirements(validator->device, buffer, &result);
+    DispatchGetBufferMemoryRequirements(validator.device, buffer, &result);
     return result;
 }
 
@@ -54,15 +54,15 @@ static bool GetMetalExport(const VkBufferViewCreateInfo *info) {
 
 namespace vvl {
 
-Buffer::Buffer(ValidationStateTracker *validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+Buffer::Buffer(ValidationStateTracker &validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       requirements(GetMemoryRequirements(validator, handle)),
       usage(GetBufferUsageFlags(create_info)),
-      supported_video_profiles(validator->video_profile_cache_.Get(
-          validator->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      supported_video_profiles(validator.video_profile_cache_.Get(
+          validator.physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
         tracker_.emplace<BindableSparseMemoryTracker>(&requirements,
                                                       (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) != 0);

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -40,7 +40,7 @@ class Buffer : public Bindable {
 
     unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
-    Buffer(ValidationStateTracker *validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
+    Buffer(ValidationStateTracker &validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
 
     Buffer(Buffer const &rh_obj) = delete;
 

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -40,7 +40,7 @@ class Buffer : public Bindable {
 
     unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
-    Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
+    Buffer(ValidationStateTracker *validator, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
 
     Buffer(Buffer const &rh_obj) = delete;
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -41,10 +41,10 @@ static ShaderObjectStage inline ConvertToShaderObjectStage(VkShaderStageFlagBits
 
 namespace vvl {
 
-CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
+CommandPool::CommandPool(ValidationStateTracker *validator, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
                          VkQueueFlags flags)
     : StateObject(handle, kVulkanObjectTypeCommandPool),
-      dev_data(dev),
+      validator(validator),
       createFlags(pCreateInfo->flags),
       queueFamilyIndex(pCreateInfo->queueFamilyIndex),
       queue_flags(flags),
@@ -52,9 +52,9 @@ CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool handle, cons
 
 void CommandPool::Allocate(const VkCommandBufferAllocateInfo *create_info, const VkCommandBuffer *command_buffers) {
     for (uint32_t i = 0; i < create_info->commandBufferCount; i++) {
-        auto new_cb = dev_data->CreateCmdBufferState(command_buffers[i], create_info, this);
+        auto new_cb = validator->CreateCmdBufferState(command_buffers[i], create_info, this);
         commandBuffers.emplace(command_buffers[i], new_cb.get());
-        dev_data->Add(std::move(new_cb));
+        validator->Add(std::move(new_cb));
     }
 }
 
@@ -62,7 +62,7 @@ void CommandPool::Free(uint32_t count, const VkCommandBuffer *command_buffers) {
     for (uint32_t i = 0; i < count; i++) {
         auto iter = commandBuffers.find(command_buffers[i]);
         if (iter != commandBuffers.end()) {
-            dev_data->Destroy<CommandBuffer>(iter->first);
+            validator->Destroy<CommandBuffer>(iter->first);
             commandBuffers.erase(iter);
         }
     }
@@ -77,7 +77,7 @@ void CommandPool::Reset() {
 
 void CommandPool::Destroy() {
     for (auto &entry : commandBuffers) {
-        dev_data->Destroy<CommandBuffer>(entry.first);
+        validator->Destroy<CommandBuffer>(entry.first);
     }
     commandBuffers.clear();
     StateObject::Destroy();
@@ -89,12 +89,12 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
     active_subpass_sample_count_ = std::nullopt;
 }
 
-CommandBuffer::CommandBuffer(ValidationStateTracker *dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                             const vvl::CommandPool *pool)
+CommandBuffer::CommandBuffer(ValidationStateTracker *validator, VkCommandBuffer handle,
+                             const VkCommandBufferAllocateInfo *pAllocateInfo, const vvl::CommandPool *pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       allocate_info(*pAllocateInfo),
       command_pool(pool),
-      dev_data(dev),
+      validator(validator),
       unprotected(pool->unprotected),
       lastBound({*this, *this, *this}) {
     ResetCBState();
@@ -225,7 +225,7 @@ void CommandBuffer::ResetCBState() {
     transform_feedback_active = false;
 
     // Clean up the label data
-    ResetCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
+    ResetCmdDebugUtilsLabel(validator->report_data, VkHandle());
 }
 
 void CommandBuffer::Reset() {
@@ -242,7 +242,7 @@ void CommandBuffer::IncrementResources() {
     //  all the corresponding cases are verified to cause CB_INVALID state and the CB_INVALID state
     //  should then be flagged prior to calling this function
     for (auto event : writeEventsBeforeWait) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+        auto event_state = validator->Get<vvl::Event>(event);
         if (event_state) event_state->write_in_use++;
     }
 }
@@ -274,7 +274,7 @@ void CommandBuffer::ResetPushConstantDataIfIncompatible(const vvl::PipelineLayou
 
 void CommandBuffer::Destroy() {
     // Remove the cb debug labels
-    EraseCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
+    EraseCmdDebugUtilsLabel(validator->report_data, VkHandle());
     {
         auto guard = WriteLock();
         ResetCBState();
@@ -511,7 +511,7 @@ void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPa
     for (uint32_t i = 0; i < attachments.size(); ++i) {
         if (imageless) {
             if (attachment_info_struct && i < attachment_info_struct->attachmentCount) {
-                auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(attachment_info_struct->pAttachments[i]));
+                auto res = attachments_view_states.insert(validator->Get<vvl::ImageView>(attachment_info_struct->pAttachments[i]));
                 attachments[i] = res.first->get();
             }
         } else {
@@ -523,15 +523,15 @@ void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPa
 
 void CommandBuffer::BeginRenderPass(Func command, const VkRenderPassBeginInfo *pRenderPassBegin, const VkSubpassContents contents) {
     RecordCmd(command);
-    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
-    activeRenderPass = dev_data->Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
+    activeFramebuffer = validator->Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
+    activeRenderPass = validator->Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     active_render_pass_begin_info = safe_VkRenderPassBeginInfo(pRenderPassBegin);
     SetActiveSubpass(0);
     activeSubpassContents = contents;
     renderPassQueries.clear();
 
     // Connect this RP to cmdBuffer
-    if (!dev_data->disabled[command_buffer_state]) {
+    if (!validator->disabled[command_buffer_state]) {
         AddChild(activeRenderPass);
     }
 
@@ -659,7 +659,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
 
         if (pRenderingInfo->pColorAttachments[i].imageView != VK_NULL_HANDLE) {
             auto res =
-                attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[i].imageView));
+                attachments_view_states.insert(validator->Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[i].imageView));
             colorAttachment = res.first->get();
             if (pRenderingInfo->pColorAttachments[i].resolveMode != VK_RESOLVE_MODE_NONE &&
                 pRenderingInfo->pColorAttachments[i].resolveImageView != VK_NULL_HANDLE) {
@@ -674,7 +674,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
         depthAttachment = nullptr;
         depthResolveAttachment = nullptr;
 
-        auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView));
+        auto res = attachments_view_states.insert(validator->Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView));
         depthAttachment = res.first->get();
         if (pRenderingInfo->pDepthAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) {
@@ -688,7 +688,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
         stencilAttachment = nullptr;
         stencilResolveAttachment = nullptr;
 
-        auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView));
+        auto res = attachments_view_states.insert(validator->Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView));
         stencilAttachment = res.first->get();
         if (pRenderingInfo->pStencilAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) {
@@ -705,19 +705,19 @@ void CommandBuffer::EndRendering(Func command) {
 
 void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo) {
     RecordCmd(Func::vkCmdBeginVideoCodingKHR);
-    bound_video_session = dev_data->Get<vvl::VideoSession>(pBeginInfo->videoSession);
-    bound_video_session_parameters = dev_data->Get<vvl::VideoSessionParameters>(pBeginInfo->videoSessionParameters);
+    bound_video_session = validator->Get<vvl::VideoSession>(pBeginInfo->videoSession);
+    bound_video_session_parameters = validator->Get<vvl::VideoSessionParameters>(pBeginInfo->videoSessionParameters);
 
     if (bound_video_session) {
         // Connect this video session to cmdBuffer
-        if (!dev_data->disabled[command_buffer_state]) {
+        if (!validator->disabled[command_buffer_state]) {
             AddChild(bound_video_session);
         }
     }
 
     if (bound_video_session_parameters) {
         // Connect this video session parameters object to cmdBuffer
-        if (!dev_data->disabled[command_buffer_state]) {
+        if (!validator->disabled[command_buffer_state]) {
             AddChild(bound_video_session_parameters);
         }
     }
@@ -734,7 +734,7 @@ void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo
             // Initialize the set of bound video picture resources
             if (pBeginInfo->pReferenceSlots[i].pPictureResource != nullptr) {
                 int32_t slot_index = pBeginInfo->pReferenceSlots[i].slotIndex;
-                vvl::VideoPictureResource res(dev_data, *pBeginInfo->pReferenceSlots[i].pPictureResource);
+                vvl::VideoPictureResource res(validator, *pBeginInfo->pReferenceSlots[i].pPictureResource);
                 bound_video_picture_resources.emplace(std::make_pair(res, slot_index));
             }
 
@@ -754,7 +754,7 @@ void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo
 
             // Enqueue submission time DPB slot deactivation
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [deactivated_slots](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [deactivated_slots](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     for (const auto &slot_index : deactivated_slots) {
                         dev_state.Deactivate(slot_index);
@@ -785,7 +785,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
             // Enqueue submission time video session state reset/initialization
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                    vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     dev_state.Reset();
                     return false;
@@ -799,7 +799,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
                 // Enqueue rate control specific device state changes
                 video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                    [state](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                    [state](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                             vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetRateControlState(state);
                         return false;
@@ -815,7 +815,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
                 // Enqueue encode quality level device state change
                 video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                    [quality_level](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                    [quality_level](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetEncodeQualityLevel(quality_level);
                         return false;
@@ -843,7 +843,7 @@ void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR *pDecodeInfo) {
 
     if (bound_video_session && pDecodeInfo) {
         if (pDecodeInfo->pSetupReferenceSlot && pDecodeInfo->pSetupReferenceSlot->pPictureResource) {
-            vvl::VideoReferenceSlot setup_slot(dev_data, *bound_video_session->profile, *pDecodeInfo->pSetupReferenceSlot);
+            vvl::VideoReferenceSlot setup_slot(validator, *bound_video_session->profile, *pDecodeInfo->pSetupReferenceSlot);
 
             // Update bound video picture resource DPB slot index association
             bound_video_picture_resources[setup_slot.resource] = setup_slot.index;
@@ -851,7 +851,7 @@ void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR *pDecodeInfo) {
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pDecodeInfo);
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [setup_slot, reference_setup_requested](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {
                         dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -883,7 +883,7 @@ void vvl::CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR *pEncodeInfo) {
 
     if (bound_video_session && pEncodeInfo) {
         if (pEncodeInfo->pSetupReferenceSlot && pEncodeInfo->pSetupReferenceSlot->pPictureResource) {
-            vvl::VideoReferenceSlot setup_slot(dev_data, *bound_video_session->profile, *pEncodeInfo->pSetupReferenceSlot);
+            vvl::VideoReferenceSlot setup_slot(validator, *bound_video_session->profile, *pEncodeInfo->pSetupReferenceSlot);
 
             // Update bound video picture resource DPB slot index association
             bound_video_picture_resources[setup_slot.resource] = setup_slot.index;
@@ -891,7 +891,7 @@ void vvl::CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR *pEncodeInfo) {
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pEncodeInfo);
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [setup_slot, reference_setup_requested](const ValidationStateTracker *validator, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {
                         dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -932,11 +932,11 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
         // If we are a secondary command-buffer and inheriting.  Update the items we should inherit.
         if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
             if (beginInfo.pInheritanceInfo->renderPass) {
-                activeRenderPass = dev_data->Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
+                activeRenderPass = validator->Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
                 SetActiveSubpass(beginInfo.pInheritanceInfo->subpass);
 
                 if (beginInfo.pInheritanceInfo->framebuffer) {
-                    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(beginInfo.pInheritanceInfo->framebuffer);
+                    activeFramebuffer = validator->Get<vvl::Framebuffer>(beginInfo.pInheritanceInfo->framebuffer);
                     active_subpasses = nullptr;
                     active_attachments = nullptr;
 
@@ -953,7 +953,7 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
                         UpdateAttachmentsView(nullptr);
 
                         // Connect this framebuffer and its children to this cmdBuffer
-                        if (!dev_data->disabled[command_buffer_state]) {
+                        if (!validator->disabled[command_buffer_state]) {
                             AddChild(activeFramebuffer);
                         }
                     }
@@ -981,9 +981,9 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     if (chained_device_group_struct) {
         initial_device_mask = chained_device_group_struct->deviceMask;
     } else {
-        initial_device_mask = (1 << dev_data->physical_device_count) - 1;
+        initial_device_mask = (1 << validator->physical_device_count) - 1;
     }
-    performance_lock_acquired = dev_data->performance_lock_acquired;
+    performance_lock_acquired = validator->performance_lock_acquired;
     updatedQueries.clear();
 }
 
@@ -996,7 +996,7 @@ void CommandBuffer::End(VkResult result) {
 void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_command_buffers) {
     RecordCmd(Func::vkCmdExecuteCommands);
     for (const VkCommandBuffer sub_command_buffer : secondary_command_buffers) {
-        auto sub_cb_state = dev_data->GetWrite<CommandBuffer>(sub_command_buffer);
+        auto sub_cb_state = validator->GetWrite<CommandBuffer>(sub_command_buffer);
         assert(sub_cb_state);
         if (!(sub_cb_state->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
             if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) {
@@ -1011,7 +1011,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
         // ValidationStateTracker these maps will be empty, so leaving the propagation in the the state tracker should be a no-op
         // for those other classes.
         for (const auto &sub_layout_map_entry : sub_cb_state->image_layout_map) {
-            const auto image_state = dev_data->Get<vvl::Image>(sub_layout_map_entry.first);
+            const auto image_state = validator->Get<vvl::Image>(sub_layout_map_entry.first);
             if (!image_state || image_state->Destroyed() || image_state->GetId() != sub_layout_map_entry.second.id) {
                 continue;
             }
@@ -1031,7 +1031,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
                                                        VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
                                                        QueryMap *localQueryToStateMap) {
             bool skip = false;
-            auto sub_cb_state_arg = cb_state_arg.dev_data->GetWrite<CommandBuffer>(sub_command_buffer);
+            auto sub_cb_state_arg = cb_state_arg.validator->GetWrite<CommandBuffer>(sub_command_buffer);
             for (auto &function : sub_cb_state_arg->queryUpdates) {
                 skip |= function(*sub_cb_state_arg, do_validate, firstPerfQueryPool, perfQueryPass, localQueryToStateMap);
             }
@@ -1090,7 +1090,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     auto &push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !IsBoundSetCompat(set, last_bound, pipeline_layout)) {
-        last_bound.UnbindAndResetPushDescriptorSet(dev_data->CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
+        last_bound.UnbindAndResetPushDescriptorSet(validator->CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, set, 1, nullptr, push_descriptor_set, 0, nullptr);
@@ -1158,18 +1158,18 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
 
             // We can skip updating the state if "nothing" has changed since the last validation.
             // See CoreChecks::ValidateActionState for more details.
-            const bool need_update = // Update if descriptor set (or contents) has changed
-                                     set_info.validated_set != descriptor_set.get() ||
-                                     set_info.validated_set_change_count != descriptor_set->GetChangeCount() ||
-                                     (!dev_data->disabled[image_layout_validation] &&
-                                     set_info.validated_set_image_layout_change_count != image_layout_change_count);
+            const bool need_update =  // Update if descriptor set (or contents) has changed
+                set_info.validated_set != descriptor_set.get() ||
+                set_info.validated_set_change_count != descriptor_set->GetChangeCount() ||
+                (!validator->disabled[image_layout_validation] &&
+                 set_info.validated_set_image_layout_change_count != image_layout_change_count);
             if (need_update) {
-                if (!dev_data->disabled[command_buffer_state] && !descriptor_set->IsPushDescriptor()) {
+                if (!validator->disabled[command_buffer_state] && !descriptor_set->IsPushDescriptor()) {
                     AddChild(descriptor_set);
                 }
 
                 // Bind this set and its active descriptor resources to the command buffer
-                descriptor_set->UpdateDrawState(dev_data, this, command, pipe, set_binding_pair.second);
+                descriptor_set->UpdateDrawState(validator, this, command, pipe, set_binding_pair.second);
 
                 set_info.validated_set = descriptor_set.get();
                 set_info.validated_set_change_count = descriptor_set->GetChangeCount();
@@ -1255,7 +1255,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
         auto &set_info = last_bound.per_set[set_idx];
         auto descriptor_set =
-            push_descriptor_set ? push_descriptor_set : dev_data->Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
+            push_descriptor_set ? push_descriptor_set : validator->Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
 
         set_info.Reset();
         // Record binding (or push)
@@ -1349,7 +1349,7 @@ void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageS
 
 // Set the initial image layout for all slices of an image view
 void CommandBuffer::SetImageViewInitialLayout(const vvl::ImageView &view_state, VkImageLayout layout) {
-    if (dev_data->disabled[image_layout_validation]) {
+    if (validator->disabled[image_layout_validation]) {
         return;
     }
     vvl::Image *image_state = view_state.image_state.get();
@@ -1369,7 +1369,7 @@ void CommandBuffer::SetImageInitialLayout(const vvl::Image &image_state, const V
 }
 
 void CommandBuffer::SetImageInitialLayout(VkImage image, const VkImageSubresourceRange &range, VkImageLayout layout) {
-    auto image_state = dev_data->Get<vvl::Image>(image);
+    auto image_state = validator->Get<vvl::Image>(image);
     if (!image_state) return;
     SetImageInitialLayout(*image_state, range, layout);
 }
@@ -1444,8 +1444,8 @@ static bool SetEventSignalInfo(VkEvent event, VkPipelineStageFlags2 src_stage_ma
 
 void CommandBuffer::RecordSetEvent(Func command, VkEvent event, VkPipelineStageFlags2KHR stageMask) {
     RecordCmd(command);
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+    if (!validator->disabled[command_buffer_state]) {
+        auto event_state = validator->Get<vvl::Event>(event);
         if (event_state) {
             AddChild(event_state);
         }
@@ -1461,8 +1461,8 @@ void CommandBuffer::RecordSetEvent(Func command, VkEvent event, VkPipelineStageF
 
 void CommandBuffer::RecordResetEvent(Func command, VkEvent event, VkPipelineStageFlags2KHR stageMask) {
     RecordCmd(command);
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+    if (!validator->disabled[command_buffer_state]) {
+        auto event_state = validator->Get<vvl::Event>(event);
         if (event_state) {
             AddChild(event_state);
         }
@@ -1482,8 +1482,8 @@ void CommandBuffer::RecordWaitEvents(Func command, uint32_t eventCount, const Vk
                                      VkPipelineStageFlags2KHR src_stage_mask) {
     RecordCmd(command);
     for (uint32_t i = 0; i < eventCount; ++i) {
-        if (!dev_data->disabled[command_buffer_state]) {
-            auto event_state = dev_data->Get<vvl::Event>(pEvents[i]);
+        if (!validator->disabled[command_buffer_state]) {
+            auto event_state = validator->Get<vvl::Event>(pEvents[i]);
             if (event_state) {
                 AddChild(event_state);
             }
@@ -1496,16 +1496,16 @@ void CommandBuffer::RecordWaitEvents(Func command, uint32_t eventCount, const Vk
 void CommandBuffer::RecordBarriers(uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
                                    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                    uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) {
-    if (dev_data->disabled[command_buffer_state]) return;
+    if (validator->disabled[command_buffer_state]) return;
 
     for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++) {
-        auto buffer_state = dev_data->Get<vvl::Buffer>(pBufferMemoryBarriers[i].buffer);
+        auto buffer_state = validator->Get<vvl::Buffer>(pBufferMemoryBarriers[i].buffer);
         if (buffer_state) {
             AddChild(buffer_state);
         }
     }
     for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) {
-        auto image_state = dev_data->Get<vvl::Image>(pImageMemoryBarriers[i].image);
+        auto image_state = validator->Get<vvl::Image>(pImageMemoryBarriers[i].image);
         if (image_state) {
             AddChild(image_state);
         }
@@ -1513,16 +1513,16 @@ void CommandBuffer::RecordBarriers(uint32_t memoryBarrierCount, const VkMemoryBa
 }
 
 void CommandBuffer::RecordBarriers(const VkDependencyInfoKHR &dep_info) {
-    if (dev_data->disabled[command_buffer_state]) return;
+    if (validator->disabled[command_buffer_state]) return;
 
     for (uint32_t i = 0; i < dep_info.bufferMemoryBarrierCount; i++) {
-        auto buffer_state = dev_data->Get<vvl::Buffer>(dep_info.pBufferMemoryBarriers[i].buffer);
+        auto buffer_state = validator->Get<vvl::Buffer>(dep_info.pBufferMemoryBarriers[i].buffer);
         if (buffer_state) {
             AddChild(buffer_state);
         }
     }
     for (uint32_t i = 0; i < dep_info.imageMemoryBarrierCount; i++) {
-        auto image_state = dev_data->Get<vvl::Image>(dep_info.pImageMemoryBarriers[i].image);
+        auto image_state = validator->Get<vvl::Image>(dep_info.pImageMemoryBarriers[i].image);
         if (image_state) {
             AddChild(image_state);
         }
@@ -1532,10 +1532,10 @@ void CommandBuffer::RecordBarriers(const VkDependencyInfoKHR &dep_info) {
 void CommandBuffer::RecordWriteTimestamp(Func command, VkPipelineStageFlags2KHR pipelineStage, VkQueryPool queryPool,
                                          uint32_t slot) {
     RecordCmd(command);
-    if (dev_data->disabled[query_validation]) return;
+    if (validator->disabled[query_validation]) return;
 
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto pool_state = dev_data->Get<vvl::QueryPool>(queryPool);
+    if (!validator->disabled[command_buffer_state]) {
+        auto pool_state = validator->Get<vvl::QueryPool>(queryPool);
         AddChild(pool_state);
     }
     QueryObject query_obj = {queryPool, slot};
@@ -1552,7 +1552,7 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
             function(*this, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
         }
         for (const auto &query_state_pair : local_query_to_state_map) {
-            auto query_pool_state = dev_data->Get<vvl::QueryPool>(query_state_pair.first.pool);
+            auto query_pool_state = validator->Get<vvl::QueryPool>(query_state_pair.first.pool);
             query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
         }
     }
@@ -1566,14 +1566,14 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
                      VK_NULL_HANDLE /* when do_validate is false then wait handler is inactive */, loc);
         }
         for (const auto &event_signal : local_event_signal_info) {
-            auto event_state = dev_data->Get<vvl::Event>(event_signal.first);
+            auto event_state = validator->Get<vvl::Event>(event_signal.first);
             event_state->signal_src_stage_mask = event_signal.second;
             event_state->signaling_queue = queue;
         }
     }
 
     for (const auto &it : video_session_updates) {
-        auto video_session_state = dev_data->Get<vvl::VideoSession>(it.first);
+        auto video_session_state = validator->Get<vvl::VideoSession>(it.first);
         auto device_state = video_session_state->DeviceStateWrite();
         for (const auto &function : it.second) {
             function(nullptr, video_session_state.get(), *device_state, /*do_validate*/ false);
@@ -1584,7 +1584,7 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
 void CommandBuffer::Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after) {
     // First perform decrement on general case bound objects
     for (auto event : writeEventsBeforeWait) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+        auto event_state = validator->Get<vvl::Event>(event);
         if (event_state) {
             event_state->write_in_use--;
         }
@@ -1597,7 +1597,7 @@ void CommandBuffer::Retire(uint32_t perf_submit_pass, const std::function<bool(c
 
     for (const auto &query_state_pair : local_query_to_state_map) {
         if (query_state_pair.second == QUERYSTATE_ENDED && !is_query_updated_after(query_state_pair.first)) {
-            auto query_pool_state = dev_data->Get<vvl::QueryPool>(query_state_pair.first.pool);
+            auto query_pool_state = validator->Get<vvl::QueryPool>(query_state_pair.first.pool);
             if (query_pool_state) {
                 query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass,
                                                 QUERYSTATE_AVAILABLE);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -100,7 +100,7 @@ class Event : public StateObject {
 // Track command pools and their command buffers
 class CommandPool : public StateObject {
   public:
-    ValidationStateTracker *validator;
+    ValidationStateTracker &validator;
     const VkCommandPoolCreateFlags createFlags;
     const uint32_t queueFamilyIndex;
     const VkQueueFlags queue_flags;
@@ -108,7 +108,7 @@ class CommandPool : public StateObject {
     // Cmd buffers allocated from this pool
     vvl::unordered_map<VkCommandBuffer, CommandBuffer *> commandBuffers;
 
-    CommandPool(ValidationStateTracker *validator, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
+    CommandPool(ValidationStateTracker &validator, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
                 VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
@@ -136,7 +136,7 @@ class CommandBuffer : public RefcountedStateObject {
     VkCommandBufferInheritanceInfo inheritanceInfo;
     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr
     const vvl::CommandPool *command_pool;
-    ValidationStateTracker *validator;
+    ValidationStateTracker &validator;
     bool unprotected;  // can't be used for protected memory
     bool hasRenderPassInstance;
     bool suspendsRenderPassInstance;
@@ -458,7 +458,7 @@ class CommandBuffer : public RefcountedStateObject {
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(ValidationStateTracker *validator, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
+    CommandBuffer(ValidationStateTracker &validator, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
                   const vvl::CommandPool *cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -100,7 +100,7 @@ class Event : public StateObject {
 // Track command pools and their command buffers
 class CommandPool : public StateObject {
   public:
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker *validator;
     const VkCommandPoolCreateFlags createFlags;
     const uint32_t queueFamilyIndex;
     const VkQueueFlags queue_flags;
@@ -108,7 +108,8 @@ class CommandPool : public StateObject {
     // Cmd buffers allocated from this pool
     vvl::unordered_map<VkCommandBuffer, CommandBuffer *> commandBuffers;
 
-    CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
+    CommandPool(ValidationStateTracker *validator, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
+                VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
     VkCommandPool VkHandle() const { return handle_.Cast<VkCommandPool>(); }
@@ -135,7 +136,7 @@ class CommandBuffer : public RefcountedStateObject {
     VkCommandBufferInheritanceInfo inheritanceInfo;
     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr
     const vvl::CommandPool *command_pool;
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker *validator;
     bool unprotected;  // can't be used for protected memory
     bool hasRenderPassInstance;
     bool suspendsRenderPassInstance;
@@ -410,7 +411,7 @@ class CommandBuffer : public RefcountedStateObject {
     // If primary, the secondary command buffers we will call.
     vvl::unordered_set<CommandBuffer *> linkedCommandBuffers;
     // Validation functions run at primary CB queue submit time
-    using QueueCallback = std::function<bool(const ValidationStateTracker &device_data, const class vvl::Queue &queue_state,
+    using QueueCallback = std::function<bool(const ValidationStateTracker &validator, const class vvl::Queue &queue_state,
                                              const CommandBuffer &cb_state)>;
     std::vector<QueueCallback> queue_submit_functions;
     // Used by some layers to defer actions until vkCmdEndRenderPass time.
@@ -457,7 +458,7 @@ class CommandBuffer : public RefcountedStateObject {
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(ValidationStateTracker *, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
+    CommandBuffer(ValidationStateTracker *validator, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
                   const vvl::CommandPool *cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }

--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -67,7 +67,7 @@ void vvl::Fence::NotifyAndWait(const Location &loc) {
     if (waiter.valid()) {
         auto result = waiter.wait_until(GetCondWaitTimeout());
         if (result != std::future_status::ready) {
-            dev_data_.LogError(
+            validator.LogError(
                 "INTERNAL-ERROR-VkFence-state-timeout", Handle(), loc,
                 "The Validation Layers hit a timeout waiting for fence state to update (this is most likely a validation bug).");
         }

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -56,14 +56,14 @@ class Fence : public RefcountedStateObject {
         kExternalPermanent,
     };
     // Default constructor
-    Fence(ValidationStateTracker &dev, VkFence handle, const VkFenceCreateInfo *pCreateInfo)
+    Fence(ValidationStateTracker &validator, VkFence handle, const VkFenceCreateInfo *pCreateInfo)
         : RefcountedStateObject(handle, kVulkanObjectTypeFence),
           flags(pCreateInfo->flags),
           exportHandleTypes(GetExportHandleTypes(pCreateInfo)),
           state_((pCreateInfo->flags & VK_FENCE_CREATE_SIGNALED_BIT) ? kRetired : kUnsignaled),
           completed_(),
           waiter_(completed_.get_future()),
-          dev_data_(dev) {}
+          validator(validator) {}
 
     VkFence VkHandle() const { return handle_.Cast<VkFence>(); }
 
@@ -120,7 +120,7 @@ class Fence : public RefcountedStateObject {
     std::promise<void> completed_;
     std::shared_future<void> waiter_;
     PresentSync present_sync_;
-    ValidationStateTracker &dev_data_;
+    ValidationStateTracker &validator;
 };
 
 }  // namespace vvl

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -94,14 +94,14 @@ static VkSwapchainKHR GetSwapchain(const VkImageCreateInfo *pCreateInfo) {
     return swapchain_info ? swapchain_info->swapchain : VK_NULL_HANDLE;
 }
 
-static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker *dev_data, VkImage img,
+static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker *validator, VkImage img,
                                                     const VkImageCreateInfo *create_info, bool disjoint, bool is_external_ahb) {
     vvl::Image::MemoryReqs result{};
     // Record the memory requirements in case they won't be queried
     // External AHB memory can't be queried until after memory is bound
     if (!is_external_ahb) {
         if (disjoint == false) {
-            DispatchGetImageMemoryRequirements(dev_data->device, img, &result[0]);
+            DispatchGetImageMemoryRequirements(validator->device, img, &result[0]);
         } else {
             uint32_t plane_count = vkuFormatPlaneCount(create_info->format);
             static const std::array<VkImageAspectFlagBits, 3> aspects{VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT,
@@ -115,12 +115,12 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker
                 VkMemoryRequirements2 mem_reqs2 = vku::InitStructHelper();
 
                 image_plane_req.planeAspect = aspects[i];
-                switch (dev_data->device_extensions.vk_khr_get_memory_requirements2) {
+                switch (validator->device_extensions.vk_khr_get_memory_requirements2) {
                     case kEnabledByApiLevel:
-                        DispatchGetImageMemoryRequirements2(dev_data->device, &mem_req_info2, &mem_reqs2);
+                        DispatchGetImageMemoryRequirements2(validator->device, &mem_req_info2, &mem_reqs2);
                         break;
                     case kEnabledByCreateinfo:
-                        DispatchGetImageMemoryRequirements2KHR(dev_data->device, &mem_req_info2, &mem_reqs2);
+                        DispatchGetImageMemoryRequirements2KHR(validator->device, &mem_req_info2, &mem_reqs2);
                         break;
                     default:
                         // The VK_KHR_sampler_ycbcr_conversion extension requires VK_KHR_get_memory_requirements2,
@@ -134,13 +134,13 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker
     return result;
 }
 
-static vvl::Image::SparseReqs GetSparseRequirements(const ValidationStateTracker *dev_data, VkImage img, bool sparse_residency) {
+static vvl::Image::SparseReqs GetSparseRequirements(const ValidationStateTracker *validator, VkImage img, bool sparse_residency) {
     vvl::Image::SparseReqs result;
     if (sparse_residency) {
         uint32_t count = 0;
-        DispatchGetImageSparseMemoryRequirements(dev_data->device, img, &count, nullptr);
+        DispatchGetImageSparseMemoryRequirements(validator->device, img, &count, nullptr);
         result.resize(count);
-        DispatchGetImageSparseMemoryRequirements(dev_data->device, img, &count, result.data());
+        DispatchGetImageSparseMemoryRequirements(validator->device, img, &count, result.data());
     }
     return result;
 }
@@ -172,7 +172,8 @@ static bool GetMetalExport(const VkImageCreateInfo *info, VkExportMetalObjectTyp
 
 namespace vvl {
 
-Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR ff)
+Image::Image(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo,
+             VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
@@ -186,9 +187,9 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
       swapchain_image_index(0),
       format_features(ff),
       disjoint((pCreateInfo->flags & VK_IMAGE_CREATE_DISJOINT_BIT) != 0),
-      requirements(GetMemoryRequirements(dev_data, img, pCreateInfo, disjoint, IsExternalBuffer())),
+      requirements(GetMemoryRequirements(validator, img, pCreateInfo, disjoint, IsExternalBuffer())),
       sparse_residency((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0),
-      sparse_requirements(GetSparseRequirements(dev_data, img, sparse_residency)),
+      sparse_requirements(GetSparseRequirements(validator, img, sparse_residency)),
       sparse_metadata_required(SparseMetaDataRequired(sparse_requirements)),
       get_sparse_reqs_called(false),
       sparse_metadata_bound(false),
@@ -198,9 +199,9 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
 #endif  // VK_USE_PLATFORM_METAL_EXT
       subresource_encoder(full_range),
       fragment_encoder(nullptr),
-      store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      store_device_as_workaround(validator->device),  // TODO REMOVE WHEN encoder can be const
+      supported_video_profiles(validator->video_profile_cache_.Get(
+          validator->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
         bool is_resident = (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0;
         tracker_.emplace<BindableSparseMemoryTracker>(requirements.data(), is_resident);
@@ -214,7 +215,7 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
     }
 }
 
-Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+Image::Image(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
              uint32_t swapchain_index, VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
@@ -241,9 +242,9 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
 #endif  // VK_USE_PLATFORM_METAL_EXT
       subresource_encoder(full_range),
       fragment_encoder(nullptr),
-      store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      store_device_as_workaround(validator->device),  // TODO REMOVE WHEN encoder can be const
+      supported_video_profiles(validator->video_profile_cache_.Get(
+          validator->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     fragment_encoder =
         std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(new subresource_adapter::ImageRangeEncoder(*this));
 
@@ -529,7 +530,7 @@ static safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR 
 
 namespace vvl {
 
-Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
+Swapchain::Swapchain(ValidationStateTracker *validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
     : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -538,7 +539,7 @@ Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateI
       shared_presentable(VK_PRESENT_MODE_SHARED_DEMAND_REFRESH_KHR == pCreateInfo->presentMode ||
                          VK_PRESENT_MODE_SHARED_CONTINUOUS_REFRESH_KHR == pCreateInfo->presentMode),
       image_create_info(GetImageCreateInfo(pCreateInfo)),
-      dev_data(dev_data_) {}
+      validator(validator) {}
 
 void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id) {
     if (image_index >= images.size()) return;
@@ -578,9 +579,9 @@ void Swapchain::Destroy() {
     for (auto &swapchain_image : images) {
         if (swapchain_image.image_state) {
             RemoveParent(swapchain_image.image_state);
-            dev_data->Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
+            validator->Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
         }
-        // NOTE: We don't have access to dev_data->fake_memory.Free() here, but it is currently a no-op
+        // NOTE: We don't have access to validator->fake_memory.Free() here, but it is currently a no-op
     }
     images.clear();
     if (surface) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -126,9 +126,9 @@ class Image : public Bindable {
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
-    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
+    Image(const ValidationStateTracker *validator, VkImage handle, const VkImageCreateInfo *pCreateInfo,
           VkFormatFeatureFlags2KHR features);
-    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker *validator, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
     Image(Image const &rh_obj) = delete;
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -334,10 +334,10 @@ class Swapchain : public StateObject {
     const safe_VkImageCreateInfo image_create_info;
 
     std::shared_ptr<vvl::Surface> surface;
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker *validator;
     uint32_t acquired_images = 0;
 
-    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
+    Swapchain(ValidationStateTracker *validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
         if (!Destroyed()) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -126,9 +126,9 @@ class Image : public Bindable {
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
-    Image(const ValidationStateTracker *validator, VkImage handle, const VkImageCreateInfo *pCreateInfo,
+    Image(const ValidationStateTracker &validator, VkImage handle, const VkImageCreateInfo *pCreateInfo,
           VkFormatFeatureFlags2KHR features);
-    Image(const ValidationStateTracker *validator, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker &validator, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
     Image(Image const &rh_obj) = delete;
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -334,10 +334,10 @@ class Swapchain : public StateObject {
     const safe_VkImageCreateInfo image_create_info;
 
     std::shared_ptr<vvl::Surface> surface;
-    ValidationStateTracker *validator;
+    ValidationStateTracker &validator;
     uint32_t acquired_images = 0;
 
-    Swapchain(ValidationStateTracker *validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
+    Swapchain(ValidationStateTracker &validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
         if (!Destroyed()) {

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -148,12 +148,12 @@ VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLa
 
 namespace vvl {
 
-static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker *validator,
+static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker &validator,
                                                      const VkPipelineLayoutCreateInfo *pCreateInfo) {
     PipelineLayout::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        set_layouts[i] = validator->Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+        set_layouts[i] = validator.Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
     }
     return set_layouts;
 }
@@ -194,7 +194,7 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
     return set_layouts;
 }
 
-PipelineLayout::PipelineLayout(ValidationStateTracker *validator, VkPipelineLayout handle,
+PipelineLayout::PipelineLayout(ValidationStateTracker &validator, VkPipelineLayout handle,
                                const VkPipelineLayoutCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(validator, pCreateInfo)),

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -148,12 +148,12 @@ VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLa
 
 namespace vvl {
 
-static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_data,
+static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker *validator,
                                                      const VkPipelineLayoutCreateInfo *pCreateInfo) {
     PipelineLayout::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+        set_layouts[i] = validator->Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
     }
     return set_layouts;
 }
@@ -194,10 +194,10 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
     return set_layouts;
 }
 
-PipelineLayout::PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle,
+PipelineLayout::PipelineLayout(ValidationStateTracker *validator, VkPipelineLayout handle,
                                const VkPipelineLayoutCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypePipelineLayout),
-      set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
+      set_layouts(GetSetLayouts(validator, pCreateInfo)),
       push_constant_ranges(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),
       set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)),
       create_flags(pCreateInfo->flags) {}

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -78,7 +78,7 @@ class PipelineLayout : public StateObject {
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
 
-    PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
+    PipelineLayout(ValidationStateTracker *validator, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
     PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts);
     template <typename Container>

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -78,7 +78,7 @@ class PipelineLayout : public StateObject {
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
 
-    PipelineLayout(ValidationStateTracker *validator, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
+    PipelineLayout(ValidationStateTracker &validator, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
     PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts);
     template <typename Container>

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -55,10 +55,10 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const safe_VkGraphics
     }
 }
 
-PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &state_data,
+PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &validator,
                                const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp)
     : PipelineSubState(p),
-      pipeline_layout(state_data.Get<vvl::PipelineLayout>(create_info.layout)),
+      pipeline_layout(validator.Get<vvl::PipelineLayout>(create_info.layout)),
       viewport_state(create_info.pViewportState),
       raster_state(create_info.pRasterizationState),
       tessellation_state(create_info.pTessellationState),
@@ -75,7 +75,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTrac
         }
         all_stages |= stage;
 
-        auto module_state = state_data.Get<vvl::ShaderModule>(stage_ci.module);
+        auto module_state = validator.Get<vvl::ShaderModule>(stage_ci.module);
         if (!module_state) {
             // If module is null and there is a VkShaderModuleCreateInfo in the pNext chain of the stage info, then this
             // module is part of a library and the state must be created
@@ -91,7 +91,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTrac
         if (!module_state) {
             if (const auto shader_stage_id = vku::FindStructInPNextChain<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>(stage_ci.pNext);
                 shader_stage_id) {
-                module_state = state_data.GetShaderModuleStateFromIdentifier(*shader_stage_id);
+                module_state = validator.GetShaderModuleStateFromIdentifier(*shader_stage_id);
             }
         }
 
@@ -179,11 +179,11 @@ std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(cons
 }
 
 template <typename CreateInfo>
-void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const ValidationStateTracker &validator,
                                   const CreateInfo &create_info) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
         if (create_info.pStages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
-            auto module_state = state_data.Get<vvl::ShaderModule>(create_info.pStages[i].module);
+            auto module_state = validator.Get<vvl::ShaderModule>(create_info.pStages[i].module);
             if (!module_state) {
                 // If module is null and there is a VkShaderModuleCreateInfo in the pNext chain of the stage info, then this
                 // module is part of a library and the state must be created
@@ -200,7 +200,7 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 if (const auto shader_stage_id =
                         vku::FindStructInPNextChain<VkPipelineShaderStageModuleIdentifierCreateInfoEXT>(create_info.pStages[i].pNext);
                     shader_stage_id) {
-                    module_state = state_data.GetShaderModuleStateFromIdentifier(*shader_stage_id);
+                    module_state = validator.GetShaderModuleStateFromIdentifier(*shader_stage_id);
                 }
             }
 
@@ -218,20 +218,20 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
 }
 
 // static
-void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &validator,
                                                 const VkGraphicsPipelineCreateInfo &create_info) {
-    SetFragmentShaderInfoPrivate(fs_state, state_data, create_info);
+    SetFragmentShaderInfoPrivate(fs_state, validator, create_info);
 }
 
 // static
-void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &validator,
                                                 const safe_VkGraphicsPipelineCreateInfo &create_info) {
-    SetFragmentShaderInfoPrivate(fs_state, state_data, create_info);
+    SetFragmentShaderInfoPrivate(fs_state, validator, create_info);
 }
 
-FragmentShaderState::FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data,
+FragmentShaderState::FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &validator,
                                          std::shared_ptr<const vvl::RenderPass> rp, uint32_t subp, VkPipelineLayout layout)
-    : PipelineSubState(p), rp_state(rp), subpass(subp), pipeline_layout(dev_data.Get<vvl::PipelineLayout>(layout)) {}
+    : PipelineSubState(p), rp_state(rp), subpass(subp), pipeline_layout(validator.Get<vvl::PipelineLayout>(layout)) {}
 
 FragmentOutputState::FragmentOutputState(const vvl::Pipeline &p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t sp)
     : PipelineSubState(p), rp_state(rp), subpass(sp) {}

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -63,12 +63,12 @@ struct VertexInputState : public PipelineSubState {
 
     std::vector<VkVertexInputAttributeDescription2EXT> vertex_attribute_descriptions;
 
-    std::shared_ptr<VertexInputState> FromCreateInfo(const ValidationStateTracker &state,
+    std::shared_ptr<VertexInputState> FromCreateInfo(const ValidationStateTracker &validator,
                                                      const safe_VkGraphicsPipelineCreateInfo &create_info);
 };
 
 struct PreRasterState : public PipelineSubState {
-    PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data,
+    PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &validator,
                    const safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp);
 
     static inline VkShaderStageFlags ValidShaderStages() {
@@ -110,20 +110,20 @@ std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(cons
 std::unique_ptr<const safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
 
 struct FragmentShaderState : public PipelineSubState {
-    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data, std::shared_ptr<const vvl::RenderPass> rp,
+    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &validator, std::shared_ptr<const vvl::RenderPass> rp,
                         uint32_t subpass, VkPipelineLayout layout);
 
     template <typename CreateInfo>
-    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data, const CreateInfo &create_info,
+    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &validator, const CreateInfo &create_info,
                         std::shared_ptr<const vvl::RenderPass> rp)
-        : FragmentShaderState(p, dev_data, rp, create_info.subpass, create_info.layout) {
+        : FragmentShaderState(p, validator, rp, create_info.subpass, create_info.layout) {
         if (create_info.pMultisampleState) {
             ms_state = ToSafeMultisampleState(*create_info.pMultisampleState);
         }
         if (create_info.pDepthStencilState) {
             ds_state = ToSafeDepthStencilState(*create_info.pDepthStencilState);
         }
-        FragmentShaderState::SetFragmentShaderInfo(*this, dev_data, create_info);
+        FragmentShaderState::SetFragmentShaderInfo(*this, validator, create_info);
     }
 
     static inline VkShaderStageFlags ValidShaderStages() { return VK_SHADER_STAGE_FRAGMENT_BIT; }
@@ -141,9 +141,9 @@ struct FragmentShaderState : public PipelineSubState {
     std::shared_ptr<const spirv::EntryPoint> fragment_entry_point;
 
   private:
-    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &validator,
                                       const VkGraphicsPipelineCreateInfo &create_info);
-    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &validator,
                                       const safe_VkGraphicsPipelineCreateInfo &create_info);
 };
 

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -116,7 +116,7 @@ void vvl::Queue::NotifyAndWait(const Location &loc, uint64_t until_seq) {
     auto waiter = Wait(until_seq);
     auto result = waiter.wait_until(GetCondWaitTimeout());
     if (result != std::future_status::ready) {
-        dev_data_.LogError(
+        validator.LogError(
             "INTERNAL-ERROR-VkQueue-state-timeout", Handle(), loc,
             "The Validation Layers hit a timeout waiting for queue state to update (this is most likely a validation bug)."
             " seq=%" PRIu64 " until=%" PRIu64,

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -78,13 +78,13 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
 
 class Queue: public StateObject {
   public:
-    Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
+    Queue(ValidationStateTracker &validator, VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
           const VkQueueFamilyProperties &queueFamilyProperties)
         : StateObject(handle, kVulkanObjectTypeQueue),
           queueFamilyIndex(index),
           flags(flags),
           queueFamilyProperties(queueFamilyProperties),
-          dev_data_(dev_data) {}
+          validator(validator) {}
 
     ~Queue() { Destroy(); }
     void Destroy() override;
@@ -131,7 +131,7 @@ class Queue: public StateObject {
     QueueSubmission *NextSubmission();
     LockGuard Lock() const { return LockGuard(lock_); }
 
-    ValidationStateTracker &dev_data_;
+    ValidationStateTracker &validator;
 
     // state related to submitting to the queue, all data members must
     // be accessed with lock_ held

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -198,7 +198,7 @@ void vvl::Semaphore::Retire(vvl::Queue *current_queue, const Location &loc, uint
         guard.unlock();
         auto result = waiter.wait_until(GetCondWaitTimeout());
         if (result != std::future_status::ready) {
-            dev_data_.LogError("INTERNAL-ERROR-VkSemaphore-state-timeout", Handle(), loc,
+            validator.LogError("INTERNAL-ERROR-VkSemaphore-state-timeout", Handle(), loc,
                                "The Validation Layers hit a timeout waiting for timeline semaphore state to update (this is most "
                                "likely a validation bug)."
                                " completed_.payload=%" PRIu64 " wait_payload=%" PRIu64,
@@ -229,11 +229,11 @@ void vvl::Semaphore::NotifyAndWait(const Location &loc, uint64_t payload) {
     if (scope_ == kInternal) {
         Notify(payload);
         auto waiter = Wait(payload);
-        dev_data_.BeginBlockingOperation();
+        validator.BeginBlockingOperation();
         auto result = waiter.wait_until(GetCondWaitTimeout());
-        dev_data_.EndBlockingOperation();
+        validator.EndBlockingOperation();
         if (result != std::future_status::ready) {
-            dev_data_.LogError("UNASSIGNED-VkSemaphore-state-timeout", Handle(), loc,
+            validator.LogError("UNASSIGNED-VkSemaphore-state-timeout", Handle(), loc,
                                "Timeout waiting for timeline semaphore state to update. This is most likely a validation bug."
                                " completed_.payload=%" PRIu64 " wait_payload=%" PRIu64,
                                completed_.payload, payload);

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -237,7 +237,7 @@ static inline bool CanWaitBinarySemaphoreAfterOperation(Semaphore::OpType op_typ
 
 class CoreChecks;
 struct SemaphoreSubmitState {
-    const CoreChecks *core;
+    const CoreChecks &validator;
     VkQueue queue;
     VkQueueFlags queue_flags;
 
@@ -251,8 +251,8 @@ struct SemaphoreSubmitState {
     vvl::unordered_map<VkSemaphore, uint64_t> timeline_signals;
     vvl::unordered_map<VkSemaphore, uint64_t> timeline_waits;
 
-    SemaphoreSubmitState(const CoreChecks *core_, VkQueue q_, VkQueueFlags queue_flags_)
-        : core(core_), queue(q_), queue_flags(queue_flags_) {}
+    SemaphoreSubmitState(const CoreChecks &validator, VkQueue q_, VkQueueFlags queue_flags_)
+        : validator(validator), queue(q_), queue_flags(queue_flags_) {}
 
     bool CannotWaitBinary(const vvl::Semaphore &semaphore_state) const;
 

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -121,10 +121,10 @@ class Semaphore : public RefcountedStateObject {
         return export_info ? export_info->handleTypes : 0;
     }
 
-    Semaphore(ValidationStateTracker &dev, VkSemaphore handle, const VkSemaphoreCreateInfo *pCreateInfo)
-        : Semaphore(dev, handle, vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext), pCreateInfo) {}
+    Semaphore(ValidationStateTracker &validator, VkSemaphore handle, const VkSemaphoreCreateInfo *pCreateInfo)
+        : Semaphore(validator, handle, vku::FindStructInPNextChain<VkSemaphoreTypeCreateInfo>(pCreateInfo->pNext), pCreateInfo) {}
 
-    Semaphore(ValidationStateTracker &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
+    Semaphore(ValidationStateTracker &validator, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
               const VkSemaphoreCreateInfo *pCreateInfo)
         : RefcountedStateObject(handle, kVulkanObjectTypeSemaphore),
 #ifdef VK_USE_PLATFORM_METAL_EXT
@@ -136,7 +136,7 @@ class Semaphore : public RefcountedStateObject {
           completed_{type == VK_SEMAPHORE_TYPE_TIMELINE ? kSignal : kNone, nullptr, 0,
                      type_create_info ? type_create_info->initialValue : 0},
           next_payload_(completed_.payload + 1),
-          dev_data_(dev) {
+          validator(validator) {
     }
 
     VkSemaphore VkHandle() const { return handle_.Cast<VkSemaphore>(); }
@@ -220,7 +220,7 @@ class Semaphore : public RefcountedStateObject {
     // can use the same payload value.
     std::map<uint64_t, TimePoint> timeline_;
     mutable std::shared_mutex lock_;
-    ValidationStateTracker &dev_data_;
+    ValidationStateTracker &validator;
 };
 
 // NOTE: Present semaphores are waited on by the implementation, not queue operations.

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -19,16 +19,16 @@
 #include "state_tracker/state_tracker.h"
 
 namespace vvl {
-static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &pCreateInfo) {
+static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker &validator, const VkShaderCreateInfoEXT &pCreateInfo) {
     ShaderObject::SetLayoutVector set_layouts(pCreateInfo.setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
-        set_layouts[i] = validator->Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
+        set_layouts[i] = validator.Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
     }
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
+ShaderObject::ShaderObject(ValidationStateTracker &validator, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                            uint32_t unique_shader_id)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -19,16 +19,16 @@
 #include "state_tracker/state_tracker.h"
 
 namespace vvl {
-static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
+static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &pCreateInfo) {
     ShaderObject::SetLayoutVector set_layouts(pCreateInfo.setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
+        set_layouts[i] = validator->Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
     }
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
+ShaderObject::ShaderObject(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                            uint32_t unique_shader_id)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),
@@ -39,7 +39,7 @@ ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreat
       gpu_validation_shader_id(unique_shader_id),
       active_slots(GetActiveSlots(entrypoint)),
       max_active_slot(GetMaxActiveSlot(active_slots)),
-      set_layouts(GetSetLayouts(dev_data, create_info)),
+      set_layouts(GetSetLayouts(validator, create_info)),
       push_constant_ranges(GetCanonicalId(create_info.pushConstantRangeCount, create_info.pPushConstantRanges)),
       set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)) {
     if ((create_info.flags & VK_SHADER_CREATE_LINK_STAGE_BIT_EXT) != 0) {

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -29,7 +29,7 @@
 namespace vvl {
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct ShaderObject : public StateObject {
-    ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
+    ShaderObject(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
                  std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                  uint32_t unique_shader_id = 0);
 

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -29,7 +29,7 @@
 namespace vvl {
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct ShaderObject : public StateObject {
-    ShaderObject(ValidationStateTracker *validator, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
+    ShaderObject(ValidationStateTracker &validator, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
                  std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                  uint32_t unique_shader_id = 0);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -687,13 +687,13 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     // The current object represents the VkInstance, look up / create the object for the device.
     ValidationObject *device_object = GetLayerDataPtr(GetDispatchKey(*pDevice), layer_data_map);
     ValidationObject *validation_data = device_object->GetValidationObject(this->container_type);
-    ValidationStateTracker *device_state = static_cast<ValidationStateTracker *>(validation_data);
+    ValidationStateTracker *validator = static_cast<ValidationStateTracker *>(validation_data);
 
-    device_state->instance_state = this;
+    validator->instance_state = this;
     // Save local link to this device's physical device state
-    device_state->physical_device_state = Get<vvl::PhysicalDevice>(gpu).get();
+    validator->physical_device_state = Get<vvl::PhysicalDevice>(gpu).get();
     // finish setup in the object representing the device
-    device_state->CreateDevice(pCreateInfo, record_obj.location);
+    validator->CreateDevice(pCreateInfo, record_obj.location);
 }
 
 std::shared_ptr<vvl::Queue> ValidationStateTracker::CreateQueue(VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -215,13 +215,13 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
 
 std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, features);
+    return std::make_shared<vvl::Image>(*this, handle, pCreateInfo, features);
 }
 
 std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<vvl::Image>(*this, handle, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
@@ -368,7 +368,7 @@ struct BufferAddressInfillUpdateOps {
 };
 
 std::shared_ptr<vvl::Buffer> ValidationStateTracker::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::Buffer>(this, handle, pCreateInfo);
+    return std::make_shared<vvl::Buffer>(*this, handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
@@ -1761,7 +1761,7 @@ void ValidationStateTracker::PreCallRecordFreeCommandBuffers(VkDevice device, Vk
 std::shared_ptr<vvl::CommandPool> ValidationStateTracker::CreateCommandPoolState(VkCommandPool handle,
                                                                                  const VkCommandPoolCreateInfo *pCreateInfo) {
     auto queue_flags = physical_device_state->queue_family_properties[pCreateInfo->queueFamilyIndex].queueFlags;
-    return std::make_shared<vvl::CommandPool>(this, handle, pCreateInfo, queue_flags);
+    return std::make_shared<vvl::CommandPool>(*this, handle, pCreateInfo, queue_flags);
 }
 
 void ValidationStateTracker::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
@@ -1884,7 +1884,7 @@ std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateGraphicsPipelineSta
     const VkGraphicsPipelineCreateInfo *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::RenderPass> &&render_pass, std::shared_ptr<const vvl::PipelineLayout> &&layout,
     CreateShaderModuleStates *csm_states) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
                                            csm_states);
 }
 
@@ -1943,7 +1943,7 @@ void ValidationStateTracker::PostCallRecordCreateGraphicsPipelines(VkDevice devi
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateComputePipelineState(
     const VkComputePipelineCreateInfo *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -1981,7 +1981,7 @@ void ValidationStateTracker::PostCallRecordCreateComputePipelines(VkDevice devic
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateRayTracingPipelineState(
     const VkRayTracingPipelineCreateInfoNV *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesNV(
@@ -2015,7 +2015,7 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateRayTracingPipelineState(
     const VkRayTracingPipelineCreateInfoKHR *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
@@ -2110,12 +2110,12 @@ void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkPipelineLayout *pPipelineLayout, const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
-    Add(std::make_shared<vvl::PipelineLayout>(this, *pPipelineLayout, pCreateInfo));
+    Add(std::make_shared<vvl::PipelineLayout>(*this, *pPipelineLayout, pCreateInfo));
 }
 
 std::shared_ptr<vvl::DescriptorPool> ValidationStateTracker::CreateDescriptorPoolState(
     VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::DescriptorPool>(this, handle, pCreateInfo);
+    return std::make_shared<vvl::DescriptorPool>(*this, handle, pCreateInfo);
 }
 
 std::shared_ptr<vvl::DescriptorSet> ValidationStateTracker::CreateDescriptorSet(
@@ -3162,7 +3162,7 @@ void ValidationStateTracker::PostCallRecordCreateVideoSessionKHR(VkDevice device
     if (VK_SUCCESS != record_obj.result) return;
 
     auto profile_desc = video_profile_cache_.Get(physical_device, pCreateInfo->pVideoProfile);
-    Add(std::make_shared<vvl::VideoSession>(this, *pVideoSession, pCreateInfo, std::move(profile_desc)));
+    Add(std::make_shared<vvl::VideoSession>(*this, *pVideoSession, pCreateInfo, std::move(profile_desc)));
 }
 
 void ValidationStateTracker::PostCallRecordGetVideoSessionMemoryRequirementsKHR(
@@ -4303,8 +4303,7 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(Vk
     auto dsl = layout_data->GetDsl(set);
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
-    vvl::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData,
-                                                            dsl->VkHandle());
+    vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
     cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, set,
                                      static_cast<uint32_t>(decoded_template.desc_writes.size()),
                                      decoded_template.desc_writes.data());
@@ -4324,7 +4323,7 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplate2KHR(
     auto dsl = layout_data->GetDsl(pPushDescriptorSetWithTemplateInfo->set);
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
-    vvl::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(),
+    vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(),
                                                 pPushDescriptorSetWithTemplateInfo->pData, dsl->VkHandle());
     cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, pPushDescriptorSetWithTemplateInfo->set,
                                      static_cast<uint32_t>(decoded_template.desc_writes.size()),
@@ -4485,7 +4484,7 @@ void ValidationStateTracker::PerformUpdateDescriptorSetsWithTemplateKHR(VkDescri
                                                                         const vvl::DescriptorUpdateTemplate *template_state,
                                                                         const void *pData) {
     // Translate the templated update into a normal update for validation...
-    vvl::DecodedTemplateUpdate decoded_update(this, descriptorSet, template_state, pData);
+    vvl::DecodedTemplateUpdate decoded_update(*this, descriptorSet, template_state, pData);
     PerformUpdateDescriptorSets(static_cast<uint32_t>(decoded_update.desc_writes.size()), decoded_update.desc_writes.data(), 0,
                                 NULL);
 }
@@ -4807,7 +4806,7 @@ void ValidationStateTracker::PostCallRecordCreateShadersEXT(VkDevice device, uin
     create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pShaders[i] != VK_NULL_HANDLE) {
-            Add(std::make_shared<vvl::ShaderObject>(this, pCreateInfos[i], pShaders[i], csm_state->module_states[i],
+            Add(std::make_shared<vvl::ShaderObject>(*this, pCreateInfos[i], pShaders[i], csm_state->module_states[i],
                                                     createInfoCount, pShaders, csm_state->unique_shader_ids[i]));
         }
     }
@@ -5636,13 +5635,13 @@ void ValidationStateTracker::PostCallRecordGetBufferDeviceAddressEXT(VkDevice de
 
 std::shared_ptr<vvl::Swapchain> ValidationStateTracker::CreateSwapchainState(const VkSwapchainCreateInfoKHR *pCreateInfo,
                                                                              VkSwapchainKHR handle) {
-    return std::make_shared<vvl::Swapchain>(this, pCreateInfo, handle);
+    return std::make_shared<vvl::Swapchain>(*this, pCreateInfo, handle);
 }
 
 std::shared_ptr<vvl::CommandBuffer> ValidationStateTracker::CreateCmdBufferState(VkCommandBuffer handle,
                                                                                  const VkCommandBufferAllocateInfo *pAllocateInfo,
                                                                                  const vvl::CommandPool *pool) {
-    return std::make_shared<vvl::CommandBuffer>(this, handle, pAllocateInfo, pool);
+    return std::make_shared<vvl::CommandBuffer>(*this, handle, pAllocateInfo, pool);
 }
 
 std::shared_ptr<vvl::DeviceMemory> ValidationStateTracker::CreateDeviceMemoryState(

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -253,8 +253,8 @@ void VideoProfileDesc::Cache::Release(VideoProfileDesc const *desc) {
 VideoPictureResource::VideoPictureResource()
     : image_view_state(nullptr), image_state(nullptr), base_array_layer(0), range(), coded_offset(), coded_extent() {}
 
-VideoPictureResource::VideoPictureResource(ValidationStateTracker const *dev_data, VkVideoPictureResourceInfoKHR const &res)
-    : image_view_state(dev_data->Get<ImageView>(res.imageViewBinding)),
+VideoPictureResource::VideoPictureResource(ValidationStateTracker const *validator, VkVideoPictureResourceInfoKHR const &res)
+    : image_view_state(validator->Get<ImageView>(res.imageViewBinding)),
       image_state(image_view_state ? image_view_state->image_state : nullptr),
       base_array_layer(res.baseArrayLayer),
       range(GetImageSubresourceRange(image_view_state.get(), res.baseArrayLayer)),
@@ -438,7 +438,7 @@ class RateControlStateMismatchRecorder {
     mutable std::string string_{};
 };
 
-bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTracker *validator, const VideoSession *vs_state,
                                                        const safe_VkVideoBeginCodingInfoKHR &begin_info,
                                                        const Location &loc) const {
     bool skip = false;
@@ -567,27 +567,27 @@ bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTrac
 #undef CHECK_RC_LAYER_INFO
 
         if (mismatch_recorder.HasMismatch()) {
-            skip |= dev_data->LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08254", vs_state->Handle(), loc,
-                                       "The video encode rate control information specified when beginning the video coding scope "
-                                       "does not match the currently configured video encode rate control state for %s:\n%s",
-                                       dev_data->FormatHandle(vs_state->Handle()).c_str(), mismatch_recorder.c_str());
+            skip |= validator->LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08254", vs_state->Handle(), loc,
+                                        "The video encode rate control information specified when beginning the video coding scope "
+                                        "does not match the currently configured video encode rate control state for %s:\n%s",
+                                        validator->FormatHandle(vs_state->Handle()).c_str(), mismatch_recorder.c_str());
         }
 
     } else {
         if (encode_.rate_control_state.base.rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR) {
-            skip |=
-                dev_data->LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08253", vs_state->Handle(), loc,
-                                   "No VkVideoEncodeRateControlInfoKHR structure was specified when beginning the "
-                                   "video coding scope but the currently set video encode rate control mode for %s is %s.",
-                                   dev_data->FormatHandle(vs_state->Handle()).c_str(),
-                                   string_VkVideoEncodeRateControlModeFlagBitsKHR(encode_.rate_control_state.base.rateControlMode));
+            skip |= validator->LogError(
+                "VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08253", vs_state->Handle(), loc,
+                "No VkVideoEncodeRateControlInfoKHR structure was specified when beginning the "
+                "video coding scope but the currently set video encode rate control mode for %s is %s.",
+                validator->FormatHandle(vs_state->Handle()).c_str(),
+                string_VkVideoEncodeRateControlModeFlagBitsKHR(encode_.rate_control_state.base.rateControlMode));
         }
     }
 
     return skip;
 }
 
-VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle,
+VideoSession::VideoSession(ValidationStateTracker *validator, VkVideoSessionKHR handle,
                            VkVideoSessionCreateInfoKHR const *pCreateInfo, std::shared_ptr<const VideoProfileDesc> &&profile_desc)
     : StateObject(handle, kVulkanObjectTypeVideoSessionKHR),
       safe_create_info(pCreateInfo),
@@ -595,18 +595,18 @@ VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR h
       profile(std::move(profile_desc)),
       memory_binding_count_queried(false),
       memory_bindings_queried(0),
-      memory_bindings_(GetMemoryBindings(dev_data, handle)),
+      memory_bindings_(GetMemoryBindings(validator, handle)),
       unbound_memory_binding_count_(static_cast<uint32_t>(memory_bindings_.size())),
       device_state_mutex_(),
       device_state_(pCreateInfo->maxDpbSlots) {}
 
-VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(ValidationStateTracker *dev_data, VkVideoSessionKHR vs) {
+VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(ValidationStateTracker *validator, VkVideoSessionKHR vs) {
     uint32_t memory_requirement_count;
-    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data->device, vs, &memory_requirement_count, nullptr);
+    DispatchGetVideoSessionMemoryRequirementsKHR(validator->device, vs, &memory_requirement_count, nullptr);
 
     std::vector<VkVideoSessionMemoryRequirementsKHR> memory_requirements(memory_requirement_count,
                                                                          vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>());
-    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data->device, vs, &memory_requirement_count, memory_requirements.data());
+    DispatchGetVideoSessionMemoryRequirementsKHR(validator->device, vs, &memory_requirement_count, memory_requirements.data());
 
     MemoryBindingMap memory_bindings;
     for (uint32_t i = 0; i < memory_requirement_count; ++i) {

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -240,7 +240,7 @@ class VideoPictureResource {
     VkExtent2D coded_extent;
 
     VideoPictureResource();
-    VideoPictureResource(ValidationStateTracker const *dev_data, VkVideoPictureResourceInfoKHR const &res);
+    VideoPictureResource(ValidationStateTracker const *validator, VkVideoPictureResourceInfoKHR const &res);
 
     operator bool() const { return image_view_state != nullptr; }
 
@@ -330,11 +330,11 @@ struct VideoReferenceSlot {
 
     VideoReferenceSlot() : index(-1), picture_id(), resource() {}
 
-    VideoReferenceSlot(ValidationStateTracker const *dev_data, VideoProfileDesc const &profile,
+    VideoReferenceSlot(ValidationStateTracker const *validator, VideoProfileDesc const &profile,
                        VkVideoReferenceSlotInfoKHR const &slot, bool has_picture_id = true)
         : index(slot.slotIndex),
           picture_id(has_picture_id ? VideoPictureID(profile, slot) : VideoPictureID()),
-          resource(slot.pPictureResource ? VideoPictureResource(dev_data, *slot.pPictureResource) : VideoPictureResource()) {}
+          resource(slot.pPictureResource ? VideoPictureResource(validator, *slot.pPictureResource) : VideoPictureResource()) {}
 
     // The reference is only valid if it refers to a valid DPB index and resource
     operator bool() const { return index >= 0 && resource; }
@@ -451,7 +451,7 @@ class VideoSessionDeviceState {
         encode_.rate_control_state = rate_control_state;
     }
 
-    bool ValidateRateControlState(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+    bool ValidateRateControlState(const ValidationStateTracker *validator, const VideoSession *vs_state,
                                   const safe_VkVideoBeginCodingInfoKHR &begin_info, const Location &loc) const;
 
   private:
@@ -490,7 +490,7 @@ class VideoSession : public StateObject {
         VideoSessionDeviceState &state_;
     };
 
-    VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
+    VideoSession(ValidationStateTracker *validator, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
     VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
@@ -534,7 +534,7 @@ class VideoSession : public StateObject {
     bool ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_info) const;
 
   private:
-    MemoryBindingMap GetMemoryBindings(ValidationStateTracker *dev_data, VkVideoSessionKHR vs);
+    MemoryBindingMap GetMemoryBindings(ValidationStateTracker *validator, VkVideoSessionKHR vs);
 
     MemoryBindingMap memory_bindings_;
     uint32_t unbound_memory_binding_count_;
@@ -708,7 +708,7 @@ class VideoSessionParameters : public StateObject {
     void AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const *info);
 };
 
-using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker *validator, const VideoSession *vs_state,
                                                               VideoSessionDeviceState &dev_state, bool do_validate)>>;
 using VideoSessionUpdateMap = unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;
 

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -240,7 +240,7 @@ class VideoPictureResource {
     VkExtent2D coded_extent;
 
     VideoPictureResource();
-    VideoPictureResource(ValidationStateTracker const *validator, VkVideoPictureResourceInfoKHR const &res);
+    VideoPictureResource(ValidationStateTracker const &validator, VkVideoPictureResourceInfoKHR const &res);
 
     operator bool() const { return image_view_state != nullptr; }
 
@@ -330,7 +330,7 @@ struct VideoReferenceSlot {
 
     VideoReferenceSlot() : index(-1), picture_id(), resource() {}
 
-    VideoReferenceSlot(ValidationStateTracker const *validator, VideoProfileDesc const &profile,
+    VideoReferenceSlot(ValidationStateTracker const &validator, VideoProfileDesc const &profile,
                        VkVideoReferenceSlotInfoKHR const &slot, bool has_picture_id = true)
         : index(slot.slotIndex),
           picture_id(has_picture_id ? VideoPictureID(profile, slot) : VideoPictureID()),
@@ -451,7 +451,7 @@ class VideoSessionDeviceState {
         encode_.rate_control_state = rate_control_state;
     }
 
-    bool ValidateRateControlState(const ValidationStateTracker *validator, const VideoSession *vs_state,
+    bool ValidateRateControlState(const ValidationStateTracker &validator, const VideoSession *vs_state,
                                   const safe_VkVideoBeginCodingInfoKHR &begin_info, const Location &loc) const;
 
   private:
@@ -490,7 +490,7 @@ class VideoSession : public StateObject {
         VideoSessionDeviceState &state_;
     };
 
-    VideoSession(ValidationStateTracker *validator, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
+    VideoSession(ValidationStateTracker &validator, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
     VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
@@ -534,7 +534,7 @@ class VideoSession : public StateObject {
     bool ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_info) const;
 
   private:
-    MemoryBindingMap GetMemoryBindings(ValidationStateTracker *validator, VkVideoSessionKHR vs);
+    MemoryBindingMap GetMemoryBindings(ValidationStateTracker &validator, VkVideoSessionKHR vs);
 
     MemoryBindingMap memory_bindings_;
     uint32_t unbound_memory_binding_count_;
@@ -708,7 +708,7 @@ class VideoSessionParameters : public StateObject {
     void AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const *info);
 };
 
-using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker *validator, const VideoSession *vs_state,
+using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker &validator, const VideoSession *vs_state,
                                                               VideoSessionDeviceState &dev_state, bool do_validate)>>;
 using VideoSessionUpdateMap = unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1188,9 +1188,9 @@ std::string SyncValidationInfo::FormatHazard(const HazardResult &hazard) const {
     return out.str();
 }
 
-syncval_state::CommandBuffer::CommandBuffer(SyncValidator *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
-                                            const vvl::CommandPool *pool)
-    : vvl::CommandBuffer(dev, cb, pCreateInfo, pool), access_context(*dev, this) {}
+syncval_state::CommandBuffer::CommandBuffer(SyncValidator &validator, VkCommandBuffer cb,
+                                            const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool)
+    : vvl::CommandBuffer(validator, cb, pCreateInfo, pool), access_context(validator, this) {}
 
 void syncval_state::CommandBuffer::Destroy() {
     access_context.Destroy();  // must be first to clean up self references correctly.

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -419,7 +419,7 @@ class CommandBuffer : public vvl::CommandBuffer {
   public:
     CommandBufferAccessContext access_context;
 
-    CommandBuffer(SyncValidator *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+    CommandBuffer(SyncValidator &validator, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
                   const vvl::CommandPool *pool);
     ~CommandBuffer() { Destroy(); }
 

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -23,18 +23,18 @@ namespace syncval_state {
 
 class ImageState : public vvl::Image {
   public:
-    ImageState(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
+    ImageState(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo,
                VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, features), opaque_base_address_(0U) {}
+        : vvl::Image(validator, img, pCreateInfo, features), opaque_base_address_(0U) {}
 
-    ImageState(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    ImageState(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
                uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, swapchain, swapchain_index, features), opaque_base_address_(0U) {}
+        : vvl::Image(validator, img, pCreateInfo, swapchain, swapchain_index, features), opaque_base_address_(0U) {}
     bool IsLinear() const { return fragment_encoder->IsLinearImage(); }
     bool IsTiled() const { return !IsLinear(); }
     bool IsSimplyBound() const;
 
-    void SetOpaqueBaseAddress(ValidationStateTracker &dev_data);
+    void SetOpaqueBaseAddress(ValidationStateTracker &validator);
 
     VkDeviceSize GetOpaqueBaseAddress() const { return opaque_base_address_; }
     bool HasOpaqueMapping() const { return 0U != opaque_base_address_; }
@@ -63,7 +63,7 @@ class ImageViewState : public vvl::ImageView {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
+    Swapchain(ValidationStateTracker *validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
     ~Swapchain() { Destroy(); }
     void RecordPresentedImage(PresentedImage &&presented_images);
     PresentedImage MovePresentedImage(uint32_t image_index);

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -23,11 +23,11 @@ namespace syncval_state {
 
 class ImageState : public vvl::Image {
   public:
-    ImageState(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo,
+    ImageState(const ValidationStateTracker &validator, VkImage img, const VkImageCreateInfo *pCreateInfo,
                VkFormatFeatureFlags2KHR features)
         : vvl::Image(validator, img, pCreateInfo, features), opaque_base_address_(0U) {}
 
-    ImageState(const ValidationStateTracker *validator, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    ImageState(const ValidationStateTracker &validator, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
                uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
         : vvl::Image(validator, img, pCreateInfo, swapchain, swapchain_index, features), opaque_base_address_(0U) {}
     bool IsLinear() const { return fragment_encoder->IsLinearImage(); }
@@ -63,7 +63,7 @@ class ImageViewState : public vvl::ImageView {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker *validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
+    Swapchain(ValidationStateTracker &validator, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
     ~Swapchain() { Destroy(); }
     void RecordPresentedImage(PresentedImage &&presented_images);
     PresentedImage MovePresentedImage(uint32_t image_index);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -161,7 +161,7 @@ FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, 
 FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, const PresentedImage& image, ResourceUsageTag tag_)
     : fence(fence_), tag(tag_), queue_id(kQueueIdInvalid), acquired(image, tag) {}
 
-syncval_state::Swapchain::Swapchain(ValidationStateTracker* validator, const VkSwapchainCreateInfoKHR* pCreateInfo,
+syncval_state::Swapchain::Swapchain(ValidationStateTracker& validator, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                     VkSwapchainKHR swapchain)
     : vvl::Swapchain(validator, pCreateInfo, swapchain) {}
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -161,9 +161,9 @@ FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, 
 FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, const PresentedImage& image, ResourceUsageTag tag_)
     : fence(fence_), tag(tag_), queue_id(kQueueIdInvalid), acquired(image, tag) {}
 
-syncval_state::Swapchain::Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo,
+syncval_state::Swapchain::Swapchain(ValidationStateTracker* validator, const VkSwapchainCreateInfoKHR* pCreateInfo,
                                     VkSwapchainKHR swapchain)
-    : vvl::Swapchain(dev_data, pCreateInfo, swapchain) {}
+    : vvl::Swapchain(validator, pCreateInfo, swapchain) {}
 
 void syncval_state::Swapchain::RecordPresentedImage(PresentedImage&& presented_image) {
     // All presented images are stored within the swapchain until the are reaquired.

--- a/layers/sync/sync_utils.cpp
+++ b/layers/sync/sync_utils.cpp
@@ -296,12 +296,12 @@ ShaderStageAccesses GetShaderStageAccesses(VkShaderStageFlagBits shader_stage) {
     return it->second;
 }
 
-const std::shared_ptr<const vvl::Buffer> BufferBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
-    return state_tracker.Get<vvl::Buffer>(buffer);
+const std::shared_ptr<const vvl::Buffer> BufferBarrier::GetResourceState(const ValidationStateTracker &validator) const {
+    return validator.Get<vvl::Buffer>(buffer);
 }
 
-const std::shared_ptr<const vvl::Image> ImageBarrier::GetResourceState(const ValidationStateTracker &state_tracker) const {
-    return state_tracker.Get<vvl::Image>(image);
+const std::shared_ptr<const vvl::Image> ImageBarrier::GetResourceState(const ValidationStateTracker &validator) const {
+    return validator.Get<vvl::Image>(image);
 }
 
 }  // namespace sync_utils

--- a/layers/sync/sync_utils.h
+++ b/layers/sync/sync_utils.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2019-2021, 2023 Valve Corporation
- * Copyright (c) 2019-2021, 2023 LunarG, Inc.
+ * Copyright (c) 2019-2021, 2023-2024 Valve Corporation
+ * Copyright (c) 2019-2021, 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -153,7 +153,7 @@ struct BufferBarrier : QueueFamilyBarrier {
           size(barrier.size) {}
 
     VulkanTypedHandle GetTypedHandle() const { return VulkanTypedHandle(buffer, kVulkanObjectTypeBuffer); }
-    const std::shared_ptr<const vvl::Buffer> GetResourceState(const ValidationStateTracker& state_tracker) const;
+    const std::shared_ptr<const vvl::Buffer> GetResourceState(const ValidationStateTracker& validator) const;
 };
 
 struct ImageBarrier : QueueFamilyBarrier {
@@ -176,7 +176,7 @@ struct ImageBarrier : QueueFamilyBarrier {
           subresourceRange(barrier.subresourceRange) {}
 
     VulkanTypedHandle GetTypedHandle() const { return VulkanTypedHandle(image, kVulkanObjectTypeImage); }
-    const std::shared_ptr<const vvl::Image> GetResourceState(const ValidationStateTracker& state_tracker) const;
+    const std::shared_ptr<const vvl::Image> GetResourceState(const ValidationStateTracker& validator) const;
 };
 
 }  // namespace sync_utils

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -3076,7 +3076,7 @@ bool syncval_state::ImageState::IsSimplyBound() const {
     return simple;
 }
 
-void syncval_state::ImageState::SetOpaqueBaseAddress(ValidationStateTracker &dev_data) {
+void syncval_state::ImageState::SetOpaqueBaseAddress(ValidationStateTracker &validator) {
     // This is safe to call if already called to simplify caller logic
     // NOTE: Not asserting IsTiled, as there could in future be other reasons for opaque representations
     if (opaque_base_address_) return;
@@ -3096,7 +3096,7 @@ void syncval_state::ImageState::SetOpaqueBaseAddress(ValidationStateTracker &dev
         // The size of the opaque range is based on the SyncVal *internal* representation of the tiled resource, unrelated
         // to the acutal size of the the resource in device memory. If differing representations become possible, the allocated
         // size would need to be changed to those representation's size requirements.
-        opaque_base = dev_data.AllocFakeMemory(fragment_encoder->TotalSize());
+        opaque_base = validator.AllocFakeMemory(fragment_encoder->TotalSize());
     }
     opaque_base_address_ = opaque_base;
 }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -134,7 +134,7 @@ std::shared_ptr<QueueSyncState> SyncValidator::GetQueueSyncStateShared(VkQueue q
 std::shared_ptr<vvl::CommandBuffer> SyncValidator::CreateCmdBufferState(VkCommandBuffer cb,
                                                                         const VkCommandBufferAllocateInfo *pCreateInfo,
                                                                         const vvl::CommandPool *cmd_pool) {
-    auto cb_state = std::make_shared<syncval_state::CommandBuffer>(this, cb, pCreateInfo, cmd_pool);
+    auto cb_state = std::make_shared<syncval_state::CommandBuffer>(*this, cb, pCreateInfo, cmd_pool);
     if (cb_state) {
         cb_state->access_context.SetSelfReference();
     }
@@ -143,18 +143,18 @@ std::shared_ptr<vvl::CommandBuffer> SyncValidator::CreateCmdBufferState(VkComman
 
 std::shared_ptr<vvl::Swapchain> SyncValidator::CreateSwapchainState(const VkSwapchainCreateInfoKHR *create_info,
                                                                     VkSwapchainKHR swapchain) {
-    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<syncval_state::Swapchain>(this, create_info, swapchain));
+    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<syncval_state::Swapchain>(*this, create_info, swapchain));
 }
 
 std::shared_ptr<vvl::Image> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<ImageState>(this, img, pCreateInfo, features);
+    return std::make_shared<ImageState>(*this, img, pCreateInfo, features);
 }
 
 std::shared_ptr<vvl::Image> SyncValidator::CreateImageState(VkImage img, const VkImageCreateInfo *pCreateInfo,
                                                             VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<ImageState>(this, img, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<ImageState>(*this, img, pCreateInfo, swapchain, swapchain_index, features);
 }
 std::shared_ptr<vvl::ImageView> SyncValidator::CreateImageViewState(
     const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci, VkFormatFeatureFlags2KHR ff,
@@ -2222,7 +2222,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
         }
     }
 
-    auto dst_resource = vvl::VideoPictureResource(this, pDecodeInfo->dstPictureResource);
+    auto dst_resource = vvl::VideoPictureResource(*this, pDecodeInfo->dstPictureResource);
     if (dst_resource) {
         auto hazard = context->DetectHazard(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
         if (hazard.IsHazard()) {
@@ -2233,7 +2233,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
     }
 
     if (pDecodeInfo->pSetupReferenceSlot != nullptr && pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        auto setup_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
+        auto setup_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
         if (setup_resource && (setup_resource != dst_resource)) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE);
             if (hazard.IsHazard()) {
@@ -2247,7 +2247,7 @@ bool SyncValidator::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuff
 
     for (uint32_t i = 0; i < pDecodeInfo->referenceSlotCount; ++i) {
         if (pDecodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            auto reference_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
+            auto reference_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ);
                 if (hazard.IsHazard()) {
@@ -2283,13 +2283,13 @@ void SyncValidator::PreCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer
         context->UpdateAccessState(*src_buffer, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, SyncOrdering::kNonAttachment, src_range, tag);
     }
 
-    auto dst_resource = vvl::VideoPictureResource(this, pDecodeInfo->dstPictureResource);
+    auto dst_resource = vvl::VideoPictureResource(*this, pDecodeInfo->dstPictureResource);
     if (dst_resource) {
         context->UpdateAccessState(*vs_state, dst_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
     }
 
     if (pDecodeInfo->pSetupReferenceSlot != nullptr && pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        auto setup_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
+        auto setup_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pSetupReferenceSlot->pPictureResource);
         if (setup_resource && (setup_resource != dst_resource)) {
             context->UpdateAccessState(*vs_state, setup_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_WRITE, tag);
         }
@@ -2297,7 +2297,7 @@ void SyncValidator::PreCallRecordCmdDecodeVideoKHR(VkCommandBuffer commandBuffer
 
     for (uint32_t i = 0; i < pDecodeInfo->referenceSlotCount; ++i) {
         if (pDecodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            auto reference_resource = vvl::VideoPictureResource(this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
+            auto reference_resource = vvl::VideoPictureResource(*this, *pDecodeInfo->pReferenceSlots[i].pPictureResource);
             if (reference_resource) {
                 context->UpdateAccessState(*vs_state, reference_resource, SYNC_VIDEO_DECODE_VIDEO_DECODE_READ, tag);
             }
@@ -2334,7 +2334,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
         }
     }
 
-    auto src_resource = vvl::VideoPictureResource(this, pEncodeInfo->srcPictureResource);
+    auto src_resource = vvl::VideoPictureResource(*this, pEncodeInfo->srcPictureResource);
     if (src_resource) {
         auto hazard = context->DetectHazard(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
         if (hazard.IsHazard()) {
@@ -2345,7 +2345,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
     }
 
     if (pEncodeInfo->pSetupReferenceSlot != nullptr && pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        auto setup_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
+        auto setup_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
         if (setup_resource) {
             auto hazard = context->DetectHazard(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE);
             if (hazard.IsHazard()) {
@@ -2359,7 +2359,7 @@ bool SyncValidator::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuff
 
     for (uint32_t i = 0; i < pEncodeInfo->referenceSlotCount; ++i) {
         if (pEncodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            auto reference_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
+            auto reference_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
             if (reference_resource) {
                 auto hazard = context->DetectHazard(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ);
                 if (hazard.IsHazard()) {
@@ -2395,13 +2395,13 @@ void SyncValidator::PreCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer
         context->UpdateAccessState(*src_buffer, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, SyncOrdering::kNonAttachment, src_range, tag);
     }
 
-    auto src_resource = vvl::VideoPictureResource(this, pEncodeInfo->srcPictureResource);
+    auto src_resource = vvl::VideoPictureResource(*this, pEncodeInfo->srcPictureResource);
     if (src_resource) {
         context->UpdateAccessState(*vs_state, src_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
     }
 
     if (pEncodeInfo->pSetupReferenceSlot != nullptr && pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
-        auto setup_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
+        auto setup_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pSetupReferenceSlot->pPictureResource);
         if (setup_resource) {
             context->UpdateAccessState(*vs_state, setup_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_WRITE, tag);
         }
@@ -2409,7 +2409,7 @@ void SyncValidator::PreCallRecordCmdEncodeVideoKHR(VkCommandBuffer commandBuffer
 
     for (uint32_t i = 0; i < pEncodeInfo->referenceSlotCount; ++i) {
         if (pEncodeInfo->pReferenceSlots[i].pPictureResource != nullptr) {
-            auto reference_resource = vvl::VideoPictureResource(this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
+            auto reference_resource = vvl::VideoPictureResource(*this, *pEncodeInfo->pReferenceSlots[i].pPictureResource);
             if (reference_resource) {
                 context->UpdateAccessState(*vs_state, reference_resource, SYNC_VIDEO_ENCODE_VIDEO_ENCODE_READ, tag);
             }


### PR DESCRIPTION
```
const ValidationStateTracker* state_tracker;
const ValidationStateTracker* state_data;
const ValidationStateTracker* dev;
const ValidationStateTracker* dev_data;
const ValidationStateTracker* device_data;
const ValidationStateTracker* state;
```

are all things I have found in the code

this PR does two things

1. Makes them all `validator`
2. Makes them reference instead of pointers consistently (where possible)

There are some more core changes I would like to make to the chassis code, but first there is a need to clean up this stuff so it is easy to understand what is going on everywhere