### PR TITLE
layers: Fix arrayPitch computation for ASTC_10x10

### DIFF
--- a/layers/containers/subresource_adapter.cpp
+++ b/layers/containers/subresource_adapter.cpp
@@ -335,8 +335,15 @@ ImageRangeEncoder::ImageRangeEncoder(const vvl::Image& image, const AspectParame
                 }
             } else {
                 layout.offset += layout.size;
-                layout.rowPitch = static_cast<VkDeviceSize>(floor(subres_extent.width * texel_sizes_[aspect_index]));
-                layout.arrayPitch = layout.rowPitch * subres_extent.height;
+
+                const double row_pitch = subres_extent.width * texel_sizes_[aspect_index];
+                // TODO: layout.rowPitch is still computed incorrectly for ASTC_10x10,
+                // but it is less trivial fix comparing to arrayPitch, so will be fixed
+                // later. There is no known rowPitch bugs, which somehow justifies why
+                // rowPitch fix is postponed, and arrayPitch, which affected Angle, was fixed.
+                layout.rowPitch = static_cast<VkDeviceSize>(row_pitch);
+
+                layout.arrayPitch = static_cast<VkDeviceSize>(row_pitch * subres_extent.height);
                 layout.depthPitch = layout.arrayPitch;
                 if (is_3_d_) {
                     layout.size = layout.depthPitch * subres_extent.depth;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1707,3 +1707,118 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImage) {
     vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
     m_commandBuffer->end();
 }
+
+TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC) {
+    TEST_DESCRIPTION("Copy from a buffer to 20x10 ASTC-compressed image without overlap.");
+
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    VkFormatProperties format_properties;
+    VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
+        GTEST_SKIP()
+            << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
+    }
+
+    const VkDeviceSize buffer_size = 32;  // enough for 20x10 ASTC_10x10 region
+    vkt::Buffer src_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Image dst_image(*m_device, 20, 10, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferImageCopy buffer_copy[2] = {};
+    buffer_copy[0].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    buffer_copy[0].imageSubresource.mipLevel = 0;
+    buffer_copy[0].imageSubresource.baseArrayLayer = 0;
+    buffer_copy[0].imageSubresource.layerCount = 1;
+    buffer_copy[0].imageOffset = {0, 0, 0};
+    buffer_copy[0].imageExtent = {10, 10, 1};
+    buffer_copy[1].imageSubresource = buffer_copy[0].imageSubresource;
+    buffer_copy[1].imageOffset = {10, 0, 0};
+    buffer_copy[1].imageExtent = {10, 10, 1};
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_commandBuffer->end();
+}
+
+TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC2) {
+    TEST_DESCRIPTION("Copy from a buffer to 10x20 ASTC-compressed image without overlap.");
+
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    VkFormatProperties format_properties;
+    VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
+        GTEST_SKIP()
+            << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
+    }
+
+    const VkDeviceSize buffer_size = 32;  // enough for 10x20 ASTC_10x10 region
+    vkt::Buffer src_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Image dst_image(*m_device, 10, 20, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferImageCopy buffer_copy[2] = {};
+    buffer_copy[0].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    buffer_copy[0].imageSubresource.mipLevel = 0;
+    buffer_copy[0].imageSubresource.baseArrayLayer = 0;
+    buffer_copy[0].imageSubresource.layerCount = 1;
+    buffer_copy[0].imageOffset = {0, 0, 0};
+    buffer_copy[0].imageExtent = {10, 10, 1};
+    buffer_copy[1].imageSubresource = buffer_copy[0].imageSubresource;
+    buffer_copy[1].imageOffset = {0, 10, 0};
+    buffer_copy[1].imageExtent = {10, 10, 1};
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_commandBuffer->end();
+}
+
+TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC3) {
+    TEST_DESCRIPTION("Copy from a buffer to 20x20 ASTC-compressed with overlap protected by a barrier.");
+
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    VkFormatProperties format_properties;
+    VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
+    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
+        GTEST_SKIP()
+            << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
+    }
+
+    const VkDeviceSize buffer_size = 64;  // enough for 20x20 ASTC_10x10 region
+    vkt::Buffer src_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    vkt::Image dst_image(*m_device, 20, 20, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
+
+    VkBufferImageCopy buffer_copy[2] = {};
+    buffer_copy[0].imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+    buffer_copy[0].imageSubresource.mipLevel = 0;
+    buffer_copy[0].imageSubresource.baseArrayLayer = 0;
+    buffer_copy[0].imageSubresource.layerCount = 1;
+    buffer_copy[0].imageOffset = {10, 10, 0};
+    buffer_copy[0].imageExtent = {10, 10, 1};
+    buffer_copy[1].imageSubresource = buffer_copy[0].imageSubresource;
+    buffer_copy[1].imageOffset = {10, 0, 0};
+    buffer_copy[1].imageExtent = {10, 20, 1};
+
+    VkImageMemoryBarrier barrier = vku::InitStructHelper();
+    barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+    barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
+    barrier.image = dst_image;
+    barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
+    vk::CmdPipelineBarrier(*m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
+                           nullptr, 1, &barrier);
+    vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
Fixes Angle regression https://ci.chromium.org/ui/p/angle/builders/try/linux-test/19351/test-results?sortby=&groupby=&cols=
Related conversation: https://github.com/KhronosGroup/Vulkan-ValidationLayers/commit/5df44678c4f4ec06dcad3eea308b1dd70eb8cc56#commitcomment-140093219

The history here is that we made a https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7713 PR recently, which is correct, but it exposes another existing issue. It did not cause troubles for Angle due to luck (two bugs compensated each other).

Our code assumed that rowPitch (bytes for one row of texels) is an integral number, which is true for most formats, including compressed ones, but it's not true for ASTC. For example, ASTC10x10, encodes 10x10=100 pixels in 16 bytes, so on average it's 1.6 bytes per row. Early rounding resulted in incorrect computation of a texture slice size (`arrayPitch`). The size of a 20x20 ASTC texture (4 blocks) was computed as 60 bytes instead of 16*4=64 bytes.

The ASTC addressing issue existed before https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7713 but was not covered by the tests. `CopyBufferToCompressedImageASTC` adds such a test. This will work as a regression test for 7713 fix for ASTC format.

`CopyBufferToCompressedImageASTC2` improves ASTC coverage, does not repro any issue.

`CopyBufferToCompressedImageASTC3` reproduces the issue that angle encountered after https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7713 and is fixed here.

This PR fixes `arrayPitch` computation. There is a similar `rowPitch` issue but it does not block anyone so far, so that fix is postponed.
