### PR TITLE
layers: Label RenderPass 1 VUID for nestedCommandBuffer

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -599,8 +599,10 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
 
     if (contents == VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT &&
         !enabled_features.nestedCommandBuffer) {
+        const char *vuid = error_obj.location.function == Func::vkCmdBeginRenderPass ? "VUID-vkCmdBeginRenderPass-contents-09640"
+                                                                                     : "VUID-VkSubpassBeginInfo-contents-09382";
         skip |=
-            LogError("VUID-VkSubpassBeginInfo-contents-09382", commandBuffer, error_obj.location.dot(Field::contents),
+            LogError(vuid, commandBuffer, error_obj.location.dot(Field::contents),
                      " is VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT, but nestedCommandBuffer was not enabled.");
     }
 

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -4315,6 +4315,20 @@ TEST_F(NegativeRenderPass, RenderPassWithRenderPassStripedQueueSubmit2) {
 
 TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature) {
     TEST_DESCRIPTION("Use VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT when nextedCommandBuffers is not enabled");
+    AddRequiredExtensions(VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass-contents-09640");
+    vk::CmdBeginRenderPass(m_commandBuffer->handle(), &m_renderPassBeginInfo,
+                           VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->end();
+}
+
+TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature2) {
+    TEST_DESCRIPTION("Use VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_EXT when nextedCommandBuffers is not enabled");
 
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_NESTED_COMMAND_BUFFER_EXTENSION_NAME);


### PR DESCRIPTION
VUID for Renderpass 1 (`VUID-vkCmdBeginRenderPass-contents-09640`) was added in 1.3.283 (https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6595)