### PR TITLE
tests: Simplify test and make it positive

### DIFF
--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1671,3 +1671,39 @@ TEST_F(PositiveSyncVal, ThreadedSubmitAndFenceWaitAndPresent) {
     }
     thread.join();
 }
+
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7713
+TEST_F(PositiveSyncVal, CopyBufferToCompressedImage) {
+    TEST_DESCRIPTION("Copy from a buffer to compressed image without overlap.");
+
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    VkFormatProperties format_properties;
+    VkFormat mp_format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), mp_format, &format_properties);
+    if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
+        GTEST_SKIP()
+            << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
+    }
+
+    const VkDeviceSize buffer_size = 32;  // enough for 8x8 BC1 region
+    vkt::Buffer src_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Image dst_image(*m_device, 16, 16, 1, mp_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferImageCopy buffer_copy[2] = {};
+    buffer_copy[0].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    buffer_copy[0].imageSubresource.mipLevel = 0;
+    buffer_copy[0].imageSubresource.baseArrayLayer = 0;
+    buffer_copy[0].imageSubresource.layerCount = 1;
+    buffer_copy[0].imageOffset = {0, 0, 0};
+    buffer_copy[0].imageExtent = {8, 8, 1};
+    buffer_copy[1].imageSubresource = buffer_copy[0].imageSubresource;
+    buffer_copy[1].imageOffset = {8, 0, 0};
+    buffer_copy[1].imageExtent = {8, 8, 1};
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
Follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7713
It's two copies instead of three that also reproduces the issue if the above fix is not applied.
