### PR TITLE
scripts: Fix PlatformGuardHelper.add_guard()

### DIFF
--- a/scripts/generators/generator_utils.py
+++ b/scripts/generators/generator_utils.py
@@ -77,11 +77,11 @@ class PlatformGuardHelper():
 
     def add_guard(self, guard, extra_newline = False):
         out = []
-        if self.current_guard is not guard and self.current_guard is not None:
+        if self.current_guard != guard and self.current_guard is not None:
             out.append(f'#endif  // {self.current_guard}\n')
         if extra_newline:
             out.append('\n')
-        if self.current_guard is not guard and guard is not None:
+        if self.current_guard != guard and guard is not None:
             out.append(f'#ifdef {guard}\n')
         self.current_guard = guard
         return out


### PR DESCRIPTION
Comparison to the existing guard should be `!=` not `is not`

Found during code review of https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/187