### PR TITLE
layers: Fix secondary command buffer query deadlock

### DIFF
--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -418,7 +418,6 @@ bool CommandBuffer::UpdatesQuery(const QueryObject &query_obj) const {
     auto key = query_obj;
     key.perf_pass = 0;
     for (auto *sub_cb : linkedCommandBuffers) {
-        auto guard = sub_cb->ReadLock();
         if (sub_cb->updatedQueries.find(key) != sub_cb->updatedQueries.end()) {
             return true;
         }


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7874

This PR is another solution for https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7880 PR kindly provided by @akeley98NV. This PR removes the source of a problem. The test is based on the test from the initial PR.

I made further analysis and it should be safe to remove the lock. In the comment from the original PR (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7880#issuecomment-2073370057) I mentioned external synchronization but that's not about it and should be ignored. It is about the requirements for pending command buffers.

For each `vkCmd*` we call `ValidateCmd` function which reports validation error if the command buffer is in the *pending* state.

`updatedQueries`  is modified by the following commands:
* vkCmdBeginQuery
* vkCmdBeginQueryIndexedEXT
* vkCmdEndQuery
* vkCmdEndQueryIndexedEXT
* vkCmdWriteAccelerationStructuresPropertiesKHR
* vkCmdResetQueryPool
* vkCmdDecodeVideoKHR
* vkCmdEncodeVideoKHR
and
* vkBeginCommandBuffer

The above commands skip `Record` phase (that's where `updatedQueries` is modified) when the command buffer is pending. All commands except `vkBeginCommandBuffer` do this through `ValidateCmd` validation and `vkBeginCommandBuffer` uses `InUse` check.

The only function left that can access `updatedQueries` during submissions is `CommandBuffer::UpdatesQuery` const method and because it's read access we can go without lock for the secondary command buffers. For the primary command buffer we did not use lock from the beginning.

Noticed one more thing that might need to be addressed (or not, should be investiagated). If that's the issue it has wider scope than this PR and affects command buffer recording in general. At the first sight it looks problematic that we call `submission.EndUse();` before `CommandBuffer::Retire`. If you are lucky it should be possible to squeeze in `vkBeginCommandBuffer` between EndUse and Retire and it might run without validation errors thinking that command buffer is not in use, and after that we will call `CommandBuffer::Retire` which looks wrong. If that's the real issue the solution might be to put ` submission.EndUse();` at the end of the function but did not try to investigate this here.

