### PR TITLE
layers: Move some state tracking out of stateless

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -684,8 +684,8 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
             const auto attachment = location_it.second.attachment;
             const auto output = location_it.second.output;
             if (attachment && !output) {
-                const auto &attachments = pipeline.Attachments();
-                if (location < attachments.size() && attachments[location].colorWriteMask != 0) {
+                const auto &attachment_states = pipeline.AttachmentStates();
+                if (location < attachment_states.size() && attachment_states[location].colorWriteMask != 0) {
                     skip |= LogUndefinedValue("Undefined-Value-ShaderInputNotProduced", module_state.handle(), create_info_loc,
                                               "Attachment %" PRIu32
                                               " not written by fragment shader; undefined values will be written to attachment",
@@ -743,8 +743,8 @@ bool CoreChecks::ValidateFsOutputsAgainstDynamicRenderingRenderPass(const spirv:
         const auto output = location_map[location].output;
 
         const auto &rp_state = pipeline.RenderPassState();
-        const auto &attachments = pipeline.Attachments();
-        if (!output && location < attachments.size() && attachments[location].colorWriteMask != 0) {
+        const auto &attachment_states = pipeline.AttachmentStates();
+        if (!output && location < attachment_states.size() && attachment_states[location].colorWriteMask != 0) {
             skip |= LogUndefinedValue(
                 "Undefined-Value-ShaderInputNotProduced", module_state.handle(), create_info_loc,
                 "Attachment %" PRIu32 " not written by fragment shader; undefined values will be written to attachment", location);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -568,13 +568,17 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineTessellationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
+    bool ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pipeline& pipeline,
+                                                           const safe_VkSubpassDescription2* subpass_desc,
+                                                           const Location& color_loc) const;
     bool ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                  const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                     const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineMultisampleState(const vvl::Pipeline& pipeline, const safe_VkSubpassDescription2* subpass_desc,
                                                   const Location& create_info_loc) const;
-    bool ValidateGraphicsPipelineDepthStencilState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
+    bool ValidateGraphicsPipelineDepthStencilState(const vvl::Pipeline& pipeline, const safe_VkSubpassDescription2* subpass_desc,
+                                                   const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineDynamicState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineFragmentShadingRateState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineDynamicRendering(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -382,11 +382,11 @@ class Pipeline : public StateObject {
         return create_info.graphics.subpass;
     }
 
-    const FragmentOutputState::AttachmentVector &Attachments() const {
+    const FragmentOutputState::AttachmentStateVector &AttachmentStates() const {
         if (fragment_output_state) {
-            return fragment_output_state->attachments;
+            return fragment_output_state->attachment_states;
         }
-        static FragmentOutputState::AttachmentVector empty_vec = {};
+        static FragmentOutputState::AttachmentStateVector empty_vec = {};
         return empty_vec;
     }
 

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -237,9 +237,9 @@ FragmentOutputState::FragmentOutputState(const vvl::Pipeline &p, std::shared_ptr
     : PipelineSubState(p), rp_state(rp), subpass(sp) {}
 
 // static
-bool FragmentOutputState::IsBlendConstantsEnabled(const AttachmentVector &attachments) {
+bool FragmentOutputState::IsBlendConstantsEnabled(const AttachmentStateVector &attachment_states) {
     bool result = false;
-    for (const auto &attachment : attachments) {
+    for (const auto &attachment : attachment_states) {
         if (VK_TRUE == attachment.blendEnable) {
             if (((attachment.dstAlphaBlendFactor >= VK_BLEND_FACTOR_CONSTANT_COLOR) &&
                  (attachment.dstAlphaBlendFactor <= VK_BLEND_FACTOR_ONE_MINUS_CONSTANT_ALPHA)) ||

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -161,7 +161,7 @@ static bool IsSampleLocationEnabled(const CreateInfo &create_info) {
 }
 
 struct FragmentOutputState : public PipelineSubState {
-    using AttachmentVector = std::vector<VkPipelineColorBlendAttachmentState>;
+    using AttachmentStateVector = std::vector<VkPipelineColorBlendAttachmentState>;
 
     FragmentOutputState(const vvl::Pipeline &p, std::shared_ptr<const vvl::RenderPass> rp, uint32_t sp);
     // For a graphics library, a "non-safe" create info must be passed in in order for pColorBlendState and pMultisampleState to not
@@ -177,10 +177,10 @@ struct FragmentOutputState : public PipelineSubState {
             if (cbci.pAttachments) {
                 dual_source_blending = GetDualSourceBlending(color_blend_state.get());
                 if (cbci.attachmentCount) {
-                    attachments.reserve(cbci.attachmentCount);
-                    std::copy(cbci.pAttachments, cbci.pAttachments + cbci.attachmentCount, std::back_inserter(attachments));
+                    attachment_states.reserve(cbci.attachmentCount);
+                    std::copy(cbci.pAttachments, cbci.pAttachments + cbci.attachmentCount, std::back_inserter(attachment_states));
                 }
-                blend_constants_enabled = IsBlendConstantsEnabled(attachments);
+                blend_constants_enabled = IsBlendConstantsEnabled(attachment_states);
             }
         }
 
@@ -193,7 +193,7 @@ struct FragmentOutputState : public PipelineSubState {
         // auto format_ci = vku::FindStructInPNextChain<VkPipelineRenderingFormatCreateInfoKHR>(gpci->pNext);
     }
 
-    static bool IsBlendConstantsEnabled(const AttachmentVector &attachments);
+    static bool IsBlendConstantsEnabled(const AttachmentStateVector &attachment_states);
     static bool GetDualSourceBlending(const safe_VkPipelineColorBlendStateCreateInfo *color_blend_state);
 
     std::shared_ptr<const vvl::RenderPass> rp_state;
@@ -202,7 +202,7 @@ struct FragmentOutputState : public PipelineSubState {
     std::unique_ptr<const safe_VkPipelineColorBlendStateCreateInfo> color_blend_state;
     std::unique_ptr<const safe_VkPipelineMultisampleStateCreateInfo> ms_state;
 
-    AttachmentVector attachments;
+    AttachmentStateVector attachment_states;
 
     bool blend_constants_enabled = false;  // Blend constants enabled for any attachments
     bool sample_location_enabled = false;

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -400,14 +400,6 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
             vertex_attribute_divisor_props.maxVertexAttribDivisor;
     }
 
-    if (IsExtEnabled(device_extensions.vk_ext_blend_operation_advanced)) {
-        // Get the needed blend operation advanced properties
-        VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props = vku::InitStructHelper();
-        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&blend_operation_advanced_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
-        phys_dev_ext_props.blend_operation_advanced_props = blend_operation_advanced_props;
-    }
-
     if (IsExtEnabled(device_extensions.vk_khr_maintenance4)) {
         // Get the needed maintenance4 properties
         VkPhysicalDeviceMaintenance4PropertiesKHR maintance4_props = vku::InitStructHelper();

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -424,10 +424,8 @@ void StatelessValidation::RecordRenderPass(VkRenderPass renderPass, const VkRend
     auto &renderpass_state = renderpasses_states[renderPass];
     lock.unlock();
 
-    renderpass_state.subpasses_flags.resize(pCreateInfo->subpassCount);
     for (uint32_t subpass = 0; subpass < pCreateInfo->subpassCount; ++subpass) {
         bool uses_color = false;
-        renderpass_state.color_attachment_count = pCreateInfo->pSubpasses[subpass].colorAttachmentCount;
 
         for (uint32_t i = 0; i < pCreateInfo->pSubpasses[subpass].colorAttachmentCount && !uses_color; ++i)
             if (pCreateInfo->pSubpasses[subpass].pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) uses_color = true;
@@ -439,7 +437,6 @@ void StatelessValidation::RecordRenderPass(VkRenderPass renderPass, const VkRend
 
         if (uses_color) renderpass_state.subpasses_using_color_attachment.insert(subpass);
         if (uses_depthstencil) renderpass_state.subpasses_using_depthstencil_attachment.insert(subpass);
-        renderpass_state.subpasses_flags[subpass] = pCreateInfo->pSubpasses[subpass].flags;
     }
 }
 void StatelessValidation::PostCallRecordCreateRenderPass(VkDevice device, const VkRenderPassCreateInfo *pCreateInfo,

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -58,7 +58,6 @@ class StatelessValidation : public ValidationObject {
         VkPhysicalDeviceAccelerationStructurePropertiesKHR acc_structure_props;
         VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props;
         VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR vertex_attribute_divisor_props;
-        VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced_props;
         VkPhysicalDeviceMaintenance4PropertiesKHR maintenance4_props;
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props;
         VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props;
@@ -70,8 +69,6 @@ class StatelessValidation : public ValidationObject {
     struct SubpassesUsageStates {
         vvl::unordered_set<uint32_t> subpasses_using_color_attachment;
         vvl::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;
-        std::vector<VkSubpassDescriptionFlags> subpasses_flags;
-        uint32_t color_attachment_count;
     };
 
     // Though this validation object is predominantly statless, the Framebuffer checks are greatly simplified by creating and

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -809,6 +809,7 @@ TEST_F(NegativeDynamicRendering, GraphicsPipelineCreateInfo) {
     pipe.ds_ci_ = vku::InitStruct<VkPipelineDepthStencilStateCreateInfo>();
     pipe.ds_ci_.flags = VK_PIPELINE_DEPTH_STENCIL_STATE_CREATE_RASTERIZATION_ORDER_ATTACHMENT_DEPTH_ACCESS_BIT_EXT;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
+    m_errorMonitor->SetDesiredError("VUID-VkPipelineColorBlendStateCreateInfo-rasterizationOrderColorAttachmentAccess-06465");
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-flags-06482");
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-None-09526");
     pipe.CreateGraphicsPipeline();


### PR DESCRIPTION
The core issue is we track the `subpass` state inside `StatelessValidation`

We currently are tracking state in `stateless_validation.h` and `StatelessValidation::RecordRenderPass`

My goal is to get rid of it, this PR removes half of it as the 2nd half will be a lot more messy to remove