### PR TITLE
layers: Add robustness check to drawn time vertex buffer

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -71,6 +71,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index, const Location& loc) const;
     bool ValidateMultiViewShaders(const vvl::Pipeline& pipeline, const Location& multiview_loc, uint32_t view_mask,
                                   bool dynamic_rendering) const;
+    bool ValidateVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline, const Location& loc,
+                                 const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipeline(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
                                uint32_t count, const uint32_t* indices, const Location& loc) const;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -138,6 +138,7 @@ class Pipeline : public StateObject {
     const VkPrimitiveTopology topology_at_rasterizer = VK_PRIMITIVE_TOPOLOGY_MAX_ENUM;
     const bool descriptor_buffer_mode = false;
     const bool uses_pipeline_robustness;
+    const bool uses_pipeline_vertex_robustness;
     bool ignore_color_attachments;
 
     // Executable or legacy pipeline

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -686,7 +686,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
     if (!extended_dynamic_state_features.extendedDynamicState) {
         GTEST_SKIP() << "Test requires (unsupported) extendedDynamicState";
     }
-
+    features2.features.robustBufferAccess = VK_FALSE;
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -138,7 +138,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
     if (multiview_features.multiview == VK_FALSE) {
         GTEST_SKIP() << "Device does not support multiview.";
     }
-
+    features2.features.robustBufferAccess = VK_FALSE;
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     VkAttachmentDescription attachmentDescription = {};

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -612,7 +612,7 @@ TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
 
 TEST_F(NegativeVertexInput, VertextBinding) {
     TEST_DESCRIPTION("Verify if VkPipelineVertexInputStateCreateInfo matches vkCmdBindVertexBuffers");
-
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -652,7 +652,7 @@ TEST_F(NegativeVertexInput, VertextBinding) {
 
 TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
     TEST_DESCRIPTION("Have Binding not be in a linear order");
-
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -691,6 +691,7 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     TEST_DESCRIPTION("Test bad binding with VK_DYNAMIC_STATE_VERTEX_INPUT_EXT");
     AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::vertexInputDynamicState);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -741,7 +742,7 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
 
 TEST_F(NegativeVertexInput, AttributeAlignment) {
     TEST_DESCRIPTION("Check for proper aligment of attribAddress which depends on a bound pipeline and on a bound vertex buffer");
-
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -840,7 +841,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
 
 TEST_F(NegativeVertexInput, BindVertexOffset) {
     TEST_DESCRIPTION("set the pOffset in vkCmdBindVertexBuffers to 3 and use R16");
-
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -872,6 +873,7 @@ TEST_F(NegativeVertexInput, BindVertexOffset) {
 
 TEST_F(NegativeVertexInput, VertexStride) {
     TEST_DESCRIPTION("set the Stride to 3 and use R16");
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -905,6 +907,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
     TEST_DESCRIPTION("set the Stride to 3 in VK_DYNAMIC_STATE_VERTEX_INPUT_EXT and use R16");
     AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::vertexInputDynamicState);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -944,6 +947,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
     TEST_DESCRIPTION("set the Stride to 3 in vkCmdBindVertexBuffers2 and use R16");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -980,6 +984,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
     TEST_DESCRIPTION("set the Stride to 3 in vkCmdBindVertexBuffers2 and use R16");
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -1019,6 +1024,7 @@ TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
     AddRequiredExtensions(VK_EXT_VERTEX_INPUT_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::vertexInputDynamicState);
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -1704,6 +1710,8 @@ TEST_F(NegativeVertexInput, BindVertexBufferNullDraw) {
     TEST_DESCRIPTION("Have null vertex but use nullDescriptor feature");
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::nullDescriptor);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess2);
+    AddDisabledFeature(vkt::Feature::robustBufferAccess);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 


### PR DESCRIPTION
from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6570

- Move logic to a dedicated `ValidateVertexAttribute` function
- wrap logic with a check for `robustBufferAccess` support

cc @ziga-lunarg 