### PR TITLE
scripts: Update VUL

### DIFF
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "v1.3.283",
+            "commit": "d0ffc68fe796ffd5752b7a2cba7c4f1d80ed7283",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
grabs changes from
https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/201

cc @ziga-lunarg (messed up on the git)