### PR TITLE
printf: Add proper vk_layer_settings support

### DIFF
--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -31,17 +31,17 @@ void debug_printf::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo
         aborted = true;
         return;
     }
-    const char *size_string = getLayerOption("khronos_validation.printf_buffer_size");
-    output_buffer_byte_size = *size_string ? atoi(size_string) : 1024;
 
-    std::string verbose_string = getLayerOption("khronos_validation.printf_verbose");
-    vvl::ToLower(verbose_string);
-    verbose = !verbose_string.compare("true");
+    output_buffer_byte_size = printf_settings.buffer_size;
+    verbose = printf_settings.verbose;
+    use_stdout = printf_settings.to_stdout;
 
-    std::string stdout_string = getLayerOption("khronos_validation.printf_to_stdout");
-    vvl::ToLower(stdout_string);
-    use_stdout = !stdout_string.compare("true");
-    if (!GetEnvironment("DEBUG_PRINTF_TO_STDOUT").empty()) use_stdout = true;
+    // This option was published when Debug PrintF came out, leave to not break people's flow
+    if (!GetEnvironment("DEBUG_PRINTF_TO_STDOUT").empty()) {
+        LogWarning("WARNING-DEBUG-PRINTF", device, loc,
+                   "DEBUG_PRINTF_TO_STDOUT was set, this is deprecated, please use VK_LAYER_PRINTF_TO_STDOUT");
+        use_stdout = true;
+    }
 
     // GpuAssistedBase::CreateDevice will set up bindings
     VkDescriptorSetLayoutBinding binding = {3, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,

--- a/layers/gpu_validation/gpu_settings.h
+++ b/layers/gpu_validation/gpu_settings.h
@@ -30,3 +30,9 @@ struct GpuAVSettings {
     bool gpuav_debug_validate_instrumented_shaders = false;
     bool gpuav_debug_dump_instrumented_shaders = false;
 };
+
+struct DebugPrintfSettings {
+    bool to_stdout = false;
+    bool verbose = false;
+    uint32_t buffer_size = 1024;
+};

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -55,6 +55,10 @@ const char *SETTING_CUSTOM_STYPE_LIST = "custom_stype_list";
 const char *SETTING_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
 const char *SETTING_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
+const char *SETTING_PRINTF_TO_STDOUT = "printf_to_stdout";
+const char *SETTING_PRINTF_VERBOSE = "printf_verbose";
+const char *SETTING_PRINTF_BUFFER_SIZE = "printf_buffer_size";
+
 const char *SETTING_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
 const char *SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
 const char *SETTING_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
@@ -395,6 +399,19 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
 
     if (vkuHasLayerSetting(layer_setting_set, SETTING_CUSTOM_STYPE_LIST)) {
         vkuGetLayerSettingValues(layer_setting_set, SETTING_CUSTOM_STYPE_LIST, custom_stype_info);
+    }
+
+    DebugPrintfSettings &printf_settings = *settings_data->printf_settings;
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_TO_STDOUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_TO_STDOUT, printf_settings.to_stdout);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_VERBOSE)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_VERBOSE, printf_settings.verbose);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_BUFFER_SIZE)) {
+        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_BUFFER_SIZE, printf_settings.buffer_size);
     }
 
     GpuAVSettings &gpuav_settings = *settings_data->gpuav_settings;

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -35,6 +35,7 @@ typedef struct {
     uint32_t *duplicate_message_limit;
     bool *fine_grained_locking;
     GpuAVSettings *gpuav_settings;
+    DebugPrintfSettings *printf_settings;
 } ConfigAndEnvSettings;
 
 static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -380,6 +380,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     CHECK_DISABLED local_disables{};
     bool lock_setting;
     GpuAVSettings local_gpuav_settings = {};
+    DebugPrintfSettings local_printf_settings = {};
     ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                       pCreateInfo,
                                                       local_enables,
@@ -387,7 +388,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
                                                       debug_report->filter_message_ids,
                                                       &debug_report->duplicate_message_limit,
                                                       &lock_setting,
-                                                      &local_gpuav_settings};
+                                                      &local_gpuav_settings,
+                                                      &local_printf_settings};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
     LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
@@ -447,6 +449,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     framework->enabled = local_enables;
     framework->fine_grained_locking = lock_setting;
     framework->gpuav_settings = local_gpuav_settings;
+    framework->printf_settings = local_printf_settings;
 
     framework->instance = *pInstance;
     layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);
@@ -466,6 +469,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
         intercept->disabled = framework->disabled;
         intercept->fine_grained_locking = framework->fine_grained_locking;
         intercept->gpuav_settings = framework->gpuav_settings;
+        intercept->printf_settings = framework->printf_settings;
         intercept->instance = *pInstance;
     }
 
@@ -595,6 +599,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         object->enabled = instance_interceptor->enabled;
         object->fine_grained_locking = instance_interceptor->fine_grained_locking;
         object->gpuav_settings = instance_interceptor->gpuav_settings;
+        object->printf_settings = instance_interceptor->printf_settings;
         object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
         object->instance_extensions = instance_interceptor->instance_extensions;
         object->device_extensions = device_interceptor->device_extensions;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2290,6 +2290,7 @@ class ValidationObject {
     CHECK_ENABLED enabled = {};
     bool fine_grained_locking{true};
     GpuAVSettings gpuav_settings = {};
+    DebugPrintfSettings printf_settings = {};
 
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -485,6 +485,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_ENABLED enabled = {};
                 bool fine_grained_locking{true};
                 GpuAVSettings gpuav_settings = {};
+                DebugPrintfSettings printf_settings = {};
 
                 VkInstance instance = VK_NULL_HANDLE;
                 VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -1126,6 +1127,7 @@ vvl::Extensions IsValidFlag64Value(vvl::FlagBitmask flag_bitmask, VkFlags64 valu
                 CHECK_DISABLED local_disables{};
                 bool lock_setting;
                 GpuAVSettings local_gpuav_settings = {};
+                DebugPrintfSettings local_printf_settings = {};
                 ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                                 pCreateInfo,
                                                                 local_enables,
@@ -1133,7 +1135,8 @@ vvl::Extensions IsValidFlag64Value(vvl::FlagBitmask flag_bitmask, VkFlags64 valu
                                                                 debug_report->filter_message_ids,
                                                                 &debug_report->duplicate_message_limit,
                                                                 &lock_setting,
-                                                                &local_gpuav_settings};
+                                                                &local_gpuav_settings,
+                                                                &local_printf_settings};
                 ProcessConfigAndEnvSettings(&config_and_env_settings_data);
                 LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
@@ -1193,6 +1196,7 @@ vvl::Extensions IsValidFlag64Value(vvl::FlagBitmask flag_bitmask, VkFlags64 valu
                 framework->enabled = local_enables;
                 framework->fine_grained_locking = lock_setting;
                 framework->gpuav_settings = local_gpuav_settings;
+                framework->printf_settings = local_printf_settings;
 
                 framework->instance = *pInstance;
                 layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);
@@ -1212,6 +1216,7 @@ vvl::Extensions IsValidFlag64Value(vvl::FlagBitmask flag_bitmask, VkFlags64 valu
                     intercept->disabled = framework->disabled;
                     intercept->fine_grained_locking = framework->fine_grained_locking;
                     intercept->gpuav_settings = framework->gpuav_settings;
+                    intercept->printf_settings = framework->printf_settings;
                     intercept->instance = *pInstance;
                 }
 
@@ -1341,6 +1346,7 @@ vvl::Extensions IsValidFlag64Value(vvl::FlagBitmask flag_bitmask, VkFlags64 valu
                     object->enabled = instance_interceptor->enabled;
                     object->fine_grained_locking = instance_interceptor->fine_grained_locking;
                     object->gpuav_settings = instance_interceptor->gpuav_settings;
+                    object->printf_settings = instance_interceptor->printf_settings;
                     object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
                     object->instance_extensions = instance_interceptor->instance_extensions;
                     object->device_extensions = device_interceptor->device_extensions;


### PR DESCRIPTION
Debug PrintF was using the old way to set its settings

Now it is hooked up with vk_layer_settings like everything else