### PR TITLE
layers: Fix sync stage for EndRendering resolve of depth and stencil textures

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -224,6 +224,8 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
             if (attachment.resolve_gen) {
                 const bool is_color = attachment.type == syncval_state::AttachmentType::kColor;
                 const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
+                const SyncStageAccessIndex kResolveRead = is_color ? kColorResolveRead : kDepthStencilResolveRead;
+
                 // The logic about whether to resolve is embedded in the Attachment constructor
                 assert(attachment.view);
                 HazardResult hazard = access_context->DetectHazard(attachment.view_gen, kResolveRead, kResolveOrder);
@@ -234,6 +236,8 @@ bool CommandBufferAccessContext::ValidateEndRendering(const ErrorObject &error_o
                                                   attachment.info.resolveMode);
                 }
                 if (!skip) {
+                    const SyncStageAccessIndex kResolveWrite = is_color ? kColorResolveWrite : kDepthStencilResolveWrite;
+
                     hazard = access_context->DetectHazard(*attachment.resolve_gen, kResolveWrite, kResolveOrder);
                     if (hazard.IsHazard()) {
                         Location loc = attachment.GetLocation(error_obj.location, i);
@@ -273,6 +277,8 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
             if (attachment.resolve_gen) {
                 const bool is_color = attachment.type == syncval_state::AttachmentType::kColor;
                 const SyncOrdering kResolveOrder = is_color ? kColorResolveOrder : kDepthStencilResolveOrder;
+                const SyncStageAccessIndex kResolveRead = is_color ? kColorResolveRead : kDepthStencilResolveRead;
+                const SyncStageAccessIndex kResolveWrite = is_color ? kColorResolveWrite : kDepthStencilResolveWrite;
                 access_context->UpdateAccessState(attachment.view_gen, kResolveRead, kResolveOrder, store_tag);
                 access_context->UpdateAccessState(*attachment.resolve_gen, kResolveWrite, kResolveOrder, store_tag);
             }

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -242,9 +242,12 @@ class CommandExecutionContext : public SyncValidationInfo {
 class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProvider {
   public:
     using SyncOpPointer = std::shared_ptr<SyncOpBase>;
-    constexpr static SyncStageAccessIndex kResolveRead = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ;
-    constexpr static SyncStageAccessIndex kResolveWrite = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE;
+    constexpr static SyncStageAccessIndex kColorResolveRead = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_READ;
+    constexpr static SyncStageAccessIndex kColorResolveWrite = SYNC_COLOR_ATTACHMENT_OUTPUT_COLOR_ATTACHMENT_WRITE;
     constexpr static SyncOrdering kColorResolveOrder = SyncOrdering::kColorAttachment;
+
+    constexpr static SyncStageAccessIndex kDepthStencilResolveRead = SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_READ;
+    constexpr static SyncStageAccessIndex kDepthStencilResolveWrite = SYNC_LATE_FRAGMENT_TESTS_DEPTH_STENCIL_ATTACHMENT_WRITE;
     // Although depth resolve runs on the color attachment output stage and uses color accesses, depth accesses
     // still participate in the ordering. That's why using raster and not only color attachment ordering
     constexpr static SyncOrdering kDepthStencilResolveOrder = SyncOrdering::kRaster;


### PR DESCRIPTION
Issue: Validation layers were not taking into account the image type when passing the sync stage to hazard detection. This would cause a false positive when resolving non-color texture attachments.

Fix: Switch between COLOR_ATTACHMENT_* and LATE_FRAGMENT_TESTS_DEPTH_STENCIL_* depending on if the texture attachment is a color or depth/stencil texture.