### PR TITLE
layers: Move things out of chassis.h to Layer Options

### DIFF
--- a/layers/layer_chassis_dispatch_manual.cpp
+++ b/layers/layer_chassis_dispatch_manual.cpp
@@ -561,7 +561,7 @@ VkResult DispatchCreateDescriptorUpdateTemplate(VkDevice device, const VkDescrip
         // Shadow template createInfo for later updates
         if (local_pCreateInfo) {
             WriteLockGuard lock(dispatch_lock);
-            std::unique_ptr<TEMPLATE_STATE> template_state(new TEMPLATE_STATE(*pDescriptorUpdateTemplate, local_pCreateInfo));
+            std::unique_ptr<TemplateState> template_state(new TemplateState(*pDescriptorUpdateTemplate, local_pCreateInfo));
             layer_data->desc_template_createinfo_map[(uint64_t)*pDescriptorUpdateTemplate] = std::move(template_state);
         }
     }
@@ -597,7 +597,7 @@ VkResult DispatchCreateDescriptorUpdateTemplateKHR(VkDevice device, const VkDesc
         // Shadow template createInfo for later updates
         if (local_pCreateInfo) {
             WriteLockGuard lock(dispatch_lock);
-            std::unique_ptr<TEMPLATE_STATE> template_state(new TEMPLATE_STATE(*pDescriptorUpdateTemplate, local_pCreateInfo));
+            std::unique_ptr<TemplateState> template_state(new TemplateState(*pDescriptorUpdateTemplate, local_pCreateInfo));
             layer_data->desc_template_createinfo_map[(uint64_t)*pDescriptorUpdateTemplate] = std::move(template_state);
         }
     }

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -17,12 +17,75 @@
  */
 
 #pragma once
-#include "generated/chassis.h"
+#include <array>
+#include <vector>
+#include <string>
+#include <cstdint>
+#include <vulkan/vulkan.h>
+#include <vulkan/utility/vk_struct_helper.hpp>
 #include "gpu_validation/gpu_settings.h"
+#include "containers/custom_containers.h"
 
 #define OBJECT_LAYER_NAME "VK_LAYER_KHRONOS_validation"
 
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
+
+typedef enum ValidationCheckDisables {
+    VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE,
+    VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
+    VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
+    VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
+    VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
+} ValidationCheckDisables;
+
+typedef enum ValidationCheckEnables {
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA,
+    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
+} ValidationCheckEnables;
+
+typedef enum VkValidationFeatureEnable {
+    VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
+} VkValidationFeatureEnable;
+
+// CHECK_DISABLED and CHECK_ENABLED vectors are containers for bools that can opt in or out of specific classes of validation
+// checks. Enum values can be specified via the vk_layer_settings.txt config file or at CreateInstance time via the
+// VK_EXT_validation_features extension that can selectively disable or enable checks.
+typedef enum DisableFlags {
+    command_buffer_state,
+    object_in_use,
+    query_validation,
+    image_layout_validation,
+    object_tracking,
+    core_checks,
+    thread_safety,
+    stateless_checks,
+    handle_wrapping,
+    shader_validation,
+    shader_validation_caching,
+    sync_validation_queue_submit,
+    // Insert new disables above this line
+    kMaxDisableFlags,
+} DisableFlags;
+
+typedef enum EnableFlags {
+    gpu_validation,
+    gpu_validation_reserve_binding_slot,
+    best_practices,
+    vendor_specific_arm,
+    vendor_specific_amd,
+    vendor_specific_img,
+    vendor_specific_nvidia,
+    debug_printf_validation,
+    sync_validation,
+    // Insert new enables above this line
+    kMaxEnableFlags,
+} EnableFlags;
+
+typedef std::array<bool, kMaxDisableFlags> CHECK_DISABLED;
+typedef std::array<bool, kMaxEnableFlags> CHECK_ENABLED;
 
 // Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -30,7 +30,6 @@
 class CoreChecks;
 class ValidationObject;
 class ValidationStateTracker;
-class UPDATE_TEMPLATE_STATE;
 struct DeviceExtensions;
 
 namespace vvl {

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -567,7 +567,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
     device_interceptor->container_type = LayerObjectTypeDevice;
 
     // Save local info in device object
-    device_interceptor->phys_dev_properties.properties = device_properties;
     device_interceptor->api_version = device_interceptor->device_extensions.InitFromDeviceCreateInfo(
         &instance_interceptor->instance_extensions, effective_api_version, pCreateInfo);
     device_interceptor->device_extensions = device_extensions;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -39,9 +39,9 @@
 #include <vulkan/vulkan.h>
 #include <vulkan/vk_layer.h>
 #include <vulkan/vk_enum_string_helper.h>
-#include <vulkan/utility/vk_struct_helper.hpp>
 #include "utils/cast_utils.h"
 #include "vk_layer_config.h"
+#include "layer_options.h"
 #include "containers/custom_containers.h"
 #include "error_message/logging.h"
 #include "error_message/error_location.h"
@@ -2183,74 +2183,14 @@ enum LayerObjectTypeId {
     LayerObjectTypeMaxEnum,              // Max enum count
 };
 
-struct TEMPLATE_STATE {
+struct TemplateState {
     VkDescriptorUpdateTemplate desc_update_template;
     safe_VkDescriptorUpdateTemplateCreateInfo create_info;
     bool destroyed;
 
-    TEMPLATE_STATE(VkDescriptorUpdateTemplate update_template, safe_VkDescriptorUpdateTemplateCreateInfo* pCreateInfo)
+    TemplateState(VkDescriptorUpdateTemplate update_template, safe_VkDescriptorUpdateTemplateCreateInfo* pCreateInfo)
         : desc_update_template(update_template), create_info(*pCreateInfo), destroyed(false) {}
 };
-
-class LAYER_PHYS_DEV_PROPERTIES {
-  public:
-    VkPhysicalDeviceProperties properties;
-    std::vector<VkQueueFamilyProperties> queue_family_properties;
-};
-
-typedef enum ValidationCheckDisables {
-    VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE,
-    VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
-    VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
-    VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
-    VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
-} ValidationCheckDisables;
-
-typedef enum ValidationCheckEnables {
-    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM,
-    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
-    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
-    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA,
-    VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
-} ValidationCheckEnables;
-
-typedef enum VkValidationFeatureEnable {
-    VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
-} VkValidationFeatureEnable;
-
-// CHECK_DISABLED and CHECK_ENABLED vectors are containers for bools that can opt in or out of specific classes of validation
-// checks. Enum values can be specified via the vk_layer_settings.txt config file or at CreateInstance time via the
-// VK_EXT_validation_features extension that can selectively disable or enable checks.
-typedef enum DisableFlags {
-    command_buffer_state,
-    object_in_use,
-    query_validation,
-    image_layout_validation,
-    object_tracking,
-    core_checks,
-    thread_safety,
-    stateless_checks,
-    handle_wrapping,
-    shader_validation,
-    shader_validation_caching,
-    sync_validation_queue_submit,
-    // Insert new disables above this line
-    kMaxDisableFlags,
-} DisableFlags;
-
-typedef enum EnableFlags {
-    gpu_validation,
-    gpu_validation_reserve_binding_slot,
-    best_practices,
-    vendor_specific_arm,
-    vendor_specific_amd,
-    vendor_specific_img,
-    vendor_specific_nvidia,
-    debug_printf_validation,
-    sync_validation,
-    // Insert new enables above this line
-    kMaxEnableFlags,
-} EnableFlags;
 
 // When testing for a valid value, allow a way to right away return how it might not be valid
 enum class ValidValue {
@@ -2258,9 +2198,6 @@ enum class ValidValue {
     NotFound,     // example, trying to use a random int for an enum
     NoExtension,  // trying to use a proper value, but the extension is required
 };
-
-typedef std::array<bool, kMaxDisableFlags> CHECK_DISABLED;
-typedef std::array<bool, kMaxEnableFlags> CHECK_ENABLED;
 
 #if defined(__clang__)
 #define DECORATE_PRINTF(_fmt_argnum, _first_param_num) __attribute__((format(printf, _fmt_argnum, _first_param_num)))
@@ -2295,7 +2232,6 @@ class ValidationObject {
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;
     VkDevice device = VK_NULL_HANDLE;
     bool is_device_lost = false;
-    LAYER_PHYS_DEV_PROPERTIES phys_dev_properties = {};
 
     std::vector<ValidationObject*> object_dispatch;
     LayerObjectTypeId container_type;
@@ -2439,7 +2375,7 @@ class ValidationObject {
     // Reverse map display handles
     vl_concurrent_unordered_map<VkDisplayKHR, uint64_t, 0> display_id_reverse_mapping;
     // Wrapping Descriptor Template Update structures requires access to the template createinfo structs
-    vvl::unordered_map<uint64_t, std::unique_ptr<TEMPLATE_STATE>> desc_template_createinfo_map;
+    vvl::unordered_map<uint64_t, std::unique_ptr<TemplateState>> desc_template_createinfo_map;
     struct SubpassesUsageStates {
         vvl::unordered_set<uint32_t> subpasses_using_color_attachment;
         vvl::unordered_set<uint32_t> subpasses_using_depthstencil_attachment;


### PR DESCRIPTION
Trying to clean up the chassis level logic

I noticed we had a lot of stuff that is only for Layer Options and moved it over there