### PR TITLE
Move functions into DebugReportData

### DIFF
--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -1029,7 +1029,7 @@ bool CoreChecks::ValidateHostCopyCurrentLayout(VkDevice device, const VkImageLay
             LogError(vuid, objlist, loc,
                      "expected to be %s. Incorrect image layout for %s %s. Current layout is %s for subresource in region %" PRIu32
                      " (aspectMask=%s, mipLevel=%" PRIu32 ", arrayLayer=%" PRIu32 ")",
-                     string_VkImageLayout(expected_layout), image_label, report_data->FormatHandle(image_state.Handle()).c_str(),
+                     string_VkImageLayout(expected_layout), image_label, debug_report->FormatHandle(image_state.Handle()).c_str(),
                      string_VkImageLayout(check_state.found_layout), region_index,
                      string_VkImageAspectFlags(subres.aspectMask).c_str(), subres.mipLevel, subres.arrayLayer);
     }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3364,31 +3364,32 @@ bool CoreChecks::ValidateShaderObjectDrawtimeState(const LastBound &last_bound_s
             skip |=
                 LogError(vuid.task_mesh_shader_08694, objlist, loc,
                          "Mesh shader %s was created without VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT, but no task shader is bound.",
-                         report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str());
+                         debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str());
         } else if (validMeshShader &&
                    (last_bound_state.GetShaderState(ShaderObjectStage::MESH)->create_info.flags &
                     VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT) != 0 &&
                    validTaskShader) {
             skip |= LogError(vuid.task_mesh_shader_08695, objlist, loc,
                              "Mesh shader %s was created with VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT, but a task shader is bound.",
-                             report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str());
+                             debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str());
         }
     }
     if (validVertShader && (validTaskShader || validMeshShader)) {
         std::stringstream msg;
         if (validTaskShader && validMeshShader) {
-            msg << "task shader " << report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::TASK))
-                << "and mesh shader " << report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH))
+            msg << "task shader " << debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::TASK))
+                << "and mesh shader " << debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH))
                 << " are bound as well";
         } else if (validTaskShader) {
-            msg << "task shader " << report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::TASK))
+            msg << "task shader " << debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::TASK))
                 << " is bound as well";
         } else if (validMeshShader) {
-            msg << "mesh shader " << report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH))
+            msg << "mesh shader " << debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH))
                 << " is bound as well";
         }
-        skip |= LogError(vuid.vert_task_mesh_shader_08696, objlist, loc, "Vertex shader %s is bound, but %s.",
-                         report_data->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str(), msg.str().c_str());
+        skip |=
+            LogError(vuid.vert_task_mesh_shader_08696, objlist, loc, "Vertex shader %s is bound, but %s.",
+                     debug_report->FormatHandle(last_bound_state.GetShader(ShaderObjectStage::MESH)).c_str(), msg.str().c_str());
     }
     for (uint32_t i = 0; i < kShaderObjectStageCount; ++i) {
         if (i != static_cast<uint32_t>(ShaderObjectStage::COMPUTE) && last_bound_state.shader_object_states[i]) {
@@ -3406,9 +3407,9 @@ bool CoreChecks::ValidateShaderObjectDrawtimeState(const LastBound &last_bound_s
                         LogError(vuid.linked_shaders_08698, objlist, loc,
                                  "Shader %s (%s) was created with VK_SHADER_CREATE_LINK_STAGE_BIT_EXT, but the linked %s "
                                  "shader (%s) is not bound.",
-                                 report_data->FormatHandle(last_bound_state.GetShader(static_cast<ShaderObjectStage>(i))).c_str(),
+                                 debug_report->FormatHandle(last_bound_state.GetShader(static_cast<ShaderObjectStage>(i))).c_str(),
                                  string_VkShaderStageFlagBits(last_bound_state.shader_object_states[i]->create_info.stage),
-                                 report_data->FormatHandle(linkedShader).c_str(),
+                                 debug_report->FormatHandle(linkedShader).c_str(),
                                  string_VkShaderStageFlagBits(missingShader->create_info.stage));
                     break;
                 }

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1949,9 +1949,8 @@ void CoreChecks::RecordBarriers(Func func_name, vvl::CommandBuffer &cb_state, co
 }
 
 template <typename TransferBarrier, typename Scoreboard>
-bool CoreChecks::ValidateAndUpdateQFOScoreboard(const debug_report_data *report_data, const vvl::CommandBuffer &cb_state,
-                                                const char *operation, const TransferBarrier &barrier, Scoreboard *scoreboard,
-                                                const Location &loc) const {
+bool CoreChecks::ValidateAndUpdateQFOScoreboard(const vvl::CommandBuffer &cb_state, const char *operation,
+                                                const TransferBarrier &barrier, Scoreboard *scoreboard, const Location &loc) const {
     // Record to the scoreboard or report that we have a duplication
     bool skip = false;
     auto inserted = scoreboard->emplace(barrier, &cb_state);
@@ -1993,7 +1992,7 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const vvl::CommandBuffer &cb_
                                    found->dstQueueFamilyIndex);
             }
         }
-        skip |= ValidateAndUpdateQFOScoreboard(report_data, cb_state, "releasing", release, &scoreboards->release, loc);
+        skip |= ValidateAndUpdateQFOScoreboard(cb_state, "releasing", release, &scoreboards->release, loc);
     }
     // Each acquire must have a matching release (ERROR)
     for (const auto &acquire : cb_barriers.acquire) {
@@ -2010,7 +2009,7 @@ bool CoreChecks::ValidateQueuedQFOTransferBarriers(const vvl::CommandBuffer &cb_
                              barrier_name, handle_name, FormatHandle(acquire.handle).c_str(), acquire.srcQueueFamilyIndex,
                              acquire.dstQueueFamilyIndex);
         }
-        skip |= ValidateAndUpdateQFOScoreboard(report_data, cb_state, "acquiring", acquire, &scoreboards->acquire, loc);
+        skip |= ValidateAndUpdateQFOScoreboard(cb_state, "acquiring", acquire, &scoreboards->acquire, loc);
     }
     return skip;
 }

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -474,9 +474,8 @@ class CoreChecks : public ValidationStateTracker {
                                     const Location& loc) const;
 
     template <typename Barrier, typename Scoreboard>
-    bool ValidateAndUpdateQFOScoreboard(const debug_report_data* report_data, const vvl::CommandBuffer& cb_state,
-                                        const char* operation, const Barrier& barrier, Scoreboard* scoreboard,
-                                        const Location& loc) const;
+    bool ValidateAndUpdateQFOScoreboard(const vvl::CommandBuffer& cb_state, const char* operation, const Barrier& barrier,
+                                        Scoreboard* scoreboard, const Location& loc) const;
     template <typename Barrier, typename TransferBarrier>
     void RecordBarrierValidationInfo(const Location& loc, vvl::CommandBuffer& cb_state, const Barrier& barrier,
                                      QFOTransferBarrierSets<TransferBarrier>& barrier_sets);

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,24 +30,52 @@
 
 [[maybe_unused]] const char *kVUIDUndefined = "VUID_Undefined";
 
-VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data) {
+static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, VkDebugUtilsMessageSeverityFlagsEXT *da_severity,
+                                                VkDebugUtilsMessageTypeFlagsEXT *da_type) {
+    *da_severity = 0;
+    *da_type = 0;
+    // If it's explicitly listed as a performance warning, treat it as a performance message. Otherwise, treat it as a validation
+    // issue.
+    if ((dr_flags & kPerformanceWarningBit) != 0) {
+        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
+        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    }
+    if ((dr_flags & kVerboseBit) != 0) {
+        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
+    }
+    if ((dr_flags & kInformationBit) != 0) {
+        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
+    }
+    if ((dr_flags & kWarningBit) != 0) {
+        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
+    }
+    if ((dr_flags & kErrorBit) != 0) {
+        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
+        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
+    }
+}
+
+void DebugReport::SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks) {
     // For all callback in list, return their complete set of severities and modes
     for (const auto &item : callbacks) {
         if (item.IsUtils()) {
-            debug_data->active_severities |= item.debug_utils_msg_flags;
-            debug_data->active_types |= item.debug_utils_msg_type;
+            active_severities |= item.debug_utils_msg_flags;
+            active_types |= item.debug_utils_msg_type;
         } else {
             VkFlags severities = 0;
             VkFlags types = 0;
             DebugReportFlagsToAnnotFlags(item.debug_report_msg_flags, &severities, &types);
-            debug_data->active_severities |= severities;
-            debug_data->active_types |= types;
+            active_severities |= severities;
+            active_types |= types;
         }
     }
 }
 
-VKAPI_ATTR void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks,
-                                            uint64_t callback) {
+void DebugReport::RemoveDebugUtilsCallback(uint64_t callback) {
+    std::vector<VkLayerDbgFunctionState> &callbacks = debug_callback_list;
     auto item = callbacks.begin();
     for (item = callbacks.begin(); item != callbacks.end(); item++) {
         if (item->IsUtils()) {
@@ -59,17 +87,17 @@ VKAPI_ATTR void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vec
     if (item != callbacks.end()) {
         callbacks.erase(item);
     }
-    SetDebugUtilsSeverityFlags(callbacks, debug_data);
+    SetDebugUtilsSeverityFlags(callbacks);
 }
 
 // Returns TRUE if the number of times this message has been logged is over the set limit
-static bool UpdateLogMsgCounts(const debug_report_data *debug_data, int32_t vuid_hash) {
-    auto vuid_count_it = debug_data->duplicate_message_count_map.find(vuid_hash);
-    if (vuid_count_it == debug_data->duplicate_message_count_map.end()) {
-        debug_data->duplicate_message_count_map.emplace(vuid_hash, 1);
+bool DebugReport::UpdateLogMsgCounts(int32_t vuid_hash) const {
+    auto vuid_count_it = duplicate_message_count_map.find(vuid_hash);
+    if (vuid_count_it == duplicate_message_count_map.end()) {
+        duplicate_message_count_map.emplace(vuid_hash, 1);
         return false;
     } else {
-        if (vuid_count_it->second >= debug_data->duplicate_message_limit) {
+        if (vuid_count_it->second >= duplicate_message_limit) {
             return true;
         } else {
             vuid_count_it->second++;
@@ -78,8 +106,7 @@ static bool UpdateLogMsgCounts(const debug_report_data *debug_data, int32_t vuid
     }
 }
 
-static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects,
-                                 const char *layer_prefix, const char *message, const char *text_vuid) {
+bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, const char *message, const char *text_vuid) const {
     bool bail = false;
     std::vector<VkDebugUtilsLabelEXT> queue_labels;
     std::vector<VkDebugUtilsLabelEXT> cmd_buf_labels;
@@ -99,7 +126,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
     for (uint32_t i = 0; i < objects.object_list.size(); i++) {
         // If only one VkDevice was created, it is just noise to print it out in the error message.
         // Also avoid printing unknown objects, likely if new function is calling error with null LogObjectList
-        if ((objects.object_list[i].type == kVulkanObjectTypeDevice && debug_data->device_created <= 1) ||
+        if ((objects.object_list[i].type == kVulkanObjectTypeDevice && device_created <= 1) ||
             (objects.object_list[i].type == kVulkanObjectTypeUnknown) || (objects.object_list[i].handle == 0)) {
             continue;
         }
@@ -112,9 +139,9 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
         std::string object_label = {};
         // Look for any debug utils or marker names to use for this object
         // NOTE: the lock (debug_output_mutex) is held by the caller (LogMsg)
-        object_label = debug_data->DebugReportGetUtilsObjectNameNoLock(objects.object_list[i].handle);
+        object_label = GetUtilsObjectNameNoLock(objects.object_list[i].handle);
         if (object_label.empty()) {
-            object_label = debug_data->DebugReportGetMarkerObjectNameNoLock(objects.object_list[i].handle);
+            object_label = GetMarkerObjectNameNoLock(objects.object_list[i].handle);
         }
         if (!object_label.empty()) {
             object_labels.push_back(std::move(object_label));
@@ -123,16 +150,15 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
 
         // If this is a queue, add any queue labels to the callback data.
         if (VK_OBJECT_TYPE_QUEUE == object_name_info.objectType) {
-            auto label_iter = debug_data->debugUtilsQueueLabels.find(reinterpret_cast<VkQueue>(object_name_info.objectHandle));
-            if (label_iter != debug_data->debugUtilsQueueLabels.end()) {
+            auto label_iter = debug_utils_queue_labels.find(reinterpret_cast<VkQueue>(object_name_info.objectHandle));
+            if (label_iter != debug_utils_queue_labels.end()) {
                 auto found_queue_labels = label_iter->second->Export();
                 queue_labels.insert(queue_labels.end(), found_queue_labels.begin(), found_queue_labels.end());
             }
             // If this is a command buffer, add any command buffer labels to the callback data.
         } else if (VK_OBJECT_TYPE_COMMAND_BUFFER == object_name_info.objectType) {
-            auto label_iter =
-                debug_data->debugUtilsCmdBufLabels.find(reinterpret_cast<VkCommandBuffer>(object_name_info.objectHandle));
-            if (label_iter != debug_data->debugUtilsCmdBufLabels.end()) {
+            auto label_iter = debug_utils_cmd_buffer_labels.find(reinterpret_cast<VkCommandBuffer>(object_name_info.objectHandle));
+            if (label_iter != debug_utils_cmd_buffer_labels.end()) {
                 auto found_cmd_buf_labels = label_iter->second->Export();
                 cmd_buf_labels.insert(cmd_buf_labels.end(), found_cmd_buf_labels.begin(), found_cmd_buf_labels.end());
             }
@@ -187,7 +213,7 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
     oss << "| MessageID = 0x" << std::hex << message_id_number << " | " << message;
     std::string composite = oss.str();
 
-    const auto callback_list = &debug_data->debug_callback_list;
+    const auto callback_list = &debug_callback_list;
     // We only output to default callbacks if there are no non-default callbacks
     bool use_default_callbacks = true;
     for (const auto &current_callback : *callback_list) {
@@ -195,11 +221,12 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
     }
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    if (debug_data->forceDefaultLogCallback) {
+    if (force_default_log_callback) {
         use_default_callbacks = true;
     }
 #endif
 
+    const char *layer_prefix = "Validation";
     for (const auto &current_callback : *callback_list) {
         // Skip callback if it's a default callback and there are non-default callbacks present
         if (current_callback.IsDefault() && !use_default_callbacks) continue;
@@ -231,15 +258,169 @@ static bool debug_log_msg(const debug_report_data *debug_data, VkFlags msg_flags
     return bail;
 }
 
-VKAPI_ATTR void LayerDebugUtilsDestroyInstance(debug_report_data *debug_data) { delete debug_data; }
+void DebugReport::SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    if (pNameInfo->pObjectName) {
+        debug_utils_object_name_map[pNameInfo->objectHandle] = pNameInfo->pObjectName;
+    } else {
+        debug_utils_object_name_map.erase(pNameInfo->objectHandle);
+    }
+}
+
+void DebugReport::SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    if (pNameInfo->pObjectName) {
+        debug_object_name_map[pNameInfo->object] = pNameInfo->pObjectName;
+    } else {
+        debug_object_name_map.erase(pNameInfo->object);
+    }
+}
+
+// NoLock suffix means that the function itself does not hold debug_output_mutex lock,
+// and it's **mandatory responsibility** of the caller to hold this lock.
+std::string DebugReport::GetUtilsObjectNameNoLock(const uint64_t object) const {
+    std::string label = "";
+    const auto utils_name_iter = debug_utils_object_name_map.find(object);
+    if (utils_name_iter != debug_utils_object_name_map.end()) {
+        label = utils_name_iter->second;
+    }
+    return label;
+}
+
+// NoLock suffix means that the function itself does not hold debug_output_mutex lock,
+// and it's **mandatory responsibility** of the caller to hold this lock.
+std::string DebugReport::GetMarkerObjectNameNoLock(const uint64_t object) const {
+    std::string label = "";
+    const auto marker_name_iter = debug_object_name_map.find(object);
+    if (marker_name_iter != debug_object_name_map.end()) {
+        label = marker_name_iter->second;
+    }
+    return label;
+}
+
+std::string DebugReport::FormatHandle(const char *handle_type_name, uint64_t handle) const {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    std::string handle_name = GetUtilsObjectNameNoLock(handle);
+    if (handle_name.empty()) {
+        handle_name = GetMarkerObjectNameNoLock(handle);
+    }
+
+    std::ostringstream str;
+    str << handle_type_name << " 0x" << std::hex << handle << "[" << handle_name.c_str() << "]";
+    return str.str();
+}
+
+template <typename Map>
+static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type key, bool insert) {
+    auto iter = map->find(key);
+    LoggingLabelState *label_state = nullptr;
+    if (iter == map->end()) {
+        if (insert) {
+            // Add a label state if not present
+            auto inserted = map->emplace(key, std::unique_ptr<LoggingLabelState>(new LoggingLabelState()));
+            assert(inserted.second);
+            iter = inserted.first;
+            label_state = iter->second.get();
+        }
+    } else {
+        label_state = iter->second.get();
+    }
+    return label_state;
+}
+
+void DebugReport::BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    if (nullptr != label_info && nullptr != label_info->pLabelName) {
+        auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
+        assert(label_state);
+        label_state->labels.emplace_back(label_info);
+
+        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+        label_state->insert_label.Reset();
+    }
+}
+
+void DebugReport::EndQueueDebugUtilsLabel(VkQueue queue) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ false);
+    if (label_state) {
+        // Pop the normal item
+        if (!label_state->labels.empty()) {
+            label_state->labels.pop_back();
+        }
+
+        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+        label_state->insert_label.Reset();
+    }
+}
+
+void DebugReport::InsertQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
+
+    // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+    label_state->insert_label = LoggingLabel(label_info);
+}
+
+void DebugReport::BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    if (nullptr != label_info && nullptr != label_info->pLabelName) {
+        auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
+        assert(label_state);
+        label_state->labels.push_back(LoggingLabel(label_info));
+
+        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+        label_state->insert_label.Reset();
+    }
+}
+
+void DebugReport::EndCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
+    if (label_state) {
+        // Pop the normal item
+        if (!label_state->labels.empty()) {
+            label_state->labels.pop_back();
+        }
+
+        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+        label_state->insert_label.Reset();
+    }
+}
+
+void DebugReport::InsertCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
+    assert(label_state);
+
+    // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
+    label_state->insert_label = LoggingLabel(label_info);
+}
+
+// Current tracking beyond a single command buffer scope is incorrect, and even when it is we need to be able to clean up
+void DebugReport::ResetCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ false);
+    if (label_state) {
+        label_state->labels.clear();
+        label_state->insert_label.Reset();
+    }
+}
+
+void DebugReport::EraseCmdDebugUtilsLabel(VkCommandBuffer command_buffer) {
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
+    debug_utils_cmd_buffer_labels.erase(command_buffer);
+}
+
+VKAPI_ATTR void LayerDebugUtilsDestroyInstance(DebugReport *debug_report) { delete debug_report; }
 
 template <typename TCreateInfo, typename TCallback>
-static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, debug_report_data *debug_data,
-                                const TCreateInfo *create_info, TCallback *callback) {
-    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, DebugReport *debug_report, const TCreateInfo *create_info,
+                                TCallback *callback) {
+    std::unique_lock<std::mutex> lock(debug_report->debug_output_mutex);
 
-    debug_data->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
-    auto &callback_state = debug_data->debug_callback_list.back();
+    debug_report->debug_callback_list.emplace_back(VkLayerDbgFunctionState());
+    auto &callback_state = debug_report->debug_callback_list.back();
     callback_state.callback_status = callback_status;
     callback_state.pUserData = create_info->pUserData;
 
@@ -268,56 +449,56 @@ static void LayerCreateCallback(DebugCallbackStatusFlags callback_status, debug_
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     // On Android, if the default callback system property is set, force the default callback to be printed
-    std::string forceLayerLog = GetEnvironment(kForceDefaultCallbackKey);
-    int forceDefaultCallback = atoi(forceLayerLog.c_str());
-    if (forceDefaultCallback == 1) {
-        debug_data->forceDefaultLogCallback = true;
+    std::string force_layer_log = GetEnvironment(kForceDefaultCallbackKey);
+    int force_default_callback = atoi(force_layer_log.c_str());
+    if (force_default_callback == 1) {
+        debug_report->force_default_log_callback = true;
     }
 #endif
 
-    SetDebugUtilsSeverityFlags(debug_data->debug_callback_list, debug_data);
+    debug_report->SetDebugUtilsSeverityFlags(debug_report->debug_callback_list);
 }
 
-VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
+VKAPI_ATTR VkResult LayerCreateMessengerCallback(DebugReport *debug_report, bool default_callback,
                                                  const VkDebugUtilsMessengerCreateInfoEXT *create_info,
                                                  VkDebugUtilsMessengerEXT *messenger) {
-    LayerCreateCallback((DEBUG_CALLBACK_UTILS | (default_callback ? DEBUG_CALLBACK_DEFAULT : 0)), debug_data, create_info,
+    LayerCreateCallback((DEBUG_CALLBACK_UTILS | (default_callback ? DEBUG_CALLBACK_DEFAULT : 0)), debug_report, create_info,
                         messenger);
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR VkResult LayerCreateReportCallback(debug_report_data *debug_data, bool default_callback,
+VKAPI_ATTR VkResult LayerCreateReportCallback(DebugReport *debug_report, bool default_callback,
                                               const VkDebugReportCallbackCreateInfoEXT *create_info,
                                               VkDebugReportCallbackEXT *callback) {
-    LayerCreateCallback((default_callback ? DEBUG_CALLBACK_DEFAULT : 0), debug_data, create_info, callback);
+    LayerCreateCallback((default_callback ? DEBUG_CALLBACK_DEFAULT : 0), debug_report, create_info, callback);
     return VK_SUCCESS;
 }
 
-VKAPI_ATTR void ActivateInstanceDebugCallbacks(debug_report_data *debug_data) {
-    auto current = debug_data->instance_pnext_chain;
+VKAPI_ATTR void ActivateInstanceDebugCallbacks(DebugReport *debug_report) {
+    auto current = debug_report->instance_pnext_chain;
     for (;;) {
         auto create_info = vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(current);
         if (!create_info) break;
         current = create_info->pNext;
         VkDebugUtilsMessengerEXT utils_callback{};
-        LayerCreateCallback((DEBUG_CALLBACK_UTILS | DEBUG_CALLBACK_INSTANCE), debug_data, create_info, &utils_callback);
+        LayerCreateCallback((DEBUG_CALLBACK_UTILS | DEBUG_CALLBACK_INSTANCE), debug_report, create_info, &utils_callback);
     }
     for (;;) {
         auto create_info = vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(current);
         if (!create_info) break;
         current = create_info->pNext;
         VkDebugReportCallbackEXT report_callback{};
-        LayerCreateCallback(DEBUG_CALLBACK_INSTANCE, debug_data, create_info, &report_callback);
+        LayerCreateCallback(DEBUG_CALLBACK_INSTANCE, debug_report, create_info, &report_callback);
     }
 }
 
-VKAPI_ATTR void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data) {
-    if (!vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(debug_data->instance_pnext_chain) &&
-        !vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(debug_data->instance_pnext_chain))
+VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport *debug_report) {
+    if (!vku::FindStructInPNextChain<VkDebugUtilsMessengerCreateInfoEXT>(debug_report->instance_pnext_chain) &&
+        !vku::FindStructInPNextChain<VkDebugReportCallbackCreateInfoEXT>(debug_report->instance_pnext_chain))
         return;
     std::vector<VkDebugUtilsMessengerEXT> instance_utils_callback_handles{};
     std::vector<VkDebugReportCallbackEXT> instance_report_callback_handles{};
-    for (const auto &item : debug_data->debug_callback_list) {
+    for (const auto &item : debug_report->debug_callback_list) {
         if (item.IsInstance()) {
             if (item.IsUtils()) {
                 instance_utils_callback_handles.push_back(item.debug_utils_callback_object);
@@ -327,43 +508,43 @@ VKAPI_ATTR void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data) 
         }
     }
     for (const auto &item : instance_utils_callback_handles) {
-        LayerDestroyCallback(debug_data, item);
+        LayerDestroyCallback(debug_report, item);
     }
     for (const auto &item : instance_report_callback_handles) {
-        LayerDestroyCallback(debug_data, item);
+        LayerDestroyCallback(debug_report, item);
     }
 }
 
 // helper for VUID based filtering. This needs to be separate so it can be called before incurring
 // the cost of sprintf()-ing the err_msg needed by LogMsgLocked().
-static bool LogMsgEnabled(const debug_report_data *debug_data, std::string_view vuid_text,
-                          VkDebugUtilsMessageSeverityFlagsEXT severity, VkDebugUtilsMessageTypeFlagsEXT type) {
-    if (!(debug_data->active_severities & severity) || !(debug_data->active_types & type)) {
+bool DebugReport::LogMsgEnabled(std::string_view vuid_text, VkDebugUtilsMessageSeverityFlagsEXT severity,
+                                VkDebugUtilsMessageTypeFlagsEXT type) {
+    if (!(active_severities & severity) || !(active_types & type)) {
         return false;
     }
     // If message is in filter list, bail out very early
     const uint32_t message_id = hash_util::VuidHash(vuid_text);
-    if (debug_data->filter_message_ids.find(message_id) != debug_data->filter_message_ids.end()) {
+    if (filter_message_ids.find(message_id) != filter_message_ids.end()) {
         return false;
     }
-    if ((debug_data->duplicate_message_limit > 0) && UpdateLogMsgCounts(debug_data, static_cast<int32_t>(message_id))) {
+    if ((duplicate_message_limit > 0) && UpdateLogMsgCounts(static_cast<int32_t>(message_id))) {
         // Count for this particular message is over the limit, ignore it
         return false;
     }
     return true;
 }
 
-VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects, const Location *loc,
-                       std::string_view vuid_text, const char *format, va_list argptr) {
+bool DebugReport::LogMsg(VkFlags msg_flags, const LogObjectList &objects, const Location *loc, std::string_view vuid_text,
+                         const char *format, va_list argptr) {
     assert(*(vuid_text.data() + vuid_text.size()) == '\0');
 
     VkDebugUtilsMessageSeverityFlagsEXT severity;
     VkDebugUtilsMessageTypeFlagsEXT type;
 
     DebugReportFlagsToAnnotFlags(msg_flags, &severity, &type);
-    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
+    std::unique_lock<std::mutex> lock(debug_output_mutex);
     // Avoid logging cost if msg is to be ignored
-    if (!LogMsgEnabled(debug_data, vuid_text, severity, type)) {
+    if (!LogMsgEnabled(vuid_text, severity, type)) {
         return false;
     }
 
@@ -462,7 +643,7 @@ VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, c
         }
     }
 
-    return debug_log_msg(debug_data, msg_flags, objects, "Validation", str_plus_spec_text.c_str(), vuid_text.data());
+    return DebugLogMsg(msg_flags, objects, str_plus_spec_text.c_str(), vuid_text.data());
 }
 
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback([[maybe_unused]] VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -178,76 +178,30 @@ class TypedHandleWrapper {
     VulkanTypedHandle handle_;
 };
 
-typedef struct _debug_report_data {
+struct Location;
+
+class DebugReport {
+  public:
     std::vector<VkLayerDbgFunctionState> debug_callback_list;
-    VkDebugUtilsMessageSeverityFlagsEXT active_severities{0};
-    VkDebugUtilsMessageTypeFlagsEXT active_types{0};
-    vvl::unordered_map<uint64_t, std::string> debugObjectNameMap;
-    vvl::unordered_map<uint64_t, std::string> debugUtilsObjectNameMap;
-    vvl::unordered_map<VkQueue, std::unique_ptr<LoggingLabelState>> debugUtilsQueueLabels;
-    vvl::unordered_map<VkCommandBuffer, std::unique_ptr<LoggingLabelState>> debugUtilsCmdBufLabels;
     // We use std::unordered_set to use trivial hashing for filter_message_ids as we already store hashed values
     std::unordered_set<uint32_t> filter_message_ids{};
     // This mutex is defined as mutable since the normal usage for a debug report object is as 'const'. The mutable keyword allows
     // the layers to continue this pattern, but also allows them to use/change this specific member for synchronization purposes.
     mutable std::mutex debug_output_mutex;
     uint32_t duplicate_message_limit = 0;
-    mutable vvl::unordered_map<uint32_t, uint32_t> duplicate_message_count_map{};
     const void *instance_pnext_chain{};
-    bool forceDefaultLogCallback{false};
+    bool force_default_log_callback{false};
     uint32_t device_created = 0;
 
-    void DebugReportSetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo) {
-        std::unique_lock<std::mutex> lock(debug_output_mutex);
-        if (pNameInfo->pObjectName) {
-            debugUtilsObjectNameMap[pNameInfo->objectHandle] = pNameInfo->pObjectName;
-        } else {
-            debugUtilsObjectNameMap.erase(pNameInfo->objectHandle);
-        }
-    }
+    void SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo);
+    void SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo);
+    std::string GetUtilsObjectNameNoLock(const uint64_t object) const;
+    std::string GetMarkerObjectNameNoLock(const uint64_t object) const;
 
-    void DebugReportSetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo) {
-        std::unique_lock<std::mutex> lock(debug_output_mutex);
-        if (pNameInfo->pObjectName) {
-            debugObjectNameMap[pNameInfo->object] = pNameInfo->pObjectName;
-        } else {
-            debugObjectNameMap.erase(pNameInfo->object);
-        }
-    }
+    void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks);
+    void RemoveDebugUtilsCallback(uint64_t callback);
 
-    // NoLock suffix means that the function itself does not hold debug_output_mutex lock,
-    // and it's **mandatory responsibility** of the caller to hold this lock.
-    std::string DebugReportGetUtilsObjectNameNoLock(const uint64_t object) const {
-        std::string label = "";
-        const auto utils_name_iter = debugUtilsObjectNameMap.find(object);
-        if (utils_name_iter != debugUtilsObjectNameMap.end()) {
-            label = utils_name_iter->second;
-        }
-        return label;
-    }
-
-    // NoLock suffix means that the function itself does not hold debug_output_mutex lock,
-    // and it's **mandatory responsibility** of the caller to hold this lock.
-    std::string DebugReportGetMarkerObjectNameNoLock(const uint64_t object) const {
-        std::string label = "";
-        const auto marker_name_iter = debugObjectNameMap.find(object);
-        if (marker_name_iter != debugObjectNameMap.end()) {
-            label = marker_name_iter->second;
-        }
-        return label;
-    }
-
-    std::string FormatHandle(const char *handle_type_name, uint64_t handle) const {
-        std::unique_lock<std::mutex> lock(debug_output_mutex);
-        std::string handle_name = DebugReportGetUtilsObjectNameNoLock(handle);
-        if (handle_name.empty()) {
-            handle_name = DebugReportGetMarkerObjectNameNoLock(handle);
-        }
-
-        std::ostringstream str;
-        str << handle_type_name << " 0x" << std::hex << handle << "[" << handle_name.c_str() << "]";
-        return str.str();
-    }
+    std::string FormatHandle(const char *handle_type_name, uint64_t handle) const;
 
     std::string FormatHandle(const VulkanTypedHandle &handle) const {
         return FormatHandle(string_VulkanObjectType(handle.type), handle.handle);
@@ -260,67 +214,56 @@ typedef struct _debug_report_data {
         return FormatHandle(VkHandleInfo<T>::Typename(), HandleToUint64(handle));
     }
 
-} debug_report_data;
+    bool LogMsg(VkFlags msg_flags, const LogObjectList &objects, const Location *loc, std::string_view vuid_text,
+                const char *format, va_list argptr);
 
-template debug_report_data *GetLayerDataPtr<debug_report_data>(void *data_key,
-                                                               std::unordered_map<void *, debug_report_data *> &data_map);
+    void BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info);
+    void EndQueueDebugUtilsLabel(VkQueue queue);
+    void InsertQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLabelEXT *label_info);
 
-static inline void DebugReportFlagsToAnnotFlags(VkDebugReportFlagsEXT dr_flags, VkDebugUtilsMessageSeverityFlagsEXT *da_severity,
-                                                VkDebugUtilsMessageTypeFlagsEXT *da_type) {
-    *da_severity = 0;
-    *da_type = 0;
-    // If it's explicitly listed as a performance warning, treat it as a performance message. Otherwise, treat it as a validation
-    // issue.
-    if ((dr_flags & kPerformanceWarningBit) != 0) {
-        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_PERFORMANCE_BIT_EXT;
-        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-    }
-    if ((dr_flags & kVerboseBit) != 0) {
-        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_GENERAL_BIT_EXT | VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
-    }
-    if ((dr_flags & kInformationBit) != 0) {
-        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_INFO_BIT_EXT;
-    }
-    if ((dr_flags & kWarningBit) != 0) {
-        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_WARNING_BIT_EXT;
-    }
-    if ((dr_flags & kErrorBit) != 0) {
-        *da_type |= VK_DEBUG_UTILS_MESSAGE_TYPE_VALIDATION_BIT_EXT;
-        *da_severity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_ERROR_BIT_EXT;
-    }
-}
+    void BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info);
+    void EndCmdDebugUtilsLabel(VkCommandBuffer command_buffer);
+    void InsertCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const VkDebugUtilsLabelEXT *label_info);
+    void ResetCmdDebugUtilsLabel(VkCommandBuffer command_buffer);
+    void EraseCmdDebugUtilsLabel(VkCommandBuffer command_buffer);
 
-struct Location;
-VKAPI_ATTR bool LogMsg(const debug_report_data *debug_data, VkFlags msg_flags, const LogObjectList &objects, const Location *loc,
-                       std::string_view vuid_text, const char *format, va_list argptr);
+  private:
+    bool UpdateLogMsgCounts(int32_t vuid_hash) const;
+    bool DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, const char *message, const char *text_vuid) const;
+    bool LogMsgEnabled(std::string_view vuid_text, VkDebugUtilsMessageSeverityFlagsEXT severity,
+                       VkDebugUtilsMessageTypeFlagsEXT type);
 
-VKAPI_ATTR VkResult LayerCreateMessengerCallback(debug_report_data *debug_data, bool default_callback,
+    VkDebugUtilsMessageSeverityFlagsEXT active_severities{0};
+    VkDebugUtilsMessageTypeFlagsEXT active_types{0};
+    mutable vvl::unordered_map<uint32_t, uint32_t> duplicate_message_count_map{};
+
+    vvl::unordered_map<VkQueue, std::unique_ptr<LoggingLabelState>> debug_utils_queue_labels;
+    vvl::unordered_map<VkCommandBuffer, std::unique_ptr<LoggingLabelState>> debug_utils_cmd_buffer_labels;
+    vvl::unordered_map<uint64_t, std::string> debug_object_name_map;
+    vvl::unordered_map<uint64_t, std::string> debug_utils_object_name_map;
+};
+
+template DebugReport *GetLayerDataPtr<DebugReport>(void *data_key, std::unordered_map<void *, DebugReport *> &data_map);
+
+VKAPI_ATTR VkResult LayerCreateMessengerCallback(DebugReport *debug_report, bool default_callback,
                                                  const VkDebugUtilsMessengerCreateInfoEXT *create_info,
                                                  VkDebugUtilsMessengerEXT *messenger);
 
-VKAPI_ATTR VkResult LayerCreateReportCallback(debug_report_data *debug_data, bool default_callback,
+VKAPI_ATTR VkResult LayerCreateReportCallback(DebugReport *debug_report, bool default_callback,
                                               const VkDebugReportCallbackCreateInfoEXT *create_info,
                                               VkDebugReportCallbackEXT *callback);
 
 template <typename T>
-static inline void LayerDestroyCallback(debug_report_data *debug_data, T callback) {
-    std::unique_lock<std::mutex> lock(debug_data->debug_output_mutex);
-    RemoveDebugUtilsCallback(debug_data, debug_data->debug_callback_list, CastToUint64(callback));
+static inline void LayerDestroyCallback(DebugReport *debug_report, T callback) {
+    std::unique_lock<std::mutex> lock(debug_report->debug_output_mutex);
+    debug_report->RemoveDebugUtilsCallback(CastToUint64(callback));
 }
 
-VKAPI_ATTR void ActivateInstanceDebugCallbacks(debug_report_data *debug_data);
+VKAPI_ATTR void ActivateInstanceDebugCallbacks(DebugReport *debug_report);
 
-VKAPI_ATTR void DeactivateInstanceDebugCallbacks(debug_report_data *debug_data);
+VKAPI_ATTR void DeactivateInstanceDebugCallbacks(DebugReport *debug_report);
 
-VKAPI_ATTR void SetDebugUtilsSeverityFlags(std::vector<VkLayerDbgFunctionState> &callbacks, debug_report_data *debug_data);
-
-VKAPI_ATTR void RemoveDebugUtilsCallback(debug_report_data *debug_data, std::vector<VkLayerDbgFunctionState> &callbacks,
-                                         uint64_t callback);
-
-VKAPI_ATTR void LayerDebugUtilsDestroyInstance(debug_report_data *debug_data);
+VKAPI_ATTR void LayerDebugUtilsDestroyInstance(DebugReport *debug_report);
 
 VKAPI_ATTR VkBool32 VKAPI_CALL MessengerBreakCallback(VkDebugUtilsMessageSeverityFlagBitsEXT message_severity,
                                                       VkDebugUtilsMessageTypeFlagsEXT message_type,
@@ -334,109 +277,3 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageS
                                                             VkDebugUtilsMessageTypeFlagsEXT message_type,
                                                             const VkDebugUtilsMessengerCallbackDataEXT *callback_data,
                                                             void *user_data);
-
-template <typename Map>
-static LoggingLabelState *GetLoggingLabelState(Map *map, typename Map::key_type key, bool insert) {
-    auto iter = map->find(key);
-    LoggingLabelState *label_state = nullptr;
-    if (iter == map->end()) {
-        if (insert) {
-            // Add a label state if not present
-            auto inserted = map->emplace(key, std::unique_ptr<LoggingLabelState>(new LoggingLabelState()));
-            assert(inserted.second);
-            iter = inserted.first;
-            label_state = iter->second.get();
-        }
-    } else {
-        label_state = iter->second.get();
-    }
-    return label_state;
-}
-
-static inline void BeginQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue,
-                                             const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    if (nullptr != label_info && nullptr != label_info->pLabelName) {
-        auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ true);
-        assert(label_state);
-        label_state->labels.emplace_back(label_info);
-
-        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-        label_state->insert_label.Reset();
-    }
-}
-
-static inline void EndQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ false);
-    if (label_state) {
-        // Pop the normal item
-        if (!label_state->labels.empty()) {
-            label_state->labels.pop_back();
-        }
-
-        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-        label_state->insert_label.Reset();
-    }
-}
-
-static inline void InsertQueueDebugUtilsLabel(debug_report_data *report_data, VkQueue queue,
-                                              const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&report_data->debugUtilsQueueLabels, queue, /* insert */ true);
-
-    // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-    label_state->insert_label = LoggingLabel(label_info);
-}
-
-static inline void BeginCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer,
-                                           const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    if (nullptr != label_info && nullptr != label_info->pLabelName) {
-        auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ true);
-        assert(label_state);
-        label_state->labels.push_back(LoggingLabel(label_info));
-
-        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-        label_state->insert_label.Reset();
-    }
-}
-
-static inline void EndCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ false);
-    if (label_state) {
-        // Pop the normal item
-        if (!label_state->labels.empty()) {
-            label_state->labels.pop_back();
-        }
-
-        // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-        label_state->insert_label.Reset();
-    }
-}
-
-static inline void InsertCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer,
-                                            const VkDebugUtilsLabelEXT *label_info) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ true);
-    assert(label_state);
-
-    // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
-    label_state->insert_label = LoggingLabel(label_info);
-}
-
-// Current tracking beyond a single command buffer scope is incorrect, and even when it is we need to be able to clean up
-static inline void ResetCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    auto *label_state = GetLoggingLabelState(&report_data->debugUtilsCmdBufLabels, command_buffer, /* insert */ false);
-    if (label_state) {
-        label_state->labels.clear();
-        label_state->insert_label.Reset();
-    }
-}
-
-static inline void EraseCmdDebugUtilsLabel(debug_report_data *report_data, VkCommandBuffer command_buffer) {
-    std::unique_lock<std::mutex> lock(report_data->debug_output_mutex);
-    report_data->debugUtilsCmdBufLabels.erase(command_buffer);
-}

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -387,8 +387,9 @@ void debug_printf::Validator::AnalyzeAndGenerateMessages(VkCommandBuffer command
             std::string common_message;
             std::string filename_message;
             std::string source_message;
-            UtilGenerateCommonMessage(report_data, command_buffer, &debug_output_buffer[index], shader_module_handle,
-                                      pipeline_handle, shader_object_handle, buffer_info.pipeline_bind_point, operation_index, common_message);
+            UtilGenerateCommonMessage(debug_report, command_buffer, &debug_output_buffer[index], shader_module_handle,
+                                      pipeline_handle, shader_object_handle, buffer_info.pipeline_bind_point, operation_index,
+                                      common_message);
             UtilGenerateSourceMessages(pgm, &debug_output_buffer[index], true, filename_message, source_message);
             if (use_stdout) {
                 std::cout << "WARNING-DEBUG-PRINTF " << common_message.c_str() << " "

--- a/layers/gpu_validation/gpu_error_message.h
+++ b/layers/gpu_validation/gpu_error_message.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2020-2023 The Khronos Group Inc.
- * Copyright (c) 2020-2023 Valve Corporation
- * Copyright (c) 2020-2023 LunarG, Inc.
+/* Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,9 +17,9 @@
 #pragma once
 #include "generated/chassis.h"
 
-void UtilGenerateCommonMessage(const debug_report_data *report_data, const VkCommandBuffer commandBuffer,
-                               const uint32_t *debug_record, const VkShaderModule shader_module_handle,
-                               const VkPipeline pipeline_handle, const VkShaderEXT shader_object_handle,
-                               const VkPipelineBindPoint pipeline_bind_point, const uint32_t operation_index, std::string &msg);
+void UtilGenerateCommonMessage(const DebugReport *debug_report, const VkCommandBuffer commandBuffer, const uint32_t *debug_record,
+                               const VkShaderModule shader_module_handle, const VkPipeline pipeline_handle,
+                               const VkShaderEXT shader_object_handle, const VkPipelineBindPoint pipeline_bind_point,
+                               const uint32_t operation_index, std::string &msg);
 void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg);

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -225,7 +225,7 @@ void CommandBuffer::ResetCBState() {
     transform_feedback_active = false;
 
     // Clean up the label data
-    ResetCmdDebugUtilsLabel(dev_data.report_data, VkHandle());
+    dev_data.debug_report->ResetCmdDebugUtilsLabel(VkHandle());
 }
 
 void CommandBuffer::Reset() {
@@ -274,7 +274,7 @@ void CommandBuffer::ResetPushConstantDataIfIncompatible(const vvl::PipelineLayou
 
 void CommandBuffer::Destroy() {
     // Remove the cb debug labels
-    EraseCmdDebugUtilsLabel(dev_data.report_data, VkHandle());
+    dev_data.debug_report->EraseCmdDebugUtilsLabel(VkHandle());
     {
         auto guard = WriteLock();
         ResetCBState();

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4177,7 +4177,7 @@ void ValidationStateTracker::PreCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBu
                                                                      const RecordObject &record_obj) {
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->RecordCmd(record_obj.location.function);
-    BeginCmdDebugUtilsLabel(report_data, commandBuffer, pLabelInfo);
+    debug_report->BeginCmdDebugUtilsLabel(commandBuffer, pLabelInfo);
 }
 
 void ValidationStateTracker::PostCallRecordCmdBeginDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
@@ -4191,13 +4191,13 @@ void ValidationStateTracker::PostCallRecordCmdEndDebugUtilsLabelEXT(VkCommandBuf
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->RecordCmd(record_obj.location.function);
     cb_state->EndLabel();
-    EndCmdDebugUtilsLabel(report_data, commandBuffer);
+    debug_report->EndCmdDebugUtilsLabel(commandBuffer);
 }
 
 void ValidationStateTracker::PreCallRecordCmdInsertDebugUtilsLabelEXT(VkCommandBuffer commandBuffer,
                                                                       const VkDebugUtilsLabelEXT *pLabelInfo,
                                                                       const RecordObject &record_obj) {
-    InsertCmdDebugUtilsLabel(report_data, commandBuffer, pLabelInfo);
+    debug_report->InsertCmdDebugUtilsLabel(commandBuffer, pLabelInfo);
 
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->RecordCmd(record_obj.location.function);

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -432,7 +432,7 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 // Message Creation Helpers
 struct SyncNodeFormatter {
-    const debug_report_data *report_data;
+    const DebugReport *debug_report;
     const vvl::StateObject *node;
     const char *label;
 

--- a/layers/utils/vk_layer_utils.cpp
+++ b/layers/utils/vk_layer_utils.cpp
@@ -34,7 +34,7 @@
 // If a vk_layer_settings.txt file is present and an application defines a debug callback, both callbacks
 // will be active.  If no vk_layer_settings.txt file is present, creating an application-defined debug
 // callback will cause the default callbacks to be unregisterd and removed.
-void layer_debug_messenger_actions(debug_report_data *report_data, const char *layer_identifier) {
+void LayerDebugMessengerActions(DebugReport *debug_report, const char *layer_identifier) {
     VkDebugUtilsMessengerEXT messenger = VK_NULL_HANDLE;
 
     std::string report_flags_key = layer_identifier;
@@ -88,7 +88,7 @@ void layer_debug_messenger_actions(debug_report_data *report_data, const char *l
         FILE *log_output = getLayerLogOutput(log_filename, layer_identifier);
         dbg_create_info.pfnUserCallback = MessengerLogCallback;
         dbg_create_info.pUserData = (void *)log_output;
-        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, &messenger);
+        LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     }
 
     messenger = VK_NULL_HANDLE;
@@ -96,7 +96,7 @@ void layer_debug_messenger_actions(debug_report_data *report_data, const char *l
     if (debug_action & VK_DBG_LAYER_ACTION_DEBUG_OUTPUT) {
         dbg_create_info.pfnUserCallback = MessengerWin32DebugOutputMsg;
         dbg_create_info.pUserData = NULL;
-        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, &messenger);
+        LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     }
 
     messenger = VK_NULL_HANDLE;
@@ -104,7 +104,7 @@ void layer_debug_messenger_actions(debug_report_data *report_data, const char *l
     if (debug_action & VK_DBG_LAYER_ACTION_BREAK) {
         dbg_create_info.pfnUserCallback = MessengerBreakCallback;
         dbg_create_info.pUserData = NULL;
-        LayerCreateMessengerCallback(report_data, default_layer_callback, &dbg_create_info, &messenger);
+        LayerCreateMessengerCallback(debug_report, default_layer_callback, &dbg_create_info, &messenger);
     }
 }
 

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -426,7 +426,7 @@ typedef enum VkStringErrorFlagBits {
 } VkStringErrorFlagBits;
 typedef VkFlags VkStringErrorFlags;
 
-void layer_debug_messenger_actions(debug_report_data *report_data, const char *layer_identifier);
+void LayerDebugMessengerActions(DebugReport *debug_report, const char *layer_identifier);
 
 std::string GetTempFilePath();
 

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2251,10 +2251,10 @@ typedef std::array<bool, kMaxEnableFlags> CHECK_ENABLED;
 class ValidationObject {
   public:
     APIVersion api_version;
-    debug_report_data* report_data = nullptr;
+    DebugReport* debug_report = nullptr;
     template <typename T>
     std::string FormatHandle(T&& h) const {
-        return report_data->FormatHandle(std::forward<T>(h));
+        return debug_report->FormatHandle(std::forward<T>(h));
     }
 
     std::vector<std::vector<ValidationObject*>> intercept_vectors;
@@ -2353,7 +2353,7 @@ class ValidationObject {
         LogError(std::string_view vuid_text, const LogObjectList& objlist, const Location& loc, const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kErrorBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kErrorBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }
@@ -2363,7 +2363,7 @@ class ValidationObject {
                                                  const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kWarningBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kWarningBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }
@@ -2372,7 +2372,7 @@ class ValidationObject {
         LogWarning(std::string_view vuid_text, const LogObjectList& objlist, const Location& loc, const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kWarningBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kWarningBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }
@@ -2381,7 +2381,7 @@ class ValidationObject {
                                                      const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kPerformanceWarningBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kPerformanceWarningBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }
@@ -2390,7 +2390,7 @@ class ValidationObject {
         LogInfo(std::string_view vuid_text, const LogObjectList& objlist, const Location& loc, const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kInformationBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kInformationBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }
@@ -2399,7 +2399,7 @@ class ValidationObject {
         LogVerbose(std::string_view vuid_text, const LogObjectList& objlist, const Location& loc, const char* format, ...) const {
         va_list argptr;
         va_start(argptr, format);
-        const bool result = LogMsg(report_data, kVerboseBit, objlist, &loc, vuid_text, format, argptr);
+        const bool result = debug_report->LogMsg(kVerboseBit, objlist, &loc, vuid_text, format, argptr);
         va_end(argptr);
         return result;
     }


### PR DESCRIPTION
On the quest to improve logging, first need to do some house cleaning

This change

1. `typedef struct debug_report_data` -> `class DebugReportData`
2. Move things into `DebugReportData` instead of passing around a pointer reference to it

I imagine a lot of this stems back from when there were multiple layers, but instead of functions like `BeginCmdDebugUtilsLabel` being globals that pass in a `debug_report_data*`, I just moved these calls into the new `DebugReportData` class