### PR TITLE
Add vuid 09382, validate render pass contents

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -170,7 +170,7 @@ class CoreChecks : public ValidationStateTracker {
                                                   const VulkanTypedHandle& typed_handle, uint32_t src_queue_family,
                                                   uint32_t dst_queue_family);
     bool ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
-                                    const ErrorObject& error_obj) const;
+                                    VkSubpassContents contents, const ErrorObject& error_obj) const;
     bool ValidateDependencies(const vvl::Framebuffer& framebuffer_state, const vvl::RenderPass& render_pass_state,
                               const ErrorObject& error_obj) const;
     bool ValidateBufferBarrier(const LogObjectList& objlist, const Location& barrier_loc, const vvl::CommandBuffer& cb_state,

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -4312,3 +4312,21 @@ TEST_F(NegativeRenderPass, RenderPassWithRenderPassStripedQueueSubmit2) {
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature) {
+    TEST_DESCRIPTION("Use VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT when nextedCommandBuffers is not enabled");
+
+    AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    auto subpassBeginInfo =
+        vku::InitStruct<VkSubpassBeginInfoKHR>(nullptr, VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT);
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredError("VUID-VkSubpassBeginInfo-contents-09382");
+    vk::CmdBeginRenderPass2KHR(m_commandBuffer->handle(), &m_renderPassBeginInfo, &subpassBeginInfo);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}


### PR DESCRIPTION
This PR adds validation for `VUID-VkSubpassBeginInfo-contents-09382`, which is for `vkCmdBeginRenderPass2`, but a similar VUID for `vkCmdBeginRenderPass` seems to be missing from the spec