### PR TITLE
layers: Move Secondary CommandBuffer tracking to chassis

### DIFF
--- a/layers/chassis/chassis_handle_data.h
+++ b/layers/chassis/chassis_handle_data.h
@@ -1,0 +1,33 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace chassis {
+
+struct CommandBufferData {
+    bool is_secondary;
+};
+
+// Some handles need their own "private data" that everyone needs (even statless chassis layers)
+// The goal is to have the chassis do the state tracking once, and pass down this selective information to everyone.
+// Using an union, we can leverage the ErrorObject/RecordObject to get the data everywhere
+union HandleData {
+    CommandBufferData command_buffer;
+};
+
+}  // namespace chassis

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -24,6 +24,7 @@
 #include "generated/error_location_helper.h"
 #include "logging.h"
 #include "containers/custom_containers.h"
+#include "chassis/chassis_handle_data.h"
 
 // Holds the 'Location' of where the code is inside a function/struct/etc
 // see docs/error_object.md for more details
@@ -82,7 +83,12 @@ struct ErrorObject {
     const Location location;   // starting location (Always the function entrypoint)
     const VulkanTypedHandle handle;  // dispatchable handle is always first parameter of the function call
     const LogObjectList objlist;
-    ErrorObject(vvl::Func command_, VulkanTypedHandle handle_) : location(Location(command_)), handle(handle_), objlist(handle) {}
+    const chassis::HandleData* handle_data;
+
+    ErrorObject(vvl::Func command_, VulkanTypedHandle handle_)
+        : location(Location(command_)), handle(handle_), objlist(handle), handle_data(nullptr) {}
+    ErrorObject(vvl::Func command_, VulkanTypedHandle handle_, const chassis::HandleData* handle_data_)
+        : location(Location(command_)), handle(handle_), objlist(handle), handle_data(handle_data_) {}
 };
 
 namespace vvl {

--- a/layers/error_message/record_object.h
+++ b/layers/error_message/record_object.h
@@ -1,5 +1,5 @@
-/* Copyright (c) 2023 LunarG, Inc.
- * Copyright (c) 2023 Valve Corporation
+/* Copyright (c) 2023-2024 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "chassis/chassis_handle_data.h"
 #include "generated/error_location_helper.h"
 
 // Contains all information for each PreCallRecord / PostCallRecord function
@@ -25,9 +26,14 @@ struct RecordObject {
     VkResult result = VK_RESULT_MAX_ENUM;  // Not all items return a VkResult
     VkDeviceAddress device_address = 0;
 
-    RecordObject(vvl::Func command_) : location(Location(command_)) {}
-    RecordObject(vvl::Func command_, VkResult result_) : location(Location(command_)), result(result_) {}
-    RecordObject(vvl::Func command_, VkDeviceAddress device_address_) : location(Location(command_)), device_address(device_address_) {}
+    const chassis::HandleData* handle_data;
+
+    RecordObject(vvl::Func command_, const chassis::HandleData* handle_data_ = nullptr)
+        : location(Location(command_)), handle_data(handle_data_) {}
+    RecordObject(vvl::Func command_, VkResult result_, const chassis::HandleData* handle_data_ = nullptr)
+        : location(Location(command_)), result(result_), handle_data(handle_data_) {}
+    RecordObject(vvl::Func command_, VkDeviceAddress device_address_, const chassis::HandleData* handle_data_ = nullptr)
+        : location(Location(command_)), device_address(device_address_), handle_data(handle_data_) {}
 
     bool HasResult() { return result != VK_RESULT_MAX_ENUM; }
 };

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -556,7 +556,7 @@ void gpu_tracker::Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
 
         // Record a global memory barrier to force availability of device memory operations to the host domain.
         VkCommandBufferBeginInfo command_buffer_begin_info = vku::InitStructHelper();
-        result = DispatchBeginCommandBuffer(barrier_command_buffer_, &command_buffer_begin_info);
+        result = DispatchBeginCommandBuffer(barrier_command_buffer_, &command_buffer_begin_info, false);
         if (result == VK_SUCCESS) {
             VkMemoryBarrier memory_barrier = vku::InitStructHelper();
             memory_barrier.srcAccessMask = VK_ACCESS_MEMORY_WRITE_BIT;

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -21,9 +21,8 @@ extern uint64_t object_track_index;
 // Object Status -- used to track state of individual objects
 typedef VkFlags ObjectStatusFlags;
 enum ObjectStatusFlagBits {
-    OBJSTATUS_NONE = 0x00000000,                      // No status is set
-    OBJSTATUS_COMMAND_BUFFER_SECONDARY = 0x00000001,  // Command Buffer is of type SECONDARY
-    OBJSTATUS_CUSTOM_ALLOCATOR = 0x00000002,          // Allocated with custom allocator
+    OBJSTATUS_NONE = 0x00000000,              // No status is set
+    OBJSTATUS_CUSTOM_ALLOCATOR = 0x00000002,  // Allocated with custom allocator
 };
 
 // Object and state information structure

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -194,11 +194,7 @@ void ObjectLifetimes::AllocateCommandBuffer(const VkCommandPool command_pool, co
     new_obj_node->object_type = kVulkanObjectTypeCommandBuffer;
     new_obj_node->handle = HandleToUint64(command_buffer);
     new_obj_node->parent_object = HandleToUint64(command_pool);
-    if (level == VK_COMMAND_BUFFER_LEVEL_SECONDARY) {
-        new_obj_node->status = OBJSTATUS_COMMAND_BUFFER_SECONDARY;
-    } else {
-        new_obj_node->status = OBJSTATUS_NONE;
-    }
+
     InsertObject(object_map[kVulkanObjectTypeCommandBuffer], command_buffer, kVulkanObjectTypeCommandBuffer, loc, new_obj_node);
     num_objects[kVulkanObjectTypeCommandBuffer]++;
     num_total_objects++;
@@ -628,7 +624,7 @@ bool ObjectLifetimes::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandB
         auto iter = object_map[kVulkanObjectTypeCommandBuffer].find(HandleToUint64(commandBuffer));
         if (iter != object_map[kVulkanObjectTypeCommandBuffer].end()) {
             auto node = iter->second;
-            if ((begin_info->pInheritanceInfo) && (node->status & OBJSTATUS_COMMAND_BUFFER_SECONDARY) &&
+            if ((begin_info->pInheritanceInfo) && error_obj.handle_data->command_buffer.is_secondary &&
                 (begin_info->flags & VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT)) {
                 const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
                 const Location inheritance_info_loc = begin_info_loc.dot(Field::pInheritanceInfo);

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -518,12 +518,6 @@ class StatelessValidation : public ValidationObject {
                                             const RecordObject &record_obj) override;
     void PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
                                          const RecordObject &record_obj) override;
-    void PostCallRecordAllocateCommandBuffers(VkDevice device, const VkCommandBufferAllocateInfo *pAllocateInfo,
-                                              VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) override;
-    void PostCallRecordFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
-                                          const VkCommandBuffer *pCommandBuffers, const RecordObject &record_obj) override;
-    void PostCallRecordDestroyCommandPool(VkDevice device, VkCommandPool commandPool, const VkAllocationCallbacks *pAllocator,
-                                          const RecordObject &record_obj) override;
     void GetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2 &pProperties) const;
     void PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,

--- a/layers/vulkan/generated/chassis_dispatch_helper.h
+++ b/layers/vulkan/generated/chassis_dispatch_helper.h
@@ -231,9 +231,6 @@ typedef enum InterceptId {
     InterceptIdPreCallValidateFreeCommandBuffers,
     InterceptIdPreCallRecordFreeCommandBuffers,
     InterceptIdPostCallRecordFreeCommandBuffers,
-    InterceptIdPreCallValidateBeginCommandBuffer,
-    InterceptIdPreCallRecordBeginCommandBuffer,
-    InterceptIdPostCallRecordBeginCommandBuffer,
     InterceptIdPreCallValidateEndCommandBuffer,
     InterceptIdPreCallRecordEndCommandBuffer,
     InterceptIdPostCallRecordEndCommandBuffer,
@@ -1966,9 +1963,6 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateFreeCommandBuffers);
     BUILD_DISPATCH_VECTOR(PreCallRecordFreeCommandBuffers);
     BUILD_DISPATCH_VECTOR(PostCallRecordFreeCommandBuffers);
-    BUILD_DISPATCH_VECTOR(PreCallValidateBeginCommandBuffer);
-    BUILD_DISPATCH_VECTOR(PreCallRecordBeginCommandBuffer);
-    BUILD_DISPATCH_VECTOR(PostCallRecordBeginCommandBuffer);
     BUILD_DISPATCH_VECTOR(PreCallValidateEndCommandBuffer);
     BUILD_DISPATCH_VECTOR(PreCallRecordEndCommandBuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordEndCommandBuffer);

--- a/layers/vulkan/generated/layer_chassis_dispatch.h
+++ b/layers/vulkan/generated/layer_chassis_dispatch.h
@@ -165,7 +165,7 @@ VkResult DispatchAllocateCommandBuffers(VkDevice device, const VkCommandBufferAl
                                         VkCommandBuffer* pCommandBuffers);
 void DispatchFreeCommandBuffers(VkDevice device, VkCommandPool commandPool, uint32_t commandBufferCount,
                                 const VkCommandBuffer* pCommandBuffers);
-VkResult DispatchBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo);
+VkResult DispatchBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo, bool is_secondary);
 VkResult DispatchEndCommandBuffer(VkCommandBuffer commandBuffer);
 VkResult DispatchResetCommandBuffer(VkCommandBuffer commandBuffer, VkCommandBufferResetFlags flags);
 void DispatchCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline);

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -103,6 +103,11 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
         # List of all extension structs strings containing handles
         self.ndo_extension_structs = []
 
+        # Dispatch functions that need special state tracking variables passed in
+        self.custom_definition = {
+            'vkBeginCommandBuffer' : ', bool is_secondary'
+        }
+
     def isNonDispatchable(self, name: str) -> bool:
         return name in self.vk.handles and not self.vk.handles[name].dispatchable
 
@@ -167,6 +172,8 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             prototype = command.cPrototype
             prototype = prototype.replace("VKAPI_ATTR ", "")
             prototype = prototype.replace("VKAPI_CALL vk", "Dispatch")
+            if command.name in self.custom_definition:
+                prototype = prototype.replace(');', f'{self.custom_definition[command.name]});')
             out.extend(guard_helper.add_guard(command.protect))
             out.append(f'{prototype}\n')
         out.extend(guard_helper.add_guard(None))

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -716,3 +716,19 @@ TEST_F(PositiveCommand, DeviceLost) {
         GTEST_SKIP() << "No device lost found";
     }
 }
+
+TEST_F(PositiveCommand, CommandBufferInheritanceInfoIgnoredPointer) {
+    TEST_DESCRIPTION("VkCommandBufferInheritanceInfo is ignored if using a primary command buffer.");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    const uint64_t fake_address_64 = 0xCDCDCDCDCDCDCDCD;
+    const uint64_t fake_address_32 = 0xCDCDCDCD;
+    const void *undereferencable_pointer =
+        sizeof(void *) == 8 ? reinterpret_cast<void *>(fake_address_64) : reinterpret_cast<void *>(fake_address_32);
+
+    VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
+    begin_info.pInheritanceInfo = reinterpret_cast<const VkCommandBufferInheritanceInfo *>(undereferencable_pointer);
+    m_commandBuffer->begin(&begin_info);
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
Currently we were tracking the command buffers for being secondary because in `VkCommandBufferBeginInfo` it says

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/2f6b2fd4-c418-4cae-9343-c80dea727882)

This is the first a few spots like this, so I created a `chassis::HandleData` object we can put into the `RecordObject`/`ErrorObject` to pass down this information

This basically provides a chassis-level way of doing state tracking, but only passing down the information we care about