### PR TITLE
scripts: Use promoted SPIR-V names

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -626,44 +626,44 @@ or the instruction that consumes the OpSampledImage that consumes the descriptor
 
 The Stage is the integer value used in SPIR-V for each of the Execution Models:
 
-| Stage         | Value |
-|---------------|:-----:|
-|Vertex         |0      |
-|TessCtrl       |1      |
-|TessEval       |2      |
-|Geometry       |3      |
-|Fragment       |4      |
-|Compute        |5      |
-|Task           |5267   |
-|Mesh           |5268   |
-|RayGenerationNV|5313   |
-|IntersectionNV |5314   |
-|AnyHitNV       |5315   |
-|ClosestHitNV   |5316   |
-|MissNV         |5317   |
-|CallableNV     |5318   |
+| Stage          | Value |
+|----------------|:-----:|
+|Vertex          |0      |
+|TessCtrl        |1      |
+|TessEval        |2      |
+|Geometry        |3      |
+|Fragment        |4      |
+|Compute         |5      |
+|Task            |5267   |
+|Mesh            |5268   |
+|RayGenerationKHR|5313   |
+|IntersectionKHR |5314   |
+|AnyHitKHR       |5315   |
+|ClosestHitKHR   |5316   |
+|MissKHR         |5317   |
+|CallableKHR     |5318   |
 
 ### Stage Specific Words
 
 These are words that identify which "instance" of the shader the validation error occurred in.
 Here are words for each stage:
 
-| Stage         | Word 0           | Word 1        | Word 2       |
-|---------------|------------------|---------------|---------------|
-|Vertex         |VertexID          |InstanceID     | unused        |
-|TessCntrl      |InvocationID      |PrimitiveID    | unused        |
-|TessEval       |PrimitiveID       |TessCoord.u    | TessCoord.v   |
-|Geometry       |PrimitiveID       |InvocationID   | unused        |
-|Fragment       |FragCoord.x       |FragCoord.y    | unused        |
-|Compute        |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
-|Task           |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
-|Mesh           |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
-|RayGenerationNV|LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
-|IntersectionNV |LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
-|AnyHitNV       |LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
-|ClosestHitNV   |LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
-|MissNV         |LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
-|CallableNV     |LaunchIdNV.x      |LaunchIdNV.y   |LaunchIdNV.z   |
+| Stage          | Word 0           | Word 1        | Word 2       |
+|----------------|------------------|---------------|---------------|
+|Vertex          |VertexID          |InstanceID     | unused        |
+|TessCntrl       |InvocationID      |PrimitiveID    | unused        |
+|TessEval        |PrimitiveID       |TessCoord.u    | TessCoord.v   |
+|Geometry        |PrimitiveID       |InvocationID   | unused        |
+|Fragment        |FragCoord.x       |FragCoord.y    | unused        |
+|Compute         |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
+|Task            |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
+|Mesh            |GlobalInvocID.x   |GlobalInvocID.y|GlobalInvocID.z|
+|RayGenerationKHR|LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
+|IntersectionKHR |LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
+|AnyHitKHR       |LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
+|ClosestHitKHR   |LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
+|MissKHR         |LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
+|CallableKHR     |LaunchIdKHR.x     |LaunchIdKHR.y  |LaunchIdKHR.z  |
 
 "unused" means not relevant, but still present.
 

--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -57,45 +57,55 @@ static void GenerateStageMessage(const uint32_t *error_record, std::string &msg)
             strm << "Stage = Compute.  Global invocation ID (x, y, z) = (" << error_record[kHeaderInvocationIdXOffset] << ", "
                  << error_record[kHeaderInvocationIdYOffset] << ", " << error_record[kHeaderInvocationIdZOffset] << " )";
         } break;
-        case spv::ExecutionModelRayGenerationNV: {
+        case spv::ExecutionModelRayGenerationKHR: {
             strm << "Stage = Ray Generation.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset]
                  << ", " << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
-        case spv::ExecutionModelIntersectionNV: {
+        case spv::ExecutionModelIntersectionKHR: {
             strm << "Stage = Intersection.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset] << ", "
                  << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
-        case spv::ExecutionModelAnyHitNV: {
+        case spv::ExecutionModelAnyHitKHR: {
             strm << "Stage = Any Hit.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset] << ", "
                  << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
-        case spv::ExecutionModelClosestHitNV: {
+        case spv::ExecutionModelClosestHitKHR: {
             strm << "Stage = Closest Hit.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset] << ", "
                  << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
-        case spv::ExecutionModelMissNV: {
+        case spv::ExecutionModelMissKHR: {
             strm << "Stage = Miss.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset] << ", "
                  << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
-        case spv::ExecutionModelCallableNV: {
+        case spv::ExecutionModelCallableKHR: {
             strm << "Stage = Callable.  Global Launch ID (x,y,z) = (" << error_record[kHeaderRayTracingLaunchIdXOffset] << ", "
                  << error_record[kHeaderRayTracingLaunchIdYOffset] << ", " << error_record[kHeaderRayTracingLaunchIdZOffset]
                  << "). ";
         } break;
+        case spv::ExecutionModelTaskEXT: {
+            strm << "Stage = TaskEXT. Global invocation ID (x, y, z) = (" << error_record[kHeaderTaskGlobalInvocationIdXOffset]
+                 << ", " << error_record[kHeaderTaskGlobalInvocationIdYOffset] << ", "
+                 << error_record[kHeaderTaskGlobalInvocationIdZOffset] << " )";
+        } break;
+        case spv::ExecutionModelMeshEXT: {
+            strm << "Stage = MeshEXT. Global invocation ID (x, y, z) = (" << error_record[kHeaderMeshGlobalInvocationIdXOffset]
+                 << ", " << error_record[kHeaderMeshGlobalInvocationIdYOffset] << ", "
+                 << error_record[kHeaderMeshGlobalInvocationIdZOffset] << " )";
+        } break;
         case spv::ExecutionModelTaskNV: {
-            strm << "Stage = Task. Global invocation ID (x, y, z) = (" << error_record[kHeaderTaskGlobalInvocationIdXOffset] << ", "
-                 << error_record[kHeaderTaskGlobalInvocationIdYOffset] << ", " << error_record[kHeaderTaskGlobalInvocationIdZOffset]
-                 << " )";
+            strm << "Stage = TaskNV. Global invocation ID (x, y, z) = (" << error_record[kHeaderTaskGlobalInvocationIdXOffset]
+                 << ", " << error_record[kHeaderTaskGlobalInvocationIdYOffset] << ", "
+                 << error_record[kHeaderTaskGlobalInvocationIdZOffset] << " )";
         } break;
         case spv::ExecutionModelMeshNV: {
-            strm << "Stage = Mesh.Global invocation ID (x, y, z) = (" << error_record[kHeaderMeshGlobalInvocationIdXOffset] << ", "
-                 << error_record[kHeaderMeshGlobalInvocationIdYOffset] << ", " << error_record[kHeaderMeshGlobalInvocationIdZOffset]
-                 << " )";
+            strm << "Stage = MeshNV. Global invocation ID (x, y, z) = (" << error_record[kHeaderMeshGlobalInvocationIdXOffset]
+                 << ", " << error_record[kHeaderMeshGlobalInvocationIdYOffset] << ", "
+                 << error_record[kHeaderMeshGlobalInvocationIdZOffset] << " )";
         } break;
         default: {
             strm << "Internal Error (unexpected stage = " << error_record[kHeaderStageIdOffset] << "). ";

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -145,7 +145,7 @@ void ExecutionModeSet::Add(const Instruction& insn) {
             primitive_topology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
             break;
         case spv::ExecutionModeOutputLineStrip:
-        case spv::ExecutionModeOutputLinesNV:
+        case spv::ExecutionModeOutputLinesEXT:  // alias ExecutionModeOutputLinesNV
             primitive_topology = VK_PRIMITIVE_TOPOLOGY_LINE_STRIP;
             break;
         case spv::ExecutionModeTriangles:
@@ -163,7 +163,7 @@ void ExecutionModeSet::Add(const Instruction& insn) {
             tessellation_subdivision = spv::ExecutionModeQuads;
             break;
         case spv::ExecutionModeOutputTriangleStrip:
-        case spv::ExecutionModeOutputTrianglesNV:
+        case spv::ExecutionModeOutputTrianglesEXT:  // alias ExecutionModeOutputTrianglesNV
             primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP;
             break;
         case spv::ExecutionModeInputPoints:

--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -971,18 +971,18 @@ const char* string_SpvStorageClass(uint32_t storage_class) {
             return "NodePayloadAMDX";
         case spv::StorageClassNodeOutputPayloadAMDX:
             return "NodeOutputPayloadAMDX";
-        case spv::StorageClassCallableDataNV:
-            return "CallableDataNV";
-        case spv::StorageClassIncomingCallableDataNV:
-            return "IncomingCallableDataNV";
-        case spv::StorageClassRayPayloadNV:
-            return "RayPayloadNV";
-        case spv::StorageClassHitAttributeNV:
-            return "HitAttributeNV";
-        case spv::StorageClassIncomingRayPayloadNV:
-            return "IncomingRayPayloadNV";
-        case spv::StorageClassShaderRecordBufferNV:
-            return "ShaderRecordBufferNV";
+        case spv::StorageClassCallableDataKHR:
+            return "CallableDataKHR";
+        case spv::StorageClassIncomingCallableDataKHR:
+            return "IncomingCallableDataKHR";
+        case spv::StorageClassRayPayloadKHR:
+            return "RayPayloadKHR";
+        case spv::StorageClassHitAttributeKHR:
+            return "HitAttributeKHR";
+        case spv::StorageClassIncomingRayPayloadKHR:
+            return "IncomingRayPayloadKHR";
+        case spv::StorageClassShaderRecordBufferKHR:
+            return "ShaderRecordBufferKHR";
         case spv::StorageClassPhysicalStorageBuffer:
             return "PhysicalStorageBuffer";
         case spv::StorageClassHitObjectAttributeNV:
@@ -1021,18 +1021,18 @@ const char* string_SpvExecutionModel(uint32_t execution_model) {
             return "TaskNV";
         case spv::ExecutionModelMeshNV:
             return "MeshNV";
-        case spv::ExecutionModelRayGenerationNV:
-            return "RayGenerationNV";
-        case spv::ExecutionModelIntersectionNV:
-            return "IntersectionNV";
-        case spv::ExecutionModelAnyHitNV:
-            return "AnyHitNV";
-        case spv::ExecutionModelClosestHitNV:
-            return "ClosestHitNV";
-        case spv::ExecutionModelMissNV:
-            return "MissNV";
-        case spv::ExecutionModelCallableNV:
-            return "CallableNV";
+        case spv::ExecutionModelRayGenerationKHR:
+            return "RayGenerationKHR";
+        case spv::ExecutionModelIntersectionKHR:
+            return "IntersectionKHR";
+        case spv::ExecutionModelAnyHitKHR:
+            return "AnyHitKHR";
+        case spv::ExecutionModelClosestHitKHR:
+            return "ClosestHitKHR";
+        case spv::ExecutionModelMissKHR:
+            return "MissKHR";
+        case spv::ExecutionModelCallableKHR:
+            return "CallableKHR";
         case spv::ExecutionModelTaskEXT:
             return "TaskEXT";
         case spv::ExecutionModelMeshEXT:
@@ -1171,16 +1171,16 @@ const char* string_SpvExecutionMode(uint32_t execution_mode) {
             return "QuadDerivativesKHR";
         case spv::ExecutionModeRequireFullQuadsKHR:
             return "RequireFullQuadsKHR";
-        case spv::ExecutionModeOutputLinesNV:
-            return "OutputLinesNV";
-        case spv::ExecutionModeOutputPrimitivesNV:
-            return "OutputPrimitivesNV";
+        case spv::ExecutionModeOutputLinesEXT:
+            return "OutputLinesEXT";
+        case spv::ExecutionModeOutputPrimitivesEXT:
+            return "OutputPrimitivesEXT";
         case spv::ExecutionModeDerivativeGroupQuadsNV:
             return "DerivativeGroupQuadsNV";
         case spv::ExecutionModeDerivativeGroupLinearNV:
             return "DerivativeGroupLinearNV";
-        case spv::ExecutionModeOutputTrianglesNV:
-            return "OutputTrianglesNV";
+        case spv::ExecutionModeOutputTrianglesEXT:
+            return "OutputTrianglesEXT";
         case spv::ExecutionModePixelInterlockOrderedEXT:
             return "PixelInterlockOrderedEXT";
         case spv::ExecutionModePixelInterlockUnorderedEXT:
@@ -1359,8 +1359,8 @@ const char* string_SpvDecoration(uint32_t decoration) {
             return "ViewportRelativeNV";
         case spv::DecorationSecondaryViewportRelativeNV:
             return "SecondaryViewportRelativeNV";
-        case spv::DecorationPerPrimitiveNV:
-            return "PerPrimitiveNV";
+        case spv::DecorationPerPrimitiveEXT:
+            return "PerPrimitiveEXT";
         case spv::DecorationPerViewNV:
             return "PerViewNV";
         case spv::DecorationPerTaskNV:
@@ -1701,32 +1701,32 @@ const char* string_SpvBuiltIn(uint32_t built_in) {
             return "PrimitiveTriangleIndicesEXT";
         case spv::BuiltInCullPrimitiveEXT:
             return "CullPrimitiveEXT";
-        case spv::BuiltInLaunchIdNV:
-            return "LaunchIdNV";
-        case spv::BuiltInLaunchSizeNV:
-            return "LaunchSizeNV";
-        case spv::BuiltInWorldRayOriginNV:
-            return "WorldRayOriginNV";
-        case spv::BuiltInWorldRayDirectionNV:
-            return "WorldRayDirectionNV";
-        case spv::BuiltInObjectRayOriginNV:
-            return "ObjectRayOriginNV";
-        case spv::BuiltInObjectRayDirectionNV:
-            return "ObjectRayDirectionNV";
-        case spv::BuiltInRayTminNV:
-            return "RayTminNV";
-        case spv::BuiltInRayTmaxNV:
-            return "RayTmaxNV";
-        case spv::BuiltInInstanceCustomIndexNV:
-            return "InstanceCustomIndexNV";
-        case spv::BuiltInObjectToWorldNV:
-            return "ObjectToWorldNV";
-        case spv::BuiltInWorldToObjectNV:
-            return "WorldToObjectNV";
+        case spv::BuiltInLaunchIdKHR:
+            return "LaunchIdKHR";
+        case spv::BuiltInLaunchSizeKHR:
+            return "LaunchSizeKHR";
+        case spv::BuiltInWorldRayOriginKHR:
+            return "WorldRayOriginKHR";
+        case spv::BuiltInWorldRayDirectionKHR:
+            return "WorldRayDirectionKHR";
+        case spv::BuiltInObjectRayOriginKHR:
+            return "ObjectRayOriginKHR";
+        case spv::BuiltInObjectRayDirectionKHR:
+            return "ObjectRayDirectionKHR";
+        case spv::BuiltInRayTminKHR:
+            return "RayTminKHR";
+        case spv::BuiltInRayTmaxKHR:
+            return "RayTmaxKHR";
+        case spv::BuiltInInstanceCustomIndexKHR:
+            return "InstanceCustomIndexKHR";
+        case spv::BuiltInObjectToWorldKHR:
+            return "ObjectToWorldKHR";
+        case spv::BuiltInWorldToObjectKHR:
+            return "WorldToObjectKHR";
         case spv::BuiltInHitTNV:
             return "HitTNV";
-        case spv::BuiltInHitKindNV:
-            return "HitKindNV";
+        case spv::BuiltInHitKindKHR:
+            return "HitKindKHR";
         case spv::BuiltInCurrentRayTimeNV:
             return "CurrentRayTimeNV";
         case spv::BuiltInHitTriangleVertexPositionsKHR:
@@ -1735,8 +1735,8 @@ const char* string_SpvBuiltIn(uint32_t built_in) {
             return "HitMicroTriangleVertexPositionsNV";
         case spv::BuiltInHitMicroTriangleVertexBarycentricsNV:
             return "HitMicroTriangleVertexBarycentricsNV";
-        case spv::BuiltInIncomingRayFlagsNV:
-            return "IncomingRayFlagsNV";
+        case spv::BuiltInIncomingRayFlagsKHR:
+            return "IncomingRayFlagsKHR";
         case spv::BuiltInRayGeometryIndexKHR:
             return "RayGeometryIndexKHR";
         case spv::BuiltInWarpsPerSMNV:

--- a/scripts/generators/spirv_grammar_generator.py
+++ b/scripts/generators/spirv_grammar_generator.py
@@ -104,11 +104,13 @@ class SpirvGrammarHelperOutputGenerator(BaseGenerator):
                         if enum['value'] not in values:
                             self.imageOperandsParamCount[count].append(enum['enumerant'])
                             values.append(enum['value'])
-                self.addToStringList(operandKind, 'StorageClass', self.storageClassList)
-                self.addToStringList(operandKind, 'ExecutionModel', self.executionModelList)
-                self.addToStringList(operandKind, 'ExecutionMode', self.executionModeList)
-                self.addToStringList(operandKind, 'Decoration', self.decorationList)
-                self.addToStringList(operandKind, 'BuiltIn', self.builtInList)
+                # Use EXT/KHR Alias names where possible
+                # Core issue is SPIR-V grammar sometimes puts alias both before/after the promotoed name
+                self.addToStringList(operandKind, 'StorageClass', self.storageClassList, ['CallableDataNV', 'IncomingCallableDataNV', 'RayPayloadNV', 'HitAttributeNV', 'IncomingRayPayloadNV', 'ShaderRecordBufferNV'])
+                self.addToStringList(operandKind, 'ExecutionModel', self.executionModelList, ['RayGenerationNV', 'IntersectionNV', 'AnyHitNV', 'ClosestHitNV', 'MissNV', 'CallableNV'])
+                self.addToStringList(operandKind, 'ExecutionMode', self.executionModeList, ['OutputLinesNV', 'OutputPrimitivesNV', 'OutputTrianglesNV'])
+                self.addToStringList(operandKind, 'Decoration', self.decorationList, ['PerPrimitiveNV'])
+                self.addToStringList(operandKind, 'BuiltIn', self.builtInList, ['BaryCoordNV', 'BaryCoordNoPerspNV', 'LaunchIdNV', 'LaunchSizeNV', 'WorldRayOriginNV', 'WorldRayDirectionNV', 'ObjectRayOriginNV', 'ObjectRayDirectionNV', 'RayTminNV', 'RayTmaxNV', 'InstanceCustomIndexNV', 'ObjectToWorldNV', 'WorldToObjectNV', 'HitKindNV', 'IncomingRayFlagsNV'])
                 self.addToStringList(operandKind, 'Dim', self.dimList)
                 self.addToStringList(operandKind, 'CooperativeMatrixOperands', self.cooperativeMatrixList, ['NoneKHR'])
 


### PR DESCRIPTION
Went through and made sure the promoted alias name for SPIR-V is used throughout the code