### PR TITLE
layers: Use VkBufferUsageFlags2 everywhere

### DIFF
--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3289,7 +3289,7 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
             if (!buffer_state) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline->Handle());
                 skip |= LogError(vuid.vertex_binding_attribute_02721, objlist, loc,
-                                 "pVertexAttributeDescriptions[%" PRIu32 "].binding (%" PRIu32 ") points to an inavlid buffer.",
+                                 "pVertexAttributeDescriptions[%" PRIu32 "].binding (%" PRIu32 ") points to an invalid buffer.",
                                  vertex_binding, i);
                 break;
             }

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -4163,7 +4163,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
                                           "VUID-vkCmdEncodeVideoKHR-commandBuffer-08203", where);
     }
 
-    if ((buffer_state->create_info.usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
+    if ((buffer_state->usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
         const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
         skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBuffer-08236", objlist, encode_info_loc.dot(Field::dstBuffer),
                          "(%s) was not created with "


### PR DESCRIPTION
I found one more example of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7759

