### PR TITLE
layers: Unify all GPU-AV settings

### DIFF
--- a/docs/gpu_validation.md
+++ b/docs/gpu_validation.md
@@ -114,7 +114,7 @@ Shader code is instrumented to validate buffer_reference addresses and report an
 Note: The mapping between a `VkBuffer` and a GPU address is not necessarily one to one. For instance, if multiple `VkBuffer` are bound to the same memory region, they can have the same GPU address.
 
 ### Selective Shader Instrumentation
-With the khronos_validation.select_instrumented_shaders feature, an application can control which shaders are instrumented and thus, will return GPU-AV errors.
+With the khronos_validation.gpuav_select_instrumented_shaders feature, an application can control which shaders are instrumented and thus, will return GPU-AV errors.
 After enabling the feature, the application will need to include a `VkValidationFeaturesEXT` structure with `VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT` in the pEnabledFeatures list
 in the pNext chain of the VkShaderModuleCreateInfo used to create the shader. Otherwise, the shader will not be instrumented.
 

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -835,7 +835,7 @@
                                             }
                                         },
                                         {
-                                            "key": "vma_linear_output",
+                                            "key": "gpuav_vma_linear_output",
                                             "label": "Linear Memory Allocation Mode",
                                             "description": "Use VMA linear memory allocations for GPU-AV output buffers instead of finding best place for new allocations among free regions to optimize memory usage. Enabling this setting reduces performance cost but disabling this method minimizes memory usage.",
                                             "type": "BOOL",
@@ -876,7 +876,7 @@
                                             },
                                             "settings": [
                                                 {
-                                                    "key": "warn_on_robust_oob",
+                                                    "key": "gpuav_warn_on_robust_oob",
                                                     "label": "Generate warning on out of bounds accesses even if buffer robustness is enabled",
                                                     "description": "Warn on out of bounds accesses even if robustness is enabled",
                                                     "type": "BOOL",
@@ -958,7 +958,7 @@
                                             }
                                         },
                                         {
-                                            "key": "use_instrumented_shader_cache",
+                                            "key": "gpuav_cache_instrumented_shaders",
                                             "label": "Cache instrumented shaders rather than instrumenting them on every run",
                                             "description": "Enable instrumented shader caching",
                                             "type": "BOOL",
@@ -978,7 +978,7 @@
                                             }
                                         },
                                         {
-                                            "key": "select_instrumented_shaders",
+                                            "key": "gpuav_select_instrumented_shaders",
                                             "label": "Enable instrumenting shaders selectively",
                                             "description": "Select which shaders to instrument passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext",
                                             "type": "BOOL",

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -37,6 +37,7 @@ void debug_printf::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo
     use_stdout = printf_settings.to_stdout;
 
     // This option was published when Debug PrintF came out, leave to not break people's flow
+    // Deprecated right after the 1.3.280 SDK release
     if (!GetEnvironment("DEBUG_PRINTF_TO_STDOUT").empty()) {
         LogWarning("WARNING-DEBUG-PRINTF", device, loc,
                    "DEBUG_PRINTF_TO_STDOUT was set, this is deprecated, please use VK_LAYER_PRINTF_TO_STDOUT");

--- a/layers/gpu_validation/gpu_settings.h
+++ b/layers/gpu_validation/gpu_settings.h
@@ -25,10 +25,10 @@ struct GpuAVSettings {
     bool warn_on_robust_oob = true;
     bool cache_instrumented_shaders = true;
     bool select_instrumented_shaders = false;
-    uint32_t gpuav_max_buffer_device_addresses = 10000;
+    uint32_t max_buffer_device_addresses = 10000;
 
-    bool gpuav_debug_validate_instrumented_shaders = false;
-    bool gpuav_debug_dump_instrumented_shaders = false;
+    bool debug_validate_instrumented_shaders = false;
+    bool debug_dump_instrumented_shaders = false;
 };
 
 struct DebugPrintfSettings {

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -144,8 +144,8 @@ void gpuav::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const
         VkBufferCreateInfo buffer_info = vku::InitStructHelper();
         buffer_info.usage = VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
         VmaAllocationCreateInfo alloc_info = {};
-        app_bda_buffer_byte_size = (1  // 1 QWORD for the number of address ranges
-                                    + 2 * gpuav_settings.gpuav_max_buffer_device_addresses  // 2 QWORDS to hold an address range
+        app_bda_buffer_byte_size = (1                                                 // 1 QWORD for the number of address ranges
+                                    + 2 * gpuav_settings.max_buffer_device_addresses  // 2 QWORDS to hold an address range
                                     ) *
                                    8;  // 64 bit words
         buffer_info.size = app_bda_buffer_byte_size;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -125,7 +125,7 @@ bool gpuav::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, 
     binaries[0].reserve(input.size());
     binaries[0].insert(binaries[0].end(), &input.front(), &input.back() + 1);
 
-    if (gpuav_settings.gpuav_debug_dump_instrumented_shaders) {
+    if (gpuav_settings.debug_dump_instrumented_shaders) {
         std::string file_name = "dump_" + std::to_string(unique_shader_id) + "_before.spv";
         std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
         debug_file.write(reinterpret_cast<char *>(binaries[0].data()),
@@ -159,7 +159,7 @@ bool gpuav::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, 
 
     module.ToBinary(instrumented_spirv);
 
-    if (gpuav_settings.gpuav_debug_dump_instrumented_shaders) {
+    if (gpuav_settings.debug_dump_instrumented_shaders) {
         std::string file_name = "dump_" + std::to_string(unique_shader_id) + "_after.spv";
         std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
         debug_file.write(reinterpret_cast<char *>(instrumented_spirv.data()),
@@ -167,7 +167,7 @@ bool gpuav::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, 
     }
 
     // (Maybe) validate the instrumented and linked shader
-    if (gpuav_settings.gpuav_debug_validate_instrumented_shaders) {
+    if (gpuav_settings.debug_validate_instrumented_shaders) {
         std::string instrumented_error;
         if (!GpuValidateShader(instrumented_spirv, device_extensions.vk_khr_relaxed_block_layout,
                                device_extensions.vk_ext_scalar_block_layout, target_env, instrumented_error)) {
@@ -194,7 +194,7 @@ bool gpuav::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, 
             return false;
         }
 
-        if (gpuav_settings.gpuav_debug_dump_instrumented_shaders) {
+        if (gpuav_settings.debug_dump_instrumented_shaders) {
             std::string file_name = "dump_" + std::to_string(unique_shader_id) + "_opt.spv";
             std::ofstream debug_file(file_name, std::ios::out | std::ios::binary);
             debug_file.write(reinterpret_cast<char *>(instrumented_spirv.data()),
@@ -285,11 +285,11 @@ void gpuav::Validator::UpdateBDABuffer(const Location &loc) {
     const auto [ranges_to_update_count, total_address_ranges_count] = GetBufferAddressRanges(bda_ranges, max_recordable_ranges);
     bda_table_ptr[0] = ranges_to_update_count;
 
-    if (total_address_ranges_count > size_t(gpuav_settings.gpuav_max_buffer_device_addresses)) {
+    if (total_address_ranges_count > size_t(gpuav_settings.max_buffer_device_addresses)) {
         std::ostringstream problem_string;
         problem_string << "Number of buffer device addresses ranges in use (" << total_address_ranges_count
                        << ") is greater than khronos_validation.gpuav_max_buffer_device_addresses ("
-                       << gpuav_settings.gpuav_max_buffer_device_addresses
+                       << gpuav_settings.max_buffer_device_addresses
                        << "). Truncating buffer device address table could result in invalid validation";
         ReportSetupProblem(device, loc, problem_string.str().c_str());
     }

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -26,50 +26,63 @@
 #include "mimalloc-new-delete.h"
 #endif
 
-const char *SETTING_ENABLES = "enables";
-const char *SETTING_VALIDATE_BEST_PRACTICES = "validate_best_practices";
-const char *SETTING_VALIDATE_BEST_PRACTICES_ARM = "validate_best_practices_arm";
-const char *SETTING_VALIDATE_BEST_PRACTICES_AMD = "validate_best_practices_amd";
-const char *SETTING_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img";
-const char *SETTING_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
-const char *SETTING_VALIDATE_SYNC = "validate_sync";
-const char *SETTING_VALIDATE_GPU_BASED = "validate_gpu_based";
-const char *SETTING_RESERVE_BINDING_SLOT = "reserve_binding_slot";
+// To enable "my_setting",
+// Set env var VK_LAYER_MY_SETTING to 1
+//
+// The ["VK_LAYER_" + toUpper(key)] logic is don in vk_layer_setting (VUL)
+//
+// To quickly be able to find the env var corresponding to a setting,
+// the following `const char*` holding setting names match their corresponding environment variable
+const char *VK_LAYER_ENABLES = "enables";
+const char *VK_LAYER_VALIDATE_BEST_PRACTICES = "validate_best_practices";
+const char *VK_LAYER_VALIDATE_BEST_PRACTICES_ARM = "validate_best_practices_arm";
+const char *VK_LAYER_VALIDATE_BEST_PRACTICES_AMD = "validate_best_practices_amd";
+const char *VK_LAYER_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img";
+const char *VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
+const char *VK_LAYER_VALIDATE_SYNC = "validate_sync";
+const char *VK_LAYER_VALIDATE_GPU_BASED = "validate_gpu_based";
+const char *VK_LAYER_RESERVE_BINDING_SLOT = "reserve_binding_slot";
 
-const char *SETTING_DISABLES = "disables";
-const char *SETTING_STATELESS_PARAM = "stateless_param";
-const char *SETTING_THREAD_SAFETY = "thread_safety";
-const char *SETTING_VALIDATE_CORE = "validate_core";
-const char *SETTING_CHECK_COMMAND_BUFFER = "check_command_buffer";
-const char *SETTING_CHECK_OBJECT_IN_USE = "check_object_in_use";
-const char *SETTING_CHECK_QUERY = "check_query";
-const char *SETTING_CHECK_IMAGE_LAYOUT = "check_image_layout";
-const char *SETTING_UNIQUE_HANDLES = "unique_handles";
-const char *SETTING_OBJECT_LIFETIME = "object_lifetime";
-const char *SETTING_CHECK_SHADERS = "check_shaders";
-const char *SETTING_CHECK_SHADERS_CACHING = "check_shaders_caching";
-const char *SETTING_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
+const char *VK_LAYER_DISABLES = "disables";
+const char *VK_LAYER_STATELESS_PARAM = "stateless_param";
+const char *VK_LAYER_THREAD_SAFETY = "thread_safety";
+const char *VK_LAYER_VALIDATE_CORE = "validate_core";
+const char *VK_LAYER_CHECK_COMMAND_BUFFER = "check_command_buffer";
+const char *VK_LAYER_CHECK_OBJECT_IN_USE = "check_object_in_use";
+const char *VK_LAYER_CHECK_QUERY = "check_query";
+const char *VK_LAYER_CHECK_IMAGE_LAYOUT = "check_image_layout";
+const char *VK_LAYER_UNIQUE_HANDLES = "unique_handles";
+const char *VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
+const char *VK_LAYER_CHECK_SHADERS = "check_shaders";
+const char *VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
+const char *VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 
-const char *SETTING_MESSAGE_ID_FILTER = "message_id_filter";
-const char *SETTING_CUSTOM_STYPE_LIST = "custom_stype_list";
-const char *SETTING_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
-const char *SETTING_FINE_GRAINED_LOCKING = "fine_grained_locking";
+const char *VK_LAYER_MESSAGE_ID_FILTER = "message_id_filter";
+const char *VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
+const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
+const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
-const char *SETTING_PRINTF_TO_STDOUT = "printf_to_stdout";
-const char *SETTING_PRINTF_VERBOSE = "printf_verbose";
-const char *SETTING_PRINTF_BUFFER_SIZE = "printf_buffer_size";
+const char *VK_LAYER_PRINTF_TO_STDOUT = "printf_to_stdout";
+const char *VK_LAYER_PRINTF_VERBOSE = "printf_verbose";
+const char *VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
 
-const char *SETTING_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
-const char *SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
-const char *SETTING_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
-const char *SETTING_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
-const char *SETTING_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
-const char *SETTING_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
-const char *SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
-const char *SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS = "select_instrumented_shaders";
-const char *SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS = "gpuav_max_buffer_device_addresses";
-const char *SETTING_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
-const char *SETTING_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+const char *VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
+const char *VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
+const char *VK_LAYER_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
+const char *VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
+const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
+const char *VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB = "gpuav_warn_on_robust_oob";
+const char *VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS = "gpuav_cache_instrumented_shaders";
+const char *VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS = "gpuav_select_instrumented_shaders";
+const char *VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS = "gpuav_max_buffer_device_addresses";
+const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "debug_validate_instrumented_shaders";
+const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+
+// These were deprecated after the 1.3.280 SDK release
+const char *DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
+const char *DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
+const char *DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
+const char *DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS = "select_instrumented_shaders";
 
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
 void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDisables disable_id) {
@@ -360,111 +373,129 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
 
     // Read legacy "enables" flags for backward compatibility
     std::vector<std::string> enables;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_ENABLES)) {
-        vkuGetLayerSettingValues(layer_setting_set, SETTING_ENABLES, enables);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_ENABLES)) {
+        vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_ENABLES, enables);
     }
     const std::string &string_enables = Merge(enables);
     SetLocalEnableSetting(string_enables, ",", settings_data->enables);
 
     // Read legacy "disables" flags for backward compatibility
     std::vector<std::string> disables;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_DISABLES)) {
-        vkuGetLayerSettingValues(layer_setting_set, SETTING_DISABLES, disables);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DISABLES)) {
+        vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_DISABLES, disables);
     }
     const std::string &string_disables = Merge(disables);
     SetLocalDisableSetting(string_disables, ",", settings_data->disables);
 
     // Fine Grained Locking
     *settings_data->fine_grained_locking = true;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_FINE_GRAINED_LOCKING)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_FINE_GRAINED_LOCKING, *settings_data->fine_grained_locking);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING, *settings_data->fine_grained_locking);
     }
 
     // Message ID Filtering
     std::vector<std::string> message_id_filter;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_MESSAGE_ID_FILTER)) {
-        vkuGetLayerSettingValues(layer_setting_set, SETTING_MESSAGE_ID_FILTER, message_id_filter);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_ID_FILTER)) {
+        vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_MESSAGE_ID_FILTER, message_id_filter);
     }
     const std::string &string_message_id_filter = Merge(message_id_filter);
     CreateFilterMessageIdList(string_message_id_filter, ",", settings_data->message_filter_list);
 
     // Duplicate message limit
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_DUPLICATE_MESSAGE_LIMIT)) {
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DUPLICATE_MESSAGE_LIMIT)) {
         uint32_t config_limit_setting = 0;
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_DUPLICATE_MESSAGE_LIMIT, config_limit_setting);
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DUPLICATE_MESSAGE_LIMIT, config_limit_setting);
         if (config_limit_setting != 0) {
             *settings_data->duplicate_message_limit = config_limit_setting;
         }
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_CUSTOM_STYPE_LIST)) {
-        vkuGetLayerSettingValues(layer_setting_set, SETTING_CUSTOM_STYPE_LIST, custom_stype_info);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST)) {
+        vkuGetLayerSettingValues(layer_setting_set, VK_LAYER_CUSTOM_STYPE_LIST, custom_stype_info);
     }
 
     DebugPrintfSettings &printf_settings = *settings_data->printf_settings;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_TO_STDOUT)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_TO_STDOUT, printf_settings.to_stdout);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_PRINTF_TO_STDOUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_PRINTF_TO_STDOUT, printf_settings.to_stdout);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_VERBOSE)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_VERBOSE, printf_settings.verbose);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_PRINTF_VERBOSE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_PRINTF_VERBOSE, printf_settings.verbose);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_PRINTF_BUFFER_SIZE)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_PRINTF_BUFFER_SIZE, printf_settings.buffer_size);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_PRINTF_BUFFER_SIZE)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_PRINTF_BUFFER_SIZE, printf_settings.buffer_size);
     }
 
     GpuAVSettings &gpuav_settings = *settings_data->gpuav_settings;
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_DESCRIPTORS)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_DESCRIPTORS, gpuav_settings.validate_descriptors);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS, gpuav_settings.validate_descriptors);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_INDIRECT_BUFFER, gpuav_settings.validate_indirect_buffer);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER,
+                                gpuav_settings.validate_indirect_buffer);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_COPIES)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_COPIES, gpuav_settings.validate_copies);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_COPIES)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_COPIES, gpuav_settings.validate_copies);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VALIDATE_RAY_QUERY)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VALIDATE_RAY_QUERY, gpuav_settings.validate_ray_query);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY, gpuav_settings.validate_ray_query);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_VMA_LINEAR_OUTPUT)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT)) {
+        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n", DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT,
+               VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_WARN_ON_ROBUST_OOB)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.warn_on_robust_oob);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.warn_on_robust_oob);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB)) {
+        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.vma_linear_output);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n", DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB,
+               VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_USE_INSTRUMENTED_SHADER_CACHE,
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS,
                                 gpuav_settings.cache_instrumented_shaders);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE)) {
+        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE,
+                                gpuav_settings.vma_linear_output);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+               DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_SELECT_INSTRUMENTED_SHADERS,
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS,
                                 gpuav_settings.select_instrumented_shaders);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, gpuav_settings.vma_linear_output);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+               DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS,
-                                gpuav_settings.gpuav_max_buffer_device_addresses);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS,
+                                gpuav_settings.max_buffer_device_addresses);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS,
-                                gpuav_settings.gpuav_debug_validate_instrumented_shaders);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS,
+                                gpuav_settings.debug_validate_instrumented_shaders);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, SETTING_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, SETTING_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS,
-                                gpuav_settings.gpuav_debug_dump_instrumented_shaders);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS,
+                                gpuav_settings.debug_dump_instrumented_shaders);
     }
 
-    if (gpuav_settings.gpuav_debug_validate_instrumented_shaders || gpuav_settings.gpuav_debug_dump_instrumented_shaders) {
+    if (gpuav_settings.debug_validate_instrumented_shaders || gpuav_settings.debug_dump_instrumented_shaders) {
         // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
         gpuav_settings.cache_instrumented_shaders = false;
     }
@@ -483,41 +514,41 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     // Only read the legacy enables flags when used, not their replacement.
     // Avoid Android C.I. performance regression from reading Android env variables
     if (use_fine_grained_settings) {
-        SetValidationSetting(layer_setting_set, settings_data->enables, best_practices, SETTING_VALIDATE_BEST_PRACTICES);
-        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_arm, SETTING_VALIDATE_BEST_PRACTICES_ARM);
-        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_amd, SETTING_VALIDATE_BEST_PRACTICES_AMD);
-        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_img, SETTING_VALIDATE_BEST_PRACTICES_IMG);
+        SetValidationSetting(layer_setting_set, settings_data->enables, best_practices, VK_LAYER_VALIDATE_BEST_PRACTICES);
+        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_arm, VK_LAYER_VALIDATE_BEST_PRACTICES_ARM);
+        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_amd, VK_LAYER_VALIDATE_BEST_PRACTICES_AMD);
+        SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_img, VK_LAYER_VALIDATE_BEST_PRACTICES_IMG);
         SetValidationSetting(layer_setting_set, settings_data->enables, vendor_specific_nvidia,
-                             SETTING_VALIDATE_BEST_PRACTICES_NVIDIA);
-        SetValidationSetting(layer_setting_set, settings_data->enables, sync_validation, SETTING_VALIDATE_SYNC);
+                             VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA);
+        SetValidationSetting(layer_setting_set, settings_data->enables, sync_validation, VK_LAYER_VALIDATE_SYNC);
 
-        if (vkuHasLayerSetting(layer_setting_set, SETTING_VALIDATE_GPU_BASED)) {
+        if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_VALIDATE_GPU_BASED)) {
             std::string setting_value;
-            vkuGetLayerSettingValue(layer_setting_set, SETTING_VALIDATE_GPU_BASED, setting_value);
+            vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_VALIDATE_GPU_BASED, setting_value);
             settings_data->enables[gpu_validation] = setting_value == "GPU_BASED_GPU_ASSISTED";
             settings_data->enables[debug_printf_validation] = setting_value == "GPU_BASED_DEBUG_PRINTF";
         }
 
         SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
-                             SETTING_RESERVE_BINDING_SLOT);
+                             VK_LAYER_RESERVE_BINDING_SLOT);
     }
 
     // Only read the legacy disables flags when used, not their replacement.
     // Avoid Android C.I. performance regression from reading Android env variables
     if (use_fine_grained_settings) {
-        SetValidationSetting(layer_setting_set, settings_data->disables, stateless_checks, SETTING_STATELESS_PARAM);
-        SetValidationSetting(layer_setting_set, settings_data->disables, thread_safety, SETTING_THREAD_SAFETY);
-        SetValidationSetting(layer_setting_set, settings_data->disables, core_checks, SETTING_VALIDATE_CORE);
-        SetValidationSetting(layer_setting_set, settings_data->disables, command_buffer_state, SETTING_CHECK_COMMAND_BUFFER);
-        SetValidationSetting(layer_setting_set, settings_data->disables, object_in_use, SETTING_CHECK_OBJECT_IN_USE);
-        SetValidationSetting(layer_setting_set, settings_data->disables, query_validation, SETTING_CHECK_QUERY);
-        SetValidationSetting(layer_setting_set, settings_data->disables, image_layout_validation, SETTING_CHECK_IMAGE_LAYOUT);
-        SetValidationSetting(layer_setting_set, settings_data->disables, handle_wrapping, SETTING_UNIQUE_HANDLES);
-        SetValidationSetting(layer_setting_set, settings_data->disables, object_tracking, SETTING_OBJECT_LIFETIME);
-        SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation, SETTING_CHECK_SHADERS);
-        SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation_caching, SETTING_CHECK_SHADERS_CACHING);
+        SetValidationSetting(layer_setting_set, settings_data->disables, stateless_checks, VK_LAYER_STATELESS_PARAM);
+        SetValidationSetting(layer_setting_set, settings_data->disables, thread_safety, VK_LAYER_THREAD_SAFETY);
+        SetValidationSetting(layer_setting_set, settings_data->disables, core_checks, VK_LAYER_VALIDATE_CORE);
+        SetValidationSetting(layer_setting_set, settings_data->disables, command_buffer_state, VK_LAYER_CHECK_COMMAND_BUFFER);
+        SetValidationSetting(layer_setting_set, settings_data->disables, object_in_use, VK_LAYER_CHECK_OBJECT_IN_USE);
+        SetValidationSetting(layer_setting_set, settings_data->disables, query_validation, VK_LAYER_CHECK_QUERY);
+        SetValidationSetting(layer_setting_set, settings_data->disables, image_layout_validation, VK_LAYER_CHECK_IMAGE_LAYOUT);
+        SetValidationSetting(layer_setting_set, settings_data->disables, handle_wrapping, VK_LAYER_UNIQUE_HANDLES);
+        SetValidationSetting(layer_setting_set, settings_data->disables, object_tracking, VK_LAYER_OBJECT_LIFETIME);
+        SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation, VK_LAYER_CHECK_SHADERS);
+        SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation_caching, VK_LAYER_CHECK_SHADERS_CACHING);
         SetValidationSetting(layer_setting_set, settings_data->disables, sync_validation_queue_submit,
-                             SETTING_VALIDATE_SYNC_QUEUE_SUBMIT);
+                             VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT);
     }
 
     vkuDestroyLayerSettingSet(layer_setting_set, nullptr);

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -100,21 +100,27 @@ khronos_validation.enables =
 
 # Cache instrumented shaders rather than instrumenting them on every run
 # =====================
-# <LayerIdentifier>.use_instrumented_shader_cache
+# <LayerIdentifier>.gpuav_cache_instrumented_shaders
 # Enable instrumented shader caching
-#khronos_validation.use_instrumented_shader_cache = true
+#khronos_validation.gpuav_cache_instrumented_shaders = true
 
 # Select which shaders to instrument by passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext
 # =====================
-# <LayerIdentifier>.
+# <LayerIdentifier>.gpuav_select_instrumented_shaders
 # Enable selection of shaders to instrument
-#khronos_validation.select_instrumented_shaders = false
+#khronos_validation.gpuav_select_instrumented_shaders = false
 
 # Use linear vma allocator for GPU-AV output buffers
 # =====================
 # <LayerIdentifier>.gpuav_vma_linear_output
 # Use VMA linear memory allocations for GPU-AV output buffers
-#khronos_validation.vma_linear_output = true
+#khronos_validation.gpuav_vma_linear_output = true
+
+# Generate warning on out of bounds accesses even if buffer robustness is enabled
+# =====================
+# <LayerIdentifier>.gpuav_warn_on_robust_oob
+# Warn on out of bounds accesses even if robustness is enabled
+#khronos_validation.gpuav_warn_on_robust_oob = true
 
 # Specify the maximum number of buffer device addresses in simultaneous use
 # =====================


### PR DESCRIPTION
- All GPU-AV settings now start with `VK_LAYER_GPUAV_` as it caused wasted time to assume this was the case as a few settings didn't follow this
  - Deprecation warning given to the few that were wrong
- It is not obvious how `vk_layer_settings` will underneath append the `VK_LAYER_`  suffix and uppercase the key name, so now all the names in `layer_options.cpp` match the actual environment variable name used to set it
