### PR TITLE
layers: Improve Shader Interface errors

### DIFF
--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -501,13 +501,14 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const spirv::Module &producer, c
                 if ((component_info.output_type != component_info.input_type) ||
                     (component_info.output_width != component_info.input_width)) {
                     const LogObjectList objlist(producer.handle(), consumer.handle());
-                    skip |=
-                        LogError("VUID-RuntimeSpirv-OpEntryPoint-07754", objlist, create_info_loc,
-                                 "(SPIR-V Interface) Type mismatch on Location %" PRIu32 " Component %" PRIu32
-                                 ", between\n%s stage:\n%s\n%s stage:\n%s\n",
-                                 location, component, string_VkShaderStageFlagBits(producer_stage),
-                                 producer.DescribeType(output_var->type_id).c_str(), string_VkShaderStageFlagBits(consumer_stage),
-                                 consumer.DescribeType(input_var->type_id).c_str());
+                    skip |= LogError("VUID-RuntimeSpirv-OpEntryPoint-07754", objlist, create_info_loc,
+                                     "(SPIR-V Interface) Type mismatch on Location %" PRIu32 " Component %" PRIu32
+                                     ", between\n\n%s stage:\n%s%s\n\n%s stage:\n%s%s\n\n",
+                                     location, component, string_VkShaderStageFlagBits(producer_stage),
+                                     producer.DescribeVariable(output_var->id).c_str(),
+                                     producer.DescribeType(output_var->type_id).c_str(),
+                                     string_VkShaderStageFlagBits(consumer_stage), consumer.DescribeVariable(input_var->id).c_str(),
+                                     consumer.DescribeType(input_var->type_id).c_str());
                     break;  // Only need to report for the first component found
                 }
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -645,8 +645,12 @@ struct Module {
     }
 
     // Used to get human readable strings for error messages
+    std::string GetDecorations(uint32_t id) const;
+    std::string GetName(uint32_t id) const;
+    std::string GetMemberName(uint32_t id, uint32_t member_index) const;
     void DescribeTypeInner(std::ostringstream &ss, uint32_t type, uint32_t indent) const;
     std::string DescribeType(uint32_t type) const;
+    std::string DescribeVariable(uint32_t id) const;
 
     std::optional<VkPrimitiveTopology> GetTopology(const EntryPoint &entrypoint) const;
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7845

its been on my todo list for a while to clean this up

before

```
vkCreateGraphicsPipelines(): pCreateInfos[0] (SPIR-V Interface) Type mismatch on Location 4 Component 0, between
VK_SHADER_STAGE_VERTEX_BIT stage:
pointer to Output ->
	struct of {
		array[2] of struct of {
	array[2] of vec4 of float32
	float32
	vec3 of 	float64
}
		sint32
	}
VK_SHADER_STAGE_FRAGMENT_BIT stage:
pointer to Input ->
	struct of {
		array[2] of struct of {
	array[2] of vec4 of float32
	float32
	vec4 of 	float32
	vec2 of 	float32
}
		sint32
	}
```

now (note, variable names are `a`, `b`, `c`, etc) 
```
vkCreateGraphicsPipelines(): pCreateInfos[0] (SPIR-V Interface) Type mismatch on Location 4 Component 0, between

VK_SHADER_STAGE_VERTEX_BIT stage:
Variable outBlock
pointer to Output -> struct of {
	- array[2] of struct of {
		- array[2] of vec4 of float32 |a|
		- float32 |b|
		- vec3 of float64 |c|
	} |S| |x|
	- sint32 |y|
} |block|

VK_SHADER_STAGE_FRAGMENT_BIT stage:
Variable inBlock
pointer to Input -> struct of {
	- array[2] of struct of {
		- array[2] of vec4 of float32 |a|
		- float32 |b|
		- array[2] of struct of {
			- sint32 |x|
		} |C| |d|
	} |S| |x|
	- sint32 |y|
} |block|
```