### PR TITLE
layers: Fix clearing depth attachment with dynamic rendering local read

### DIFF
--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -1095,7 +1095,8 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
         if (cb_state.activeRenderPass->UsesDynamicRendering()) {
             uint32_t colorAttachment = clear_desc->colorAttachment;
 
-            if (cb_state.rendering_attachments.set_color_locations &&
+            if ((clear_desc->aspectMask & VK_IMAGE_ASPECT_COLOR_BIT) != 0 && cb_state.rendering_attachments.set_color_locations &&
+                colorAttachment < cb_state.rendering_attachments.color_locations.size() &&
                 cb_state.rendering_attachments.color_locations[colorAttachment] == VK_ATTACHMENT_UNUSED) {
                 const LogObjectList objlist(commandBuffer, cb_state.activeRenderPass->VkHandle());
                 skip |=
@@ -1103,7 +1104,6 @@ bool CoreChecks::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBuffe
                              "cannot be cleared because VkRenderingAttachmentLocationInfoKHR::pColorAttachmentLocations[%" PRIu32
                              "] is VK_ATTACHMENT_UNUSED.",
                              colorAttachment);
-                break;
             }
 
             color_view_state = cb_state.GetActiveAttachmentImageViewState(cb_state.GetDynamicColorAttachmentImageIndex(colorAttachment));


### PR DESCRIPTION
#7799 did not fix everything

From spec:

> colorAttachment is only meaningful if VK_IMAGE_ASPECT_COLOR_BIT is set in aspectMask, in which case it is an index into the currently bound color attachments

So this check needs to be skipped if the aspect does not contain `VK_IMAGE_ASPECT_COLOR_BIT`