### PR TITLE
scripts: Add InterceptId where possible

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -832,7 +832,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(VkDevice device, const VkPip
     chassis::CreatePipelineLayout chassis_state{};
     chassis_state.modified_create_info = *pCreateInfo;
 
-    for (const ValidationObject* intercept : layer_data->object_dispatch) {
+    for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreatePipelineLayout]) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
@@ -847,7 +847,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(VkDevice device, const VkPip
     VkResult result = DispatchCreatePipelineLayout(device, &chassis_state.modified_create_info, pAllocator, pPipelineLayout);
     record_obj.result = result;
 
-    for (ValidationObject* intercept : layer_data->object_dispatch) {
+    for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordCreatePipelineLayout]) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, record_obj);
     }
@@ -946,7 +946,7 @@ VKAPI_ATTR VkResult VKAPI_CALL AllocateDescriptorSets(VkDevice device, const VkD
     }
 
     RecordObject record_obj(vvl::Func::vkAllocateDescriptorSets);
-    for (ValidationObject* intercept : layer_data->object_dispatch) {
+    for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordAllocateDescriptorSets]) {
         auto lock = intercept->WriteLock();
         intercept->PreCallRecordAllocateDescriptorSets(device, pAllocateInfo, pDescriptorSets, record_obj);
     }
@@ -972,7 +972,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     chassis::CreateBuffer chassis_state{};
     chassis_state.modified_create_info = *pCreateInfo;
 
-    for (const ValidationObject* intercept : layer_data->object_dispatch) {
+    for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateBuffer]) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
@@ -987,7 +987,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     VkResult result = DispatchCreateBuffer(device, &chassis_state.modified_create_info, pAllocator, pBuffer);
     record_obj.result = result;
 
-    for (ValidationObject* intercept : layer_data->object_dispatch) {
+    for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordCreateBuffer]) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, record_obj);
     }
@@ -1005,14 +1005,14 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer,
 
     ErrorObject error_obj(vvl::Func::vkBeginCommandBuffer, VulkanTypedHandle(commandBuffer, kVulkanObjectTypeCommandBuffer),
                           &handle_data);
-    for (const ValidationObject* intercept : layer_data->object_dispatch) {
+    for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateBeginCommandBuffer]) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateBeginCommandBuffer(commandBuffer, pBeginInfo, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
 
     RecordObject record_obj(vvl::Func::vkBeginCommandBuffer, &handle_data);
-    for (ValidationObject* intercept : layer_data->object_dispatch) {
+    for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallRecordBeginCommandBuffer]) {
         auto lock = intercept->WriteLock();
         intercept->PreCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo, record_obj);
     }
@@ -1020,7 +1020,7 @@ VKAPI_ATTR VkResult VKAPI_CALL BeginCommandBuffer(VkCommandBuffer commandBuffer,
     VkResult result = DispatchBeginCommandBuffer(commandBuffer, pBeginInfo, handle_data.command_buffer.is_secondary);
     record_obj.result = result;
 
-    for (ValidationObject* intercept : layer_data->object_dispatch) {
+    for (ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPostCallRecordBeginCommandBuffer]) {
         auto lock = intercept->WriteLock();
         intercept->PostCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo, record_obj);
     }

--- a/layers/vulkan/generated/chassis_dispatch_helper.h
+++ b/layers/vulkan/generated/chassis_dispatch_helper.h
@@ -129,6 +129,8 @@ typedef enum InterceptId {
     InterceptIdPreCallValidateGetQueryPoolResults,
     InterceptIdPreCallRecordGetQueryPoolResults,
     InterceptIdPostCallRecordGetQueryPoolResults,
+    InterceptIdPreCallValidateCreateBuffer,
+    InterceptIdPostCallRecordCreateBuffer,
     InterceptIdPreCallValidateDestroyBuffer,
     InterceptIdPreCallRecordDestroyBuffer,
     InterceptIdPostCallRecordDestroyBuffer,
@@ -171,6 +173,8 @@ typedef enum InterceptId {
     InterceptIdPreCallValidateDestroyPipeline,
     InterceptIdPreCallRecordDestroyPipeline,
     InterceptIdPostCallRecordDestroyPipeline,
+    InterceptIdPreCallValidateCreatePipelineLayout,
+    InterceptIdPostCallRecordCreatePipelineLayout,
     InterceptIdPreCallValidateDestroyPipelineLayout,
     InterceptIdPreCallRecordDestroyPipelineLayout,
     InterceptIdPostCallRecordDestroyPipelineLayout,
@@ -195,6 +199,7 @@ typedef enum InterceptId {
     InterceptIdPreCallValidateResetDescriptorPool,
     InterceptIdPreCallRecordResetDescriptorPool,
     InterceptIdPostCallRecordResetDescriptorPool,
+    InterceptIdPreCallRecordAllocateDescriptorSets,
     InterceptIdPreCallValidateFreeDescriptorSets,
     InterceptIdPreCallRecordFreeDescriptorSets,
     InterceptIdPostCallRecordFreeDescriptorSets,
@@ -231,6 +236,9 @@ typedef enum InterceptId {
     InterceptIdPreCallValidateFreeCommandBuffers,
     InterceptIdPreCallRecordFreeCommandBuffers,
     InterceptIdPostCallRecordFreeCommandBuffers,
+    InterceptIdPreCallValidateBeginCommandBuffer,
+    InterceptIdPreCallRecordBeginCommandBuffer,
+    InterceptIdPostCallRecordBeginCommandBuffer,
     InterceptIdPreCallValidateEndCommandBuffer,
     InterceptIdPreCallRecordEndCommandBuffer,
     InterceptIdPostCallRecordEndCommandBuffer,
@@ -1861,6 +1869,8 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateGetQueryPoolResults);
     BUILD_DISPATCH_VECTOR(PreCallRecordGetQueryPoolResults);
     BUILD_DISPATCH_VECTOR(PostCallRecordGetQueryPoolResults);
+    BUILD_DISPATCH_VECTOR(PreCallValidateCreateBuffer);
+    BUILD_DISPATCH_VECTOR(PostCallRecordCreateBuffer);
     BUILD_DISPATCH_VECTOR(PreCallValidateDestroyBuffer);
     BUILD_DISPATCH_VECTOR(PreCallRecordDestroyBuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordDestroyBuffer);
@@ -1903,6 +1913,8 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipeline);
     BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipeline);
     BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipeline);
+    BUILD_DISPATCH_VECTOR(PreCallValidateCreatePipelineLayout);
+    BUILD_DISPATCH_VECTOR(PostCallRecordCreatePipelineLayout);
     BUILD_DISPATCH_VECTOR(PreCallValidateDestroyPipelineLayout);
     BUILD_DISPATCH_VECTOR(PreCallRecordDestroyPipelineLayout);
     BUILD_DISPATCH_VECTOR(PostCallRecordDestroyPipelineLayout);
@@ -1927,6 +1939,7 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateResetDescriptorPool);
     BUILD_DISPATCH_VECTOR(PreCallRecordResetDescriptorPool);
     BUILD_DISPATCH_VECTOR(PostCallRecordResetDescriptorPool);
+    BUILD_DISPATCH_VECTOR(PreCallRecordAllocateDescriptorSets);
     BUILD_DISPATCH_VECTOR(PreCallValidateFreeDescriptorSets);
     BUILD_DISPATCH_VECTOR(PreCallRecordFreeDescriptorSets);
     BUILD_DISPATCH_VECTOR(PostCallRecordFreeDescriptorSets);
@@ -1963,6 +1976,9 @@ void ValidationObject::InitObjectDispatchVectors() {
     BUILD_DISPATCH_VECTOR(PreCallValidateFreeCommandBuffers);
     BUILD_DISPATCH_VECTOR(PreCallRecordFreeCommandBuffers);
     BUILD_DISPATCH_VECTOR(PostCallRecordFreeCommandBuffers);
+    BUILD_DISPATCH_VECTOR(PreCallValidateBeginCommandBuffer);
+    BUILD_DISPATCH_VECTOR(PreCallRecordBeginCommandBuffer);
+    BUILD_DISPATCH_VECTOR(PostCallRecordBeginCommandBuffer);
     BUILD_DISPATCH_VECTOR(PreCallValidateEndCommandBuffer);
     BUILD_DISPATCH_VECTOR(PreCallRecordEndCommandBuffer);
     BUILD_DISPATCH_VECTOR(PostCallRecordEndCommandBuffer);


### PR DESCRIPTION
I noticed in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7817 that we have a single "manual function" for the chassis logic but we only need a subset for the `chassis_dispatch_helper.h` file because it has some functions that can still make use of the `intercept_vectors`