### PR TITLE
gpuav: Split debug instructions and make a switch case

### DIFF
--- a/layers/gpu_validation/spirv/module.h
+++ b/layers/gpu_validation/spirv/module.h
@@ -49,7 +49,9 @@ class Module {
     InstructionList memory_model_;
     InstructionList entry_points_;
     InstructionList execution_modes_;
-    InstructionList debug_infos_;
+    InstructionList debug_source_;
+    InstructionList debug_name_;
+    InstructionList debug_module_processed_;
     InstructionList annotations_;
     InstructionList types_values_constants_;
     FunctionList functions_;

--- a/layers/vulkan/generated/spirv_grammar_helper.h
+++ b/layers/vulkan/generated/spirv_grammar_helper.h
@@ -839,39 +839,6 @@ static constexpr bool GroupOperation(uint32_t opcode) {
     }
 }
 
-static constexpr bool DebugOperation(uint32_t opcode) {
-    switch (opcode) {
-        case spv::OpSourceContinued:
-        case spv::OpSource:
-        case spv::OpSourceExtension:
-        case spv::OpName:
-        case spv::OpMemberName:
-        case spv::OpString:
-        case spv::OpLine:
-        case spv::OpNoLine:
-        case spv::OpModuleProcessed:
-            return true;
-        default:
-            return false;
-    }
-}
-
-static constexpr bool AnnotationOperation(uint32_t opcode) {
-    switch (opcode) {
-        case spv::OpDecorate:
-        case spv::OpMemberDecorate:
-        case spv::OpDecorationGroup:
-        case spv::OpGroupDecorate:
-        case spv::OpGroupMemberDecorate:
-        case spv::OpDecorateId:
-        case spv::OpDecorateString:
-        case spv::OpMemberDecorateString:
-            return true;
-        default:
-            return false;
-    }
-}
-
 static constexpr bool ImageGatherOperation(uint32_t opcode) {
     switch (opcode) {
         case spv::OpImageGather:

--- a/scripts/generators/spirv_grammar_generator.py
+++ b/scripts/generators/spirv_grammar_generator.py
@@ -33,8 +33,6 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
         self.opnames = []
         self.atomicsOps = []
         self.groupOps = []
-        self.debugOps = []
-        self.annotationOps = []
         self.imageGatherOps = []
         self.imageSampleOps = []
         self.imageFetchOps = []
@@ -162,10 +160,6 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
                     self.atomicsOps.append(opname)
                 if instruction['class'] == 'Non-Uniform':
                     self.groupOps.append(opname)
-                if instruction['class'] == 'Debug':
-                    self.debugOps.append(opname)
-                if instruction['class'] == 'Annotation':
-                    self.annotationOps.append(opname)
                 if re.search("OpImage.*Gather", opname) is not None:
                     self.imageGatherOps.append(opname)
                 if re.search("OpImageFetch.*", opname) is not None:
@@ -331,8 +325,6 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
         # \n is not allowed in f-string until 3.12
         atomicCase = "\n".join([f"        case spv::{f}:" for f in self.atomicsOps])
         groupCase = "\n".join([f"        case spv::{f}:" for f in self.groupOps])
-        debugCase = "\n".join([f"        case spv::{f}:" for f in self.debugOps])
-        annotationCase = "\n".join([f"        case spv::{f}:" for f in self.annotationOps])
         out.append(f'''
             // Any non supported operation will be covered with other VUs
             static constexpr bool AtomicOperation(uint32_t opcode) {{
@@ -348,24 +340,6 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
             static constexpr bool GroupOperation(uint32_t opcode) {{
                 switch (opcode) {{
             {groupCase}
-                        return true;
-                    default:
-                        return false;
-                }}
-            }}
-
-           static constexpr  bool DebugOperation(uint32_t opcode) {{
-                switch (opcode) {{
-            {debugCase}
-                        return true;
-                    default:
-                        return false;
-                }}
-            }}
-
-            static constexpr bool AnnotationOperation(uint32_t opcode) {{
-                switch (opcode) {{
-            {annotationCase}
                         return true;
                     default:
                         return false;


### PR DESCRIPTION
This fixes small bug were I was injecting a `OpName` after a `OpModuleProcessed`
