### PR TITLE
layers: Move UNASSIGNED to Warning

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -296,9 +296,10 @@ VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL GetDeviceProcAddr(VkDevice device, cons
     if (item != name_to_funcptr_map.end()) {
         if (item->second.function_type != kFuncTypeDev) {
             Location loc(vvl::Func::vkGetDeviceProcAddr);
-            // VUID being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6583
-            layer_data->LogError("UNASSIGNED-vkGetDeviceProcAddr-device", device, loc.dot(vvl::Field::pName),
-                                 "is trying to grab %s which is an instance level function", funcName);
+            // Was discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6583
+            // This has "valid" behavior to return null, but still worth warning users for this unqiue function
+            layer_data->LogWarning("WARNING-vkGetDeviceProcAddr-device", device, loc.dot(vvl::Field::pName),
+                                   "is trying to grab %s which is an instance level function", funcName);
             return nullptr;
         } else {
             return reinterpret_cast<PFN_vkVoidFunction>(item->second.funcptr);

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -969,9 +969,10 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 if (item != name_to_funcptr_map.end()) {
                     if (item->second.function_type != kFuncTypeDev) {
                         Location loc(vvl::Func::vkGetDeviceProcAddr);
-                        // VUID being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6583
-                        layer_data->LogError("UNASSIGNED-vkGetDeviceProcAddr-device", device, loc.dot(vvl::Field::pName),
-                                            "is trying to grab %s which is an instance level function", funcName);
+                        // Was discussed in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6583
+                        // This has "valid" behavior to return null, but still worth warning users for this unqiue function
+                        layer_data->LogWarning("WARNING-vkGetDeviceProcAddr-device", device, loc.dot(vvl::Field::pName),
+                                               "is trying to grab %s which is an instance level function", funcName);
                         return nullptr;
                     } else {
                         return reinterpret_cast<PFN_vkVoidFunction>(item->second.funcptr);

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -224,7 +224,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrNullPtr) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr on an enabled instance extension expecting nullptr");
     AddRequiredExtensions(VK_KHR_SURFACE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    m_errorMonitor->SetAllowedFailureMsg("UNASSIGNED-vkGetDeviceProcAddr-device");
+    m_errorMonitor->SetAllowedFailureMsg("WARNING-vkGetDeviceProcAddr-device");
     auto fpDestroySurface = (PFN_vkCreateValidationCacheEXT)vk::GetDeviceProcAddr(device(), "vkDestroySurfaceKHR");
     if (fpDestroySurface) {
         m_errorMonitor->SetError("Null was expected!");

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -2055,7 +2055,7 @@ TEST_F(VkLayerTest, Features11WithoutVulkan12) {
 TEST_F(VkLayerTest, GetDeviceProcAddrInstance) {
     TEST_DESCRIPTION("Call GetDeviceProcAddr on an instance function");
     RETURN_IF_SKIP(Init());
-    m_errorMonitor->SetDesiredError("UNASSIGNED-vkGetDeviceProcAddr-device");
+    m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "WARNING-vkGetDeviceProcAddr-device");
     vk::GetDeviceProcAddr(device(), "vkGetPhysicalDeviceProperties");
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
was discussed today in WG call

This should be a warning since this table shows it returns null

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/c712d460-dc5f-4234-8828-7fbec7e0290f)
