### PR TITLE
tests: Avoid race in NegativeSyncObject.Sync2SignalSemaphoreValue

### DIFF
--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -3239,6 +3239,7 @@ TEST_F(NegativeSyncObject, Sync2SignalSemaphoreValue) {
     m_errorMonitor->VerifyFound();
 
     signal_info.value = 20;
+    wait_info.value = 15;
     wait_info.semaphore = semaphore[1].handle();
     ASSERT_EQ(VK_SUCCESS, vk::QueueSubmit2KHR(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE));
 


### PR DESCRIPTION
Fixes #7885.

The previously used wait value of 5 is already signalled (at the semaphore creation time). This makes the queue submission immediately executable and may signal the semaphore[0] = 20 at any time now.

The queue will race with the subsequent signal operations. If queue signals first then the subsequent semaphore[0] = 25 becomes a valid use (no pending signal operations, change from 20 to 25) rather than a violation of the VUID-VkSemaphoreSignalInfo-value-03259.

The next signal of the semaphore[0] = 15 becomes invalid use violating the VUID-VkSemaphoreSignalInfo-value-03258 (change from 25 back to 15).

Change-Id: I2768ef5c6b3868f00965ac7d881ad1f6ac7ee515