### PR TITLE
tests: Don't use max queueCount

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -185,7 +185,7 @@ class QueueCreateInfoArray {
     std::vector<std::vector<float>> queue_priorities_;
 
   public:
-    QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties> &queue_props);
+    QueueCreateInfoArray(const std::vector<VkQueueFamilyProperties> &queue_props, bool all_queue_count = false);
     size_t size() const { return queue_info_.size(); }
     const VkDeviceQueueCreateInfo *data() const { return queue_info_.data(); }
 };
@@ -195,9 +195,9 @@ class Device : public internal::Handle<VkDevice> {
     explicit Device(VkPhysicalDevice phy) : phy_(phy) { init(); }
     explicit Device(VkPhysicalDevice phy, const VkDeviceCreateInfo &info) : phy_(phy) { init(info); }
     explicit Device(VkPhysicalDevice phy, std::vector<const char *> &extension_names, VkPhysicalDeviceFeatures *features = nullptr,
-                    void *create_device_pnext = nullptr)
+                    void *create_device_pnext = nullptr, bool all_queue_count = false)
         : phy_(phy) {
-        init(extension_names, features, create_device_pnext);
+        init(extension_names, features, create_device_pnext, all_queue_count);
     }
 
     ~Device() noexcept;
@@ -206,7 +206,7 @@ class Device : public internal::Handle<VkDevice> {
     // vkCreateDevice()
     void init(const VkDeviceCreateInfo &info);
     void init(std::vector<const char *> &extensions, VkPhysicalDeviceFeatures *features = nullptr,
-              void *create_device_pnext = nullptr);  // all queues, all extensions, etc
+              void *create_device_pnext = nullptr, bool all_queue_count = false);  // all queues, all extensions, etc
     void init() {
         std::vector<const char *> extensions;
         init(extensions);

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -669,7 +669,7 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
         }
     }
 
-    m_device = new vkt::Device(gpu_, m_device_extension_names, features, create_device_pnext);
+    m_device = new vkt::Device(gpu_, m_device_extension_names, features, create_device_pnext, all_queue_count_);
 
     for (const char *device_ext_name : m_device_extension_names) {
         vk::InitDeviceExtension(instance_, *m_device, device_ext_name);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -191,6 +191,7 @@ class VkRenderFramework : public VkTestFramework {
     VkPhysicalDevice gpu_ = VK_NULL_HANDLE;
     VkPhysicalDeviceProperties physDevProps_;
     vkt::FeatureRequirements feature_requirements_;
+    bool all_queue_count_ = false;
 
     uint32_t m_gpu_index;
     vkt::Device *m_device;

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1062,7 +1062,7 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     }
 
     // Now get information correctly
-    vkt::QueueCreateInfoArray queue_info(phys_device_obj.queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(phys_device_obj.queue_properties_, true);
     // Only request creation with queuefamilies that have at least one queue
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
     auto qci = queue_info.data();

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -50,7 +50,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
     if (get_physical_device_properties2) {
         m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     }
-
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
     VkBufferCreateInfo buffCI = vku::InitStructHelper();

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -329,8 +329,8 @@ TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
 
 TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     TEST_DESCRIPTION("General testing of vkGetDeviceQueue and general Device creation cases");
+    all_queue_count_ = true;
     SetTargetApiVersion(VK_API_VERSION_1_1);
-
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  * Modifications Copyright (C) 2020 Advanced Micro Devices, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,8 +17,8 @@
 
 TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
     TEST_DESCRIPTION("Test creating 2 queues, 1 protected, and getting both with vkGetDeviceQueue2");
+    all_queue_count_ = true;
     SetTargetApiVersion(VK_API_VERSION_1_1);
-
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -233,6 +233,7 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
 TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
     TEST_DESCRIPTION("Issue a query on a secondary command buffer and copy it on a primary.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
@@ -289,6 +290,7 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
 TEST_F(PositiveQuery, QueryAndCopyMultipleCommandBuffers) {
     TEST_DESCRIPTION("Issue a query and copy from it on a second command buffer.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -2921,6 +2921,7 @@ TEST_F(NegativeSyncObject, QueueSubmitTimelineSemaphoreOutOfOrder) {
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
 
     // We need two queues for this

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -314,6 +314,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     TEST_DESCRIPTION(
         "Two command buffers, each in a separate QueueSubmit call submitted on separate queues followed by a QueueWaitIdle.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
@@ -396,6 +397,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         "Two command buffers, each in a separate QueueSubmit call submitted on separate queues, the second having a fence followed "
         "by a QueueWaitIdle.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
@@ -479,6 +481,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         "Two command buffers, each in a separate QueueSubmit call submitted on separate queues, the second having a fence followed "
         "by two consecutive WaitForFences calls on the same fence.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
@@ -559,6 +562,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
 }
 
 TEST_F(PositiveSyncObject, TwoQueuesEnsureCorrectRetirementWithWorkStolen) {
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Test requires two queues";
@@ -612,6 +616,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
         "Two command buffers, each in a separate QueueSubmit call submitted on separate queues, the second having a fence, "
         "followed by a WaitForFences call.");
 
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
@@ -697,6 +702,7 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAnd
 
     AddRequiredExtensions(VK_KHR_TIMELINE_SEMAPHORE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::timelineSemaphore);
+    all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
 
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -2178,6 +2178,7 @@ TEST_F(NegativeSyncVal, CmdClear) {
 
 TEST_F(NegativeSyncVal, CmdQuery) {
     // CmdCopyQueryPoolResults
+    all_queue_count_ = true;
     RETURN_IF_SKIP(InitSyncValFramework());
     RETURN_IF_SKIP(InitState());
     if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {


### PR DESCRIPTION
each test on the Windows NVIDIA machine takes 170ms to run at a minimum, it was discovered this is from using the max number of `queueCount` when creating a `VkDevice`

```
// Baseline number
Took 8 min 8 sec on tcubuand3
Took 5 min 35 sec on tcubumes6
Took 31 min on tcwinnvi6
Took 14 min on tcubunvi

// With this PR
Took 8 min 30 sec on tcubuand3
Took 4 min 31 sec on tcubumes6
Took 24 min on tcwinnvi6
Took 10 min on tcubunvi
```