### PR TITLE
layers: Expose semaphore payload instead of operation object

### DIFF
--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1394,11 +1394,11 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
         return skip;
     }
 
-    const auto completed = semaphore_state->Completed();
-    if (completed.payload >= pSignalInfo->value) {
+    const auto current_payload = semaphore_state->CurrentPayload();
+    if (current_payload >= pSignalInfo->value) {
         skip |= LogError("VUID-VkSemaphoreSignalInfo-value-03258", pSignalInfo->semaphore, signal_loc.dot(Field::value),
                          "(%" PRIu64 ") must be greater than current semaphore %s value (%" PRIu64 ").", pSignalInfo->value,
-                         FormatHandle(pSignalInfo->semaphore).c_str(), completed.payload);
+                         FormatHandle(pSignalInfo->semaphore).c_str(), current_payload);
         return skip;
     }
     auto exceeds_pending = [pSignalInfo](const vvl::Semaphore::OpType op_type, uint64_t payload, bool is_pending) {
@@ -1418,7 +1418,7 @@ bool CoreChecks::PreCallValidateSignalSemaphore(VkDevice device, const VkSemapho
     last_op = semaphore_state->LastOp(exceeds_max_diff);
     if (last_op) {
         bad_value = last_op->payload;
-        if (last_op->payload == semaphore_state->Completed().payload) {
+        if (last_op->payload == semaphore_state->CurrentPayload()) {
             where = "current";
         } else {
             where = "pending";

--- a/layers/state_tracker/semaphore_state.cpp
+++ b/layers/state_tracker/semaphore_state.cpp
@@ -154,9 +154,9 @@ std::optional<vvl::SubmissionReference> vvl::Semaphore::GetPendingBinaryWaitSubm
     return timepoint.wait_submits[0];
 }
 
-vvl::Semaphore::SemOp vvl::Semaphore::Completed() const {
+uint64_t vvl::Semaphore::CurrentPayload() const {
     auto guard = ReadLock();
-    return completed_;
+    return completed_.payload;
 }
 
 bool vvl::Semaphore::CanBinaryBeSignaled() const {
@@ -443,7 +443,7 @@ bool SemaphoreSubmitState::CheckSemaphoreValue(
     }
     auto pending = semaphore_state.LastOp(compare_func);
     if (pending) {
-        if (pending->payload == semaphore_state.Completed().payload) {
+        if (pending->payload == semaphore_state.CurrentPayload()) {
             where = "current";
         } else {
             where = pending->op_type == vvl::Semaphore::OpType::kSignal ? "pending signal" : "pending wait";

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -100,9 +100,9 @@ class Semaphore : public RefcountedStateObject {
     // Returns pending queue submission that waits on this binary semaphore.
     std::optional<SubmissionReference> GetPendingBinaryWaitSubmission() const;
 
-    // This is the most recently completed operation. It is returned by value so that the caller
-    // has a correct copy even if something else is completing on this queue in a different thread.
-    SemOp Completed() const;
+    // Current payload value.
+    // If a queue submission command is pending execution, then the returned value may immediately be out of date.
+    uint64_t CurrentPayload() const;
 
     bool CanBinaryBeSignaled() const;
     bool CanBinaryBeWaited() const;


### PR DESCRIPTION
Trying to remove SemOp usage in the Semaphore public interface.

In some place places where Completed() was called, the code uses "current" payload terminology, which seems logical. Hense the new name of the method.