### PR TITLE
layers: Add back RT VUs 03703 03704 03705

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -90,7 +90,7 @@ class BufferAddressValidation {
         }
         return skip;
     }
-    [[nodiscard]] bool LogErrorsIfInvalidBufferFound(const CoreChecks& checker, vvl::span<const vvl::Buffer*> buffer_list,
+    [[nodiscard]] bool LogErrorsIfInvalidBufferFound(const CoreChecks& checker, vvl::span<vvl::Buffer* const> buffer_list,
                                                      const Location& device_address_loc, const LogObjectList& objlist,
                                                      VkDeviceAddress device_address) const noexcept {
         bool skip = false;
@@ -235,7 +235,7 @@ bool BufferAddressValidation<N>::LogInvalidBuffers(const CoreChecks& checker, vv
         const auto& error = errors[i];
         if (!error.Empty()) {
             skip |=
-                checker.LogError(vuidAndValidation.vuid.data(), error.objlist, device_address_loc, "%s", error.error_msg.c_str());
+                checker.LogError(vuidAndValidation.vuid.data(), error.objlist, device_address_loc, "%s\n", error.error_msg.c_str());
         }
     }
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -318,6 +318,15 @@ class CoreChecks : public ValidationStateTracker {
                                                 const vvl::AccelerationStructureKHR& accel_struct_a, const Location& loc_a,
                                                 const vvl::AccelerationStructureKHR& accel_struct_b, const Location& loc_b,
                                                 const char* vuid) const;
+    // Look for a buffer in scratches_a that does not overlap with src_accel_struct, dst_accel_struct, and at least one buffer from
+    // scratches_b
+    bool ValidateScratchMemoryNoOverlap(const Location& function_loc, LogObjectList objlist,
+                                        const vvl::span<vvl::Buffer* const>& scratches_a, VkDeviceAddress scratch_a_address,
+                                        VkDeviceSize scratch_a_size, const Location& loc_scratches_a,
+                                        const vvl::AccelerationStructureKHR* src_accel_struct, const Location& loc_src_accel_struct,
+                                        const vvl::AccelerationStructureKHR& dst_accel_struct, const Location& loc_dst_accel_struct,
+                                        const vvl::span<vvl::Buffer* const>& scratches_b, VkDeviceAddress scratch_b_address,
+                                        VkDeviceSize scratch_b_size, const Location* loc_scratches_b) const;
     bool ValidateAccelStructBufferMemoryIsHostVisible(const vvl::AccelerationStructureKHR& accel_struct, const Location& buffer_loc,
                                                       const char* vuid) const;
     bool ValidateAccelStructBufferMemoryIsNotMultiInstance(const vvl::AccelerationStructureKHR& accel_struct,
@@ -1440,6 +1449,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateAccelerationStructuresMemoryAlisasing(const LogObjectList& objlist, uint32_t infoCount,
                                                        const VkAccelerationStructureBuildGeometryInfoKHR* pInfos, uint32_t info_i,
                                                        const ErrorObject& error_obj) const;
+    bool ValidateAccelerationStructuresDeviceScratchBufferMemoryAlisasing(
+        const LogObjectList& objlist, uint32_t infoCount, const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
+        uint32_t info_i, const VkAccelerationStructureBuildRangeInfoKHR* range_infos, const ErrorObject& error_obj) const;
     bool PreCallValidateCmdBuildAccelerationStructuresKHR(VkCommandBuffer commandBuffer, uint32_t infoCount,
                                                           const VkAccelerationStructureBuildGeometryInfoKHR* pInfos,
                                                           const VkAccelerationStructureBuildRangeInfoKHR* const* ppBuildRangeInfos,

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -484,7 +484,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
             auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
             blas.SetScratchBuffer(scratch_buffer);
             blas.SetDeviceScratchOffset(consumed_buffer_size);
-            consumed_buffer_size = blas.GetSizeInfo().buildScratchSize;
+            consumed_buffer_size += blas.GetSizeInfo().buildScratchSize;
             consumed_buffer_size = Align<VkDeviceSize>(consumed_buffer_size, 4096);
             blas_vec.emplace_back(std::move(blas));
         }


### PR DESCRIPTION
VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703
The range of memory backing the dstAccelerationStructure member of any element of pInfos that is accessed by this command must not overlap the memory backing the scratchData member of any element of pInfos (including the same element), which is accessed by this command

VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705
The range of memory backing the scratchData member of any element of pInfos that is accessed by this command must not overlap the memory backing the srcAccelerationStructure member of any element of pInfos with a mode equal to VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR (including the same element), which is accessed by this command

VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704
The range of memory backing the scratchData member of any element of pInfos that is accessed by this command must not overlap the memory backing the scratchData member of any other element of pInfos, which is accessed by this command

Nvidia driver in CI has been updated, will see how this goes for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6040
