### PR TITLE
layers: Fix out-of-bounds memory access in Best Practices

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -201,7 +201,6 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
 
     const VkIndexType ib_type = cmd_state.index_buffer_binding.index_type;
     const auto& ib_mem_state = *ib_state->MemState();
-    const VkDeviceSize ib_mem_offset = ib_mem_state.mapped_range.offset;
     const void* ib_mem = ib_mem_state.p_driver_data;
     bool primitive_restart_enable = false;
 
@@ -217,7 +216,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
     // no point checking index buffer if the memory is nonexistant/unmapped, or if there is no graphics pipeline bound to this CB
     if (ib_mem && last_bound.IsUsing()) {
         const uint32_t scan_stride = GetIndexAlignment(ib_type);
-        const uint8_t* scan_begin = static_cast<const uint8_t*>(ib_mem) + ib_mem_offset + firstIndex * scan_stride;
+        const uint8_t* scan_begin = static_cast<const uint8_t*>(ib_mem) + firstIndex * scan_stride;
         const uint8_t* scan_end = scan_begin + indexCount * scan_stride;
 
         // Min and max are important to track for some Mali architectures. In older Mali devices without IDVS, all


### PR DESCRIPTION
`BestPractices-vkCmdDrawIndexed-sparse-index-buffer` introduced a warning if the bound index buffer doesn't make good use of the range of values in the index buffer. To do this, the validation layer captures any call to `vkMapMemory` and notes where the memory was mapped. [Here](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/layers/state_tracker/state_tracker.cpp#L1451)

Later, the best practices layer uses this stored pointer to iterate over the index buffer and read the values, [here](https://github.com/KhronosGroup/Vulkan-ValidationLayers/blob/main/layers/best_practices/bp_drawdispatch.cpp#L219). However, when accessing the pointer to the buffer's memory, the layer adds on the offset that was originally passed to `vkMapMemory`. This shouldn't happen, as the pointer returned from `vkMapMemory` has already been offset by that value.

This PR simply removes the double-offset so the function reads the correct area of memory.