### PR TITLE
layers: Add Protected buffer usage flag combo

### DIFF
--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -87,6 +87,21 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
                               "VUID-VkBufferCreateInfo-None-09500");
     }
 
+    if (pCreateInfo->flags & VK_BUFFER_CREATE_PROTECTED_BIT) {
+        const VkBufferUsageFlags invalid =
+            VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT | VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT |
+            VK_BUFFER_USAGE_CONDITIONAL_RENDERING_BIT_EXT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
+            VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR |
+            VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT |
+            VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_MICROMAP_BUILD_INPUT_READ_ONLY_BIT_EXT |
+            VK_BUFFER_USAGE_MICROMAP_STORAGE_BIT_EXT;
+        if (pCreateInfo->usage & invalid) {
+            skip |= LogError("VUID-VkBufferCreateInfo-flags-09641", device, create_info_loc.dot(Field::flags),
+                             "includes VK_BUFFER_CREATE_PROTECTED_BIT, but the usage is %s.",
+                             string_VkBufferUsageFlags(pCreateInfo->usage).c_str());
+        }
+    };
+
     return skip;
 }
 

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -1184,3 +1184,17 @@ TEST_F(NegativeProtectedMemory, RayQuery) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 }
+
+TEST_F(NegativeProtectedMemory, Usage) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorBuffer);
+    AddRequiredFeature(vkt::Feature::protectedMemory);
+    RETURN_IF_SKIP(Init());
+
+    VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
+    buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
+    buffer_create_info.size = 4096;
+    buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
+    CreateBufferTest(*this, &buffer_create_info, "VUID-VkBufferCreateInfo-flags-09641");
+}


### PR DESCRIPTION
`VUID-VkBufferCreateInfo-flags-09641` was added in 1.3.283 spec