### PR TITLE
layers: Pass ValidationStateTracker as reference

### DIFF
--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -50,12 +50,13 @@ WriteLockGuard BestPractices::WriteLock() {
 std::shared_ptr<vvl::CommandBuffer> BestPractices::CreateCmdBufferState(VkCommandBuffer handle,
                                                                         const VkCommandBufferAllocateInfo* pCreateInfo,
                                                                         const vvl::CommandPool* pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<bp_state::CommandBuffer>(this, handle, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(
+        std::make_shared<bp_state::CommandBuffer>(*this, handle, pCreateInfo, pool));
 }
 
-bp_state::CommandBuffer::CommandBuffer(BestPractices* bp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+bp_state::CommandBuffer::CommandBuffer(BestPractices& bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
                                        const vvl::CommandPool* pool)
-    : vvl::CommandBuffer(bp, cb, pCreateInfo, pool) {}
+    : vvl::CommandBuffer(bp, handle, pCreateInfo, pool) {}
 
 bool BestPractices::VendorCheckEnabled(BPVendorFlags vendors) const {
     for (const auto& vendor : kVendorInfo) {

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -184,5 +184,5 @@ bool BestPractices::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice devic
 
 std::shared_ptr<vvl::DescriptorPool> BestPractices::CreateDescriptorPoolState(VkDescriptorPool handle,
                                                                               const VkDescriptorPoolCreateInfo* pCreateInfo) {
-    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(this, handle, pCreateInfo));
+    return std::static_pointer_cast<vvl::DescriptorPool>(std::make_shared<bp_state::DescriptorPool>(*this, handle, pCreateInfo));
 }

--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -297,11 +297,11 @@ void BestPractices::ValidateImageInQueue(const vvl::Queue& qs, const vvl::Comman
 
 std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<bp_state::Image>(this, handle, pCreateInfo, features);
+    return std::make_shared<bp_state::Image>(*this, handle, pCreateInfo, features);
 }
 
 std::shared_ptr<vvl::Image> BestPractices::CreateImageState(VkImage handle, const VkImageCreateInfo* pCreateInfo,
                                                             VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                             VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<bp_state::Image>(this, handle, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<bp_state::Image>(*this, handle, pCreateInfo, swapchain, swapchain_index, features);
 }

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -252,7 +252,7 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
     return result;
 }
 
-bp_state::Pipeline::Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+bp_state::Pipeline::Pipeline(const ValidationStateTracker& state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
                              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache,
                              std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout,
                              CreateShaderModuleStates* csm_states)
@@ -265,7 +265,7 @@ std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(const 
                                                                           std::shared_ptr<const vvl::PipelineLayout>&& layout,
                                                                           CreateShaderModuleStates* csm_states) const {
     return std::static_pointer_cast<vvl::Pipeline>(std::make_shared<bp_state::Pipeline>(
-        this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), csm_states));
+        *this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), csm_states));
 }
 
 void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -31,13 +31,13 @@ class BestPractices;
 namespace bp_state {
 class Image : public vvl::Image {
   public:
-    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo,
+    Image(const ValidationStateTracker& dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo,
           VkFormatFeatureFlags2KHR features)
         : vvl::Image(dev_data, handle, pCreateInfo, features) {
         SetupUsages();
     }
 
-    Image(const ValidationStateTracker* dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker& dev_data, VkImage handle, const VkImageCreateInfo* pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
         : vvl::Image(dev_data, handle, pCreateInfo, swapchain, swapchain_index, features) {
         SetupUsages();
@@ -100,7 +100,7 @@ class PhysicalDevice : public vvl::PhysicalDevice {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
+    Swapchain(ValidationStateTracker& dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo, VkSwapchainKHR handle)
         : vvl::Swapchain(dev_data, pCreateInfo, handle) {}
 
     CALL_STATE vkGetSwapchainImagesKHRState = UNCALLED;
@@ -189,7 +189,7 @@ struct CommandBufferStateNV {
 
 class CommandBuffer : public vvl::CommandBuffer {
   public:
-    CommandBuffer(BestPractices* bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CommandBuffer(BestPractices& bp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
                   const vvl::CommandPool* pool);
 
     RenderPassState render_pass_state;
@@ -203,7 +203,7 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 class DescriptorPool : public vvl::DescriptorPool {
   public:
-    DescriptorPool(ValidationStateTracker* dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
+    DescriptorPool(ValidationStateTracker& dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo* pCreateInfo)
         : vvl::DescriptorPool(dev, handle, pCreateInfo) {}
 
     uint32_t freed_count{0};
@@ -211,7 +211,7 @@ class DescriptorPool : public vvl::DescriptorPool {
 
 class Pipeline : public vvl::Pipeline {
   public:
-    Pipeline(const ValidationStateTracker* state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
+    Pipeline(const ValidationStateTracker& state_data, const VkGraphicsPipelineCreateInfo* pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache, std::shared_ptr<const vvl::RenderPass>&& rpstate,
              std::shared_ptr<const vvl::PipelineLayout>&& layout, CreateShaderModuleStates* csm_states);
 

--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -386,5 +386,5 @@ void BestPractices::ManualPostCallRecordGetSwapchainImagesKHR(VkDevice device, V
 
 std::shared_ptr<vvl::Swapchain> BestPractices::CreateSwapchainState(const VkSwapchainCreateInfoKHR* pCreateInfo,
                                                                     VkSwapchainKHR handle) {
-    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(this, pCreateInfo, handle));
+    return std::static_pointer_cast<vvl::Swapchain>(std::make_shared<bp_state::Swapchain>(*this, pCreateInfo, handle));
 }

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1433,7 +1433,7 @@ bool CoreChecks::ValidateUpdateDescriptorSets(uint32_t descriptorWriteCount, con
     return skip;
 }
 
-vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const ValidationStateTracker *device_data, VkDescriptorSet descriptorSet,
+vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const ValidationStateTracker &device_data, VkDescriptorSet descriptorSet,
                                                   const vvl::DescriptorUpdateTemplate *template_state, const void *pData,
                                                   VkDescriptorSetLayout push_layout) {
     auto const &create_info = template_state->create_info;
@@ -1444,7 +1444,7 @@ vvl::DecodedTemplateUpdate::DecodedTemplateUpdate(const ValidationStateTracker *
     VkDescriptorSetLayout effective_dsl = create_info.templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET
                                               ? create_info.descriptorSetLayout
                                               : push_layout;
-    auto layout_obj = device_data->Get<vvl::DescriptorSetLayout>(effective_dsl);
+    auto layout_obj = device_data.Get<vvl::DescriptorSetLayout>(effective_dsl);
 
     // Create a WriteDescriptorSet struct for each template update entry
     for (uint32_t i = 0; i < create_info.descriptorUpdateEntryCount; i++) {
@@ -2177,7 +2177,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
 
                     if (pSetLayoutSize == nullptr) {
                         const auto pool = cb_state.command_pool;
-                        DispatchGetDescriptorSetLayoutSizeEXT(pool->dev_data->device, set_layout->VkHandle(), &setLayoutSize);
+                        DispatchGetDescriptorSetLayoutSizeEXT(pool->dev_data.device, set_layout->VkHandle(), &setLayoutSize);
                     } else {
                         setLayoutSize = *pSetLayoutSize;
                     }
@@ -2193,7 +2193,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
                                 // must validate is just the offset of the last binding.
                                 const auto pool = cb_state.command_pool;
                                 uint32_t binding = set_layout->GetDescriptorSetLayoutBindingPtrFromIndex(j)->binding;
-                                DispatchGetDescriptorSetLayoutBindingOffsetEXT(pool->dev_data->device, set_layout->VkHandle(),
+                                DispatchGetDescriptorSetLayoutBindingOffsetEXT(pool->dev_data.device, set_layout->VkHandle(),
                                                                                binding, &setLayoutSize);
 
                                 // If the descriptor set only consists of VARIABLE_DESCRIPTOR_COUNT bindings, the
@@ -3646,7 +3646,7 @@ bool CoreChecks::PreCallValidateUpdateDescriptorSetWithTemplate(VkDevice device,
     if (template_state->create_info.templateType == VK_DESCRIPTOR_UPDATE_TEMPLATE_TYPE_DESCRIPTOR_SET) {
         // decode the templatized data and leverage the non-template UpdateDescriptor helper functions.
         // Translate the templated update into a normal update for validation...
-        vvl::DecodedTemplateUpdate decoded_update(this, descriptorSet, template_state.get(), pData);
+        vvl::DecodedTemplateUpdate decoded_update(*this, descriptorSet, template_state.get(), pData);
         return ValidateUpdateDescriptorSets(static_cast<uint32_t>(decoded_update.desc_writes.size()),
                                             decoded_update.desc_writes.data(), 0, nullptr, error_obj.location);
     }
@@ -3735,7 +3735,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSetWithTemplate(VkCommandBuffer comman
             // Create an empty proxy in order to use the existing descriptor set update validation
             vvl::DescriptorSet proxy_ds(VK_NULL_HANDLE, nullptr, dsl, 0, const_cast<CoreChecks *>(this));
             // Decode the template into a set of write updates
-            vvl::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
+            vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
             // Validate the decoded update against the proxy_ds
             skip |= ValidatePushDescriptorsUpdate(proxy_ds, static_cast<uint32_t>(decoded_template.desc_writes.size()),
                                                   decoded_template.desc_writes.data(), loc);

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -756,9 +756,9 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
 bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, Func command,
                                     VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
     bool skip = false;
-    auto state_data = cb_state.dev_data;
+    const auto &state_data = cb_state.dev_data;
 
-    auto query_pool_state = state_data->Get<vvl::QueryPool>(query_obj.pool);
+    auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
     const auto &query_pool_ci = query_pool_state->create_info;
 
     QueryState state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
@@ -793,12 +793,12 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
                                : unexpected_caller_vuid;
         assert(strcmp(vuid, unexpected_caller_vuid) != 0);
 
-        skip |= state_data->LogError(vuid, objlist, loc,
-                                     "%s and query %" PRIu32
-                                     ": query not reset. "
-                                     "After query pool creation, each query must be reset before it is used. "
-                                     "Queries must also be reset between uses.",
-                                     state_data->FormatHandle(query_obj.pool).c_str(), query_obj.slot);
+        skip |= state_data.LogError(vuid, objlist, loc,
+                                    "%s and query %" PRIu32
+                                    ": query not reset. "
+                                    "After query pool creation, each query must be reset before it is used. "
+                                    "Queries must also be reset between uses.",
+                                    state_data.FormatHandle(query_obj.pool).c_str(), query_obj.slot);
     }
 
     return skip;
@@ -806,8 +806,8 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
 
 bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, Func command,
                                           VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
-    auto state_data = cb_state.dev_data;
-    auto query_pool_state = state_data->Get<vvl::QueryPool>(query_obj.pool);
+    const auto &state_data = cb_state.dev_data;
+    auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
     const auto &query_pool_ci = query_pool_state->create_info;
     const Location loc(command);
 
@@ -817,23 +817,23 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
 
     if (perfPass >= query_pool_state->n_performance_passes) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError("VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221", objlist, loc,
-                                     "Invalid counterPassIndex (%u, maximum allowed %u) value for query pool %s.", perfPass,
-                                     query_pool_state->n_performance_passes, state_data->FormatHandle(query_obj.pool).c_str());
+        skip |= state_data.LogError("VUID-VkPerformanceQuerySubmitInfoKHR-counterPassIndex-03221", objlist, loc,
+                                    "Invalid counterPassIndex (%u, maximum allowed %u) value for query pool %s.", perfPass,
+                                    query_pool_state->n_performance_passes, state_data.FormatHandle(query_obj.pool).c_str());
     }
 
     if (!cb_state.performance_lock_acquired || cb_state.performance_lock_released) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError("VUID-vkQueueSubmit-pCommandBuffers-03220", objlist, loc,
-                                     "Commandbuffer %s was submitted and contains a performance query but the"
-                                     "profiling lock was not held continuously throughout the recording of commands.",
-                                     state_data->FormatHandle(cb_state).c_str());
+        skip |= state_data.LogError("VUID-vkQueueSubmit-pCommandBuffers-03220", objlist, loc,
+                                    "Commandbuffer %s was submitted and contains a performance query but the"
+                                    "profiling lock was not held continuously throughout the recording of commands.",
+                                    state_data.FormatHandle(cb_state).c_str());
     }
 
     QueryState command_buffer_state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
     if (command_buffer_state == QUERYSTATE_RESET) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-        skip |= state_data->LogError(
+        skip |= state_data.LogError(
             query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-None-02863" : "VUID-vkCmdBeginQuery-None-02863", objlist, loc,
             "VkQuery begin command recorded in a command buffer that, either directly or "
             "through secondary command buffers, also contains a vkCmdResetQueryPool command "
@@ -841,14 +841,14 @@ bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, co
     }
 
     if (firstPerfQueryPool != VK_NULL_HANDLE) {
-        if (firstPerfQueryPool != query_obj.pool && !state_data->enabled_features.performanceCounterMultipleQueryPools) {
+        if (firstPerfQueryPool != query_obj.pool && !state_data.enabled_features.performanceCounterMultipleQueryPools) {
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
-            skip |= state_data->LogError(
+            skip |= state_data.LogError(
                 query_obj.indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-03226" : "VUID-vkCmdBeginQuery-queryPool-03226",
                 objlist, loc,
                 "Commandbuffer %s contains more than one performance query pool but "
                 "performanceCounterMultipleQueryPools is not enabled.",
-                state_data->FormatHandle(cb_state).c_str());
+                state_data.FormatHandle(cb_state).c_str());
         }
     } else {
         firstPerfQueryPool = query_obj.pool;
@@ -887,7 +887,7 @@ void CoreChecks::EnqueueVerifyEndQuery(vvl::CommandBuffer &cb_state, const Query
         if (!do_validate) return false;
         bool skip = false;
         // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
-        auto query_pool_state = cb_state_arg.dev_data->Get<vvl::QueryPool>(query_obj.pool);
+        auto query_pool_state = cb_state_arg.dev_data.Get<vvl::QueryPool>(query_obj.pool);
         if (query_pool_state->has_perf_scope_command_buffer && (cb_state_arg.command_count - 1) != query_obj.end_command_index) {
             const LogObjectList objlist(cb_state_arg.Handle(), query_pool_state->Handle());
             const Location loc(command);
@@ -1058,15 +1058,15 @@ void CoreChecks::PreCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, V
                                                 vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                                 uint32_t perfPass, QueryMap *localQueryToStateMap) {
             if (!do_validate) return false;
-            const auto state_data = cb_state_arg.dev_data;
+            const auto &state_data = cb_state_arg.dev_data;
             bool skip = false;
             for (uint32_t i = 0; i < queryCount; i++) {
                 QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
                 if (state == QUERYSTATE_ENDED) {
                     const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
-                    skip |= state_data->LogError("VUID-vkCmdResetQueryPool-firstQuery-02862", objlist, record_obj.location,
-                                                 "Query index %" PRIu32 " was begun and reset in the same command buffer.",
-                                                 firstQuery + i);
+                    skip |= state_data.LogError("VUID-vkCmdResetQueryPool-firstQuery-02862", objlist, record_obj.location,
+                                                "Query index %" PRIu32 " was begun and reset in the same command buffer.",
+                                                firstQuery + i);
                     break;
                 }
             }
@@ -1196,22 +1196,22 @@ void CoreChecks::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuf
                                             vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                             uint32_t perfPass, QueryMap *localQueryToStateMap) {
         if (!do_validate) return false;
-        const auto state_data = cb_state_arg.dev_data;
+        const auto &state_data = cb_state_arg.dev_data;
         bool skip = false;
         for (uint32_t i = 0; i < queryCount; i++) {
             QueryState state = GetLocalQueryState(localQueryToStateMap, queryPool, firstQuery + i, perfPass);
             QueryResultType result_type = GetQueryResultType(state, flags);
             if (result_type != QUERYRESULT_SOME_DATA && result_type != QUERYRESULT_UNKNOWN) {
                 const LogObjectList objlist(cb_state_arg.Handle(), queryPool);
-                skip |= state_data->LogError("VUID-vkCmdCopyQueryPoolResults-None-08752", objlist, record_obj.location,
-                                             "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
-                                             state_data->FormatHandle(queryPool).c_str(), firstQuery + i,
-                                             string_QueryResultType(result_type));
+                skip |= state_data.LogError("VUID-vkCmdCopyQueryPoolResults-None-08752", objlist, record_obj.location,
+                                            "Requesting a copy from query to buffer on %s query %" PRIu32 ": %s",
+                                            state_data.FormatHandle(queryPool).c_str(), firstQuery + i,
+                                            string_QueryResultType(result_type));
             }
         }
 
         // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
-        auto query_pool_state = cb_state_arg.dev_data->Get<vvl::QueryPool>(queryPool);
+        auto query_pool_state = cb_state_arg.dev_data.Get<vvl::QueryPool>(queryPool);
         skip |= ValidateQueryPoolWasReset(*query_pool_state, firstQuery, queryCount, record_obj.location, localQueryToStateMap,
                                           perfPass);
 

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -31,7 +31,7 @@
 #include "sync/sync_vuid_maps.h"
 
 struct CommandBufferSubmitState {
-    const CoreChecks *core;
+    const CoreChecks &core;
     const vvl::Queue *queue_state;
     QFOTransferCBScoreboards<QFOImageTransferBarrier> qfo_image_scoreboards;
     QFOTransferCBScoreboards<QFOBufferTransferBarrier> qfo_buffer_scoreboards;
@@ -48,7 +48,7 @@ struct CommandBufferSubmitState {
     EventToStageMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
 
-    CommandBufferSubmitState(const CoreChecks *c, const vvl::Queue *q) : core(c), queue_state(q) {
+    CommandBufferSubmitState(const CoreChecks &c, const vvl::Queue *q) : core(c), queue_state(q) {
         // Queue label state is updated during PostRecord phase.
         // Copy state to be able to track labels during validation.
         cmdbuf_label_stack = queue_state->cmdbuf_label_stack;
@@ -58,13 +58,13 @@ struct CommandBufferSubmitState {
 
     bool Validate(const Location &loc, const vvl::CommandBuffer &cb_state, uint32_t perf_pass) {
         bool skip = false;
-        skip |= core->ValidateCmdBufImageLayouts(loc, cb_state, overlay_image_layout_map);
+        skip |= core.ValidateCmdBufImageLayouts(loc, cb_state, overlay_image_layout_map);
         const VkCommandBuffer cmd = cb_state.VkHandle();
         current_cmds.push_back(cmd);
-        skip |= core->ValidatePrimaryCommandBufferState(
+        skip |= core.ValidatePrimaryCommandBufferState(
             loc, cb_state, static_cast<uint32_t>(std::count(current_cmds.begin(), current_cmds.end(), cmd)), &qfo_image_scoreboards,
             &qfo_buffer_scoreboards);
-        skip |= core->ValidateQueueFamilyIndices(loc, cb_state, queue_state->VkHandle());
+        skip |= core.ValidateQueueFamilyIndices(loc, cb_state, queue_state->VkHandle());
         skip |= ValidateCmdBufLabelMatching(loc, cb_state);
 
         // Potential early exit here as bad object state may crash in delayed function calls
@@ -74,7 +74,7 @@ struct CommandBufferSubmitState {
 
         // Call submit-time functions to validate or update local mirrors of state (to preserve const-ness at validate time)
         for (auto &function : cb_state.queue_submit_functions) {
-            skip |= function(*core, *queue_state, cb_state);
+            skip |= function(core, *queue_state, cb_state);
         }
         for (auto &function : cb_state.eventUpdates) {
             skip |= function(const_cast<vvl::CommandBuffer &>(cb_state), /*do_validate*/ true, local_event_signal_info,
@@ -87,7 +87,7 @@ struct CommandBufferSubmitState {
         }
 
         for (const auto &it : cb_state.video_session_updates) {
-            auto video_session_state = core->Get<vvl::VideoSession>(it.first);
+            auto video_session_state = core.Get<vvl::VideoSession>(it.first);
             auto local_state_it = local_video_session_state.find(it.first);
             if (local_state_it == local_video_session_state.end()) {
                 local_state_it = local_video_session_state.insert({it.first, video_session_state->DeviceStateCopy()}).first;
@@ -127,10 +127,10 @@ private:
                 previous_debug_region =
                     std::string("The previous debug region before the invalid command is '") + last_closed_cmdbuf_label + "'.";
             }
-            skip |= core->LogError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912", cb_state.Handle(), loc,
-                                   "(%s) contains vkCmdEndDebugUtilsLabelEXT that does not have a matching "
-                                   "vkCmdBeginDebugUtilsLabelEXT in this or one of the previously submitted command buffers. %s",
-                                   core->FormatHandle(cb_state).c_str(), previous_debug_region.c_str());
+            skip |= core.LogError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912", cb_state.Handle(), loc,
+                                  "(%s) contains vkCmdEndDebugUtilsLabelEXT that does not have a matching "
+                                  "vkCmdBeginDebugUtilsLabelEXT in this or one of the previously submitted command buffers. %s",
+                                  core.FormatHandle(cb_state).c_str(), previous_debug_region.c_str());
         }
         return skip;
     }
@@ -149,8 +149,8 @@ bool CoreChecks::PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount,
     }
 
     auto queue_state = Get<vvl::Queue>(queue);
-    CommandBufferSubmitState cb_submit_state(this, queue_state.get());
-    SemaphoreSubmitState sem_submit_state(this, queue, queue_state->queueFamilyProperties.queueFlags);
+    CommandBufferSubmitState cb_submit_state(*this, queue_state.get());
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->queueFamilyProperties.queueFlags);
 
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
@@ -316,8 +316,8 @@ bool CoreChecks::ValidateQueueSubmit2(VkQueue queue, uint32_t submitCount, const
     }
 
     auto queue_state = Get<vvl::Queue>(queue);
-    CommandBufferSubmitState cb_submit_state(this, queue_state.get());
-    SemaphoreSubmitState sem_submit_state(this, queue, queue_state->queueFamilyProperties.queueFlags);
+    CommandBufferSubmitState cb_submit_state(*this, queue_state.get());
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_state->queueFamilyProperties.queueFlags);
 
     // Now verify each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
@@ -656,7 +656,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                          string_VkQueueFlags(queue_flags).c_str());
     }
 
-    SemaphoreSubmitState sem_submit_state(this, queue, queue_flags);
+    SemaphoreSubmitState sem_submit_state(*this, queue, queue_flags);
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; ++bind_idx) {
         const Location bind_info_loc = error_obj.location.dot(Struct::VkBindSparseInfo, Field::pBindInfo, bind_idx);
         const VkBindSparseInfo &bind_info = pBindInfo[bind_idx];

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -114,13 +114,13 @@ bool SemaphoreSubmitState::ValidateBinaryWait(const Location &loc, VkQueue queue
         if (other_queue) {
             const auto &vuid = GetQueueSubmitVUID(loc, SubmitError::kOtherQueueWaiting);
             const LogObjectList objlist(semaphore, queue, other_queue);
-            skip |= core->LogError(vuid, objlist, loc, "queue (%s) is already waiting on semaphore (%s).",
-                                   core->FormatHandle(other_queue).c_str(), core->FormatHandle(semaphore).c_str());
+            skip |= core.LogError(vuid, objlist, loc, "queue (%s) is already waiting on semaphore (%s).",
+                                  core.FormatHandle(other_queue).c_str(), core.FormatHandle(semaphore).c_str());
         } else if (CannotWaitBinary(semaphore_state)) {
             const auto &vuid = GetQueueSubmitVUID(loc, SubmitError::kBinaryCannotBeSignalled);
             const LogObjectList objlist(semaphore, queue);
-            skip |= core->LogError(vuid, objlist, loc, "queue (%s) is waiting on semaphore (%s) that has no way to be signaled.",
-                                   core->FormatHandle(queue).c_str(), core->FormatHandle(semaphore).c_str());
+            skip |= core.LogError(vuid, objlist, loc, "queue (%s) is waiting on semaphore (%s) that has no way to be signaled.",
+                                  core.FormatHandle(queue).c_str(), core.FormatHandle(semaphore).c_str());
         } else {
             binary_signaling_state[semaphore] = false;
         }
@@ -135,7 +135,7 @@ bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_
     using sync_vuid_maps::SubmitError;
     bool skip = false;
 
-    auto semaphore_state = core->Get<vvl::Semaphore>(semaphore);
+    auto semaphore_state = core.Get<vvl::Semaphore>(semaphore);
     if (!semaphore_state) {
         return skip;
     }
@@ -146,12 +146,12 @@ bool SemaphoreSubmitState::ValidateWaitSemaphore(const Location &wait_semaphore_
         case VK_SEMAPHORE_TYPE_TIMELINE: {
             uint64_t bad_value = 0;
             std::string where;
-            TimelineMaxDiffCheck exceeds_max_diff(value, core->phys_dev_props_core12.maxTimelineSemaphoreValueDifference);
+            TimelineMaxDiffCheck exceeds_max_diff(value, core.phys_dev_props_core12.maxTimelineSemaphoreValueDifference);
             if (CheckSemaphoreValue(*semaphore_state, where, bad_value, exceeds_max_diff)) {
                 const auto &vuid = GetQueueSubmitVUID(wait_semaphore_loc, SubmitError::kTimelineSemMaxDiff);
-                skip |= core->LogError(vuid, semaphore, wait_semaphore_loc,
-                                       "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value,
-                                       where.c_str(), core->FormatHandle(semaphore).c_str(), bad_value);
+                skip |= core.LogError(vuid, semaphore, wait_semaphore_loc,
+                                      "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value,
+                                      where.c_str(), core.FormatHandle(semaphore).c_str(), bad_value);
                 break;
             }
             timeline_waits[semaphore] = value;
@@ -168,7 +168,7 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
     bool skip = false;
     LogObjectList objlist(semaphore, queue);
 
-    auto semaphore_state = core->Get<vvl::Semaphore>(semaphore);
+    auto semaphore_state = core.Get<vvl::Semaphore>(semaphore);
     if (!semaphore_state) {
         return skip;
     }
@@ -186,13 +186,13 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
                         if (other_command != vvl::Func::Empty) {
                             initiator << " on ";
                         }
-                        initiator << core->FormatHandle(other_queue);
+                        initiator << core.FormatHandle(other_queue);
                         objlist.add(other_queue);
                     }
-                    skip |= core->LogError(
+                    skip |= core.LogError(
                         "VUID-vkQueueSubmit-pCommandBuffers-00065", objlist, signal_semaphore_loc,
                         "(%s) is being signaled by %s, but it was previously signaled by %s and has not since been waited on",
-                        core->FormatHandle(semaphore).c_str(), core->FormatHandle(queue).c_str(), initiator.str().c_str());
+                        core.FormatHandle(semaphore).c_str(), core.FormatHandle(queue).c_str(), initiator.str().c_str());
                 } else {
                     binary_signaling_state[semaphore] = true;
                 }
@@ -215,18 +215,18 @@ bool SemaphoreSubmitState::ValidateSignalSemaphore(const Location &signal_semaph
             };
             if (CheckSemaphoreValue(*semaphore_state, where, bad_value, must_be_greater)) {
                 const auto &vuid = GetQueueSubmitVUID(signal_semaphore_loc, SubmitError::kTimelineSemSmallValue);
-                skip |= core->LogError(
+                skip |= core.LogError(
                     vuid, objlist, signal_semaphore_loc,
                     "signal value (0x%" PRIx64 ") in %s must be greater than %s timeline semaphore %s value (0x%" PRIx64 ")", value,
-                    core->FormatHandle(queue).c_str(), where.c_str(), core->FormatHandle(semaphore).c_str(), bad_value);
+                    core.FormatHandle(queue).c_str(), where.c_str(), core.FormatHandle(semaphore).c_str(), bad_value);
                 break;
             }
-            TimelineMaxDiffCheck exceeds_max_diff(value, core->phys_dev_props_core12.maxTimelineSemaphoreValueDifference);
+            TimelineMaxDiffCheck exceeds_max_diff(value, core.phys_dev_props_core12.maxTimelineSemaphoreValueDifference);
             if (CheckSemaphoreValue(*semaphore_state, where, bad_value, exceeds_max_diff)) {
                 const auto &vuid = GetQueueSubmitVUID(signal_semaphore_loc, SubmitError::kTimelineSemMaxDiff);
-                skip |= core->LogError(vuid, semaphore, signal_semaphore_loc,
-                                       "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value,
-                                       where.c_str(), core->FormatHandle(semaphore).c_str(), bad_value);
+                skip |= core.LogError(vuid, semaphore, signal_semaphore_loc,
+                                      "value (%" PRIu64 ") exceeds limit regarding %s semaphore %s value (%" PRIu64 ").", value,
+                                      where.c_str(), core.FormatHandle(semaphore).c_str(), bad_value);
                 break;
             }
             timeline_signals[semaphore] = value;
@@ -678,7 +678,7 @@ bool CoreChecks::PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer,
 struct RenderPassDepState {
     using Field = vvl::Field;
 
-    const CoreChecks *core;
+    const CoreChecks &core;
     const std::string vuid;
     uint32_t active_subpass;
     const VkRenderPass rp_handle;
@@ -686,7 +686,7 @@ struct RenderPassDepState {
     const std::vector<uint32_t> &self_dependencies;
     const safe_VkSubpassDependency2 *dependencies;
 
-    RenderPassDepState(const CoreChecks *c, const std::string &v, uint32_t subpass, const VkRenderPass handle,
+    RenderPassDepState(const CoreChecks &c, const std::string &v, uint32_t subpass, const VkRenderPass handle,
                        const DeviceFeatures &features, const DeviceExtensions &device_extensions,
                        const std::vector<uint32_t> &self_deps, const safe_VkSubpassDependency2 *deps)
         : core(c),
@@ -733,12 +733,12 @@ struct RenderPassDepState {
                                    (barrier_dst_stages == (subpass_dst_stages & barrier_dst_stages));
             if (is_subset) return false;  // subset is found, return skip value (false)
         }
-        return core->LogError(
-            vuid, rp_handle, barrier_loc.dot(Field::srcStageMask),
-            "(%s) and dstStageMask (%s) is not a subset of subpass dependency's srcStageMask and dstStageMask for "
-            "any self-dependency of subpass %" PRIu32 " of %s.",
-            string_VkPipelineStageFlags2(src_stage_mask).c_str(), string_VkPipelineStageFlags2(dst_stage_mask).c_str(),
-            active_subpass, core->FormatHandle(rp_handle).c_str());
+        return core.LogError(vuid, rp_handle, barrier_loc.dot(Field::srcStageMask),
+                             "(%s) and dstStageMask (%s) is not a subset of subpass dependency's srcStageMask and dstStageMask for "
+                             "any self-dependency of subpass %" PRIu32 " of %s.",
+                             string_VkPipelineStageFlags2(src_stage_mask).c_str(),
+                             string_VkPipelineStageFlags2(dst_stage_mask).c_str(), active_subpass,
+                             core.FormatHandle(rp_handle).c_str());
     }
 
     bool ValidateAccess(const Location &barrier_loc, VkAccessFlags2 src_access_mask, VkAccessFlags2 dst_access_mask) const {
@@ -749,11 +749,11 @@ struct RenderPassDepState {
                                    (dst_access_mask == (subpass_dep.dstAccessMask & dst_access_mask));
             if (is_subset) return false;  // subset is found, return skip value (false)
         }
-        return core->LogError(vuid, rp_handle, barrier_loc.dot(Field::srcAccessMask),
-                              "(%s) and dstAccessMask (%s) is not a subset of subpass dependency's srcAccessMask and dstAccessMask "
-                              "of subpass %" PRIu32 " of %s.",
-                              string_VkAccessFlags2(src_access_mask).c_str(), string_VkAccessFlags2(dst_access_mask).c_str(),
-                              active_subpass, core->FormatHandle(rp_handle).c_str());
+        return core.LogError(vuid, rp_handle, barrier_loc.dot(Field::srcAccessMask),
+                             "(%s) and dstAccessMask (%s) is not a subset of subpass dependency's srcAccessMask and dstAccessMask "
+                             "of subpass %" PRIu32 " of %s.",
+                             string_VkAccessFlags2(src_access_mask).c_str(), string_VkAccessFlags2(dst_access_mask).c_str(),
+                             active_subpass, core.FormatHandle(rp_handle).c_str());
     }
 
     bool ValidateDependencyFlag(const Location &dep_flags_loc, VkDependencyFlags dependency_flags) const {
@@ -762,11 +762,11 @@ struct RenderPassDepState {
             const bool match = subpass_dep.dependencyFlags == dependency_flags;
             if (match) return false;  // match is found, return skip value (false)
         }
-        return core->LogError(vuid, rp_handle, dep_flags_loc,
-                              "(%s) does not equal VkSubpassDependency dependencyFlags value for any "
-                              "self-dependency of subpass %" PRIu32 " of %s.",
-                              string_VkDependencyFlags(dependency_flags).c_str(), active_subpass,
-                              core->FormatHandle(rp_handle).c_str());
+        return core.LogError(vuid, rp_handle, dep_flags_loc,
+                             "(%s) does not equal VkSubpassDependency dependencyFlags value for any "
+                             "self-dependency of subpass %" PRIu32 " of %s.",
+                             string_VkDependencyFlags(dependency_flags).c_str(), active_subpass,
+                             core.FormatHandle(rp_handle).c_str());
     }
 };
 
@@ -804,7 +804,7 @@ bool CoreChecks::ValidateRenderPassPipelineBarriers(const Location &outer_loc, c
                                                     uint32_t image_mem_barrier_count, const VkImageMemoryBarrier *image_barriers) const {
     bool skip = false;
     const auto &rp_state = cb_state.activeRenderPass;
-    RenderPassDepState state(this, "VUID-vkCmdPipelineBarrier-None-07889", cb_state.GetActiveSubpass(), rp_state->VkHandle(),
+    RenderPassDepState state(*this, "VUID-vkCmdPipelineBarrier-None-07889", cb_state.GetActiveSubpass(), rp_state->VkHandle(),
                              enabled_features, device_extensions, rp_state->self_dependencies[cb_state.GetActiveSubpass()],
                              rp_state->create_info.pDependencies);
     if (state.self_dependencies.size() == 0) {
@@ -864,7 +864,7 @@ bool CoreChecks::ValidateRenderPassPipelineBarriers(const Location &outer_loc, c
     if (rp_state->UsesDynamicRendering()) {
         return skip;
     }
-    RenderPassDepState state(this, "VUID-vkCmdPipelineBarrier2-None-07889", cb_state.GetActiveSubpass(), rp_state->VkHandle(),
+    RenderPassDepState state(*this, "VUID-vkCmdPipelineBarrier2-None-07889", cb_state.GetActiveSubpass(), rp_state->VkHandle(),
                              enabled_features, device_extensions, rp_state->self_dependencies[cb_state.GetActiveSubpass()],
                              rp_state->create_info.pDependencies);
 
@@ -1045,7 +1045,7 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::Comman
                                             const EventToStageMap &local_event_signal_info, VkQueue waiting_queue,
                                             const Location &loc) {
     bool skip = false;
-    const ValidationStateTracker *state_data = cb_state.dev_data;
+    const ValidationStateTracker &state_data = cb_state.dev_data;
     VkPipelineStageFlags2KHR stage_mask = 0;
     const auto max_event = std::min((firstEventIndex + eventCount), cb_state.events.size());
     for (size_t event_index = firstEventIndex; event_index < max_event; ++event_index) {
@@ -1062,24 +1062,23 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::Comman
             stage_mask |= signal_info->second;
             // The "set event" is found in the current submission (the same queue); there can't be inter-queue usage errors
         } else {
-            auto event_state = state_data->Get<vvl::Event>(event);
+            auto event_state = state_data.Get<vvl::Event>(event);
             assert(event_state);  // caught with VUID-vkCmdWaitEvents-pEvents-parameter
             stage_mask |= event_state->signal_src_stage_mask;
 
             if (event_state->signaling_queue != VK_NULL_HANDLE && event_state->signaling_queue != waiting_queue) {
                 const LogObjectList objlist(cb_state.Handle(), event, event_state->signaling_queue, waiting_queue);
-                skip |=
-                    state_data->LogError("UNASSIGNED-SubmitValidation-WaitEvents-WrongQueue", objlist, Location(command),
-                                         "waits for event %s on the queue %s but the event was signaled on a different queue %s",
-                                         state_data->FormatHandle(event).c_str(), state_data->FormatHandle(waiting_queue).c_str(),
-                                         state_data->FormatHandle(event_state->signaling_queue).c_str());
+                skip |= state_data.LogError("UNASSIGNED-SubmitValidation-WaitEvents-WrongQueue", objlist, Location(command),
+                                            "waits for event %s on the queue %s but the event was signaled on a different queue %s",
+                                            state_data.FormatHandle(event).c_str(), state_data.FormatHandle(waiting_queue).c_str(),
+                                            state_data.FormatHandle(event_state->signaling_queue).c_str());
             }
         }
     }
     // TODO: Need to validate that host_bit is only set if set event is called
     // but set event can be called at any time.
     if (sourceStageMask != stage_mask && sourceStageMask != (stage_mask | VK_PIPELINE_STAGE_HOST_BIT)) {
-        skip |= state_data->LogError(
+        skip |= state_data.LogError(
             "VUID-vkCmdWaitEvents-srcStageMask-parameter", cb_state.Handle(), loc,
             "Submitting cmdbuffer with call to VkCmdWaitEvents using srcStageMask %s which must be the bitwise OR of the stageMask "
             "parameters used in calls to vkCmdSetEvent and VK_PIPELINE_STAGE_HOST_BIT if used with vkSetEvent but instead is %s.",
@@ -2106,54 +2105,54 @@ using sync_vuid_maps::QueueError;
 
 class ValidatorState {
   public:
-    ValidatorState(const ValidationStateTracker *device_data, const LogObjectList &obj, const Location &location,
+    ValidatorState(const ValidationStateTracker &device_data, const LogObjectList &obj, const Location &location,
                    const VulkanTypedHandle &barrier_handle, const VkSharingMode sharing_mode)
         : device_data_(device_data),
           objects_(std::move(obj)),
           loc_(location),
           barrier_handle_(barrier_handle),
           sharing_mode_(sharing_mode),
-          limit_(static_cast<uint32_t>(device_data->physical_device_state->queue_family_properties.size())) {}
+          limit_(static_cast<uint32_t>(device_data.physical_device_state->queue_family_properties.size())) {}
 
     // Log the messages using boilerplate from object state, and Vu specific information from the template arg
     // One and two family versions, in the single family version, Vu holds the name of the passed parameter
     bool LogMsg(QueueError vu_index, uint32_t family, const char *param_name) const {
         const std::string val_code = GetBarrierQueueVUID(loc_, vu_index);
         const char *annotation = GetFamilyAnnotation(family);
-        return device_data_->LogError(val_code, objects_, loc_,
-                                      "barrier using %s %s created with sharingMode %s, has %s %" PRIu32 "%s. %s", GetTypeString(),
-                                      device_data_->FormatHandle(barrier_handle_).c_str(), GetModeString(), param_name, family,
-                                      annotation, kQueueErrorSummary.at(vu_index).c_str());
+        return device_data_.LogError(val_code, objects_, loc_,
+                                     "barrier using %s %s created with sharingMode %s, has %s %" PRIu32 "%s. %s", GetTypeString(),
+                                     device_data_.FormatHandle(barrier_handle_).c_str(), GetModeString(), param_name, family,
+                                     annotation, kQueueErrorSummary.at(vu_index).c_str());
     }
 
     bool LogMsg(QueueError vu_index, uint32_t src_family, uint32_t dst_family) const {
         const std::string val_code = GetBarrierQueueVUID(loc_, vu_index);
         const char *src_annotation = GetFamilyAnnotation(src_family);
         const char *dst_annotation = GetFamilyAnnotation(dst_family);
-        return device_data_->LogError(val_code, objects_, loc_,
-                                      "barrier using %s %s created with sharingMode %s, has srcQueueFamilyIndex %" PRIu32
-                                      "%s and dstQueueFamilyIndex %" PRIu32 "%s. %s",
-                                      GetTypeString(), device_data_->FormatHandle(barrier_handle_).c_str(), GetModeString(),
-                                      src_family, src_annotation, dst_family, dst_annotation,
-                                      kQueueErrorSummary.at(vu_index).c_str());
+        return device_data_.LogError(val_code, objects_, loc_,
+                                     "barrier using %s %s created with sharingMode %s, has srcQueueFamilyIndex %" PRIu32
+                                     "%s and dstQueueFamilyIndex %" PRIu32 "%s. %s",
+                                     GetTypeString(), device_data_.FormatHandle(barrier_handle_).c_str(), GetModeString(),
+                                     src_family, src_annotation, dst_family, dst_annotation,
+                                     kQueueErrorSummary.at(vu_index).c_str());
     }
 
     // This abstract Vu can only be tested at submit time, thus we need a callback from the closure containing the needed
     // data. Note that the mem_barrier is copied to the closure as the lambda lifespan exceed the guarantees of validity for
     // application input.
-    static bool ValidateAtQueueSubmit(const vvl::Queue *queue_state, const ValidationStateTracker *device_data,
-                                      uint32_t src_family, uint32_t dst_family, const ValidatorState &val) {
+    static bool ValidateAtQueueSubmit(const vvl::Queue *queue_state, const ValidationStateTracker &device_data, uint32_t src_family,
+                                      uint32_t dst_family, const ValidatorState &val) {
         uint32_t queue_family = queue_state->queueFamilyIndex;
         if ((src_family != queue_family) && (dst_family != queue_family)) {
             const char *src_annotation = val.GetFamilyAnnotation(src_family);
             const char *dst_annotation = val.GetFamilyAnnotation(dst_family);
-            return device_data->LogError("VUID-vkQueueSubmit-pSubmits-04626", queue_state->Handle(), val.loc_,
-                                         "barrier submitted to queue with family index %" PRIu32
-                                         ", using %s %s created with sharingMode %s, has "
-                                         "srcQueueFamilyIndex %" PRIu32 "%s and dstQueueFamilyIndex %" PRIu32
-                                         "%s. Source or destination queue family must match submit queue family, if not ignored.",
-                                         queue_family, val.GetTypeString(), device_data->FormatHandle(val.barrier_handle_).c_str(),
-                                         val.GetModeString(), src_family, src_annotation, dst_family, dst_annotation);
+            return device_data.LogError("VUID-vkQueueSubmit-pSubmits-04626", queue_state->Handle(), val.loc_,
+                                        "barrier submitted to queue with family index %" PRIu32
+                                        ", using %s %s created with sharingMode %s, has "
+                                        "srcQueueFamilyIndex %" PRIu32 "%s and dstQueueFamilyIndex %" PRIu32
+                                        "%s. Source or destination queue family must match submit queue family, if not ignored.",
+                                        queue_family, val.GetTypeString(), device_data.FormatHandle(val.barrier_handle_).c_str(),
+                                        val.GetModeString(), src_family, src_annotation, dst_family, dst_annotation);
         }
         return false;
     }
@@ -2191,7 +2190,7 @@ class ValidatorState {
     VkSharingMode GetSharingMode() const { return sharing_mode_; }
 
   protected:
-    const ValidationStateTracker *device_data_;
+    const ValidationStateTracker &device_data_;
     const LogObjectList objects_;
     const Location loc_;
     const VulkanTypedHandle barrier_handle_;
@@ -2282,15 +2281,15 @@ bool CoreChecks::ValidateConcurrentBarrierAtSubmit(const Location &loc, const Va
                                                    const VulkanTypedHandle &typed_handle, uint32_t src_queue_family,
                                                    uint32_t dst_queue_family) {
     using barrier_queue_families::ValidatorState;
-    ValidatorState val(&state_data, LogObjectList(cb_state.Handle()), loc, typed_handle, VK_SHARING_MODE_CONCURRENT);
-    return ValidatorState::ValidateAtQueueSubmit(&queue_state, &state_data, src_queue_family, dst_queue_family, val);
+    ValidatorState val(state_data, LogObjectList(cb_state.Handle()), loc, typed_handle, VK_SHARING_MODE_CONCURRENT);
+    return ValidatorState::ValidateAtQueueSubmit(&queue_state, state_data, src_queue_family, dst_queue_family, val);
 }
 
 bool CoreChecks::ValidateBarrierQueueFamilies(const LogObjectList &objects, const Location &barrier_loc, const Location &field_loc,
                                               const QueueFamilyBarrier &barrier, const VulkanTypedHandle &handle,
                                               VkSharingMode sharing_mode) const {
     bool skip = false;
-    barrier_queue_families::ValidatorState val(this, objects, field_loc, handle, sharing_mode);
+    barrier_queue_families::ValidatorState val(*this, objects, field_loc, handle, sharing_mode);
     skip |= barrier_queue_families::Validate(this, val, barrier.srcQueueFamilyIndex, barrier.dstQueueFamilyIndex);
     skip |= barrier_queue_families::ValidateHostStage(this, objects, barrier_loc, barrier);
     return skip;

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -833,7 +833,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
     bool skip = false;
     auto queue_state = Get<vvl::Queue>(queue);
 
-    SemaphoreSubmitState sem_submit_state(this, queue,
+    SemaphoreSubmitState sem_submit_state(*this, queue,
                                           physical_device_state->queue_family_properties[queue_state->queueFamilyIndex].queueFlags);
 
     const Location present_info_loc = error_obj.location.dot(Struct::VkPresentInfoKHR, Field::pPresentInfo);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -44,9 +44,9 @@ typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRan
 // class.
 class CORE_CMD_BUFFER_STATE : public vvl::CommandBuffer {
   public:
-    CORE_CMD_BUFFER_STATE(ValidationStateTracker* dev_data, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* pCreateInfo,
+    CORE_CMD_BUFFER_STATE(ValidationStateTracker& dev_data, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
                           const vvl::CommandPool* cmd_pool)
-        : vvl::CommandBuffer(dev_data, cb, pCreateInfo, cmd_pool) {}
+        : vvl::CommandBuffer(dev_data, handle, pCreateInfo, cmd_pool) {}
 
     void RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
                           VkPipelineStageFlags2KHR src_stage_mask) override;
@@ -2444,8 +2444,9 @@ class CoreChecks : public ValidationStateTracker {
                                                                       struct _screen_window* window,
                                                                       const ErrorObject& error_obj) const override;
 #endif  // VK_USE_PLATFORM_SCREEN_QNX
-    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
+    std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle, const VkCommandBufferAllocateInfo* create_info,
                                                              const vvl::CommandPool* pool) override {
-        return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CORE_CMD_BUFFER_STATE>(this, cb, create_info, pool));
+        return std::static_pointer_cast<vvl::CommandBuffer>(
+            std::make_shared<CORE_CMD_BUFFER_STATE>(*this, handle, create_info, pool));
     }
 };  // Class CoreChecks

--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -59,7 +59,8 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
   public:
     std::vector<BufferInfo> buffer_infos;
 
-    CommandBuffer(Validator* dp, VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info, const vvl::CommandPool* pool);
+    CommandBuffer(Validator& dp, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* create_info,
+                  const vvl::CommandPool* pool);
     ~CommandBuffer();
 
     bool PreProcess() final { return !buffer_infos.empty(); }

--- a/layers/gpu_validation/gpu_descriptor_set.cpp
+++ b/layers/gpu_validation/gpu_descriptor_set.cpp
@@ -69,10 +69,10 @@ static uint32_t BitBufferSize(uint32_t num_bits) {
     return (((num_bits + (kBitsPerWord - 1)) & ~(kBitsPerWord - 1))/kBitsPerWord) * sizeof(uint32_t);
 }
 
-gpuav::DescriptorSet::DescriptorSet(const VkDescriptorSet set, vvl::DescriptorPool *pool,
+gpuav::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorPool *pool,
                                     const std::shared_ptr<vvl::DescriptorSetLayout const> &layout, uint32_t variable_count,
                                     ValidationStateTracker *state_data)
-    : vvl::DescriptorSet(set, pool, layout, variable_count, state_data) {}
+    : vvl::DescriptorSet(handle, pool, layout, variable_count, state_data) {}
 
 gpuav::DescriptorSet::~DescriptorSet() {
     Destroy();

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -38,8 +38,8 @@
 #include "generated/gpu_pre_trace_rays_rgen.h"
 #include "generated/gpu_inst_shader_hash.h"
 
-std::shared_ptr<vvl::Buffer> gpuav::Validator::CreateBufferState(VkBuffer buf, const VkBufferCreateInfo *pCreateInfo) {
-    return std::make_shared<Buffer>(this, buf, pCreateInfo, *desc_heap);
+std::shared_ptr<vvl::Buffer> gpuav::Validator::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo *pCreateInfo) {
+    return std::make_shared<Buffer>(*this, handle, pCreateInfo, *desc_heap);
 }
 
 std::shared_ptr<vvl::BufferView> gpuav::Validator::CreateBufferViewState(const std::shared_ptr<vvl::Buffer> &bf, VkBufferView bv,
@@ -64,10 +64,10 @@ std::shared_ptr<vvl::DescriptorSet> gpuav::Validator::CreateDescriptorSet(
     return std::static_pointer_cast<vvl::DescriptorSet>(std::make_shared<DescriptorSet>(set, pool, layout, variable_count, this));
 }
 
-std::shared_ptr<vvl::CommandBuffer> gpuav::Validator::CreateCmdBufferState(VkCommandBuffer cb,
+std::shared_ptr<vvl::CommandBuffer> gpuav::Validator::CreateCmdBufferState(VkCommandBuffer handle,
                                                                            const VkCommandBufferAllocateInfo *pCreateInfo,
                                                                            const vvl::CommandPool *pool) {
-    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(this, cb, pCreateInfo, pool));
+    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(*this, handle, pCreateInfo, pool));
 }
 
 std::shared_ptr<vvl::Queue> gpuav::Validator::CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -226,9 +226,9 @@ VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device
     return vmaCreateAllocator(&allocator_info, pAllocator);
 }
 
-gpu_tracker::CommandBuffer::CommandBuffer(gpu_tracker::Validator *ga, VkCommandBuffer cb,
+gpu_tracker::CommandBuffer::CommandBuffer(gpu_tracker::Validator &gpuav, VkCommandBuffer handle,
                                           const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool)
-    : vvl::CommandBuffer(ga, cb, pCreateInfo, pool) {}
+    : vvl::CommandBuffer(gpuav, handle, pCreateInfo, pool) {}
 
 ReadLockGuard gpu_tracker::Validator::ReadLock() const {
     if (fine_grained_locking) {

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -45,7 +45,8 @@ class Queue : public vvl::Queue {
 
 class CommandBuffer : public vvl::CommandBuffer {
   public:
-    CommandBuffer(Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool);
+    CommandBuffer(Validator &gpuav, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
+                  const vvl::CommandPool *pool);
 
     virtual bool PreProcess() = 0;
     virtual void PostProcess(VkQueue queue, const Location &loc) = 0;

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -20,7 +20,7 @@
 #include "gpu_vuids.h"
 #include "drawdispatch/descriptor_validator.h"
 
-gpuav::Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo,
+gpuav::Buffer::Buffer(ValidationStateTracker &dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo,
                       DescriptorHeap &desc_heap_)
     : vvl::Buffer(dev_data, buff, pCreateInfo),
       desc_heap(desc_heap_),
@@ -115,9 +115,9 @@ void gpuav::AccelerationStructureNV::NotifyInvalidate(const NodeList &invalid_no
     vvl::AccelerationStructureNV::NotifyInvalidate(invalid_nodes, unlink);
 }
 
-gpuav::CommandBuffer::CommandBuffer(gpuav::Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+gpuav::CommandBuffer::CommandBuffer(gpuav::Validator &gpuav, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
                                     const vvl::CommandPool *pool)
-    : gpu_tracker::CommandBuffer(ga, cb, pCreateInfo, pool), state_(*ga) {}
+    : gpu_tracker::CommandBuffer(gpuav, handle, pCreateInfo, pool), state_(gpuav) {}
 
 gpuav::CommandBuffer::~CommandBuffer() { Destroy(); }
 
@@ -132,7 +132,7 @@ void gpuav::CommandBuffer::Reset() {
 }
 
 void gpuav::CommandBuffer::ResetCBState() {
-    auto gpuav = static_cast<Validator *>(dev_data);
+    auto gpuav = static_cast<Validator *>(&dev_data);
     // Free the device memory and descriptor set(s) associated with a command buffer.
 
     for (auto &cmd_info : per_command_resources) {
@@ -154,7 +154,7 @@ bool gpuav::CommandBuffer::PreProcess() {
 
 // For the given command buffer, map its debug data buffers and read their contents for analysis.
 void gpuav::CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
-    auto *device_state = static_cast<Validator *>(dev_data);
+    auto *device_state = static_cast<Validator *>(&dev_data);
     uint32_t draw_index = 0;
     uint32_t compute_index = 0;
     uint32_t ray_trace_index = 0;

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -74,7 +74,8 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
     std::vector<DescBindingInfo> di_input_buffer_list;
     VkBuffer current_bindless_buffer = VK_NULL_HANDLE;
 
-    CommandBuffer(Validator *ga, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool);
+    CommandBuffer(Validator &gpuav, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
+                  const vvl::CommandPool *pool);
     ~CommandBuffer();
 
     bool PreProcess() final;
@@ -98,7 +99,7 @@ class Queue : public gpu_tracker::Queue {
 
 class Buffer : public vvl::Buffer {
   public:
-    Buffer(ValidationStateTracker *dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);
+    Buffer(ValidationStateTracker &dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);
 
     void Destroy() final;
     void NotifyInvalidate(const NodeList &invalid_nodes, bool unlink) final;

--- a/layers/state_tracker/buffer_state.cpp
+++ b/layers/state_tracker/buffer_state.cpp
@@ -26,9 +26,9 @@ static VkExternalMemoryHandleTypeFlags GetExternalHandleTypes(const VkBufferCrea
     return external_memory_info ? external_memory_info->handleTypes : 0;
 }
 
-static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker *dev_data, VkBuffer buffer) {
+static VkMemoryRequirements GetMemoryRequirements(ValidationStateTracker &dev_data, VkBuffer buffer) {
     VkMemoryRequirements result{};
-    DispatchGetBufferMemoryRequirements(dev_data->device, buffer, &result);
+    DispatchGetBufferMemoryRequirements(dev_data.device, buffer, &result);
     return result;
 }
 
@@ -54,15 +54,15 @@ static bool GetMetalExport(const VkBufferViewCreateInfo *info) {
 
 namespace vvl {
 
-Buffer::Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
+Buffer::Buffer(ValidationStateTracker &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo)
     : Bindable(handle, kVulkanObjectTypeBuffer, (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
       requirements(GetMemoryRequirements(dev_data, handle)),
       usage(GetBufferUsageFlags(create_info)),
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      supported_video_profiles(dev_data.video_profile_cache_.Get(
+          dev_data.physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) {
         tracker_.emplace<BindableSparseMemoryTracker>(&requirements,
                                                       (pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) != 0);

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -40,7 +40,7 @@ class Buffer : public Bindable {
 
     unordered_set<std::shared_ptr<const VideoProfileDesc>> supported_video_profiles;
 
-    Buffer(ValidationStateTracker *dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
+    Buffer(ValidationStateTracker &dev_data, VkBuffer handle, const VkBufferCreateInfo *pCreateInfo);
 
     Buffer(Buffer const &rh_obj) = delete;
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -41,7 +41,7 @@ static ShaderObjectStage inline ConvertToShaderObjectStage(VkShaderStageFlagBits
 
 namespace vvl {
 
-CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
+CommandPool::CommandPool(ValidationStateTracker &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo,
                          VkQueueFlags flags)
     : StateObject(handle, kVulkanObjectTypeCommandPool),
       dev_data(dev),
@@ -52,9 +52,9 @@ CommandPool::CommandPool(ValidationStateTracker *dev, VkCommandPool handle, cons
 
 void CommandPool::Allocate(const VkCommandBufferAllocateInfo *create_info, const VkCommandBuffer *command_buffers) {
     for (uint32_t i = 0; i < create_info->commandBufferCount; i++) {
-        auto new_cb = dev_data->CreateCmdBufferState(command_buffers[i], create_info, this);
+        auto new_cb = dev_data.CreateCmdBufferState(command_buffers[i], create_info, this);
         commandBuffers.emplace(command_buffers[i], new_cb.get());
-        dev_data->Add(std::move(new_cb));
+        dev_data.Add(std::move(new_cb));
     }
 }
 
@@ -62,7 +62,7 @@ void CommandPool::Free(uint32_t count, const VkCommandBuffer *command_buffers) {
     for (uint32_t i = 0; i < count; i++) {
         auto iter = commandBuffers.find(command_buffers[i]);
         if (iter != commandBuffers.end()) {
-            dev_data->Destroy<CommandBuffer>(iter->first);
+            dev_data.Destroy<CommandBuffer>(iter->first);
             commandBuffers.erase(iter);
         }
     }
@@ -77,7 +77,7 @@ void CommandPool::Reset() {
 
 void CommandPool::Destroy() {
     for (auto &entry : commandBuffers) {
-        dev_data->Destroy<CommandBuffer>(entry.first);
+        dev_data.Destroy<CommandBuffer>(entry.first);
     }
     commandBuffers.clear();
     StateObject::Destroy();
@@ -89,7 +89,7 @@ void CommandBuffer::SetActiveSubpass(uint32_t subpass) {
     active_subpass_sample_count_ = std::nullopt;
 }
 
-CommandBuffer::CommandBuffer(ValidationStateTracker *dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
+CommandBuffer::CommandBuffer(ValidationStateTracker &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
                              const vvl::CommandPool *pool)
     : RefcountedStateObject(handle, kVulkanObjectTypeCommandBuffer),
       allocate_info(*pAllocateInfo),
@@ -225,7 +225,7 @@ void CommandBuffer::ResetCBState() {
     transform_feedback_active = false;
 
     // Clean up the label data
-    ResetCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
+    ResetCmdDebugUtilsLabel(dev_data.report_data, VkHandle());
 }
 
 void CommandBuffer::Reset() {
@@ -242,7 +242,7 @@ void CommandBuffer::IncrementResources() {
     //  all the corresponding cases are verified to cause CB_INVALID state and the CB_INVALID state
     //  should then be flagged prior to calling this function
     for (auto event : writeEventsBeforeWait) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+        auto event_state = dev_data.Get<vvl::Event>(event);
         if (event_state) event_state->write_in_use++;
     }
 }
@@ -274,7 +274,7 @@ void CommandBuffer::ResetPushConstantDataIfIncompatible(const vvl::PipelineLayou
 
 void CommandBuffer::Destroy() {
     // Remove the cb debug labels
-    EraseCmdDebugUtilsLabel(dev_data->report_data, VkHandle());
+    EraseCmdDebugUtilsLabel(dev_data.report_data, VkHandle());
     {
         auto guard = WriteLock();
         ResetCBState();
@@ -511,7 +511,7 @@ void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPa
     for (uint32_t i = 0; i < attachments.size(); ++i) {
         if (imageless) {
             if (attachment_info_struct && i < attachment_info_struct->attachmentCount) {
-                auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(attachment_info_struct->pAttachments[i]));
+                auto res = attachments_view_states.insert(dev_data.Get<vvl::ImageView>(attachment_info_struct->pAttachments[i]));
                 attachments[i] = res.first->get();
             }
         } else {
@@ -523,15 +523,15 @@ void CommandBuffer::UpdateAttachmentsView(const VkRenderPassBeginInfo *pRenderPa
 
 void CommandBuffer::BeginRenderPass(Func command, const VkRenderPassBeginInfo *pRenderPassBegin, const VkSubpassContents contents) {
     RecordCmd(command);
-    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
-    activeRenderPass = dev_data->Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
+    activeFramebuffer = dev_data.Get<vvl::Framebuffer>(pRenderPassBegin->framebuffer);
+    activeRenderPass = dev_data.Get<vvl::RenderPass>(pRenderPassBegin->renderPass);
     active_render_pass_begin_info = safe_VkRenderPassBeginInfo(pRenderPassBegin);
     SetActiveSubpass(0);
     activeSubpassContents = contents;
     renderPassQueries.clear();
 
     // Connect this RP to cmdBuffer
-    if (!dev_data->disabled[command_buffer_state]) {
+    if (!dev_data.disabled[command_buffer_state]) {
         AddChild(activeRenderPass);
     }
 
@@ -658,8 +658,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
         rendering_attachments.color_indexes[i] = i;
 
         if (pRenderingInfo->pColorAttachments[i].imageView != VK_NULL_HANDLE) {
-            auto res =
-                attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[i].imageView));
+            auto res = attachments_view_states.insert(dev_data.Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[i].imageView));
             colorAttachment = res.first->get();
             if (pRenderingInfo->pColorAttachments[i].resolveMode != VK_RESOLVE_MODE_NONE &&
                 pRenderingInfo->pColorAttachments[i].resolveImageView != VK_NULL_HANDLE) {
@@ -674,7 +673,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
         depthAttachment = nullptr;
         depthResolveAttachment = nullptr;
 
-        auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView));
+        auto res = attachments_view_states.insert(dev_data.Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView));
         depthAttachment = res.first->get();
         if (pRenderingInfo->pDepthAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             pRenderingInfo->pDepthAttachment->resolveImageView != VK_NULL_HANDLE) {
@@ -688,7 +687,7 @@ void CommandBuffer::BeginRendering(Func command, const VkRenderingInfo *pRenderi
         stencilAttachment = nullptr;
         stencilResolveAttachment = nullptr;
 
-        auto res = attachments_view_states.insert(dev_data->Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView));
+        auto res = attachments_view_states.insert(dev_data.Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView));
         stencilAttachment = res.first->get();
         if (pRenderingInfo->pStencilAttachment->resolveMode != VK_RESOLVE_MODE_NONE &&
             pRenderingInfo->pStencilAttachment->resolveImageView != VK_NULL_HANDLE) {
@@ -705,19 +704,19 @@ void CommandBuffer::EndRendering(Func command) {
 
 void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo) {
     RecordCmd(Func::vkCmdBeginVideoCodingKHR);
-    bound_video_session = dev_data->Get<vvl::VideoSession>(pBeginInfo->videoSession);
-    bound_video_session_parameters = dev_data->Get<vvl::VideoSessionParameters>(pBeginInfo->videoSessionParameters);
+    bound_video_session = dev_data.Get<vvl::VideoSession>(pBeginInfo->videoSession);
+    bound_video_session_parameters = dev_data.Get<vvl::VideoSessionParameters>(pBeginInfo->videoSessionParameters);
 
     if (bound_video_session) {
         // Connect this video session to cmdBuffer
-        if (!dev_data->disabled[command_buffer_state]) {
+        if (!dev_data.disabled[command_buffer_state]) {
             AddChild(bound_video_session);
         }
     }
 
     if (bound_video_session_parameters) {
         // Connect this video session parameters object to cmdBuffer
-        if (!dev_data->disabled[command_buffer_state]) {
+        if (!dev_data.disabled[command_buffer_state]) {
             AddChild(bound_video_session_parameters);
         }
     }
@@ -754,7 +753,7 @@ void CommandBuffer::BeginVideoCoding(const VkVideoBeginCodingInfoKHR *pBeginInfo
 
             // Enqueue submission time DPB slot deactivation
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [deactivated_slots](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [deactivated_slots](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     for (const auto &slot_index : deactivated_slots) {
                         dev_state.Deactivate(slot_index);
@@ -785,7 +784,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
             // Enqueue submission time video session state reset/initialization
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                    vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     dev_state.Reset();
                     return false;
@@ -799,7 +798,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
                 // Enqueue rate control specific device state changes
                 video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                    [state](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                    [state](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                             vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetRateControlState(state);
                         return false;
@@ -815,7 +814,7 @@ void CommandBuffer::ControlVideoCoding(const VkVideoCodingControlInfoKHR *pContr
 
                 // Enqueue encode quality level device state change
                 video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                    [quality_level](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                    [quality_level](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                                     vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                         dev_state.SetEncodeQualityLevel(quality_level);
                         return false;
@@ -851,7 +850,7 @@ void CommandBuffer::DecodeVideo(const VkVideoDecodeInfoKHR *pDecodeInfo) {
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pDecodeInfo);
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [setup_slot, reference_setup_requested](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {
                         dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -891,7 +890,7 @@ void vvl::CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR *pEncodeInfo) {
             // Enqueue submission time reference slot setup or invalidation
             bool reference_setup_requested = bound_video_session->ReferenceSetupRequested(*pEncodeInfo);
             video_session_updates[bound_video_session->VkHandle()].emplace_back(
-                [setup_slot, reference_setup_requested](const ValidationStateTracker *dev_data, const vvl::VideoSession *vs_state,
+                [setup_slot, reference_setup_requested](const ValidationStateTracker &dev_data, const vvl::VideoSession *vs_state,
                                                         vvl::VideoSessionDeviceState &dev_state, bool do_validate) {
                     if (reference_setup_requested) {
                         dev_state.Activate(setup_slot.index, setup_slot.picture_id, setup_slot.resource);
@@ -932,11 +931,11 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
         // If we are a secondary command-buffer and inheriting.  Update the items we should inherit.
         if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT) {
             if (beginInfo.pInheritanceInfo->renderPass) {
-                activeRenderPass = dev_data->Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
+                activeRenderPass = dev_data.Get<vvl::RenderPass>(beginInfo.pInheritanceInfo->renderPass);
                 SetActiveSubpass(beginInfo.pInheritanceInfo->subpass);
 
                 if (beginInfo.pInheritanceInfo->framebuffer) {
-                    activeFramebuffer = dev_data->Get<vvl::Framebuffer>(beginInfo.pInheritanceInfo->framebuffer);
+                    activeFramebuffer = dev_data.Get<vvl::Framebuffer>(beginInfo.pInheritanceInfo->framebuffer);
                     active_subpasses = nullptr;
                     active_attachments = nullptr;
 
@@ -953,7 +952,7 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
                         UpdateAttachmentsView(nullptr);
 
                         // Connect this framebuffer and its children to this cmdBuffer
-                        if (!dev_data->disabled[command_buffer_state]) {
+                        if (!dev_data.disabled[command_buffer_state]) {
                             AddChild(activeFramebuffer);
                         }
                     }
@@ -981,9 +980,9 @@ void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     if (chained_device_group_struct) {
         initial_device_mask = chained_device_group_struct->deviceMask;
     } else {
-        initial_device_mask = (1 << dev_data->physical_device_count) - 1;
+        initial_device_mask = (1 << dev_data.physical_device_count) - 1;
     }
-    performance_lock_acquired = dev_data->performance_lock_acquired;
+    performance_lock_acquired = dev_data.performance_lock_acquired;
     updatedQueries.clear();
 }
 
@@ -996,7 +995,7 @@ void CommandBuffer::End(VkResult result) {
 void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_command_buffers) {
     RecordCmd(Func::vkCmdExecuteCommands);
     for (const VkCommandBuffer sub_command_buffer : secondary_command_buffers) {
-        auto sub_cb_state = dev_data->GetWrite<CommandBuffer>(sub_command_buffer);
+        auto sub_cb_state = dev_data.GetWrite<CommandBuffer>(sub_command_buffer);
         assert(sub_cb_state);
         if (!(sub_cb_state->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
             if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) {
@@ -1011,7 +1010,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
         // ValidationStateTracker these maps will be empty, so leaving the propagation in the the state tracker should be a no-op
         // for those other classes.
         for (const auto &sub_layout_map_entry : sub_cb_state->image_layout_map) {
-            const auto image_state = dev_data->Get<vvl::Image>(sub_layout_map_entry.first);
+            const auto image_state = dev_data.Get<vvl::Image>(sub_layout_map_entry.first);
             if (!image_state || image_state->Destroyed() || image_state->GetId() != sub_layout_map_entry.second.id) {
                 continue;
             }
@@ -1031,7 +1030,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
                                                        VkQueryPool &firstPerfQueryPool, uint32_t perfQueryPass,
                                                        QueryMap *localQueryToStateMap) {
             bool skip = false;
-            auto sub_cb_state_arg = cb_state_arg.dev_data->GetWrite<CommandBuffer>(sub_command_buffer);
+            auto sub_cb_state_arg = cb_state_arg.dev_data.GetWrite<CommandBuffer>(sub_command_buffer);
             for (auto &function : sub_cb_state_arg->queryUpdates) {
                 skip |= function(*sub_cb_state_arg, do_validate, firstPerfQueryPool, perfQueryPass, localQueryToStateMap);
             }
@@ -1090,7 +1089,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     auto &push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
     if (!push_descriptor_set || !IsBoundSetCompat(set, last_bound, pipeline_layout)) {
-        last_bound.UnbindAndResetPushDescriptorSet(dev_data->CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
+        last_bound.UnbindAndResetPushDescriptorSet(dev_data.CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
     }
 
     UpdateLastBoundDescriptorSets(pipelineBindPoint, pipeline_layout, set, 1, nullptr, push_descriptor_set, 0, nullptr);
@@ -1158,18 +1157,18 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
 
             // We can skip updating the state if "nothing" has changed since the last validation.
             // See CoreChecks::ValidateActionState for more details.
-            const bool need_update = // Update if descriptor set (or contents) has changed
-                                     set_info.validated_set != descriptor_set.get() ||
-                                     set_info.validated_set_change_count != descriptor_set->GetChangeCount() ||
-                                     (!dev_data->disabled[image_layout_validation] &&
-                                     set_info.validated_set_image_layout_change_count != image_layout_change_count);
+            const bool need_update =  // Update if descriptor set (or contents) has changed
+                set_info.validated_set != descriptor_set.get() ||
+                set_info.validated_set_change_count != descriptor_set->GetChangeCount() ||
+                (!dev_data.disabled[image_layout_validation] &&
+                 set_info.validated_set_image_layout_change_count != image_layout_change_count);
             if (need_update) {
-                if (!dev_data->disabled[command_buffer_state] && !descriptor_set->IsPushDescriptor()) {
+                if (!dev_data.disabled[command_buffer_state] && !descriptor_set->IsPushDescriptor()) {
                     AddChild(descriptor_set);
                 }
 
                 // Bind this set and its active descriptor resources to the command buffer
-                descriptor_set->UpdateDrawState(dev_data, this, command, pipe, set_binding_pair.second);
+                descriptor_set->UpdateDrawState(&dev_data, this, command, pipe, set_binding_pair.second);
 
                 set_info.validated_set = descriptor_set.get();
                 set_info.validated_set_change_count = descriptor_set->GetChangeCount();
@@ -1255,7 +1254,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
         auto set_idx = input_idx + first_set;  // set_idx is index within layout, input_idx is index within input descriptor sets
         auto &set_info = last_bound.per_set[set_idx];
         auto descriptor_set =
-            push_descriptor_set ? push_descriptor_set : dev_data->Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
+            push_descriptor_set ? push_descriptor_set : dev_data.Get<vvl::DescriptorSet>(pDescriptorSets[input_idx]);
 
         set_info.Reset();
         // Record binding (or push)
@@ -1349,7 +1348,7 @@ void CommandBuffer::SetImageLayout(const vvl::Image &image_state, const VkImageS
 
 // Set the initial image layout for all slices of an image view
 void CommandBuffer::SetImageViewInitialLayout(const vvl::ImageView &view_state, VkImageLayout layout) {
-    if (dev_data->disabled[image_layout_validation]) {
+    if (dev_data.disabled[image_layout_validation]) {
         return;
     }
     vvl::Image *image_state = view_state.image_state.get();
@@ -1369,7 +1368,7 @@ void CommandBuffer::SetImageInitialLayout(const vvl::Image &image_state, const V
 }
 
 void CommandBuffer::SetImageInitialLayout(VkImage image, const VkImageSubresourceRange &range, VkImageLayout layout) {
-    auto image_state = dev_data->Get<vvl::Image>(image);
+    auto image_state = dev_data.Get<vvl::Image>(image);
     if (!image_state) return;
     SetImageInitialLayout(*image_state, range, layout);
 }
@@ -1444,8 +1443,8 @@ static bool SetEventSignalInfo(VkEvent event, VkPipelineStageFlags2 src_stage_ma
 
 void CommandBuffer::RecordSetEvent(Func command, VkEvent event, VkPipelineStageFlags2KHR stageMask) {
     RecordCmd(command);
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+    if (!dev_data.disabled[command_buffer_state]) {
+        auto event_state = dev_data.Get<vvl::Event>(event);
         if (event_state) {
             AddChild(event_state);
         }
@@ -1461,8 +1460,8 @@ void CommandBuffer::RecordSetEvent(Func command, VkEvent event, VkPipelineStageF
 
 void CommandBuffer::RecordResetEvent(Func command, VkEvent event, VkPipelineStageFlags2KHR stageMask) {
     RecordCmd(command);
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+    if (!dev_data.disabled[command_buffer_state]) {
+        auto event_state = dev_data.Get<vvl::Event>(event);
         if (event_state) {
             AddChild(event_state);
         }
@@ -1482,8 +1481,8 @@ void CommandBuffer::RecordWaitEvents(Func command, uint32_t eventCount, const Vk
                                      VkPipelineStageFlags2KHR src_stage_mask) {
     RecordCmd(command);
     for (uint32_t i = 0; i < eventCount; ++i) {
-        if (!dev_data->disabled[command_buffer_state]) {
-            auto event_state = dev_data->Get<vvl::Event>(pEvents[i]);
+        if (!dev_data.disabled[command_buffer_state]) {
+            auto event_state = dev_data.Get<vvl::Event>(pEvents[i]);
             if (event_state) {
                 AddChild(event_state);
             }
@@ -1496,16 +1495,16 @@ void CommandBuffer::RecordWaitEvents(Func command, uint32_t eventCount, const Vk
 void CommandBuffer::RecordBarriers(uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,
                                    uint32_t bufferMemoryBarrierCount, const VkBufferMemoryBarrier *pBufferMemoryBarriers,
                                    uint32_t imageMemoryBarrierCount, const VkImageMemoryBarrier *pImageMemoryBarriers) {
-    if (dev_data->disabled[command_buffer_state]) return;
+    if (dev_data.disabled[command_buffer_state]) return;
 
     for (uint32_t i = 0; i < bufferMemoryBarrierCount; i++) {
-        auto buffer_state = dev_data->Get<vvl::Buffer>(pBufferMemoryBarriers[i].buffer);
+        auto buffer_state = dev_data.Get<vvl::Buffer>(pBufferMemoryBarriers[i].buffer);
         if (buffer_state) {
             AddChild(buffer_state);
         }
     }
     for (uint32_t i = 0; i < imageMemoryBarrierCount; i++) {
-        auto image_state = dev_data->Get<vvl::Image>(pImageMemoryBarriers[i].image);
+        auto image_state = dev_data.Get<vvl::Image>(pImageMemoryBarriers[i].image);
         if (image_state) {
             AddChild(image_state);
         }
@@ -1513,16 +1512,16 @@ void CommandBuffer::RecordBarriers(uint32_t memoryBarrierCount, const VkMemoryBa
 }
 
 void CommandBuffer::RecordBarriers(const VkDependencyInfoKHR &dep_info) {
-    if (dev_data->disabled[command_buffer_state]) return;
+    if (dev_data.disabled[command_buffer_state]) return;
 
     for (uint32_t i = 0; i < dep_info.bufferMemoryBarrierCount; i++) {
-        auto buffer_state = dev_data->Get<vvl::Buffer>(dep_info.pBufferMemoryBarriers[i].buffer);
+        auto buffer_state = dev_data.Get<vvl::Buffer>(dep_info.pBufferMemoryBarriers[i].buffer);
         if (buffer_state) {
             AddChild(buffer_state);
         }
     }
     for (uint32_t i = 0; i < dep_info.imageMemoryBarrierCount; i++) {
-        auto image_state = dev_data->Get<vvl::Image>(dep_info.pImageMemoryBarriers[i].image);
+        auto image_state = dev_data.Get<vvl::Image>(dep_info.pImageMemoryBarriers[i].image);
         if (image_state) {
             AddChild(image_state);
         }
@@ -1532,10 +1531,10 @@ void CommandBuffer::RecordBarriers(const VkDependencyInfoKHR &dep_info) {
 void CommandBuffer::RecordWriteTimestamp(Func command, VkPipelineStageFlags2KHR pipelineStage, VkQueryPool queryPool,
                                          uint32_t slot) {
     RecordCmd(command);
-    if (dev_data->disabled[query_validation]) return;
+    if (dev_data.disabled[query_validation]) return;
 
-    if (!dev_data->disabled[command_buffer_state]) {
-        auto pool_state = dev_data->Get<vvl::QueryPool>(queryPool);
+    if (!dev_data.disabled[command_buffer_state]) {
+        auto pool_state = dev_data.Get<vvl::QueryPool>(queryPool);
         AddChild(pool_state);
     }
     QueryObject query_obj = {queryPool, slot};
@@ -1552,7 +1551,7 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
             function(*this, /*do_validate*/ false, first_pool, perf_submit_pass, &local_query_to_state_map);
         }
         for (const auto &query_state_pair : local_query_to_state_map) {
-            auto query_pool_state = dev_data->Get<vvl::QueryPool>(query_state_pair.first.pool);
+            auto query_pool_state = dev_data.Get<vvl::QueryPool>(query_state_pair.first.pool);
             query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
         }
     }
@@ -1566,17 +1565,17 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
                      VK_NULL_HANDLE /* when do_validate is false then wait handler is inactive */, loc);
         }
         for (const auto &event_signal : local_event_signal_info) {
-            auto event_state = dev_data->Get<vvl::Event>(event_signal.first);
+            auto event_state = dev_data.Get<vvl::Event>(event_signal.first);
             event_state->signal_src_stage_mask = event_signal.second;
             event_state->signaling_queue = queue;
         }
     }
 
     for (const auto &it : video_session_updates) {
-        auto video_session_state = dev_data->Get<vvl::VideoSession>(it.first);
+        auto video_session_state = dev_data.Get<vvl::VideoSession>(it.first);
         auto device_state = video_session_state->DeviceStateWrite();
         for (const auto &function : it.second) {
-            function(nullptr, video_session_state.get(), *device_state, /*do_validate*/ false);
+            function(dev_data, video_session_state.get(), *device_state, /*do_validate*/ false);
         }
     }
 }
@@ -1584,7 +1583,7 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
 void CommandBuffer::Retire(uint32_t perf_submit_pass, const std::function<bool(const QueryObject &)> &is_query_updated_after) {
     // First perform decrement on general case bound objects
     for (auto event : writeEventsBeforeWait) {
-        auto event_state = dev_data->Get<vvl::Event>(event);
+        auto event_state = dev_data.Get<vvl::Event>(event);
         if (event_state) {
             event_state->write_in_use--;
         }
@@ -1597,7 +1596,7 @@ void CommandBuffer::Retire(uint32_t perf_submit_pass, const std::function<bool(c
 
     for (const auto &query_state_pair : local_query_to_state_map) {
         if (query_state_pair.second == QUERYSTATE_ENDED && !is_query_updated_after(query_state_pair.first)) {
-            auto query_pool_state = dev_data->Get<vvl::QueryPool>(query_state_pair.first.pool);
+            auto query_pool_state = dev_data.Get<vvl::QueryPool>(query_state_pair.first.pool);
             if (query_pool_state) {
                 query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass,
                                                 QUERYSTATE_AVAILABLE);

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -100,7 +100,7 @@ class Event : public StateObject {
 // Track command pools and their command buffers
 class CommandPool : public StateObject {
   public:
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker &dev_data;
     const VkCommandPoolCreateFlags createFlags;
     const uint32_t queueFamilyIndex;
     const VkQueueFlags queue_flags;
@@ -108,7 +108,7 @@ class CommandPool : public StateObject {
     // Cmd buffers allocated from this pool
     vvl::unordered_map<VkCommandBuffer, CommandBuffer *> commandBuffers;
 
-    CommandPool(ValidationStateTracker *dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
+    CommandPool(ValidationStateTracker &dev, VkCommandPool handle, const VkCommandPoolCreateInfo *pCreateInfo, VkQueueFlags flags);
     virtual ~CommandPool() { Destroy(); }
 
     VkCommandPool VkHandle() const { return handle_.Cast<VkCommandPool>(); }
@@ -135,7 +135,7 @@ class CommandBuffer : public RefcountedStateObject {
     VkCommandBufferInheritanceInfo inheritanceInfo;
     // since command buffers can only be destroyed by their command pool, this does not need to be a shared_ptr
     const vvl::CommandPool *command_pool;
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker &dev_data;
     bool unprotected;  // can't be used for protected memory
     bool hasRenderPassInstance;
     bool suspendsRenderPassInstance;
@@ -457,7 +457,7 @@ class CommandBuffer : public RefcountedStateObject {
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock); }
 
-    CommandBuffer(ValidationStateTracker *, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
+    CommandBuffer(ValidationStateTracker &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pAllocateInfo,
                   const vvl::CommandPool *cmd_pool);
 
     virtual ~CommandBuffer() { Destroy(); }

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -47,7 +47,7 @@ struct AllocateDescriptorSetsData;
 
 class DescriptorPool : public StateObject {
   public:
-    DescriptorPool(ValidationStateTracker *dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo);
+    DescriptorPool(ValidationStateTracker &dev, const VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo);
     ~DescriptorPool() { Destroy(); }
 
     VkDescriptorPool VkHandle() const { return handle_.Cast<VkDescriptorPool>(); };
@@ -90,7 +90,7 @@ class DescriptorPool : public StateObject {
     uint32_t available_sets_;        // Available descriptor sets in this pool
     TypeCountMap available_counts_;  // Available # of descriptors of each type in this pool
     vvl::unordered_map<VkDescriptorSet, vvl::DescriptorSet *> sets_;  // Collection of all sets in this pool
-    ValidationStateTracker *dev_data_;
+    ValidationStateTracker &dev_data_;
     mutable std::shared_mutex lock_;
 };
 
@@ -615,7 +615,7 @@ struct AllocateDescriptorSetsData {
     AllocateDescriptorSetsData(){};
 };
 // "Perform" does the update with the assumption that ValidateUpdateDescriptorSets() has passed for the given update
-void PerformUpdateDescriptorSets(ValidationStateTracker *, uint32_t, const VkWriteDescriptorSet *, uint32_t,
+void PerformUpdateDescriptorSets(ValidationStateTracker &, uint32_t, const VkWriteDescriptorSet *, uint32_t,
                                  const VkCopyDescriptorSet *);
 
 class DescriptorBinding {
@@ -724,7 +724,7 @@ struct DecodedTemplateUpdate {
     std::vector<VkWriteDescriptorSetInlineUniformBlockEXT> inline_infos;
     std::vector<VkWriteDescriptorSetAccelerationStructureKHR> inline_infos_khr;
     std::vector<VkWriteDescriptorSetAccelerationStructureNV> inline_infos_nv;
-    DecodedTemplateUpdate(const ValidationStateTracker *device_data, VkDescriptorSet descriptorSet,
+    DecodedTemplateUpdate(const ValidationStateTracker &device_data, VkDescriptorSet descriptorSet,
                           const DescriptorUpdateTemplate *template_state, const void *pData,
                           VkDescriptorSetLayout push_layout = VK_NULL_HANDLE);
 };

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -94,14 +94,14 @@ static VkSwapchainKHR GetSwapchain(const VkImageCreateInfo *pCreateInfo) {
     return swapchain_info ? swapchain_info->swapchain : VK_NULL_HANDLE;
 }
 
-static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker *dev_data, VkImage img,
+static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker &dev_data, VkImage img,
                                                     const VkImageCreateInfo *create_info, bool disjoint, bool is_external_ahb) {
     vvl::Image::MemoryReqs result{};
     // Record the memory requirements in case they won't be queried
     // External AHB memory can't be queried until after memory is bound
     if (!is_external_ahb) {
         if (disjoint == false) {
-            DispatchGetImageMemoryRequirements(dev_data->device, img, &result[0]);
+            DispatchGetImageMemoryRequirements(dev_data.device, img, &result[0]);
         } else {
             uint32_t plane_count = vkuFormatPlaneCount(create_info->format);
             static const std::array<VkImageAspectFlagBits, 3> aspects{VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT,
@@ -115,12 +115,12 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker
                 VkMemoryRequirements2 mem_reqs2 = vku::InitStructHelper();
 
                 image_plane_req.planeAspect = aspects[i];
-                switch (dev_data->device_extensions.vk_khr_get_memory_requirements2) {
+                switch (dev_data.device_extensions.vk_khr_get_memory_requirements2) {
                     case kEnabledByApiLevel:
-                        DispatchGetImageMemoryRequirements2(dev_data->device, &mem_req_info2, &mem_reqs2);
+                        DispatchGetImageMemoryRequirements2(dev_data.device, &mem_req_info2, &mem_reqs2);
                         break;
                     case kEnabledByCreateinfo:
-                        DispatchGetImageMemoryRequirements2KHR(dev_data->device, &mem_req_info2, &mem_reqs2);
+                        DispatchGetImageMemoryRequirements2KHR(dev_data.device, &mem_req_info2, &mem_reqs2);
                         break;
                     default:
                         // The VK_KHR_sampler_ycbcr_conversion extension requires VK_KHR_get_memory_requirements2,
@@ -134,13 +134,13 @@ static vvl::Image::MemoryReqs GetMemoryRequirements(const ValidationStateTracker
     return result;
 }
 
-static vvl::Image::SparseReqs GetSparseRequirements(const ValidationStateTracker *dev_data, VkImage img, bool sparse_residency) {
+static vvl::Image::SparseReqs GetSparseRequirements(const ValidationStateTracker &dev_data, VkImage img, bool sparse_residency) {
     vvl::Image::SparseReqs result;
     if (sparse_residency) {
         uint32_t count = 0;
-        DispatchGetImageSparseMemoryRequirements(dev_data->device, img, &count, nullptr);
+        DispatchGetImageSparseMemoryRequirements(dev_data.device, img, &count, nullptr);
         result.resize(count);
-        DispatchGetImageSparseMemoryRequirements(dev_data->device, img, &count, result.data());
+        DispatchGetImageSparseMemoryRequirements(dev_data.device, img, &count, result.data());
     }
     return result;
 }
@@ -172,7 +172,7 @@ static bool GetMetalExport(const VkImageCreateInfo *info, VkExportMetalObjectTyp
 
 namespace vvl {
 
-Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR ff)
+Image::Image(const ValidationStateTracker &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
       safe_create_info(pCreateInfo),
@@ -198,9 +198,9 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
 #endif  // VK_USE_PLATFORM_METAL_EXT
       subresource_encoder(full_range),
       fragment_encoder(nullptr),
-      store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      store_device_as_workaround(dev_data.device),  // TODO REMOVE WHEN encoder can be const
+      supported_video_profiles(dev_data.video_profile_cache_.Get(
+          dev_data.physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     if (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) {
         bool is_resident = (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT) != 0;
         tracker_.emplace<BindableSparseMemoryTracker>(requirements.data(), is_resident);
@@ -214,7 +214,7 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
     }
 }
 
-Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+Image::Image(const ValidationStateTracker &dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
              uint32_t swapchain_index, VkFormatFeatureFlags2KHR ff)
     : Bindable(img, kVulkanObjectTypeImage, (pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0,
                (pCreateInfo->flags & VK_IMAGE_CREATE_PROTECTED_BIT) == 0, GetExternalHandleTypes(pCreateInfo)),
@@ -241,9 +241,9 @@ Image::Image(const ValidationStateTracker *dev_data, VkImage img, const VkImageC
 #endif  // VK_USE_PLATFORM_METAL_EXT
       subresource_encoder(full_range),
       fragment_encoder(nullptr),
-      store_device_as_workaround(dev_data->device),  // TODO REMOVE WHEN encoder can be const
-      supported_video_profiles(dev_data->video_profile_cache_.Get(
-          dev_data->physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
+      store_device_as_workaround(dev_data.device),  // TODO REMOVE WHEN encoder can be const
+      supported_video_profiles(dev_data.video_profile_cache_.Get(
+          dev_data.physical_device, vku::FindStructInPNextChain<VkVideoProfileListInfoKHR>(pCreateInfo->pNext))) {
     fragment_encoder =
         std::unique_ptr<const subresource_adapter::ImageRangeEncoder>(new subresource_adapter::ImageRangeEncoder(*this));
 
@@ -529,7 +529,7 @@ static safe_VkImageCreateInfo GetImageCreateInfo(const VkSwapchainCreateInfoKHR 
 
 namespace vvl {
 
-Swapchain::Swapchain(ValidationStateTracker *dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
+Swapchain::Swapchain(ValidationStateTracker &dev_data_, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle)
     : StateObject(handle, kVulkanObjectTypeSwapchainKHR),
       safe_create_info(pCreateInfo),
       create_info(*safe_create_info.ptr()),
@@ -578,9 +578,9 @@ void Swapchain::Destroy() {
     for (auto &swapchain_image : images) {
         if (swapchain_image.image_state) {
             RemoveParent(swapchain_image.image_state);
-            dev_data->Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
+            dev_data.Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
         }
-        // NOTE: We don't have access to dev_data->fake_memory.Free() here, but it is currently a no-op
+        // NOTE: We don't have access to dev_data.fake_memory.Free() here, but it is currently a no-op
     }
     images.clear();
     if (surface) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -126,9 +126,9 @@ class Image : public Bindable {
 
     vvl::unordered_set<std::shared_ptr<const vvl::VideoProfileDesc>> supported_video_profiles;
 
-    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
+    Image(const ValidationStateTracker &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
           VkFormatFeatureFlags2KHR features);
-    Image(const ValidationStateTracker *dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
+    Image(const ValidationStateTracker &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
           uint32_t swapchain_index, VkFormatFeatureFlags2KHR features);
     Image(Image const &rh_obj) = delete;
     std::shared_ptr<const Image> shared_from_this() const { return SharedFromThisImpl(this); }
@@ -334,10 +334,10 @@ class Swapchain : public StateObject {
     const safe_VkImageCreateInfo image_create_info;
 
     std::shared_ptr<vvl::Surface> surface;
-    ValidationStateTracker *dev_data;
+    ValidationStateTracker &dev_data;
     uint32_t acquired_images = 0;
 
-    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
+    Swapchain(ValidationStateTracker &dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
 
     ~Swapchain() {
         if (!Destroyed()) {

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -148,12 +148,12 @@ VkPipelineLayoutCreateFlags GetCreateFlags(const vvl::span<const vvl::PipelineLa
 
 namespace vvl {
 
-static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_data,
+static PipelineLayout::SetLayoutVector GetSetLayouts(ValidationStateTracker &dev_data,
                                                      const VkPipelineLayoutCreateInfo *pCreateInfo) {
     PipelineLayout::SetLayoutVector set_layouts(pCreateInfo->setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+        set_layouts[i] = dev_data.Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
     }
     return set_layouts;
 }
@@ -194,7 +194,7 @@ static PipelineLayout::SetLayoutVector GetSetLayouts(const vvl::span<const Pipel
     return set_layouts;
 }
 
-PipelineLayout::PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle,
+PipelineLayout::PipelineLayout(ValidationStateTracker &dev_data, VkPipelineLayout handle,
                                const VkPipelineLayoutCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(dev_data, pCreateInfo)),

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -78,7 +78,7 @@ class PipelineLayout : public StateObject {
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;
 
-    PipelineLayout(ValidationStateTracker *dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
+    PipelineLayout(ValidationStateTracker &dev_data, VkPipelineLayout handle, const VkPipelineLayoutCreateInfo *pCreateInfo);
     // Merge 2 or more non-overlapping layouts
     PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts);
     template <typename Container>

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -40,7 +40,7 @@ StageCreateInfo::StageCreateInfo(const VkShaderCreateInfoEXT &create_info)
 namespace vvl {
 
 Pipeline::CreateInfo::CreateInfo(const VkGraphicsPipelineCreateInfo &ci, std::shared_ptr<const vvl::RenderPass> rpstate,
-                                 const ValidationStateTracker *state_data)
+                                 const ValidationStateTracker &state_data)
     : graphics() {
     bool use_color = false;
     bool use_depth_stencil = false;
@@ -60,8 +60,8 @@ Pipeline::CreateInfo::CreateInfo(const VkGraphicsPipelineCreateInfo &ci, std::sh
         use_depth_stencil = rpstate->UsesDepthStencilAttachment(ci.subpass);
     }
 
-    PNextCopyState copy_state = {[state_data, &ci](VkBaseOutStructure *safe_struct, const VkBaseOutStructure *in_struct) -> bool {
-        return Pipeline::PnextRenderingInfoCustomCopy(state_data, ci, safe_struct, in_struct);
+    PNextCopyState copy_state = {[&state_data, &ci](VkBaseOutStructure *safe_struct, const VkBaseOutStructure *in_struct) -> bool {
+        return Pipeline::PnextRenderingInfoCustomCopy(&state_data, ci, safe_struct, in_struct);
     }};
     graphics.initialize(&ci, use_color, use_depth_stencil, &copy_state);
 }
@@ -416,11 +416,11 @@ static bool UsesPipelineRobustness(const void *pNext, const Pipeline &pipe_state
     return result;
 }
 
-static bool IgnoreColorAttachments(const ValidationStateTracker *state_data, Pipeline &pipe_state) {
+static bool IgnoreColorAttachments(const ValidationStateTracker &state_data, Pipeline &pipe_state) {
     // If the libraries used to create this pipeline are ignoring color attachments, this pipeline should as well
     if (pipe_state.library_create_info) {
         for (uint32_t i = 0; i < pipe_state.library_create_info->libraryCount; i++) {
-            const auto lib = state_data->Get<vvl::Pipeline>(pipe_state.library_create_info->pLibraries[i]);
+            const auto lib = state_data.Get<vvl::Pipeline>(pipe_state.library_create_info->pLibraries[i]);
             if (lib->ignore_color_attachments) return true;
         }
     }
@@ -660,7 +660,7 @@ std::shared_ptr<const vvl::ShaderModule> Pipeline::GetSubStateShader(VkShaderSta
     }
 }
 
-Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
+Pipeline::Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                    std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
                    std::shared_ptr<const vvl::PipelineLayout> &&layout, CreateShaderModuleStates *csm_states)
     : StateObject(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
@@ -674,13 +674,13 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPip
       create_flags(GetPipelineCreateFlags(PNext(), create_info.graphics.flags)),
       shader_stages_ci(create_info.graphics.pStages, create_info.graphics.stageCount),
       uses_shader_module_id(UsesShaderModuleId(*this)),
-      vertex_input_state(CreateVertexInputState(*this, *state_data, create_info.graphics)),
-      pre_raster_state(CreatePreRasterState(*this, *state_data, create_info.graphics, rpstate)),
-      fragment_shader_state(CreateFragmentShaderState(*this, *state_data, *pCreateInfo, create_info.graphics, rpstate)),
-      fragment_output_state(CreateFragmentOutputState(*this, *state_data, *pCreateInfo, create_info.graphics, rpstate)),
-      stage_states(GetStageStates(*state_data, *this, csm_states)),
+      vertex_input_state(CreateVertexInputState(*this, state_data, create_info.graphics)),
+      pre_raster_state(CreatePreRasterState(*this, state_data, create_info.graphics, rpstate)),
+      fragment_shader_state(CreateFragmentShaderState(*this, state_data, *pCreateInfo, create_info.graphics, rpstate)),
+      fragment_output_state(CreateFragmentOutputState(*this, state_data, *pCreateInfo, create_info.graphics, rpstate)),
+      stage_states(GetStageStates(state_data, *this, csm_states)),
       create_info_shaders(GetCreateInfoShaders(*this)),
-      linking_shaders(GetLinkingShaders(library_create_info, *state_data)),
+      linking_shaders(GetLinkingShaders(library_create_info, state_data)),
       active_shaders(create_info_shaders | linking_shaders),
       fragmentShader_writable_output_location_list(GetFSOutputLocations(stage_states)),
       active_slots(GetActiveSlots(stage_states)),
@@ -692,7 +692,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPip
       ignore_color_attachments(IgnoreColorAttachments(state_data, *this)),
       csm_states(csm_states) {
     if (library_create_info) {
-        const auto &exe_layout_state = state_data->Get<vvl::PipelineLayout>(create_info.graphics.layout);
+        const auto &exe_layout_state = state_data.Get<vvl::PipelineLayout>(create_info.graphics.layout);
         const auto *exe_layout = exe_layout_state.get();
         const auto *pre_raster_layout =
             (pre_raster_state && pre_raster_state->pipeline_layout) ? pre_raster_state->pipeline_layout.get() : nullptr;
@@ -708,7 +708,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPip
         // TODO Could store the graphics_lib_type in the sub-state rather than searching for it again here.
         //      Or, could store a pointer back to the owning Pipeline.
         for (uint32_t i = 0; i < library_create_info->libraryCount; ++i) {
-            const auto &state = state_data->Get<vvl::Pipeline>(library_create_info->pLibraries[i]);
+            const auto &state = state_data.Get<vvl::Pipeline>(library_create_info->pLibraries[i]);
             if (state) {
                 graphics_lib_type |= state->graphics_lib_type;
             }
@@ -716,7 +716,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPip
     }
 }
 
-Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkComputePipelineCreateInfo *pCreateInfo,
+Pipeline::Pipeline(const ValidationStateTracker &state_data, const VkComputePipelineCreateInfo *pCreateInfo,
                    std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
                    CreateShaderModuleStates *csm_states)
     : StateObject(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
@@ -726,7 +726,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkComputePipe
       create_flags(GetPipelineCreateFlags(PNext(), create_info.compute.flags)),
       shader_stages_ci(&create_info.compute.stage, 1),
       uses_shader_module_id(UsesShaderModuleId(*this)),
-      stage_states(GetStageStates(*state_data, *this, csm_states)),
+      stage_states(GetStageStates(state_data, *this, csm_states)),
       create_info_shaders(GetCreateInfoShaders(*this)),
       active_shaders(create_info_shaders),  // compute has no linking shaders
       active_slots(GetActiveSlots(stage_states)),
@@ -740,7 +740,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkComputePipe
     assert(active_shaders == VK_SHADER_STAGE_COMPUTE_BIT);
 }
 
-Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoKHR *pCreateInfo,
+Pipeline::Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoKHR *pCreateInfo,
                    std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
                    CreateShaderModuleStates *csm_states)
     : StateObject(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
@@ -751,7 +751,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkRayTracingP
       shader_stages_ci(create_info.raytracing.pStages, create_info.raytracing.stageCount),
       ray_tracing_library_ci(create_info.raytracing.pLibraryInfo),
       uses_shader_module_id(UsesShaderModuleId(*this)),
-      stage_states(GetStageStates(*state_data, *this, csm_states)),
+      stage_states(GetStageStates(state_data, *this, csm_states)),
       create_info_shaders(GetCreateInfoShaders(*this)),
       active_shaders(create_info_shaders),  // RTX has no linking shaders
       active_slots(GetActiveSlots(stage_states)),
@@ -767,7 +767,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkRayTracingP
                    VK_SHADER_STAGE_MISS_BIT_KHR | VK_SHADER_STAGE_INTERSECTION_BIT_KHR | VK_SHADER_STAGE_CALLABLE_BIT_KHR)));
 }
 
-Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
+Pipeline::Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
                    std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
                    CreateShaderModuleStates *csm_states)
     : StateObject(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
@@ -778,7 +778,7 @@ Pipeline::Pipeline(const ValidationStateTracker *state_data, const VkRayTracingP
       shader_stages_ci(create_info.raytracing.pStages, create_info.raytracing.stageCount),
       ray_tracing_library_ci(create_info.raytracing.pLibraryInfo),
       uses_shader_module_id(UsesShaderModuleId(*this)),
-      stage_states(GetStageStates(*state_data, *this, csm_states)),
+      stage_states(GetStageStates(state_data, *this, csm_states)),
       create_info_shaders(GetCreateInfoShaders(*this)),
       active_shaders(create_info_shaders),  // RTX has no linking shaders
       active_slots(GetActiveSlots(stage_states)),

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -79,7 +79,7 @@ class Pipeline : public StateObject {
         struct Traits {};
 
         CreateInfo(const VkGraphicsPipelineCreateInfo &ci, std::shared_ptr<const vvl::RenderPass> rpstate,
-                   const ValidationStateTracker *state_data);
+                   const ValidationStateTracker &state_data);
         CreateInfo(const VkComputePipelineCreateInfo *ci) : compute(ci) {}
         CreateInfo(const VkRayTracingPipelineCreateInfoKHR *ci) : raytracing(ci) {}
         CreateInfo(const VkRayTracingPipelineCreateInfoNV *ci) : raytracing(ci) {}
@@ -169,20 +169,20 @@ class Pipeline : public StateObject {
     CreateShaderModuleStates *csm_states = nullptr;
 
     // Executable or legacy pipeline
-    Pipeline(const ValidationStateTracker *state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
+    Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
              std::shared_ptr<const vvl::PipelineLayout> &&layout, CreateShaderModuleStates *csm_states = nullptr);
 
     // Compute pipeline
-    Pipeline(const ValidationStateTracker *state_data, const VkComputePipelineCreateInfo *pCreateInfo,
+    Pipeline(const ValidationStateTracker &state_data, const VkComputePipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
              CreateShaderModuleStates *csm_states = nullptr);
 
-    Pipeline(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoKHR *pCreateInfo,
+    Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoKHR *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
              CreateShaderModuleStates *csm_states = nullptr);
 
-    Pipeline(const ValidationStateTracker *state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
+    Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
              CreateShaderModuleStates *csm_states = nullptr);
 
@@ -524,6 +524,7 @@ class Pipeline : public StateObject {
 
     // This is a helper that is meant to be used during safe_VkPipelineRenderingCreateInfo construction to determine whether or not
     // certain fields should be ignored based on graphics pipeline state
+    // TODO - This is only a pointer to ValidationStateTracker because we are trying to do state tracking outside the state tracker
     static bool PnextRenderingInfoCustomCopy(const ValidationStateTracker *state_data,
                                              const VkGraphicsPipelineCreateInfo &graphics_info, VkBaseOutStructure *safe_struct,
                                              const VkBaseOutStructure *in_struct) {

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -228,7 +228,7 @@ static inline bool CanWaitBinarySemaphoreAfterOperation(Semaphore::OpType op_typ
 
 class CoreChecks;
 struct SemaphoreSubmitState {
-    const CoreChecks *core;
+    const CoreChecks &core;
     VkQueue queue;
     VkQueueFlags queue_flags;
 
@@ -242,7 +242,7 @@ struct SemaphoreSubmitState {
     vvl::unordered_map<VkSemaphore, uint64_t> timeline_signals;
     vvl::unordered_map<VkSemaphore, uint64_t> timeline_waits;
 
-    SemaphoreSubmitState(const CoreChecks *core_, VkQueue q_, VkQueueFlags queue_flags_)
+    SemaphoreSubmitState(const CoreChecks &core_, VkQueue q_, VkQueueFlags queue_flags_)
         : core(core_), queue(q_), queue_flags(queue_flags_) {}
 
     bool CannotWaitBinary(const vvl::Semaphore &semaphore_state) const;

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -19,16 +19,16 @@
 #include "state_tracker/state_tracker.h"
 
 namespace vvl {
-static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
+static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker &dev_data, const VkShaderCreateInfoEXT &pCreateInfo) {
     ShaderObject::SetLayoutVector set_layouts(pCreateInfo.setLayoutCount);
 
     for (uint32_t i = 0; i < pCreateInfo.setLayoutCount; ++i) {
-        set_layouts[i] = dev_data->Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
+        set_layouts[i] = dev_data.Get<vvl::DescriptorSetLayout>(pCreateInfo.pSetLayouts[i]);
     }
     return set_layouts;
 }
 
-ShaderObject::ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
+ShaderObject::ShaderObject(ValidationStateTracker &dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
                            std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                            uint32_t unique_shader_id)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -29,7 +29,7 @@
 namespace vvl {
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct ShaderObject : public StateObject {
-    ShaderObject(ValidationStateTracker *dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
+    ShaderObject(ValidationStateTracker &dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
                  std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
                  uint32_t unique_shader_id = 0);
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -215,13 +215,13 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
 
 std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, features);
+    return std::make_shared<vvl::Image>(*this, handle, pCreateInfo, features);
 }
 
 std::shared_ptr<vvl::Image> ValidationStateTracker::CreateImageState(VkImage handle, const VkImageCreateInfo *pCreateInfo,
                                                                      VkSwapchainKHR swapchain, uint32_t swapchain_index,
                                                                      VkFormatFeatureFlags2KHR features) {
-    return std::make_shared<vvl::Image>(this, handle, pCreateInfo, swapchain, swapchain_index, features);
+    return std::make_shared<vvl::Image>(*this, handle, pCreateInfo, swapchain, swapchain_index, features);
 }
 
 void ValidationStateTracker::PostCallRecordCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
@@ -368,7 +368,7 @@ struct BufferAddressInfillUpdateOps {
 };
 
 std::shared_ptr<vvl::Buffer> ValidationStateTracker::CreateBufferState(VkBuffer handle, const VkBufferCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::Buffer>(this, handle, pCreateInfo);
+    return std::make_shared<vvl::Buffer>(*this, handle, pCreateInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
@@ -1761,7 +1761,7 @@ void ValidationStateTracker::PreCallRecordFreeCommandBuffers(VkDevice device, Vk
 std::shared_ptr<vvl::CommandPool> ValidationStateTracker::CreateCommandPoolState(VkCommandPool handle,
                                                                                  const VkCommandPoolCreateInfo *pCreateInfo) {
     auto queue_flags = physical_device_state->queue_family_properties[pCreateInfo->queueFamilyIndex].queueFlags;
-    return std::make_shared<vvl::CommandPool>(this, handle, pCreateInfo, queue_flags);
+    return std::make_shared<vvl::CommandPool>(*this, handle, pCreateInfo, queue_flags);
 }
 
 void ValidationStateTracker::PostCallRecordCreateCommandPool(VkDevice device, const VkCommandPoolCreateInfo *pCreateInfo,
@@ -1884,7 +1884,7 @@ std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateGraphicsPipelineSta
     const VkGraphicsPipelineCreateInfo *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::RenderPass> &&render_pass, std::shared_ptr<const vvl::PipelineLayout> &&layout,
     CreateShaderModuleStates *csm_states) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
                                            csm_states);
 }
 
@@ -1943,7 +1943,7 @@ void ValidationStateTracker::PostCallRecordCreateGraphicsPipelines(VkDevice devi
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateComputePipelineState(
     const VkComputePipelineCreateInfo *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -1981,7 +1981,7 @@ void ValidationStateTracker::PostCallRecordCreateComputePipelines(VkDevice devic
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateRayTracingPipelineState(
     const VkRayTracingPipelineCreateInfoNV *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesNV(
@@ -2015,7 +2015,7 @@ void ValidationStateTracker::PostCallRecordCreateRayTracingPipelinesNV(
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateRayTracingPipelineState(
     const VkRayTracingPipelineCreateInfoKHR *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::PipelineLayout> &&layout) const {
-    return std::make_shared<vvl::Pipeline>(this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
+    return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(layout));
 }
 
 bool ValidationStateTracker::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
@@ -2110,12 +2110,12 @@ void ValidationStateTracker::PostCallRecordCreatePipelineLayout(VkDevice device,
                                                                 const VkAllocationCallbacks *pAllocator,
                                                                 VkPipelineLayout *pPipelineLayout, const RecordObject &record_obj) {
     if (VK_SUCCESS != record_obj.result) return;
-    Add(std::make_shared<vvl::PipelineLayout>(this, *pPipelineLayout, pCreateInfo));
+    Add(std::make_shared<vvl::PipelineLayout>(*this, *pPipelineLayout, pCreateInfo));
 }
 
 std::shared_ptr<vvl::DescriptorPool> ValidationStateTracker::CreateDescriptorPoolState(
     VkDescriptorPool handle, const VkDescriptorPoolCreateInfo *pCreateInfo) {
-    return std::make_shared<vvl::DescriptorPool>(this, handle, pCreateInfo);
+    return std::make_shared<vvl::DescriptorPool>(*this, handle, pCreateInfo);
 }
 
 std::shared_ptr<vvl::DescriptorSet> ValidationStateTracker::CreateDescriptorSet(
@@ -3162,7 +3162,7 @@ void ValidationStateTracker::PostCallRecordCreateVideoSessionKHR(VkDevice device
     if (VK_SUCCESS != record_obj.result) return;
 
     auto profile_desc = video_profile_cache_.Get(physical_device, pCreateInfo->pVideoProfile);
-    Add(std::make_shared<vvl::VideoSession>(this, *pVideoSession, pCreateInfo, std::move(profile_desc)));
+    Add(std::make_shared<vvl::VideoSession>(*this, *pVideoSession, pCreateInfo, std::move(profile_desc)));
 }
 
 void ValidationStateTracker::PostCallRecordGetVideoSessionMemoryRequirementsKHR(
@@ -4303,8 +4303,7 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplateKHR(Vk
     auto dsl = layout_data->GetDsl(set);
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
-    vvl::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(), pData,
-                                                            dsl->VkHandle());
+    vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(), pData, dsl->VkHandle());
     cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, set,
                                      static_cast<uint32_t>(decoded_template.desc_writes.size()),
                                      decoded_template.desc_writes.data());
@@ -4324,7 +4323,7 @@ void ValidationStateTracker::PreCallRecordCmdPushDescriptorSetWithTemplate2KHR(
     auto dsl = layout_data->GetDsl(pPushDescriptorSetWithTemplateInfo->set);
     const auto &template_ci = template_state->create_info;
     // Decode the template into a set of write updates
-    vvl::DecodedTemplateUpdate decoded_template(this, VK_NULL_HANDLE, template_state.get(),
+    vvl::DecodedTemplateUpdate decoded_template(*this, VK_NULL_HANDLE, template_state.get(),
                                                 pPushDescriptorSetWithTemplateInfo->pData, dsl->VkHandle());
     cb_state->PushDescriptorSetState(template_ci.pipelineBindPoint, *layout_data, pPushDescriptorSetWithTemplateInfo->set,
                                      static_cast<uint32_t>(decoded_template.desc_writes.size()),
@@ -4485,7 +4484,7 @@ void ValidationStateTracker::PerformUpdateDescriptorSetsWithTemplateKHR(VkDescri
                                                                         const vvl::DescriptorUpdateTemplate *template_state,
                                                                         const void *pData) {
     // Translate the templated update into a normal update for validation...
-    vvl::DecodedTemplateUpdate decoded_update(this, descriptorSet, template_state, pData);
+    vvl::DecodedTemplateUpdate decoded_update(*this, descriptorSet, template_state, pData);
     PerformUpdateDescriptorSets(static_cast<uint32_t>(decoded_update.desc_writes.size()), decoded_update.desc_writes.data(), 0,
                                 NULL);
 }
@@ -4807,7 +4806,7 @@ void ValidationStateTracker::PostCallRecordCreateShadersEXT(VkDevice device, uin
     create_shader_object_api_state *csm_state = static_cast<create_shader_object_api_state *>(csm_state_data);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pShaders[i] != VK_NULL_HANDLE) {
-            Add(std::make_shared<vvl::ShaderObject>(this, pCreateInfos[i], pShaders[i], csm_state->module_states[i],
+            Add(std::make_shared<vvl::ShaderObject>(*this, pCreateInfos[i], pShaders[i], csm_state->module_states[i],
                                                     createInfoCount, pShaders, csm_state->unique_shader_ids[i]));
         }
     }
@@ -5636,13 +5635,13 @@ void ValidationStateTracker::PostCallRecordGetBufferDeviceAddressEXT(VkDevice de
 
 std::shared_ptr<vvl::Swapchain> ValidationStateTracker::CreateSwapchainState(const VkSwapchainCreateInfoKHR *pCreateInfo,
                                                                              VkSwapchainKHR handle) {
-    return std::make_shared<vvl::Swapchain>(this, pCreateInfo, handle);
+    return std::make_shared<vvl::Swapchain>(*this, pCreateInfo, handle);
 }
 
 std::shared_ptr<vvl::CommandBuffer> ValidationStateTracker::CreateCmdBufferState(VkCommandBuffer handle,
                                                                                  const VkCommandBufferAllocateInfo *pAllocateInfo,
                                                                                  const vvl::CommandPool *pool) {
-    return std::make_shared<vvl::CommandBuffer>(this, handle, pAllocateInfo, pool);
+    return std::make_shared<vvl::CommandBuffer>(*this, handle, pAllocateInfo, pool);
 }
 
 std::shared_ptr<vvl::DeviceMemory> ValidationStateTracker::CreateDeviceMemoryState(

--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -253,8 +253,8 @@ void VideoProfileDesc::Cache::Release(VideoProfileDesc const *desc) {
 VideoPictureResource::VideoPictureResource()
     : image_view_state(nullptr), image_state(nullptr), base_array_layer(0), range(), coded_offset(), coded_extent() {}
 
-VideoPictureResource::VideoPictureResource(ValidationStateTracker const *dev_data, VkVideoPictureResourceInfoKHR const &res)
-    : image_view_state(dev_data->Get<ImageView>(res.imageViewBinding)),
+VideoPictureResource::VideoPictureResource(const ValidationStateTracker &dev_data, VkVideoPictureResourceInfoKHR const &res)
+    : image_view_state(dev_data.Get<ImageView>(res.imageViewBinding)),
       image_state(image_view_state ? image_view_state->image_state : nullptr),
       base_array_layer(res.baseArrayLayer),
       range(GetImageSubresourceRange(image_view_state.get(), res.baseArrayLayer)),
@@ -438,7 +438,7 @@ class RateControlStateMismatchRecorder {
     mutable std::string string_{};
 };
 
-bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTracker &dev_data, const VideoSession *vs_state,
                                                        const safe_VkVideoBeginCodingInfoKHR &begin_info,
                                                        const Location &loc) const {
     bool skip = false;
@@ -567,27 +567,27 @@ bool VideoSessionDeviceState::ValidateRateControlState(const ValidationStateTrac
 #undef CHECK_RC_LAYER_INFO
 
         if (mismatch_recorder.HasMismatch()) {
-            skip |= dev_data->LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08254", vs_state->Handle(), loc,
-                                       "The video encode rate control information specified when beginning the video coding scope "
-                                       "does not match the currently configured video encode rate control state for %s:\n%s",
-                                       dev_data->FormatHandle(vs_state->Handle()).c_str(), mismatch_recorder.c_str());
+            skip |= dev_data.LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08254", vs_state->Handle(), loc,
+                                      "The video encode rate control information specified when beginning the video coding scope "
+                                      "does not match the currently configured video encode rate control state for %s:\n%s",
+                                      dev_data.FormatHandle(vs_state->Handle()).c_str(), mismatch_recorder.c_str());
         }
 
     } else {
         if (encode_.rate_control_state.base.rateControlMode != VK_VIDEO_ENCODE_RATE_CONTROL_MODE_DEFAULT_KHR) {
             skip |=
-                dev_data->LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08253", vs_state->Handle(), loc,
-                                   "No VkVideoEncodeRateControlInfoKHR structure was specified when beginning the "
-                                   "video coding scope but the currently set video encode rate control mode for %s is %s.",
-                                   dev_data->FormatHandle(vs_state->Handle()).c_str(),
-                                   string_VkVideoEncodeRateControlModeFlagBitsKHR(encode_.rate_control_state.base.rateControlMode));
+                dev_data.LogError("VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-08253", vs_state->Handle(), loc,
+                                  "No VkVideoEncodeRateControlInfoKHR structure was specified when beginning the "
+                                  "video coding scope but the currently set video encode rate control mode for %s is %s.",
+                                  dev_data.FormatHandle(vs_state->Handle()).c_str(),
+                                  string_VkVideoEncodeRateControlModeFlagBitsKHR(encode_.rate_control_state.base.rateControlMode));
         }
     }
 
     return skip;
 }
 
-VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle,
+VideoSession::VideoSession(const ValidationStateTracker &dev_data, VkVideoSessionKHR handle,
                            VkVideoSessionCreateInfoKHR const *pCreateInfo, std::shared_ptr<const VideoProfileDesc> &&profile_desc)
     : StateObject(handle, kVulkanObjectTypeVideoSessionKHR),
       safe_create_info(pCreateInfo),
@@ -600,13 +600,13 @@ VideoSession::VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR h
       device_state_mutex_(),
       device_state_(pCreateInfo->maxDpbSlots) {}
 
-VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(ValidationStateTracker *dev_data, VkVideoSessionKHR vs) {
+VideoSession::MemoryBindingMap VideoSession::GetMemoryBindings(const ValidationStateTracker &dev_data, VkVideoSessionKHR vs) {
     uint32_t memory_requirement_count;
-    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data->device, vs, &memory_requirement_count, nullptr);
+    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data.device, vs, &memory_requirement_count, nullptr);
 
     std::vector<VkVideoSessionMemoryRequirementsKHR> memory_requirements(memory_requirement_count,
                                                                          vku::InitStruct<VkVideoSessionMemoryRequirementsKHR>());
-    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data->device, vs, &memory_requirement_count, memory_requirements.data());
+    DispatchGetVideoSessionMemoryRequirementsKHR(dev_data.device, vs, &memory_requirement_count, memory_requirements.data());
 
     MemoryBindingMap memory_bindings;
     for (uint32_t i = 0; i < memory_requirement_count; ++i) {

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -240,7 +240,7 @@ class VideoPictureResource {
     VkExtent2D coded_extent;
 
     VideoPictureResource();
-    VideoPictureResource(ValidationStateTracker const *dev_data, VkVideoPictureResourceInfoKHR const &res);
+    VideoPictureResource(const ValidationStateTracker &dev_data, VkVideoPictureResourceInfoKHR const &res);
 
     operator bool() const { return image_view_state != nullptr; }
 
@@ -330,7 +330,7 @@ struct VideoReferenceSlot {
 
     VideoReferenceSlot() : index(-1), picture_id(), resource() {}
 
-    VideoReferenceSlot(ValidationStateTracker const *dev_data, VideoProfileDesc const &profile,
+    VideoReferenceSlot(const ValidationStateTracker &dev_data, VideoProfileDesc const &profile,
                        VkVideoReferenceSlotInfoKHR const &slot, bool has_picture_id = true)
         : index(slot.slotIndex),
           picture_id(has_picture_id ? VideoPictureID(profile, slot) : VideoPictureID()),
@@ -451,7 +451,7 @@ class VideoSessionDeviceState {
         encode_.rate_control_state = rate_control_state;
     }
 
-    bool ValidateRateControlState(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+    bool ValidateRateControlState(const ValidationStateTracker &dev_data, const VideoSession *vs_state,
                                   const safe_VkVideoBeginCodingInfoKHR &begin_info, const Location &loc) const;
 
   private:
@@ -490,7 +490,7 @@ class VideoSession : public StateObject {
         VideoSessionDeviceState &state_;
     };
 
-    VideoSession(ValidationStateTracker *dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
+    VideoSession(const ValidationStateTracker &dev_data, VkVideoSessionKHR handle, VkVideoSessionCreateInfoKHR const *pCreateInfo,
                  std::shared_ptr<const VideoProfileDesc> &&profile_desc);
 
     VkVideoSessionKHR VkHandle() const { return handle_.Cast<VkVideoSessionKHR>(); }
@@ -534,7 +534,7 @@ class VideoSession : public StateObject {
     bool ReferenceSetupRequested(VkVideoEncodeInfoKHR const &encode_info) const;
 
   private:
-    MemoryBindingMap GetMemoryBindings(ValidationStateTracker *dev_data, VkVideoSessionKHR vs);
+    MemoryBindingMap GetMemoryBindings(const ValidationStateTracker &dev_data, VkVideoSessionKHR vs);
 
     MemoryBindingMap memory_bindings_;
     uint32_t unbound_memory_binding_count_;
@@ -708,7 +708,7 @@ class VideoSessionParameters : public StateObject {
     void AddEncodeH265(VkVideoEncodeH265SessionParametersAddInfoKHR const *info);
 };
 
-using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker *dev_data, const VideoSession *vs_state,
+using VideoSessionUpdateList = std::vector<std::function<bool(const ValidationStateTracker &dev_data, const VideoSession *vs_state,
                                                               VideoSessionDeviceState &dev_state, bool do_validate)>>;
 using VideoSessionUpdateMap = unordered_map<VkVideoSessionKHR, VideoSessionUpdateList>;
 

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1188,9 +1188,9 @@ std::string SyncValidationInfo::FormatHazard(const HazardResult &hazard) const {
     return out.str();
 }
 
-syncval_state::CommandBuffer::CommandBuffer(SyncValidator *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
-                                            const vvl::CommandPool *pool)
-    : vvl::CommandBuffer(dev, cb, pCreateInfo, pool), access_context(*dev, this) {}
+syncval_state::CommandBuffer::CommandBuffer(SyncValidator &dev, VkCommandBuffer handle,
+                                            const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool)
+    : vvl::CommandBuffer(dev, handle, pCreateInfo, pool), access_context(dev, this) {}
 
 void syncval_state::CommandBuffer::Destroy() {
     access_context.Destroy();  // must be first to clean up self references correctly.

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -419,7 +419,7 @@ class CommandBuffer : public vvl::CommandBuffer {
   public:
     CommandBufferAccessContext access_context;
 
-    CommandBuffer(SyncValidator *dev, VkCommandBuffer cb, const VkCommandBufferAllocateInfo *pCreateInfo,
+    CommandBuffer(SyncValidator &dev, VkCommandBuffer handle, const VkCommandBufferAllocateInfo *pCreateInfo,
                   const vvl::CommandPool *pool);
     ~CommandBuffer() { Destroy(); }
 

--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -23,13 +23,13 @@ namespace syncval_state {
 
 class ImageState : public vvl::Image {
   public:
-    ImageState(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo,
+    ImageState(const ValidationStateTracker &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
                VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, features), opaque_base_address_(0U) {}
+        : vvl::Image(dev_data, handle, pCreateInfo, features), opaque_base_address_(0U) {}
 
-    ImageState(const ValidationStateTracker *dev_data, VkImage img, const VkImageCreateInfo *pCreateInfo, VkSwapchainKHR swapchain,
-               uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
-        : vvl::Image(dev_data, img, pCreateInfo, swapchain, swapchain_index, features), opaque_base_address_(0U) {}
+    ImageState(const ValidationStateTracker &dev_data, VkImage handle, const VkImageCreateInfo *pCreateInfo,
+               VkSwapchainKHR swapchain, uint32_t swapchain_index, VkFormatFeatureFlags2KHR features)
+        : vvl::Image(dev_data, handle, pCreateInfo, swapchain, swapchain_index, features), opaque_base_address_(0U) {}
     bool IsLinear() const { return fragment_encoder->IsLinearImage(); }
     bool IsTiled() const { return !IsLinear(); }
     bool IsSimplyBound() const;
@@ -49,7 +49,7 @@ class ImageState : public vvl::Image {
 
 class ImageViewState : public vvl::ImageView {
   public:
-    ImageViewState(const std::shared_ptr<vvl::Image> &image_state, VkImageView iv, const VkImageViewCreateInfo *ci,
+    ImageViewState(const std::shared_ptr<vvl::Image> &image_state, VkImageView handle, const VkImageViewCreateInfo *ci,
                    VkFormatFeatureFlags2KHR ff, const VkFilterCubicImageViewImageFormatPropertiesEXT &cubic_props);
     const ImageState *GetImageState() const { return static_cast<const syncval_state::ImageState *>(image_state.get()); }
     ImageRangeGen MakeImageRangeGen(const VkOffset3D &offset, const VkExtent3D &extent, VkImageAspectFlags aspect_mask = 0) const;
@@ -63,7 +63,7 @@ class ImageViewState : public vvl::ImageView {
 
 class Swapchain : public vvl::Swapchain {
   public:
-    Swapchain(ValidationStateTracker *dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR swapchain);
+    Swapchain(ValidationStateTracker &dev_data, const VkSwapchainCreateInfoKHR *pCreateInfo, VkSwapchainKHR handle);
     ~Swapchain() { Destroy(); }
     void RecordPresentedImage(PresentedImage &&presented_images);
     PresentedImage MovePresentedImage(uint32_t image_index);

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -161,9 +161,9 @@ FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, 
 FenceSyncState::FenceSyncState(const std::shared_ptr<const vvl::Fence>& fence_, const PresentedImage& image, ResourceUsageTag tag_)
     : fence(fence_), tag(tag_), queue_id(kQueueIdInvalid), acquired(image, tag) {}
 
-syncval_state::Swapchain::Swapchain(ValidationStateTracker* dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo,
-                                    VkSwapchainKHR swapchain)
-    : vvl::Swapchain(dev_data, pCreateInfo, swapchain) {}
+syncval_state::Swapchain::Swapchain(ValidationStateTracker& dev_data, const VkSwapchainCreateInfoKHR* pCreateInfo,
+                                    VkSwapchainKHR handle)
+    : vvl::Swapchain(dev_data, pCreateInfo, handle) {}
 
 void syncval_state::Swapchain::RecordPresentedImage(PresentedImage&& presented_image) {
     // All presented images are stored within the swapchain until the are reaquired.


### PR DESCRIPTION
2nd attempt at https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7718

There are 2 spots I know we currently need/rely on passing as a pointer, so went and changed the other as references where they weren't

I think the next thing I plan to is look into the fact that most of these don't need `ValidationStateTracker` but really the `debug_report_data` object to do `LogError` and it would nice to make that explicit