### PR TITLE
gpu: Fix concurrent access of cmb buffer resources

### DIFF
--- a/layers/gpu_validation/gpu_resources.h
+++ b/layers/gpu_validation/gpu_resources.h
@@ -24,8 +24,8 @@ class Validator;
 struct DescBindingInfo;
 
 struct DeviceMemoryBlock {
-    VkBuffer buffer;
-    VmaAllocation allocation;
+    VkBuffer buffer = VK_NULL_HANDLE;
+    VmaAllocation allocation = VK_NULL_HANDLE;
     void Destroy(VmaAllocator allocator) {
         if (buffer != VK_NULL_HANDLE) {
             vmaDestroyBuffer(allocator, buffer, allocation);
@@ -33,6 +33,7 @@ struct DeviceMemoryBlock {
             allocation = VK_NULL_HANDLE;
         }
     }
+    bool IsNull() { return buffer == VK_NULL_HANDLE; }
 };
 
 struct AccelerationStructureBuildValidationState {

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -122,6 +122,7 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
   private:
     void AllocateResources();
     void ResetCBState();
+    bool NeedsPostProcess();
 
     Validator &state_;
 


### PR DESCRIPTION
After acquiring a command buffer's lock to call PostProcess on it, its resources could have been freed by another thread in the meantime, so PostProcess should account for that.
Bug showed up while replaying a capture of Doom 2

I looked at making sure we just do not end up having "empty" command buffers in `gpu_tracker::Queue::retiring_` but not sure it is worth to go down that route.
Would love @jeremyg-lunarg's eyes on that PR!