### PR TITLE
layers: Avoid UB in ValidateStructTypeArray

### DIFF
--- a/layers/stateless/sl_utils.cpp
+++ b/layers/stateless/sl_utils.cpp
@@ -180,7 +180,7 @@ bool StatelessValidation::ValidateStringArray(const Location &count_loc, const L
                                               const char *count_required_vuid, const char *array_required_vuid) const {
     bool skip = false;
 
-    if ((count == 0) || (array == nullptr)) {
+    if ((array == nullptr) || (count == 0)) {
         skip |= ValidateArray(count_loc, array_loc, count, &array, countRequired, arrayRequired, count_required_vuid,
                               array_required_vuid);
     } else {
@@ -329,7 +329,7 @@ bool StatelessValidation::ValidateBool32Array(const Location &count_loc, const L
                                               const char *count_required_vuid, const char *array_required_vuid) const {
     bool skip = false;
 
-    if ((count == 0) || (array == nullptr)) {
+    if ((array == nullptr) || (count == 0)) {
         skip |= ValidateArray(count_loc, array_loc, count, &array, countRequired, arrayRequired, count_required_vuid,
                               array_required_vuid);
     } else {
@@ -480,7 +480,7 @@ bool StatelessValidation::ValidateFlagsArray(const Location &count_loc, const Lo
                                              const char *count_required_vuid, const char *array_required_vuid) const {
     bool skip = false;
 
-    if ((count == 0) || (array == nullptr)) {
+    if ((array == nullptr) || (count == 0)) {
         // Flag arrays always need to have a valid array
         skip |= ValidateArray(count_loc, array_loc, count, &array, count_required, true, count_required_vuid, array_required_vuid);
     } else {

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -200,7 +200,7 @@ class StatelessValidation : public ValidationObject {
                                  const char *stype_vuid, const char *param_vuid, const char *count_required_vuid) const {
         bool skip = false;
 
-        if ((count == 0) || (array == nullptr)) {
+        if ((array == nullptr) || (count == 0)) {
             skip |=
                 ValidateArray(count_loc, array_loc, count, &array, countRequired, arrayRequired, count_required_vuid, param_vuid);
         } else {
@@ -238,7 +238,7 @@ class StatelessValidation : public ValidationObject {
                                         const char *stype_vuid, const char *param_vuid, const char *count_required_vuid) const {
         bool skip = false;
 
-        if ((count == 0) || (array == nullptr)) {
+        if ((array == nullptr) || (count == 0)) {
             skip |=
                 ValidateArray(count_loc, array_loc, count, &array, countRequired, arrayRequired, count_required_vuid, param_vuid);
         } else {
@@ -337,7 +337,7 @@ class StatelessValidation : public ValidationObject {
                              bool count_required, bool array_required, const char *count_required_vuid) const {
         bool skip = false;
 
-        if ((count == 0) || (array == nullptr)) {
+        if ((array == nullptr) || (count == 0)) {
             skip |= ValidateArray(count_loc, array_loc, count, &array, count_required, array_required, count_required_vuid,
                                   kVUIDUndefined);
         } else {
@@ -443,7 +443,7 @@ class StatelessValidation : public ValidationObject {
                                  const char *array_required_vuid) const {
         bool skip = false;
 
-        if ((count == 0) || (array == nullptr)) {
+        if ((array == nullptr) || (count == 0)) {
             skip |= ValidateArray(count_loc, array_loc, count, &array, countRequired, arrayRequired, count_required_vuid,
                                   array_required_vuid);
         } else {


### PR DESCRIPTION
The read of count in ValidateStructTypeArray can invoke UB if the application does something like this:

```c++
uint32_t num_format_props;
CHECK_RESULT(vkGetPhysicalDeviceVideoFormatPropertiesKHR(physical_device, &video_format_info, &num_format_props, nullptr));
```

By moving the count check after the nullptr check, we avoid reading a possibly uninitialized variable.