### PR TITLE
layers: Add explanation why to cache surface caps

### DIFF
--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -437,6 +437,17 @@ class Surface : public StateObject {
         std::optional<std::vector<VkPresentModeKHR>> compatible_present_modes;
     };
     // Cached information per physical device. Optional indicates if element is in the cache.
+    //
+    // NOTE: One of the reasons to cache surface caps is to prevent a false-positive
+    // when the surface change happens (e.g. resize) after the surface caps are queried
+    // and before the swapchain is created. The assumption is that with the current API,
+    // the app can't do better than this (no atomicity between query and swapchain creation).
+    // The caching ensures that validation sees the same surface state as the application.
+    //
+    // The priority is to avoid false-positives for correctly written application.
+    // When the application behaves incorrectly (e.g. forgets to query surface caps after
+    // it processed the resize event), then the caching can hide a problem, since validation
+    // will think that application respects surface caps values.
     struct PhysDevCache {
         std::optional<std::vector<VkPresentModeKHR>> present_modes;
         std::optional<VkSurfaceCapabilitiesKHR> capabilities;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4057,8 +4057,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceCapabilities2
             if (surface_present_mode) {
                 // The surface caps caching should take into account pSurfaceInfo->pNext chain structure,
                 // because each pNext element can affect query result. Here we support caching for a common
-                // case when pNext chain is a single VkSurfacePresentModeEXT structure. Surface queries are
-                // not high frequency operations, disabling caching alltogether might be an option too.
+                // case when pNext chain is a single VkSurfacePresentModeEXT structure.
                 const bool single_pnext_element = (pSurfaceInfo->pNext == surface_present_mode) && !surface_present_mode->pNext;
                 if (single_pnext_element) {
                     surface_state->UpdateCapabilitiesCache(physicalDevice, *pSurfaceCapabilities,


### PR DESCRIPTION
Based on this comment and the following discussion: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7820#discussion_r1559123395

@spencer-lunarg @Eearslya please let me know if this explanation makes sense.
