### PR TITLE
layers: Remove WSI validation dependency on GetSwapchainImages

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1809,8 +1809,6 @@ class CoreChecks : public ValidationStateTracker {
                                            const ErrorObject& error_obj) const override;
     void PreCallRecordDestroySwapchainKHR(VkDevice device, VkSwapchainKHR swapchain, const VkAllocationCallbacks* pAllocator,
                                           const RecordObject& record_obj) override;
-    void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
-                                             VkImage* pSwapchainImages, const RecordObject& record_obj) override;
     bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                         const ErrorObject& error_obj) const override;
     bool ValidateImageAcquireWait(const vvl::SwapchainImage& swapchain_image, uint32_t image_index,

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -359,8 +359,6 @@ class Validator : public gpu_tracker::Validator {
                                    VkImage* pImage, const RecordObject& record_obj) override;
     void PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks* pAllocator,
                                    const RecordObject&) override;
-    void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
-                                             VkImage* pSwapchainImages, const RecordObject& record_obj) override;
 
     void PreCallRecordCmdClearColorImage(VkCommandBuffer commandBuffer, VkImage image, VkImageLayout imageLayout,
                                          const VkClearColorValue* pColor, uint32_t rangeCount,

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -549,10 +549,7 @@ void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id) {
         images[image_index].acquire_semaphore.reset();
         images[image_index].acquire_fence.reset();
     } else {
-        vvl::Image *image_state = images[image_index].image_state;
-        if (image_state) {
-            image_state->layout_locked = true;
-        }
+        images[image_index].image_state->layout_locked = true;
     }
     if (present_id > max_present_id) {
         max_present_id = present_id;
@@ -561,25 +558,19 @@ void Swapchain::PresentImage(uint32_t image_index, uint64_t present_id) {
 
 void Swapchain::AcquireImage(uint32_t image_index, const std::shared_ptr<vvl::Semaphore> &semaphore_state,
                              const std::shared_ptr<vvl::Fence> &fence_state) {
-    assert(acquired_images < std::numeric_limits<uint32_t>::max());
     acquired_images++;
     images[image_index].acquired = true;
     images[image_index].acquire_semaphore = semaphore_state;
     images[image_index].acquire_fence = fence_state;
     if (shared_presentable) {
-        vvl::Image *image_state = images[image_index].image_state;
-        if (image_state) {
-            image_state->shared_presentable = shared_presentable;
-        }
+        images[image_index].image_state->shared_presentable = shared_presentable;
     }
 }
 
 void Swapchain::Destroy() {
     for (auto &swapchain_image : images) {
-        if (swapchain_image.image_state) {
-            RemoveParent(swapchain_image.image_state);
-            dev_data.Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
-        }
+        RemoveParent(swapchain_image.image_state);
+        dev_data.Destroy<vvl::Image>(swapchain_image.image_state->VkHandle());
         // NOTE: We don't have access to dev_data.fake_memory.Free() here, but it is currently a no-op
     }
     images.clear();

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -547,10 +547,6 @@ class ValidationStateTracker : public ValidationObject {
     void PostCallRecordGetSemaphoreWin32HandleKHR(VkDevice device, const VkSemaphoreGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                   HANDLE* pHandle, const RecordObject& record_obj) override;
 #endif  // VK_USE_PLATFORM_WIN32_KHR
-    void RecordGetSwapchainImages(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
-                                  VkImage* pSwapchainImages);
-    void PostCallRecordGetSwapchainImagesKHR(VkDevice device, VkSwapchainKHR swapchain, uint32_t* pSwapchainImageCount,
-                                             VkImage* pSwapchainImages, const RecordObject& record_obj) override;
 #ifdef VK_USE_PLATFORM_WIN32_KHR
     void PostCallRecordGetMemoryWin32HandleKHR(VkDevice device, const VkMemoryGetWin32HandleInfoKHR* pGetWin32HandleInfo,
                                                HANDLE* pHandle, const RecordObject& record_obj) override;

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -909,12 +909,7 @@ bool VkRenderFramework::CreateSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags
     swapchain_create_info.oldSwapchain = oldSwapchain;
 
     VkResult result = vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &swapchain);
-    if (result != VK_SUCCESS) return false;
-    // We must call vkGetSwapchainImagesKHR after creating the swapchain because the Validation Layer variables
-    // for the swapchain image count are set inside that call. Otherwise, various validation fails due to
-    // thinking that the swapchain image count is zero.
-    GetSwapchainImages(swapchain);
-    return true;
+    return result == VK_SUCCESS;
 }
 
 std::vector<VkImage> VkRenderFramework::GetSwapchainImages(const VkSwapchainKHR swapchain) {

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -370,6 +370,8 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
     bind_info.memoryOffset = 0;
 
     vk::BindImageMemory2(device(), 1, &bind_info);
+    // Can transition layout after the memory is bound
+    peer_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
 


### PR DESCRIPTION
This is follow-up to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7703

Found two reasons why we couldn't easily get rid of `GetSwapchainImages` from `VkRenderFramework::CreateSwapchain`:
- VUs like `VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644` check swapchain image count and can run before the image is acquired.
-  Swapchain image layout map initialization relied on GetSwapchainImagesKHR call.

This solution initializes swapchain image state immediately when swapchain object is created.
