### PR TITLE
gpuav: Don't crash if shader_map fails to find handle

### DIFF
--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -240,6 +240,11 @@ static bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, 
 void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg) {
     using namespace spvtools;
+    if (pgm.empty()) {
+        // TODO - We currently don't have a good single code path if the shader_map can't find the shader module handle
+        return;
+    }
+
     std::ostringstream filename_stream;
     std::ostringstream source_stream;
     spirv::Module module_state(pgm);


### PR DESCRIPTION
This is a quick fix for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7746

I have plans to better clean this all up, but want https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7711 to land first

This change will for now not crash if `shader_map` fails to find the handle and move on