### PR TITLE
layers: Ignore non-zero binary semaphore payload

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1218,7 +1218,9 @@ void ValidationStateTracker::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t s
         const VkSubmitInfo2KHR *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->waitSemaphoreInfoCount; ++i) {
             const auto &sem_info = submit->pWaitSemaphoreInfos[i];
-            submission.AddWaitSemaphore(Get<vvl::Semaphore>(sem_info.semaphore), sem_info.value);
+            auto semaphore = Get<vvl::Semaphore>(sem_info.semaphore);
+            const uint64_t value = (semaphore->type == VK_SEMAPHORE_TYPE_BINARY) ? 0 : sem_info.value;
+            submission.AddWaitSemaphore(std::move(semaphore), value);
         }
         for (uint32_t i = 0; i < submit->signalSemaphoreInfoCount; ++i) {
             const auto &sem_info = submit->pSignalSemaphoreInfos[i];


### PR DESCRIPTION
Non-zero payload value for imported binary semaphore caused a crash in Semaphore::Retire. We use *internal payload values* for binary semaphores as part of our implementation, but the *payload values provided through the API* (QueueSubmit2) have no meaning for binary semaphores and should be ignored. The main code path generates internal binary payload values, but there is a special case for the imported binary semaphore wait, which allowed API-provided payload to leak into our implementation details.

This also fixes CTS issue found by @ncesario-lunarg  that `dEQP-VK.synchronization2.cross_instance.suballocated.write_fill_buffer_read_copy_buffer.buffer_16384_binary_semaphore_fd` triggers assert about non-zero binary payload.