### PR TITLE
gpuav: Don't create an entire spirv::Module for errors

### DIFF
--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -88,8 +88,8 @@ class Validator : public gpu_tracker::Validator {
     }
 
     void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
-    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm, uint32_t unique_shader_id,
-                          const Location& loc) override;
+    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& instrumented_spirv,
+                          uint32_t unique_shader_id, const Location& loc) override;
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) override;
@@ -97,7 +97,7 @@ class Validator : public gpu_tracker::Validator {
                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                        const RecordObject& record_obj, chassis::ShaderObject& chassis_state) override;
     std::vector<Substring> ParseFormatString(const std::string& format_string);
-    std::string FindFormatString(vvl::span<const uint32_t> pgm, uint32_t string_id);
+    std::string FindFormatString(const std::vector<spirv::Instruction>& instructions, uint32_t string_id);
     void AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueue queue, BufferInfo& buffer_info, uint32_t operation_index,
                                    uint32_t* const debug_output_buffer, const Location& loc);
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,

--- a/layers/gpu_validation/gpu_error_message.h
+++ b/layers/gpu_validation/gpu_error_message.h
@@ -17,9 +17,13 @@
 #pragma once
 #include "generated/chassis.h"
 
+namespace spirv {
+class Instruction;
+}  // namespace spirv
+
 void UtilGenerateCommonMessage(const DebugReport *debug_report, const VkCommandBuffer commandBuffer, const uint32_t *debug_record,
                                const VkShaderModule shader_module_handle, const VkPipeline pipeline_handle,
                                const VkShaderEXT shader_object_handle, const VkPipelineBindPoint pipeline_bind_point,
                                const uint32_t operation_index, std::string &msg);
-void UtilGenerateSourceMessages(vvl::span<const uint32_t> pgm, const uint32_t *debug_record, bool from_printf,
+void UtilGenerateSourceMessages(const std::vector<spirv::Instruction> &instructions, const uint32_t *debug_record, bool from_printf,
                                 std::string &filename_msg, std::string &source_msg);

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -27,6 +27,7 @@
 #include "gpu_validation/gpu_validation.h"
 #include "gpu_validation/gpu_subclasses.h"
 #include "state_tracker/device_state.h"
+#include "state_tracker/shader_object_state.h"
 #include "spirv-tools/instrument.hpp"
 #include "spirv-tools/linker.hpp"
 #include "generated/layer_chassis_dispatch.h"

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -91,7 +91,7 @@ struct GpuAssistedShaderTracker {
     VkPipeline pipeline;
     VkShaderModule shader_module;
     VkShaderEXT shader_object;
-    std::vector<uint32_t> pgm;
+    std::vector<uint32_t> instrumented_spirv;
 };
 
 class Validator : public ValidationStateTracker {
@@ -196,8 +196,8 @@ class Validator : public ValidationStateTracker {
                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                          const SafeCreateInfo &modified_create_infos);
 
-    virtual bool InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &new_pgm, uint32_t unique_shader_id,
-                                  const Location &loc) = 0;
+    virtual bool InstrumentShader(const vvl::span<const uint32_t> &input, std::vector<uint32_t> &instrumented_spirv,
+                                  uint32_t unique_shader_id, const Location &loc) = 0;
 
   public:
     mutable bool aborted = false;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -21,8 +21,6 @@
 #include "gpu_validation/gpu_error_message.h"
 #include "gpu_validation/gpu_descriptor_set.h"
 #include "gpu_validation/gpu_resources.h"
-#include "state_tracker/pipeline_state.h"
-#include "state_tracker/shader_object_state.h"
 
 #include <typeinfo>
 #include <unordered_map>
@@ -108,8 +106,8 @@ class Validator : public gpu_tracker::Validator {
   public:
     VkDeviceAddress GetBufferDeviceAddress(VkBuffer buffer, const Location& loc) const;
     bool CheckForDescriptorIndexing(DeviceFeatures enabled_features) const;
-    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& new_pgm, uint32_t unique_shader_id,
-                          const Location& loc) override;
+    bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& instrumented_spirv,
+                          uint32_t unique_shader_id, const Location& loc) override;
     bool CheckForCachedInstrumentedShader(const uint32_t shader_hash, chassis::CreateShaderModule& chassis_state);
     bool CheckForCachedInstrumentedShader(const uint32_t index, const uint32_t shader_hash, chassis::ShaderObject& chassis_state);
     void UpdateInstrumentationBuffer(CommandBuffer* cb_node);

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -25,7 +25,23 @@ Instruction::Instruction(std::vector<uint32_t>::const_iterator it) {
     for (uint32_t i = 1; i < Length(); i++) {
         words_.emplace_back(*it++);
     }
+    SetResultTypeIndex();
+    UpdateDebugInfo();
+}
 
+Instruction::Instruction(const uint32_t* it) {
+    words_.emplace_back(*it);
+    it++;
+    words_.reserve(Length());
+    for (uint32_t i = 1; i < Length(); i++) {
+        words_.emplace_back(*it);
+        it++;
+    }
+    SetResultTypeIndex();
+    UpdateDebugInfo();
+}
+
+void Instruction::SetResultTypeIndex() {
     const bool has_result = OpcodeHasResult(Opcode());
     if (OpcodeHasType(Opcode())) {
         type_id_index_ = 1;
@@ -35,7 +51,9 @@ Instruction::Instruction(std::vector<uint32_t>::const_iterator it) {
     } else if (has_result) {
         result_id_index_ = 1;
     }
+}
 
+void Instruction::UpdateDebugInfo() {
 #ifndef NDEBUG
     d_opcode_ = std::string(string_SpvOpcode(Opcode()));
     d_length_ = Length();
@@ -166,6 +184,22 @@ spv::StorageClass Instruction::StorageClass() const {
             break;
     }
     return storage_class;
+}
+
+// All post SPIR-V processing we do is just needing to inspect single instructions without knowledge of the rest of the module.
+// It is very wasteful (both time and memory) to create an entire spirv::Module object for this, so do the simple parsing here
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<spirv::Instruction>& instructions) {
+    if (spirv.empty()) {
+        return;  // We *should not* get here, but incase, rather not report the SPIR-V debug info than crash
+    }
+    auto it = spirv.begin();
+    it += 5;  // skip first 5 word of header
+    while (it != spirv.end()) {
+        spirv::Instruction insn(it);
+        instructions.emplace_back(insn);
+        it += insn.Length();
+    }
+    instructions.shrink_to_fit();
 }
 
 }  // namespace spirv

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -35,6 +35,7 @@ namespace spirv {
 class Instruction {
   public:
     Instruction(std::vector<uint32_t>::const_iterator it);
+    Instruction(const uint32_t* it);
     ~Instruction() = default;
 
     // The word used to define the Instruction
@@ -78,6 +79,9 @@ class Instruction {
     bool operator!=(Instruction const& other) const { return words_ != other.words_; }
 
   private:
+    void SetResultTypeIndex();
+    void UpdateDebugInfo();
+
     // When this class was created, for SPIR-V Instructions that could be used in Vulkan,
     //   414 of 423 had 6 or less operands
     //   361 of 423 had 5 or less operands
@@ -100,5 +104,7 @@ class Instruction {
     uint32_t d_words_[12];
 #endif
 };
+
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<spirv::Instruction>& instructions);
 
 }  // namespace spirv

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -811,7 +811,7 @@ Module::StaticData::StaticData(const Module& module_state, StatelessData* statel
                 }
             }
 
-            instructions.push_back(insn);
+            instructions.emplace_back(insn);
             it += insn.Length();
         }
         instructions.shrink_to_fit();
@@ -887,10 +887,6 @@ Module::StaticData::StaticData(const Module& module_state, StatelessData* statel
                 if (stateless_data) {
                     stateless_data->transform_feedback_stream_inst.push_back(&insn);
                 }
-                break;
-
-            case spv::OpString:
-                debug_string_inst.push_back(&insn);
                 break;
 
             // Execution Mode

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -535,8 +535,6 @@ struct Module {
         std::vector<const Instruction *> variable_inst;
         // both OpDecorate and OpMemberDecorate builtin instructions
         std::vector<const Instruction *> builtin_decoration_inst;
-        // OpString - used to find debug information
-        std::vector<const Instruction *> debug_string_inst;
         // For shader tile image - OpDepthAttachmentReadEXT/OpStencilAttachmentReadEXT/OpColorAttachmentReadEXT
         bool has_shader_tile_image_depth_read{false};
         bool has_shader_tile_image_stencil_read{false};


### PR DESCRIPTION
When we print the error for GPU-AV and DebugPrintF we need `spirv::Instrument` to make parsing the SPIR-V easy

Before we were creating an entire `spirv::Module` in order to get `std::vector<spirv::Instruction> instructions;` while ignore all the other state tracking that `spirv::Module` does

This splits it up to make printing errors smoother
