### PR TITLE
tests: Add second helper queue

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -51,29 +51,21 @@ namespace vkt {
 
 VkPhysicalDeviceProperties PhysicalDevice::properties() const {
     VkPhysicalDeviceProperties info;
-
     vk::GetPhysicalDeviceProperties(handle(), &info);
-
     return info;
 }
 
 std::vector<VkQueueFamilyProperties> PhysicalDevice::queue_properties() const {
-    std::vector<VkQueueFamilyProperties> info;
-    uint32_t count;
-
-    // Call once with NULL data to receive count
-    vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, NULL);
-    info.resize(count);
+    uint32_t count = 0;
+    vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, nullptr);
+    std::vector<VkQueueFamilyProperties> info(count);
     vk::GetPhysicalDeviceQueueFamilyProperties(handle(), &count, info.data());
-
     return info;
 }
 
 VkPhysicalDeviceMemoryProperties PhysicalDevice::memory_properties() const {
     VkPhysicalDeviceMemoryProperties info;
-
     vk::GetPhysicalDeviceMemoryProperties(handle(), &info);
-
     return info;
 }
 

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -247,7 +247,7 @@ class Device : public internal::Handle<VkDevice> {
     std::optional<uint32_t> NonGraphicsQueueFamily() const;
     Queue *NonGraphicsQueue() const;
 
-    uint32_t graphics_queue_node_index_;
+    uint32_t graphics_queue_node_index_ = vvl::kU32Max;
 
     const PhysicalDevice phy_;
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -73,7 +73,10 @@ class VkRenderFramework : public VkTestFramework {
     VkPhysicalDevice gpu() const;
     VkRenderPass renderPass() const { return m_renderPass; }
     VkFramebuffer framebuffer() const { return m_framebuffer->handle(); }
-    VkQueue DefaultQueue() const { return m_default_queue->handle(); }
+
+    vkt::Queue *DefaultQueue() const { return m_default_queue; }
+    vkt::Queue *SecondQueue() const { return m_second_queue; }
+
     ErrorMonitor &Monitor();
     const VkPhysicalDeviceProperties &physDevProps() const;
 
@@ -214,7 +217,12 @@ class VkRenderFramework : public VkTestFramework {
     VkClearColorValue m_clear_color;
     vkt::Image *m_depthStencil;
     // first graphics queue, used must often, don't overwrite, use Device class
-    vkt::Queue *m_default_queue;
+    vkt::Queue *m_default_queue = nullptr;
+
+    // A different queue than a default one. The queue with the most capabilities is selected (graphics > compute > transfer).
+    // It is null if implementation provides the only queue. Capabilities should be checked if necessary (m_second_queue_caps).
+    vkt::Queue *m_second_queue = nullptr;
+    VkQueueFlags m_second_queue_caps = 0;
 
     // Requested extensions to enable at device creation time
     std::vector<const char *> m_required_extensions;

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2398,14 +2398,12 @@ TEST_F(PositiveSyncObject, TwoQueuesReuseBinarySemaphore) {
     TEST_DESCRIPTION("Use binary semaphore with the first queue then re-use on a different queue");
     RETURN_IF_SKIP(Init());
 
-    if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
+    if (!m_second_queue) {
         GTEST_SKIP() << "Test requires two queues";
     }
 
     VkQueue q0 = m_default_queue->handle();
-    VkQueue q1 = nullptr;
-    vk::GetDeviceQueue(device(), m_device->graphics_queue_node_index_, 1, &q1);
-    ASSERT_NE(q1, nullptr);
+    VkQueue q1 = m_second_queue->handle();
 
     constexpr VkPipelineStageFlags wait_dst_stages = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     vkt::Semaphore semaphore(*m_device);

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -384,7 +384,7 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
         end_render(command_buffer);
         command_buffer.end();
         command_buffer.QueueCommandBuffer();
-        vk::QueueWaitIdle(test.DefaultQueue());
+        test.DefaultQueue()->wait();
     }
 
     // RAW hazard: clear render target then copy from it.
@@ -416,7 +416,7 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
 
         command_buffer.end();
         command_buffer.QueueCommandBuffer();
-        vk::QueueWaitIdle(test.DefaultQueue());
+        test.DefaultQueue()->wait();
     }
 
     // RAW hazard: two regions with a single pixel overlap, otherwise the same as the previous scenario.
@@ -449,7 +449,7 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
 
         command_buffer.end();
         command_buffer.QueueCommandBuffer();
-        vk::QueueWaitIdle(test.DefaultQueue());
+        test.DefaultQueue()->wait();
     }
 
     // Nudge regions by one pixel compared to the previous test, now they touch but do not overlap. There should be no errors.
@@ -479,7 +479,7 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
         end_render(command_buffer);
         command_buffer.end();
         command_buffer.QueueCommandBuffer();
-        vk::QueueWaitIdle(test.DefaultQueue());
+        test.DefaultQueue()->wait();
     }
 }
 


### PR DESCRIPTION
Sometimes the tests check for the second graphics queue if 2 queues are needed.
This can decrease test coverage. For example, AMD windows drivers usually expose a single graphics queue.

This PR adds one more helper queue in addition to the default one. It will be a graphics queue if the second graphics queue is available, otherwise it's a compute if available, then transfer. Null when only 1 queue is exposed.

It can be used in situations when the test can work with the queues with different capabilities. Even if the queue with a specific capability is needed it might be easier to check`m_second_queue`'s  `VkQueueFlags` than iterating over `QueuesWithXXXCapability()` in order to skip the default queue.
