### PR TITLE
tests: Add Host Image Copy support for Max Profile

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -123,7 +123,7 @@
             "sub_dir": "Vulkan-Profiles",
             "build_dir": "Vulkan-Profiles/build",
             "install_dir": "Vulkan-Profiles/build/install",
-            "commit": "eba7c602a68c5114d8b06d177038e98e10e8fb45",
+            "commit": "1ff97fd38c2f563bfadd6290162168299c2b5d3d",
             "build_step": "skip",
             "optional": [
                 "tests"
@@ -136,7 +136,7 @@
             "sub_dir": "Vulkan-Tools",
             "build_dir": "Vulkan-Tools/build",
             "install_dir": "Vulkan-Tools/build/install",
-            "commit": "934b5f7c13374949527b71b9732b93b5bc0fcc3e",
+            "commit": "e3f8bd7aa6a77eff9b9c4328c79db5b91732817a",
             "build_step": "skip",
             "optional": [
                 "tests"

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -135,6 +135,9 @@
                 "VkPhysicalDeviceMultiDrawFeaturesEXT": {
                     "multiDraw": true
                 },
+                "VkPhysicalDeviceHostImageCopyFeaturesEXT": {
+                    "hostImageCopy": true
+                },
                 "VkPhysicalDeviceSubgroupSizeControlFeatures": {
                     "subgroupSizeControl": true,
                     "computeFullSubgroups": true
@@ -881,7 +884,7 @@
                     "floatRepresentation": true,
                     "depthBiasExact": true
                 },
-                "VkPhysicalDeviceRenderPassStripedFeaturesARM":{
+                "VkPhysicalDeviceRenderPassStripedFeaturesARM": {
                     "renderPassStriped": true
                 },
                 "VkPhysicalDeviceDynamicRenderingLocalReadFeaturesKHR": {
@@ -1879,6 +1882,7 @@
                 "VK_EXT_graphics_pipeline_library": 1,
                 "VK_EXT_hdr_metadata": 1,
                 "VK_EXT_headless_surface": 1,
+                "VK_EXT_host_image_copy": 1,
                 "VK_EXT_host_query_reset": 1,
                 "VK_EXT_image_2d_view_of_3d": 1,
                 "VK_EXT_image_compression_control": 1,
@@ -3143,6 +3147,7 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
@@ -3169,6 +3174,7 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_DENSITY_MAP_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
@@ -6383,7 +6389,8 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT"
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT"
                         ],
                         "optimalTilingFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
@@ -6405,7 +6412,8 @@
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT"
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT"
                         ],
                         "bufferFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
@@ -6898,7 +6906,8 @@
                             "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT"
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT"
                         ],
                         "optimalTilingFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
@@ -6927,7 +6936,8 @@
                             "VK_FORMAT_FEATURE_2_COSITED_CHROMA_SAMPLES_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
-                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT"
+                            "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT"
                         ],
                         "bufferFeatures": [
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT",
@@ -6990,6 +7000,7 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",
@@ -7023,6 +7034,7 @@
                             "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT",
                             "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT",
+                            "VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_OUTPUT_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_DECODE_DPB_BIT_KHR",
                             "VK_FORMAT_FEATURE_2_VIDEO_ENCODE_INPUT_BIT_KHR",

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -853,11 +853,6 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
         m_errorMonitor->SetDesiredError("VUID-VkCopyImageToMemoryInfoEXT-srcImage-07981");
         vk::CopyImageToMemoryEXT(*m_device, &copy_from_image);
         m_errorMonitor->VerifyFound();
-
-        region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        copy_to_image.dstImage = image;
-        region_from_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        copy_from_image.srcImage = image;
     }
 
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
@@ -867,7 +862,7 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
         // VK_IMAGE_ASPECT_PLANE_2_BIT
         vkt::Image image_multi_planar3(*m_device, 128, 128, 1, VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM,
                                        VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-        image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
+        image_multi_planar3.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
         region_to_image.imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         copy_to_image.dstImage = image_multi_planar3;
         m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfoEXT-dstImage-07981");
@@ -1566,7 +1561,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToFromMemorySubsampled) {
 
     image_ci.flags = VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT;
     vkt::Image image_subsampled(*m_device, image_ci, vkt::set_layout);
-    image_subsampled.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
+    image_subsampled.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     copy_to_image.dstImage = image_subsampled;
     m_errorMonitor->SetDesiredError("VUID-VkCopyMemoryToImageInfoEXT-dstImage-07969");
     vk::CopyMemoryToImageEXT(*m_device, &copy_to_image);


### PR DESCRIPTION
Currently we were not running `VK_EXT_host_image_copy` on MockICD due to an issue with profiles handling the strange property struct of this extension

This adds support and fixes few tests that I now see had issues but were missed from lack of testing them