### PR TITLE
layers: Create a core::CommandBuffer

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -146,6 +146,8 @@ vvl_sources = [
   "layers/core_checks/cc_shader_interface.cpp",
   "layers/core_checks/cc_shader_object.cpp",
   "layers/core_checks/cc_spirv.cpp",
+  "layers/core_checks/cc_state_tracker.h",
+  "layers/core_checks/cc_state_tracker.cpp",
   "layers/core_checks/cc_synchronization.cpp",
   "layers/core_checks/cc_video.cpp",
   "layers/core_checks/cc_vuid_maps.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -169,6 +169,8 @@ target_sources(vvl PRIVATE
     core_checks/cc_spirv.cpp
     core_checks/cc_shader_interface.cpp
     core_checks/cc_shader_object.cpp
+    core_checks/cc_state_tracker.h
+    core_checks/cc_state_tracker.cpp
     core_checks/cc_synchronization.cpp
     core_checks/cc_video.cpp
     core_checks/cc_vuid_maps.cpp

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -1,0 +1,61 @@
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (C) 2022 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc_state_tracker.h"
+#include "core_validation.h"
+
+core::CommandBuffer::CommandBuffer(CoreChecks& core, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
+                                   const vvl::CommandPool* pool)
+    : vvl::CommandBuffer(core, handle, pCreateInfo, pool) {}
+
+// Much of the data stored in vvl::CommandBuffer is only used by core validation, and is
+// set up by Record calls in class CoreChecks. Because both the state tracker and
+// core methods must lock vvl::CommandBuffer, it is possible for a Validate call to
+// 'interrupt' a Record call and get only the state updated by whichever code
+// locked and unlocked the CB first. This can only happen if the application
+// is violating section 3.6 'Threading Behavior' of the specification, which
+// requires that command buffers be externally synchronized. Still, we'd prefer
+// not to crash if that happens. In most cases the core Record method is operating
+// on separate data members from the state tracker. But in the case of vkCmdWaitEvents*,
+// both methods operate on the same state in ways that could very easily crash if
+// not done within the same lock guard. Overriding RecordWaitEvents() allows
+// this to all happen completely while the state tracker is holding the lock.
+// Eventually we'll probably want to move all of the core state into this derived
+// class.
+void core::CommandBuffer::RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
+                                           VkPipelineStageFlags2KHR srcStageMask) {
+    // vvl::CommandBuffer will add to the events vector.
+    auto first_event_index = events.size();
+    vvl::CommandBuffer::RecordWaitEvents(command, eventCount, pEvents, srcStageMask);
+    auto event_added_count = events.size() - first_event_index;
+    eventUpdates.emplace_back([command, event_added_count, first_event_index, srcStageMask](
+                                  vvl::CommandBuffer& cb_state, bool do_validate, EventToStageMap& local_event_signal_info,
+                                  VkQueue queue, const Location& loc) {
+        if (!do_validate) return false;
+        return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, srcStageMask,
+                                                      local_event_signal_info, queue, loc);
+    });
+}
+
+std::shared_ptr<vvl::CommandBuffer> CoreChecks::CreateCmdBufferState(VkCommandBuffer handle,
+                                                                     const VkCommandBufferAllocateInfo* create_info,
+                                                                     const vvl::CommandPool* pool) {
+    return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<core::CommandBuffer>(*this, handle, create_info, pool));
+}

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -1,0 +1,38 @@
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
+ * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
+ * Modifications Copyright (C) 2022 RasterGrid Kft.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "state_tracker/state_tracker.h"
+#include "state_tracker/cmd_buffer_state.h"
+
+namespace core {
+
+// CommandBuffer is over 3 times larger than the next largest state object struct, but the majority of the state is only used in
+// CoreChecks. This state object is used by everyone else (best practice, sync val, GPU-AV, etc). For this reason, we have
+// CommandBuffer object only for core and keep only the most basic items in the parent class
+class CommandBuffer : public vvl::CommandBuffer {
+  public:
+    CommandBuffer(CoreChecks& core, VkCommandBuffer handle, const VkCommandBufferAllocateInfo* pCreateInfo,
+                  const vvl::CommandPool* cmd_pool);
+
+    void RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
+                          VkPipelineStageFlags2KHR src_stage_mask) override;
+};
+
+}  // namespace core

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1158,21 +1158,6 @@ bool CoreChecks::PreCallValidateCmdWaitEvents2KHR(VkCommandBuffer commandBuffer,
     return PreCallValidateCmdWaitEvents2(commandBuffer, eventCount, pEvents, pDependencyInfos, error_obj);
 }
 
-void CORE_CMD_BUFFER_STATE::RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent *pEvents,
-                                             VkPipelineStageFlags2KHR srcStageMask) {
-    // vvl::CommandBuffer will add to the events vector.
-    auto first_event_index = events.size();
-    vvl::CommandBuffer::RecordWaitEvents(command, eventCount, pEvents, srcStageMask);
-    auto event_added_count = events.size() - first_event_index;
-    eventUpdates.emplace_back([command, event_added_count, first_event_index, srcStageMask](
-                                  vvl::CommandBuffer &cb_state, bool do_validate, EventToStageMap &local_event_signal_info,
-                                  VkQueue queue, const Location &loc) {
-        if (!do_validate) return false;
-        return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, srcStageMask,
-                                                      local_event_signal_info, queue, loc);
-    });
-}
-
 void CoreChecks::PreCallRecordCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent *pEvents,
                                             VkPipelineStageFlags sourceStageMask, VkPipelineStageFlags dstStageMask,
                                             uint32_t memoryBarrierCount, const VkMemoryBarrier *pMemoryBarriers,


### PR DESCRIPTION
Due to memory usage (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7387) the `CommandBuffer` state object should be broken up as everyone inherent a lot of  unnecessary data