### PR TITLE
layers: Refactor surface caps caching

### DIFF
--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -31,8 +31,8 @@ static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &creat
     if (vkuFormatIsColor(format) || vkuFormatIsMultiplane(format) || GetExternalFormat(create_info.pNext) != 0) {
         init_range.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;  // Normalization will expand this for multiplane
     } else {
-        init_range.aspectMask =
-            (vkuFormatHasDepth(format) ? VK_IMAGE_ASPECT_DEPTH_BIT : 0) | (vkuFormatHasStencil(format) ? VK_IMAGE_ASPECT_STENCIL_BIT : 0);
+        init_range.aspectMask = (vkuFormatHasDepth(format) ? VK_IMAGE_ASPECT_DEPTH_BIT : 0) |
+                                (vkuFormatHasStencil(format) ? VK_IMAGE_ASPECT_STENCIL_BIT : 0);
     }
     return NormalizeSubresourceRange(create_info, init_range);
 }
@@ -641,48 +641,26 @@ bool Surface::GetQueueSupport(VkPhysicalDevice phys_dev, uint32_t qfi) const {
 // Save data from vkGetPhysicalDeviceSurfacePresentModes
 void Surface::SetPresentModes(VkPhysicalDevice phys_dev, vvl::span<const VkPresentModeKHR> modes) {
     auto guard = Lock();
-    assert(phys_dev);
-    for (auto new_present_mode : modes) {
-        if ((present_modes_data_.find(phys_dev) == present_modes_data_.end()) ||
-            (present_modes_data_[phys_dev].find(new_present_mode) == present_modes_data_[phys_dev].end())) {
-            present_modes_data_[phys_dev][new_present_mode] = std::nullopt;
-        }
-    }
+    cache_[phys_dev].present_modes.emplace(modes.begin(), modes.end());
 }
 
 // Helper for data obtained from vkGetPhysicalDeviceSurfacePresentModesKHR
 std::vector<VkPresentModeKHR> Surface::GetPresentModes(VkPhysicalDevice phys_dev, const Location &loc,
                                                        const ValidationObject *validation_obj) const {
-    auto guard = Lock();
-    assert(phys_dev);
-    std::vector<VkPresentModeKHR> result;
-    if (auto search = present_modes_data_.find(phys_dev); search != present_modes_data_.end()) {
-        for (auto mode = search->second.begin(); mode != search->second.end(); mode++) {
-            result.push_back(mode->first);
+    if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
+        if (cache->present_modes.has_value()) {
+            return cache->present_modes.value();
         }
-        return result;
     }
-
-    const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
-        if (validation_obj) {
-            LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfacePresentModesKHR", err);
-        }
-    };
-
     uint32_t count = 0;
-    if (const VkResult err = DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, VkHandle(), &count, nullptr);
-        !IsValueIn(err, {VK_SUCCESS, VK_INCOMPLETE})) {
-        log_internal_error(err, phys_dev, VkHandle());
-        return result;
+    if (DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, VkHandle(), &count, nullptr) != VK_SUCCESS) {
+        return {};
     }
-    result.resize(count);
-    if (const VkResult err = DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, VkHandle(), &count, result.data());
-        err != VK_SUCCESS) {
-        log_internal_error(err, phys_dev, VkHandle());
-        return result;
+    std::vector<VkPresentModeKHR> present_modes(count);
+    if (DispatchGetPhysicalDeviceSurfacePresentModesKHR(phys_dev, VkHandle(), &count, present_modes.data()) != VK_SUCCESS) {
+        return {};
     }
-    return result;
+    return present_modes;
 }
 
 void Surface::SetFormats(VkPhysicalDevice phys_dev, std::vector<vku::safe_VkSurfaceFormat2KHR> &&fmts) {
@@ -692,36 +670,27 @@ void Surface::SetFormats(VkPhysicalDevice phys_dev, std::vector<vku::safe_VkSurf
 }
 
 vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                                  const void *surface_info2_pnext, const Location &loc,
-                                                                  const ValidationObject *validation_obj) const {
+                                                                   const void *surface_info2_pnext, const Location &loc,
+                                                                   const ValidationObject *validation_obj) const {
     auto guard = Lock();
-    assert(phys_dev);
 
+    // TODO: BUG: format also depends on pNext. Rework this function similar to GetSurfaceCapabilities
     if (const auto search = formats_.find(phys_dev); search != formats_.end()) {
         vvl::span<const vku::safe_VkSurfaceFormat2KHR>(search->second);
     }
 
     std::vector<vku::safe_VkSurfaceFormat2KHR> result;
     if (get_surface_capabilities2) {
-        const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
-            if (validation_obj) {
-                LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceFormats2KHR", err);
-            }
-        };
-
+        VkPhysicalDeviceSurfaceInfo2KHR surface_info2 = vku::InitStructHelper();
+        surface_info2.pNext = surface_info2_pnext;
+        surface_info2.surface = VkHandle();
         uint32_t count = 0;
-        const auto surface_info2 = GetSurfaceInfo2(surface_info2_pnext);
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, nullptr);
-            !IsValueIn(err, {VK_SUCCESS, VK_INCOMPLETE})) {
-            log_internal_error(err, phys_dev, surface_info2.surface);
-            return result;
+        if (DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, nullptr) != VK_SUCCESS) {
+            return {};
         }
         std::vector<VkSurfaceFormat2KHR> formats2(count, vku::InitStruct<VkSurfaceFormat2KHR>());
 
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, formats2.data());
-            err != VK_SUCCESS) {
-            log_internal_error(err, phys_dev, surface_info2.surface);
+        if (DispatchGetPhysicalDeviceSurfaceFormats2KHR(phys_dev, &surface_info2, &count, formats2.data()) != VK_SUCCESS) {
             result.clear();
         } else {
             result.resize(count);
@@ -729,27 +698,15 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
                 result.emplace_back(vku::safe_VkSurfaceFormat2KHR(&formats2[surface_format_index]));
             }
         }
-
     } else {
-        const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
-            if (validation_obj) {
-                LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-                validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceFormatsKHR", err);
-            }
-        };
-
         std::vector<VkSurfaceFormatKHR> formats;
         uint32_t count = 0;
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, VkHandle(), &count, nullptr);
-            !IsValueIn(err, {VK_SUCCESS, VK_INCOMPLETE})) {
-            log_internal_error(err, phys_dev, VkHandle());
-            return result;
+        if (DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, VkHandle(), &count, nullptr) != VK_SUCCESS) {
+            return {};
         }
         formats.resize(count);
 
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, VkHandle(), &count, formats.data());
-            err != VK_SUCCESS) {
-            log_internal_error(err, phys_dev, VkHandle());
+        if (DispatchGetPhysicalDeviceSurfaceFormatsKHR(phys_dev, VkHandle(), &count, formats.data()) != VK_SUCCESS) {
             result.clear();
         } else {
             result.reserve(count);
@@ -764,158 +721,131 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
     return vvl::span<const vku::safe_VkSurfaceFormat2KHR>(formats_[phys_dev]);
 }
 
-void Surface::SetCapabilities(VkPhysicalDevice phys_dev, const vku::safe_VkSurfaceCapabilities2KHR &caps) {
-    auto guard = Lock();
-    assert(phys_dev);
-    capabilities_[phys_dev] = caps;
+const Surface::PresentModeInfo *Surface::PhysDevCache::GetPresentModeInfo(VkPresentModeKHR present_mode) const {
+    for (auto &info : present_mode_infos) {
+        if (info.present_mode == present_mode) {
+            return &info;
+        }
+    }
+    return nullptr;
 }
 
-vku::safe_VkSurfaceCapabilities2KHR Surface::GetCapabilities(bool get_surface_capabilities2, VkPhysicalDevice phys_dev,
-                                                            const void *surface_info2_pnext, const Location &loc,
-                                                            const ValidationObject *validation_obj) const {
-    auto guard = Lock();
-    assert(phys_dev);
-
-    if (auto search = capabilities_.find(phys_dev); search != capabilities_.end()) {
-        return search->second;
-    }
-
-    const auto log_internal_error = [validation_obj, loc](VkResult err, auto &&...objects) {
-        if (validation_obj) {
-            LogObjectList obj_list(std::forward<decltype(objects)>(objects)...);
-            validation_obj->LogInternalError(VVL_PRETTY_FUNCTION, obj_list, loc, "vkGetPhysicalDeviceSurfaceCapabilities2KHR", err);
-        }
-    };
-
-    VkSurfaceCapabilities2KHR surface_caps2 = vku::InitStructHelper();
-    if (get_surface_capabilities2) {
-        const auto surface_info2 = GetSurfaceInfo2(surface_info2_pnext);
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info2, &surface_caps2);
-            err != VK_SUCCESS) {
-            log_internal_error(err, phys_dev, surface_info2.surface);
-        }
-    } else {
-        VkSurfaceCapabilitiesKHR caps{};
-        if (const VkResult err = DispatchGetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev, VkHandle(), &caps); err != VK_SUCCESS) {
-            log_internal_error(err, phys_dev, VkHandle());
-        }
-        surface_caps2.surfaceCapabilities = caps;
-    }
-    vku::safe_VkSurfaceCapabilities2KHR safe_surface_caps2(&surface_caps2);
-    capabilities_[phys_dev] = safe_surface_caps2;
-    return safe_surface_caps2;
+const Surface::PhysDevCache *Surface::GetPhysDevCache(VkPhysicalDevice phys_dev) const {
+    auto it = cache_.find(phys_dev);
+    return (it == cache_.end()) ? nullptr : &it->second;
 }
 
-void Surface::SetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                                 vvl::span<const VkPresentModeKHR> compatible_modes) {
+void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilitiesKHR &surface_caps) {
     auto guard = Lock();
-    assert(phys_dev);
+    cache_[phys_dev].capabilities = surface_caps;
+}
 
-    // If this surface or the present_mode is not in the map, or if the state structure has no value,
-    // create and add the new present_mode state structure for each of the compatible modes
-    auto surface_map = present_modes_data_.find(phys_dev);
-    if ((surface_map == present_modes_data_.end()) || (surface_map->second.find(present_mode) == surface_map->second.end()) ||
-        (surface_map->second.find(present_mode)->second.has_value() == false)) {
-        auto present_mode_state = std::make_shared<PresentModeState>();
-        present_mode_state->compatible_present_modes_.assign(compatible_modes.begin(), compatible_modes.end());
-
-        // For every present mode in compatible modes, add present_mode_state for it in present_modes_data_
-        for (auto mode : compatible_modes) {
-            present_modes_data_[phys_dev][mode] = present_mode_state;
+void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurfaceCapabilities2KHR &surface_caps,
+                                      VkPresentModeKHR present_mode) {
+    auto guard = Lock();
+    auto &cache = cache_[phys_dev];
+    PresentModeInfo *info = nullptr;
+    for (auto &cur_info : cache.present_mode_infos) {
+        if (cur_info.present_mode == present_mode) {
+            info = &cur_info;
+            break;
+        }
+    }
+    if (!info) {
+        cache.present_mode_infos.push_back(PresentModeInfo{});
+        info = &cache.present_mode_infos.back();
+        info->present_mode = present_mode;
+        info->surface_capabilities = surface_caps.surfaceCapabilities;
+    }
+    if (!info->scaling_capabilities.has_value()) {
+        const auto *present_scaling_caps = vku::FindStructInPNextChain<VkSurfacePresentScalingCapabilitiesEXT>(surface_caps.pNext);
+        if (present_scaling_caps) {
+            info->scaling_capabilities = *present_scaling_caps;
+        }
+    }
+    if (!info->compatible_present_modes.has_value()) {
+        const auto *compat_modes = vku::FindStructInPNextChain<VkSurfacePresentModeCompatibilityEXT>(surface_caps.pNext);
+        if (compat_modes && compat_modes->pPresentModes) {
+            info->compatible_present_modes.emplace(compat_modes->pPresentModes,
+                                                   compat_modes->pPresentModes + compat_modes->presentModeCount);
         }
     }
 }
 
-std::vector<VkPresentModeKHR> Surface::GetCompatibleModes(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode) const {
-    auto guard = Lock();
-    assert(phys_dev);
-    auto iter = present_modes_data_.find(phys_dev);
-    if ((iter != present_modes_data_.end()) && (iter->second.find(present_mode) != iter->second.end())) {
-        if (((iter->second)[present_mode]).has_value()) {
-            auto &compatible_modes = *(iter->second)[present_mode];
-            if (compatible_modes->compatible_present_modes_.empty()) {
-                return compatible_modes->compatible_present_modes_;
+VkSurfaceCapabilitiesKHR Surface::GetSurfaceCapabilities(VkPhysicalDevice phys_dev, const void *surface_info_pnext) const {
+    if (!surface_info_pnext) {
+        if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
+            if (cache->capabilities.has_value()) {
+                return cache->capabilities.value();
+            }
+        }
+        VkSurfaceCapabilitiesKHR surface_caps{};
+        DispatchGetPhysicalDeviceSurfaceCapabilitiesKHR(phys_dev, VkHandle(), &surface_caps);
+        return surface_caps;
+    }
+
+    // Per present mode caching is supported for a common case when pNext chain is a single VkSurfacePresentModeEXT structure.
+    const auto *surface_present_mode = vku::FindStructInPNextChain<VkSurfacePresentModeEXT>(surface_info_pnext);
+    const bool single_pnext_element = static_cast<const VkBaseInStructure *>(surface_info_pnext)->pNext == nullptr;
+    if (surface_present_mode && single_pnext_element) {
+        if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
+            const PresentModeInfo *info = cache->GetPresentModeInfo(surface_present_mode->presentMode);
+            if (info) {
+                return info->surface_capabilities;
             }
         }
     }
-
-    // Compatible modes not in state tracker, call to get compatible modes
-    std::vector<VkPresentModeKHR> result;
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
+    surface_info.pNext = surface_info_pnext;
     surface_info.surface = VkHandle();
-    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
-    surface_present_mode.presentMode = present_mode;
-    surface_info.pNext = &surface_present_mode;
-    VkSurfacePresentModeCompatibilityEXT present_mode_compatibility = vku::InitStructHelper();
-    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
-    surface_capabilities.pNext = &present_mode_compatibility;
-    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
-    result.resize(present_mode_compatibility.presentModeCount);
-    present_mode_compatibility.pPresentModes = result.data();
-    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
-    return result;
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
+    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_caps);
+    return surface_caps.surfaceCapabilities;
 }
 
-// Set the surface and scaling caps for this present mode
-void Surface::SetPresentModeCapabilities(VkPhysicalDevice phys_dev, const VkPresentModeKHR present_mode,
-                                         const VkSurfaceCapabilitiesKHR &caps,
-                                         const VkSurfacePresentScalingCapabilitiesEXT &scaling_caps) {
-    auto guard = Lock();
-    assert(phys_dev);
-    if (!present_modes_data_[phys_dev][present_mode].has_value()) {
-        present_modes_data_[phys_dev][present_mode] = std::make_shared<PresentModeState>();
-    }
-    auto &present_mode_state = present_modes_data_[phys_dev][present_mode].value();
-    present_mode_state->scaling_capabilities_ = scaling_caps;
-    present_mode_state->surface_capabilities_ = caps;
-}
-
-// Get the surface caps this particular present mode
 VkSurfaceCapabilitiesKHR Surface::GetPresentModeSurfaceCapabilities(VkPhysicalDevice phys_dev,
-                                                                    const VkPresentModeKHR present_mode) const {
-    auto iter = present_modes_data_.find(phys_dev);
-    if ((iter != present_modes_data_.end()) && (iter->second.find(present_mode) != iter->second.end())) {
-        auto const caps = (iter->second)[present_mode];
-        if (caps.has_value()) {
-            auto &surface_caps = *caps;
-            return surface_caps->surface_capabilities_;
-        }
-    }
-
-    // Present mode surface capabilties not in state tracker, call to get surface capabilities
-    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
-    surface_info.surface = VkHandle();
+                                                                    VkPresentModeKHR present_mode) const {
     VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
-    surface_info.pNext = &surface_present_mode;
-    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
-    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
-    return surface_capabilities.surfaceCapabilities;
+    return GetSurfaceCapabilities(phys_dev, &surface_present_mode);
 }
 
-// Get the scaling capabilities for this particular present mode
 VkSurfacePresentScalingCapabilitiesEXT Surface::GetPresentModeScalingCapabilities(VkPhysicalDevice phys_dev,
-                                                                                  const VkPresentModeKHR present_mode) const {
-    auto iter = present_modes_data_.find(phys_dev);
-    if ((iter != present_modes_data_.end()) && (iter->second.find(present_mode) != iter->second.end())) {
-        auto const &caps = (iter->second)[present_mode];
-        if (caps.has_value()) {
-            auto &scaling_caps = *caps;
-            return scaling_caps->scaling_capabilities_;
+                                                                                  VkPresentModeKHR present_mode) const {
+    if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
+        const PresentModeInfo *info = cache->GetPresentModeInfo(present_mode);
+        if (info && info->scaling_capabilities.has_value()) {
+            return info->scaling_capabilities.value();
         }
     }
-
-    // Present mode scaling capabilties not in state tracker, call to get scaling capabilities
-    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
-    surface_info.surface = VkHandle();
     VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
-    surface_info.pNext = &surface_present_mode;
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&surface_present_mode);
+    surface_info.surface = VkHandle();
     VkSurfacePresentScalingCapabilitiesEXT scaling_caps = vku::InitStructHelper();
-    VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
-    surface_capabilities.pNext = &scaling_caps;
-    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_capabilities);
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper(&scaling_caps);
+    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_caps);
     return scaling_caps;
+}
+
+std::vector<VkPresentModeKHR> Surface::GetCompatibleModes(VkPhysicalDevice phys_dev, VkPresentModeKHR present_mode) const {
+    if (auto guard = Lock(); auto cache = GetPhysDevCache(phys_dev)) {
+        const PresentModeInfo *info = cache->GetPresentModeInfo(present_mode);
+        if (info && info->compatible_present_modes.has_value()) {
+            return info->compatible_present_modes.value();
+        }
+    }
+    VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
+    surface_present_mode.presentMode = present_mode;
+    VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper(&surface_present_mode);
+    surface_info.surface = VkHandle();
+    VkSurfacePresentModeCompatibilityEXT present_mode_compat = vku::InitStructHelper();
+    VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper(&present_mode_compat);
+    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_caps);
+    std::vector<VkPresentModeKHR> present_modes(present_mode_compat.presentModeCount);
+    present_mode_compat.pPresentModes = present_modes.data();
+    DispatchGetPhysicalDeviceSurfaceCapabilities2KHR(phys_dev, &surface_info, &surface_caps);
+    return present_modes;
 }
 
 }  // namespace vvl

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -22,6 +22,10 @@
 #include <android_native_app_glue.h>
 #endif
 
+#if defined(VK_USE_PLATFORM_WAYLAND_KHR)
+#include "wayland-client.h"
+#endif
+
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
@@ -646,6 +650,19 @@ class WsiTest : public VkLayerTest {
     // most tests need images in VK_IMAGE_LAYOUT_PRESENT_SRC_KHR layout
     void SetImageLayoutPresentSrc(VkImage image);
     VkImageMemoryBarrier TransitionToPresent(VkImage swapchain_image, VkImageLayout old_layout, VkAccessFlags src_access_mask);
+
+  protected:
+#ifdef VK_USE_PLATFORM_WAYLAND_KHR
+    struct WaylandContext {
+        wl_display *display = nullptr;
+        wl_registry *registry = nullptr;
+        wl_surface *surface = nullptr;
+        wl_compositor *compositor = nullptr;
+    };
+    void InitWaylandContext(WaylandContext& context);
+    void ReleaseWaylandContext(WaylandContext& context);
+#endif
+
 };
 class NegativeWsi : public WsiTest {};
 class PositiveWsi : public WsiTest {};


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7786 (tested on Granite renderer).

This reworks surface capabilities caching. The result of a surface caps query depends on the surface info's pNext chain, each element can affect results. This solution caches data for two types of queries: surface info's pNext is a) null or b) a single `VkSurfacePresentModeEXT` structure. For other types of pNext chains caching is not performed and corresponding queries will skip the cache and run regular Vulkan API calls.
