### PR TITLE
layers: Fix false-positive when reusing binary semaphore

### DIFF
--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -94,8 +94,11 @@ class Semaphore : public RefcountedStateObject {
     std::optional<SemOp> LastOp(
         const std::function<bool(OpType op_type, uint64_t payload, bool is_pending)> &filter = nullptr) const;
 
-    // Returns pending queue submission associated with the last binary signal.
+    // Returns pending queue submission that signals this binary semaphore.
     std::optional<SubmissionReference> GetPendingBinarySignalSubmission() const;
+
+    // Returns pending queue submission that waits on this binary semaphore.
+    std::optional<SubmissionReference> GetPendingBinaryWaitSubmission() const;
 
     // This is the most recently completed operation. It is returned by value so that the caller
     // has a correct copy even if something else is completing on this queue in a different thread.

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2394,3 +2394,38 @@ TEST_F(PositiveSyncObject, DynamicRenderingLocalReadImageBarrier) {
                            VK_DEPENDENCY_BY_REGION_BIT, 0u, nullptr, 0u, nullptr, 1u, &imageMemoryBarrier);
     secondary.end();
 }
+
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6172
+TEST_F(PositiveSyncObject, TwoQueuesReuseBinarySemaphore) {
+    TEST_DESCRIPTION("Use binary semaphore with the first queue then re-use on a different queue");
+    RETURN_IF_SKIP(Init());
+
+    if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
+        GTEST_SKIP() << "Test requires two queues";
+    }
+
+    VkQueue q0 = m_default_queue->handle();
+    VkQueue q1 = nullptr;
+    vk::GetDeviceQueue(device(), m_device->graphics_queue_node_index_, 1, &q1);
+    ASSERT_NE(q1, nullptr);
+
+    constexpr VkPipelineStageFlags wait_dst_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    vkt::Semaphore semaphore(*m_device);
+
+    VkSubmitInfo submits[2];
+
+    submits[0] = vku::InitStructHelper();
+    submits[0].signalSemaphoreCount = 1;
+    submits[0].pSignalSemaphores = &semaphore.handle();
+
+    submits[1] = vku::InitStructHelper();
+    submits[1].waitSemaphoreCount = 1;
+    submits[1].pWaitSemaphores = &semaphore.handle();
+    submits[1].pWaitDstStageMask = &wait_dst_stages;
+
+    vk::QueueSubmit(q0, 2, submits, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(q0);
+
+    vk::QueueSubmit(q1, 2, submits, VK_NULL_HANDLE);
+    vk::QueueWaitIdle(q1);
+}


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6172

The previous refactor clarified some terminology and helped with this fix. For example, `GetLastBinarySignalSubmission` was  renamed to `GetPendingBinarySignalSubmission`.  In the current code the `pending` operation usually refers to something that is still (or was recently) in the semaphore timeline (pending execution), and the `last` operation can refer either to the `pending` operation, if it exists, otherwise it's the last completed operation.

`LastOp()` is not a proper tool to implement `AnotherQueueWaits()` because we are interesting only in the pending operations. 

One direction of further code improvements is to review LastOp() usage. It's pretty complicated. Maybe it can be split into smaller scenarios similar to this fix.
