### PR TITLE
test: Set VK_LAYER_PATH automatically if missing

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -6,7 +6,9 @@ This is an "up-to-speed" document for writing tests to validate the Validation L
 
 ## Rule #1
 
-The first rule is to make sure you are actually running the tests on the built version of the Validation Layers you want. If you have the Vulkan SDK installed, then you will have a pre-built version of the Validation Layers set in your path and those are probably not the version you want to test.
+The first rule is to make sure you are actually running the tests on the built version of the Validation Layers you want. Set the environment variable `VK_LOADER_DEBUG` to `layer` and check that the output of the tests report that the path of the validation layer matches what is expected.
+
+The tests automatically set `VK_LAYER_PATH` to the validation layer in the build tree. However if you wish to use a different validation layer than the one that was built, or if you wish to use multiple layers in the tests at the same time, you must set `VK_LAYER_PATH` to include each path to the desired layers, including the validation layer.
 
 Make sure you have the correct `VK_LAYER_PATH` set on Windows or Linux (on Android the layers are baked into the APK so there is nothing to worry about)
 

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -111,6 +111,18 @@ std::string GetEnvironment(const char *variable) {
 #endif
 }
 
+void SetEnvironment(const char *variable, const char *value) {
+#if !defined(__ANDROID__) && !defined(_WIN32)
+    setenv(variable, value, 1);
+#elif defined(_WIN32)
+    SetEnvironmentVariable(variable, value);
+#elif defined(__ANDROID__)
+    (void)variable;
+    (void)value;
+    assert(false && "Not supported on android");
+#endif
+}
+
 const char *getLayerOption(const char *option) { return layer_config.GetOption(option); }
 
 const SettingsFileInfo *GetLayerSettingsFileInfo() { return &layer_config.settings_info; }

--- a/layers/vk_layer_config.h
+++ b/layers/vk_layer_config.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,9 @@
 #endif
 
 std::string GetEnvironment(const char *variable);
+
+// Not supported on Android
+void SetEnvironment(const char *variable, const char *value);
 
 enum SettingsFileSource {
     kVkConfig,
@@ -68,9 +71,8 @@ const char *getLayerOption(const char *option);
 const SettingsFileInfo *GetLayerSettingsFileInfo();
 
 FILE *getLayerLogOutput(const char *option, const char *layer_name);
-VkFlags GetLayerOptionFlags(const std::string &option,
-                                            vvl::unordered_map<std::string, VkFlags> const &enum_data,
-                                            uint32_t option_default);
+VkFlags GetLayerOptionFlags(const std::string &option, vvl::unordered_map<std::string, VkFlags> const &enum_data,
+                            uint32_t option_default);
 
 void PrintMessageFlags(VkFlags vk_flags, char *msg_flags);
 void PrintMessageSeverity(VkFlags vk_flags, char *msg_flags);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -272,6 +272,24 @@ target_link_libraries(vk_layer_validation_tests PRIVATE
     $<TARGET_NAME_IF_EXISTS:PkgConfig::WAYlAND_CLIENT>
 )
 
+# setup framework/config.h using framework/config.h.in as a source
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/framework/config.h.in")
+
+# copy config$<CONFIG>.h to the build directory
+add_custom_command(
+    PRE_BUILD
+    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h" "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    VERBATIM
+    DEPENDS  "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h"
+    OUTPUT   "${CMAKE_CURRENT_BINARY_DIR}/config.h"
+    COMMENT  "creating config.h file ({event: PRE_BUILD}, {filename: config.h })"
+    )
+add_custom_target (generate_framework_config DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/config.h")
+add_dependencies (generate_framework_config vk_layer_validation_tests)
+
+target_sources(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+target_include_directories(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
 # More details in tests/android/mock/README.md
 option(VVL_MOCK_ANDROID "Enable building for Android on desktop for testing with MockICD setup")
 if(VVL_MOCK_ANDROID)

--- a/tests/README.md
+++ b/tests/README.md
@@ -30,10 +30,11 @@ export VK_LOADER_LAYERS_DISABLE=VK_LAYER_OBS_HOOK
 
 ## Running Test on Linux
 
-**IMPORTANT** Make sure you have the correct `VK_LAYER_PATH` set on Linux
+`VK_LAYER_PATH` is set automatically by the tests. However if you wish to use a different validation layer than the one that was built, or if you wish to use multiple layers in the tests at the same time, you must set `VK_LAYER_PATH` to include each path to the desired layers, including the validation layer.
 
+To set `VK_LAYER_PATH` with multiple layers:
 ```bash
-export VK_LAYER_PATH=/path/to/Vulkan-ValidationLayers/build/layers/
+export VK_LAYER_PATH=/path/to/Vulkan-ValidationLayers/build/layers/:/path/to/other/layers/
 ```
 
 To run the tests

--- a/tests/framework/config.h.in
+++ b/tests/framework/config.h.in
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#define VALIDATION_LAYERS_BUILD_PATH "$<TARGET_FILE_DIR:vvl>"


### PR DESCRIPTION
Changes:
* Add mechanism to set VK_LAYER_PATH automatically if it isn't set or if it is set but doesn't contain a path to a valid layer manifest.
* Search VK_ADD_LAYER_PATH in addition to VK_LAYER_PATH when looking for the layer manifest
* Enhance searching of the layer manifest to include directory support rather than only allowing files
* Enhance VK_ICD_FILENAMES & VK_DRIVER_FILES checking to support files in addition to the existing support for directories