### PR TITLE
tests: Add helpers to get queue directly

### DIFF
--- a/tests/framework/barrier_queue_family.cpp
+++ b/tests/framework/barrier_queue_family.cpp
@@ -35,7 +35,7 @@ BarrierQueueFamilyBase::Context::Context(VkLayerTest *test, const std::vector<ui
     queue_families.reserve(queue_family_indices.size());
     default_index = queue_family_indices[0];
     for (auto qfi : queue_family_indices) {
-        VkQueue queue = device_obj->queue_family_queues(qfi)[0]->handle();
+        VkQueue queue = device_obj->QueuesFromFamily(qfi)[0]->handle();
         queue_families.emplace(std::make_pair(qfi, QueueFamilyObjs()));
         queue_families[qfi].Init(device_obj, qfi, queue, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     }

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -225,24 +225,27 @@ class Device : public internal::Handle<VkDevice> {
     const std::vector<Queue *> &QueuesWithTransferCapability() const { return queues_[TRANSFER]; }
     const std::vector<Queue *> &QueuesWithSparseCapability() const { return queues_[SPARSE]; }
 
-    typedef std::vector<std::unique_ptr<Queue>> QueueFamilyQueues;
-    typedef std::vector<QueueFamilyQueues> QueueFamilies;
-    const QueueFamilyQueues &queue_family_queues(uint32_t queue_family) const;
+    using QueueFamilyQueues = std::vector<std::unique_ptr<Queue>>;
+    const QueueFamilyQueues &QueuesFromFamily(uint32_t queue_family) const;
 
     // Queue family that has "with" capabilities and optionally without "without" capabilities.
     std::optional<uint32_t> QueueFamily(VkQueueFlags with, VkQueueFlags without = 0) const;
 
     // Queue family that does not have "without" capabilities
-    std::optional<uint32_t> QueueFamilyWithoutCapabilities(VkQueueFlags without);
+    std::optional<uint32_t> QueueFamilyWithoutCapabilities(VkQueueFlags without) const;
+    Queue *QueueWithoutCapabilities(VkQueueFlags without) const;
 
     // Dedicated compute queue family: has compute but no graphics
     std::optional<uint32_t> ComputeOnlyQueueFamily() const;
+    Queue *ComputeOnlyQueue() const;
 
     // Dedicated transfer queue family: has tranfer but no graphics/compute
     std::optional<uint32_t> TransferOnlyQueueFamily() const;
+    Queue *TransferOnlyQueue() const;
 
     // Compute or transfer
     std::optional<uint32_t> NonGraphicsQueueFamily() const;
+    Queue *NonGraphicsQueue() const;
 
     uint32_t graphics_queue_node_index_;
 
@@ -303,7 +306,7 @@ class Device : public internal::Handle<VkDevice> {
 
     std::vector<const char *> enabled_extensions_;
 
-    QueueFamilies queue_families_;
+    std::vector<QueueFamilyQueues> queue_families_;
     std::vector<Queue *> queues_[QUEUE_CAPABILITY_COUNT];
 };
 

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -706,13 +706,12 @@ TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
         "compute opeartions");
 
     RETURN_IF_SKIP(Init());
-    const std::optional<uint32_t> transfer_qfi = m_device->TransferOnlyQueueFamily();
-    if (!transfer_qfi) {
-        GTEST_SKIP() << "Transfer-only queue family not found";
+    vkt::Queue* queue = m_device->TransferOnlyQueue();
+    if (!queue) {
+        GTEST_SKIP() << "Transfer-only queue not found";
     }
-    vkt::Queue *queue = m_device->queue_family_queues(transfer_qfi.value())[0].get();
 
-    vkt::CommandPool pool(*m_device, transfer_qfi.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    vkt::CommandPool pool(*m_device, queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     cb.begin();

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -436,13 +436,12 @@ TEST_F(PositiveCommand, FillBufferCmdPoolTransferQueue) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    const std::optional<uint32_t> transfer_qfi = m_device->TransferOnlyQueueFamily();
-    if (!transfer_qfi) {
-        GTEST_SKIP() << "Transfer-only queue family not found";
+    vkt::Queue *queue = m_device->TransferOnlyQueue();
+    if (!queue) {
+        GTEST_SKIP() << "Transfer-only queue not found";
     }
-    vkt::Queue *queue = m_device->queue_family_queues(transfer_qfi.value())[0].get();
 
-    vkt::CommandPool pool(*m_device, transfer_qfi.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    vkt::CommandPool pool(*m_device, queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -79,13 +79,10 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     uint32_t ray_tracing_queue_family_index = 0;
 
     // If supported, run on the compute only queue.
-    const std::optional<uint32_t> compute_only_queue_family_index = m_device->ComputeOnlyQueueFamily();
-    if (compute_only_queue_family_index) {
-        const auto &compute_only_queues = m_device->queue_family_queues(compute_only_queue_family_index.value());
-        if (!compute_only_queues.empty()) {
-            ray_tracing_queue = compute_only_queues[0].get();
-            ray_tracing_queue_family_index = compute_only_queue_family_index.value();
-        }
+    vkt::Queue *compute_only_queue = m_device->ComputeOnlyQueue();
+    if (compute_only_queue) {
+        ray_tracing_queue = compute_only_queue;
+        ray_tracing_queue_family_index = compute_only_queue->get_family_index();
     }
 
     vkt::CommandPool ray_tracing_command_pool(*m_device, ray_tracing_queue_family_index,

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -6352,11 +6352,10 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
-    const std::optional<uint32_t> transfer_family = m_device->TransferOnlyQueueFamily();
-    if (!transfer_family) {
-        GTEST_SKIP() << "Transfer-only queue family is not present";
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
     }
-    vkt::Queue* transfer_queue = m_device->queue_family_queues(transfer_family.value())[0].get();
 
     vkt::Image image(*m_device, 64, 64, 1, VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer(*m_device, 64 * 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -6391,7 +6390,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite) {
     vk::QueueSubmit2(*m_default_queue, 1, &submit0, VK_NULL_HANDLE);
 
     // Submit from Transfer queue: write image data (racing WRITE access)
-    vkt::CommandPool transfer_pool(*m_device, transfer_family.value());
+    vkt::CommandPool transfer_pool(*m_device, transfer_queue->get_family_index());
     vkt::CommandBuffer cb1(*m_device, &transfer_pool);
     cb1.begin();
     vk::CmdCopyBufferToImage(cb1, buffer, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
@@ -6418,11 +6417,10 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite2) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
-    const std::optional<uint32_t> transfer_family = m_device->TransferOnlyQueueFamily();
-    if (!transfer_family) {
-        GTEST_SKIP() << "Transfer-only queue family is not present";
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
     }
-    vkt::Queue* transfer_queue = m_device->queue_family_queues(transfer_family.value())[0].get();
 
     vkt::Image image(*m_device, 64, 64, 1, VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer(*m_device, 64 * 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
@@ -6468,7 +6466,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite2) {
     vk::QueueSubmit2(*m_default_queue, 1, &submit1, VK_NULL_HANDLE);
 
     // Submit on Transfer queue: write image data (racing WRITE access)
-    vkt::CommandPool transfer_pool(*m_device, transfer_family.value());
+    vkt::CommandPool transfer_pool(*m_device, transfer_queue->get_family_index());
     vkt::CommandBuffer cb2(*m_device, &transfer_pool);
     cb2.begin();
     vk::CmdCopyBufferToImage(cb2, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
@@ -6508,25 +6506,19 @@ TEST_F(NegativeSyncVal, QSWriteRacingRead) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
-    const std::optional<uint32_t> gfx_family = m_device->QueueFamily(VK_QUEUE_GRAPHICS_BIT);
-    if (!gfx_family) {
-        GTEST_SKIP() << "Graphics family is not present";
-    }
-    vkt::Queue* gfx_queue = m_device->queue_family_queues(gfx_family.value())[0].get();
+    vkt::Queue* gfx_queue = m_default_queue;
     vkt::CommandPool gfx_pool(*m_device, gfx_queue->get_family_index());
 
-    const std::optional<uint32_t> compute_family = m_device->ComputeOnlyQueueFamily();
-    if (!compute_family) {
-        GTEST_SKIP() << "Compute-only queue family is not present";
+    vkt::Queue* compute_queue = m_device->ComputeOnlyQueue();
+    if (!compute_queue) {
+        GTEST_SKIP() << "Compute-only queue is not present";
     }
-    vkt::Queue* compute_queue = m_device->queue_family_queues(compute_family.value())[0].get();
     vkt::CommandPool compute_pool(*m_device, compute_queue->get_family_index());
 
-    const std::optional<uint32_t> transfer_family = m_device->TransferOnlyQueueFamily();
-    if (!transfer_family) {
-        GTEST_SKIP() << "Transfer-only queue family is not present";
+    vkt::Queue* transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
     }
-    vkt::Queue* transfer_queue = m_device->queue_family_queues(transfer_family.value())[0].get();
     vkt::CommandPool transfer_pool(*m_device, transfer_queue->get_family_index());
 
     constexpr VkDeviceSize size = 1024;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1355,11 +1355,10 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
-    const std::optional<uint32_t> transfer_family = m_device->TransferOnlyQueueFamily();
-    if (!transfer_family) {
-        GTEST_SKIP() << "Transfer-only queue family is not present";
+    vkt::Queue *transfer_queue = m_device->TransferOnlyQueue();
+    if (!transfer_queue) {
+        GTEST_SKIP() << "Transfer-only queue is not present";
     }
-    vkt::Queue *transfer_queue = m_device->queue_family_queues(transfer_family.value())[0].get();
 
     vkt::Image image(*m_device, 64, 64, 1, VK_FORMAT_R8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer(*m_device, 64 * 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);


### PR DESCRIPTION
Replaces *get family index -> get queue from family* sequence with directly requesting the queue.