### PR TITLE
layers: Store submit reference instead of SemOp in timeline

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -244,6 +244,7 @@ vvl_sources = [
   "layers/state_tracker/state_object.h",
   "layers/state_tracker/state_tracker.cpp",
   "layers/state_tracker/state_tracker.h",
+  "layers/state_tracker/submission_reference.h",
   "layers/state_tracker/vertex_index_buffer_state.h",
   "layers/state_tracker/video_session_state.cpp",
   "layers/state_tracker/video_session_state.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -274,6 +274,7 @@ target_sources(vvl PRIVATE
     state_tracker/shader_object_state.h
     state_tracker/state_tracker.cpp
     state_tracker/state_tracker.h
+    state_tracker/submission_reference.h
     state_tracker/vertex_index_buffer_state.h
     state_tracker/video_session_state.cpp
     state_tracker/video_session_state.h

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -63,7 +63,7 @@ struct TimelineMaxDiffCheck {
     // compute the differents between 2 timeline values, without rollover if the difference is greater than INT64_MAX
     uint64_t AbsDiff(uint64_t a, uint64_t b) { return a > b ? a - b : b - a; }
 
-    bool operator()(const vvl::Semaphore::SemOp &op, bool is_pending) { return AbsDiff(value, op.payload) > max_diff; }
+    bool operator()(const vvl::Semaphore::SemOp &, uint64_t payload, bool is_pending) { return AbsDiff(value, payload) > max_diff; }
 
     uint64_t value;
     uint64_t max_diff;
@@ -202,16 +202,16 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
         case VK_SEMAPHORE_TYPE_TIMELINE: {
             uint64_t bad_value = 0;
             std::string where;
-            auto must_be_greater = [value](const vvl::Semaphore::SemOp &op, bool is_pending) {
+            auto must_be_greater = [value](const vvl::Semaphore::SemOp &op, uint64_t payload, bool is_pending) {
                 if (!op.IsSignal()) {
                     return false;
                 }
                 // duplicate signal values are never allowed.
-                if (value == op.payload) {
+                if (value == payload) {
                     return true;
                 }
                 // exact value ordering cannot be determined until execution time
-                return !is_pending && value < op.payload;
+                return !is_pending && value < payload;
             };
             if (CheckSemaphoreValue(*semaphore_state, where, bad_value, must_be_greater)) {
                 const auto &vuid = GetQueueSubmitVUID(signal_semaphore_loc, SubmitError::kTimelineSemSmallValue);
@@ -1402,8 +1402,8 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
                          FormatHandle(pSignalInfo->semaphore).c_str(), completed.payload);
         return skip;
     }
-    auto exceeds_pending = [pSignalInfo](const vvl::Semaphore::SemOp &op, bool is_pending) {
-        return is_pending && op.IsSignal() && pSignalInfo->value >= op.payload;
+    auto exceeds_pending = [pSignalInfo](const vvl::Semaphore::SemOp &op, uint64_t payload, bool is_pending) {
+        return is_pending && op.IsSignal() && pSignalInfo->value >= payload;
     };
     auto last_op = semaphore_state->LastOp(exceeds_pending);
     if (last_op) {

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include "state_tracker/state_object.h"
+#include "state_tracker/submission_reference.h"
 #include <future>
 #include <mutex>
 
@@ -30,18 +31,12 @@ namespace vvl {
 class Queue;
 class Swapchain;
 
-// References a specific submission on the given queue.
-struct SubmissionLocator {
-    Queue *queue = nullptr;
-    uint64_t seq = kU64Max;
-};
-
 // present-based sync is when a fence from AcquireNextImage is used to synchronize
 // with submissions presented in one of the previous frames.
 // More common scheme is to use QueueSubmit fence for frame synchronization.
 struct PresentSync {
     // Queue submissions that will be notified when WaitForFences is called.
-    small_vector<SubmissionLocator, 2, uint32_t> submissions;
+    small_vector<SubmissionReference, 2, uint32_t> submissions;
 
     // Swapchain associated with this PresentSync.
     std::shared_ptr<vvl::Swapchain> swapchain;

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -185,7 +185,8 @@ class Semaphore : public RefcountedStateObject {
     void Retire(Queue *current_queue, const Location &loc, uint64_t payload);
 
     // look for most recent / highest payload operation that matches
-    std::optional<SemOpTemp> LastOp(const std::function<bool(const SemOp &, uint64_t, bool is_pending)> &filter = nullptr) const;
+    std::optional<SemOpTemp> LastOp(
+        const std::function<bool(OpType op_type, uint64_t payload, bool is_pending)> &filter = nullptr) const;
 
     // Returns queue submission associated with the last binary signal.
     std::optional<SubmissionLocator> GetLastBinarySignalSubmission() const;
@@ -268,5 +269,5 @@ struct SemaphoreSubmitState {
     bool CannotSignalBinary(const vvl::Semaphore &semaphore_state, VkQueue &other_queue, vvl::Func &other_command) const;
 
     bool CheckSemaphoreValue(const vvl::Semaphore &semaphore_state, std::string &where, uint64_t &bad_value,
-                             std::function<bool(const vvl::Semaphore::SemOp &, uint64_t, bool is_pending)> compare_func);
+                             std::function<bool(const vvl::Semaphore::OpType, uint64_t, bool is_pending)> compare_func);
 };

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -70,8 +70,6 @@ class Semaphore : public RefcountedStateObject {
         uint64_t seq;
         uint64_t payload;
 
-        bool operator<(const SemOp &rhs) const { return payload < rhs.payload; }
-
         bool IsWait() const { return op_type == kWait; }
         bool IsSignal() const { return op_type == kSignal; }
         bool IsAcquire() const { return op_type == kBinaryAcquire; }

--- a/layers/state_tracker/submission_reference.h
+++ b/layers/state_tracker/submission_reference.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+namespace vvl {
+
+class Queue;
+
+// References a specific submission on the given queue.
+// The naming convention matches other parts of the core synchronization, where "submission" refers to a separate batch from the
+// submission command. Synchronization validation follows more closely the specification terminology and uses "batch" term.
+struct SubmissionReference {
+    Queue *queue = nullptr;
+    uint64_t seq = kU64Max;
+
+    SubmissionReference() = default;
+    SubmissionReference(Queue *q, uint64_t queue_seq) : queue(q), seq(queue_seq) {}
+};
+
+}  // namespace vvl


### PR DESCRIPTION
Before starting with some core sync bugs, I decided it was a good time to make a change I had been thinking about for some time. I feel this makes concepts a bit more orthogonal and hopefully helps to dig faster into the code.

It is a refactor to store only submission references instead of SemOps inside the semaphore's timeline. The main gain is that a submission reference is a simpler abstraction than SemOp. As a bonus, this avoids some data duplication and the need to keep asserts to ensure that duplicated data is consistent.

SemOps are continued to be used outside the semaphore's timeline (completed/last operation, other contexts). 

We can avoid storing `payload` and `op_type` values inside timeline because:
* payload value is already known when we access semaphore timeline - it is the key of the timeline map to get corresponding TimePoint object.
* op_type is determined by the TimePoint's variable that stores information: signal_op, wait_ops, acquire.

Each refactor step has its commit with comments, some commits are more challenging than others, might be good to keep this way in case of regression.

That's a minimal change to get it work, some more clean up is needed, which I'd like to make separately: rename some variables from ops to refs, simplify some signatures to pass SubmissionReference instead of (queue, seq), check if there are places that don't require null check anymore.
