### PR TITLE
gpu: Fix Descriptor Indexing assuming pipeline bound first

### DIFF
--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -279,6 +279,12 @@ void gpuav::Validator::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuff
     RecordCmdNextSubpassLayouts(commandBuffer, pSubpassBeginInfo->contents);
 }
 
+void gpuav::Validator::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
+                                                     VkPipeline pipeline, const RecordObject &record_obj) {
+    BaseClass::PostCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, record_obj);
+    UpdateBoundPipeline(commandBuffer, pipelineBindPoint, pipeline, record_obj.location);
+}
+
 void gpuav::Validator::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                            VkPipelineLayout layout, uint32_t firstSet, uint32_t descriptorSetCount,
                                                            const VkDescriptorSet *pDescriptorSets, uint32_t dynamicOffsetCount,

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -52,6 +52,8 @@ struct DescSetState {
 struct DescBindingInfo {
     VkBuffer bindless_state_buffer;
     VmaAllocation bindless_state_buffer_allocation;
+    // Hold a buffer for each descriptor set
+    // Note: The index here is from vkCmdBindDescriptorSets::firstSet
     std::vector<DescSetState> descriptor_set_buffers;
 };
 
@@ -81,7 +83,7 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
 
     bool PreProcess() final;
     void PostProcess(VkQueue queue, const Location &loc) final;
-    
+
     const VkDescriptorSetLayout &GetInstrumentationDescriptorSetLayout() const {
         assert(instrumentation_desc_set_layout_ != VK_NULL_HANDLE);
         return instrumentation_desc_set_layout_;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -113,6 +113,8 @@ class Validator : public gpu_tracker::Validator {
     void UpdateInstrumentationBuffer(CommandBuffer* cb_node);
     void UpdateBDABuffer(const Location& loc);
 
+    void UpdateBoundPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
+                             const Location& loc);
     void UpdateBoundDescriptors(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, const Location& loc);
 
     void BindDiagnosticCallsCommonDescSet(const LockedSharedPtr<CommandBuffer, WriteLockGuard>& cmd_buffer_state,
@@ -246,6 +248,8 @@ class Validator : public gpu_tracker::Validator {
     void PostCallRecordCmdEndRenderPass2(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                          const RecordObject& record_obj) override;
 
+    void PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint, VkPipeline pipeline,
+                                       const RecordObject& record_obj) override;
     void PostCallRecordCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
                                                  const VkBindDescriptorSetsInfoKHR* pBindDescriptorSetsInfo,
                                                  const RecordObject& record_obj) override;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1174,7 +1174,6 @@ void CommandBuffer::UpdatePipelineState(Func command, const VkPipelineBindPoint 
                 set_info.validated_set = descriptor_set.get();
                 set_info.validated_set_change_count = descriptor_set->GetChangeCount();
                 set_info.validated_set_image_layout_change_count = image_layout_change_count;
-                set_info.validated_set_binding_req_map = BindingVariableMap();
             }
         }
     }

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -660,7 +660,6 @@ struct LastBound {
         const vvl::DescriptorSet *validated_set{nullptr};
         uint64_t validated_set_change_count{~0ULL};
         uint64_t validated_set_image_layout_change_count{~0ULL};
-        BindingVariableMap validated_set_binding_req_map;
 
         void Reset() {
             bound_descriptor_set.reset();

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -666,9 +666,9 @@ TEST_F(NegativeGpuAV, ShareOpSampledImage) {
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(m_renderPassBeginInfo);
-    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
 
     if (!m_gpuav_disable_core) {
         m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdDraw-None-08610");


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7737

Before we only updated the `binding_req` (that part that maps the `OpVariable` from the pipeline to the `VkImage` in the descriptor set) at `vkCmdBindDescriptorSets` time, this caused the following to produce a false error

```
vkCmdBindPipeline(); // bad
vkCmdBindDescriptorSets();
vkCmdBindPipeline(); // good
vkCmdDraw()
```

This now updates the last `vkCmdBindDescriptorSets` if there is a `vkCmdBindPipeline` after it