### PR TITLE
printf: Add way to disconnect from chassis on abort

### DIFF
--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -87,6 +87,8 @@ class Validator : public gpu_tracker::Validator {
         desired_features.fragmentStoresAndAtomics = true;
     }
 
+    void ReportSetupProblemPrintF(LogObjectList objlist, const Location& loc, const char* const specific_message,
+                                  bool vma_fail) const;
     void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
     bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& instrumented_spirv,
                           uint32_t unique_shader_id, const Location& loc) override;

--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -884,5 +884,8 @@ void gpu_tracker::Validator::ReportSetupProblem(LogObjectList objlist, const Loc
         logit += stats_string;
         vmaFreeStatsString(vmaAllocator, stats_string);
     }
-    LogError(setup_vuid, objlist, loc, "Setup Error. Detail: (%s)", logit.c_str());
+
+    char const *layer_name = container_type == LayerObjectTypeDebugPrintf ? "Debug PrintF" : "GPU-AV";
+
+    LogError(setup_vuid, objlist, loc, "Setup Error, %s is being disabled. Detail: (%s)", layer_name, logit.c_str());
 }

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2235,6 +2235,7 @@ class ValidationObject {
 
     std::vector<ValidationObject*> object_dispatch;
     LayerObjectTypeId container_type;
+    void ReleaseDeviceDispatchObject(LayerObjectTypeId type_id) const;
 
     vvl::concurrent_unordered_map<VkDeferredOperationKHR, std::vector<std::function<void()>>, 0> deferred_operation_post_completion;
     vvl::concurrent_unordered_map<VkDeferredOperationKHR, std::vector<std::function<void(const std::vector<VkPipeline>&)>>, 0>


### PR DESCRIPTION
(plan to do with GPU-AV, but starting easy with DebugPrintF)

When we want to abort in GPU-AV/DebugPrintf it can be annoying to try and going `if (aborted) return;` everywhere. This adds a `ReleaseDeviceDispatchObject` that will remove the object from the chassis so that no function calls are ever called into after an abort
