### PR TITLE
tests: Make vkt::Queue the only helper to submit to the queue

### DIFF
--- a/tests/framework/barrier_queue_family.cpp
+++ b/tests/framework/barrier_queue_family.cpp
@@ -147,7 +147,12 @@ void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const 
             // the Fence resolves to VK_NULL_HANLE... i.e. no fence
             qf->queue->submit({{qf->command_buffer, qf->command_buffer2}}, vkt::Fence(), positive);
         } else {
-            qf->command_buffer->QueueCommandBuffer(qf->queue, positive);  // Check for success on positive tests only
+            if (positive) {  // Check for success on positive tests only
+                qf->queue->submit(*qf->command_buffer);
+            } else {
+                qf->queue->submit(*qf->command_buffer, false);
+            }
+            qf->queue->wait();
         }
     }
 
@@ -198,7 +203,12 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
             // the Fence resolves to VK_NULL_HANLE... i.e. no fence
             qf->queue->submit({{qf->command_buffer, qf->command_buffer2}}, vkt::Fence(), positive);
         } else {
-            qf->command_buffer->QueueCommandBuffer(qf->queue, positive);  // Check for success on positive tests only
+            if (positive) {  // Check for success on positive tests only
+                qf->queue->submit(*qf->command_buffer);
+            } else {
+                qf->queue->submit(*qf->command_buffer, false);
+            }
+            qf->queue->wait();
         }
     }
 
@@ -217,7 +227,8 @@ void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::Com
     vk::CmdPipelineBarrier(cb->handle(), src_stages, dst_stages, 0, 0, nullptr, num_buf_barrier, buf_barrier, num_img_barrier,
                            img_barrier);
     cb->end();
-    cb->QueueCommandBuffer(queue);  // Implicitly waits
+    queue->submit(*cb);
+    queue->wait();
 }
 
 void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer *cb_from, vkt::Queue *queue_to,
@@ -238,7 +249,8 @@ void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::Com
     dep_info.pImageMemoryBarriers = img_barrier;
     vk::CmdPipelineBarrier2KHR(cb->handle(), &dep_info);
     cb->end();
-    cb->QueueCommandBuffer(queue);  // Implicitly waits
+    queue->submit(*cb);
+    queue->wait();
 }
 
 void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer *cb_from, vkt::Queue *queue_to,

--- a/tests/framework/barrier_queue_family.h
+++ b/tests/framework/barrier_queue_family.h
@@ -89,16 +89,17 @@ class Barrier2QueueFamilyTestHelper : public BarrierQueueFamilyBase {
     VkBufferMemoryBarrier2KHR buffer_barrier_;
 };
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::CommandBuffer *cb, VkPipelineStageFlags src_stages,
+void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer *cb, VkPipelineStageFlags src_stages,
                               VkPipelineStageFlags dst_stages, const VkBufferMemoryBarrier *buf_barrier,
                               const VkImageMemoryBarrier *img_barrier);
 
-void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::CommandBuffer *cb, const VkBufferMemoryBarrier2KHR *buf_barrier,
-                              const VkImageMemoryBarrier2KHR *img_barrier);
+void ValidOwnershipTransferOp(ErrorMonitor *monitor, vkt::Queue *queue, vkt::CommandBuffer *cb,
+                              const VkBufferMemoryBarrier2KHR *buf_barrier, const VkImageMemoryBarrier2KHR *img_barrier);
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::CommandBuffer *cb_from, vkt::CommandBuffer *cb_to,
-                            VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
+void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer *cb_from, vkt::Queue *queue_to,
+                            vkt::CommandBuffer *cb_to, VkPipelineStageFlags src_stages, VkPipelineStageFlags dst_stages,
                             const VkBufferMemoryBarrier *buf_barrier, const VkImageMemoryBarrier *img_barrier);
 
-void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::CommandBuffer *cb_from, vkt::CommandBuffer *cb_to,
-                            const VkBufferMemoryBarrier2KHR *buf_barrier, const VkImageMemoryBarrier2KHR *img_barrier);
+void ValidOwnershipTransfer(ErrorMonitor *monitor, vkt::Queue *queue_from, vkt::CommandBuffer *cb_from, vkt::Queue *queue_to,
+                            vkt::CommandBuffer *cb_to, const VkBufferMemoryBarrier2KHR *buf_barrier,
+                            const VkImageMemoryBarrier2KHR *img_barrier);

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1032,9 +1032,6 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     void EncodeVideo(const VkVideoEncodeInfoKHR &encodeInfo);
     void EndVideoCoding(const VkVideoEndCodingInfoKHR &endInfo);
 
-    void QueueCommandBuffer(Queue *queue, bool check_success = true);
-    void QueueCommandBuffer(Queue *queue, const Fence &fence, bool check_success = true, bool submit_2 = false);
-
     void SetEvent(Event &event, VkPipelineStageFlags stageMask) { event.cmd_set(*this, stageMask); }
     void ResetEvent(Event &event, VkPipelineStageFlags stageMask) { event.cmd_reset(*this, stageMask); }
     void WaitEvents(uint32_t eventCount, const VkEvent *pEvents, VkPipelineStageFlags srcStageMask,

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1166,7 +1166,7 @@ BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Queue
     bot_level_accel_struct->BuildCmdBuffer(cmd_buffer);
     cmd_buffer.end();
 
-    cmd_buffer.QueueCommandBuffer(&queue);
+    queue.submit(cmd_buffer);
     device.wait();
 
     cmd_buffer.begin();
@@ -1176,7 +1176,7 @@ BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Queue
     top_level_accel_struct.BuildCmdBuffer(cmd_buffer);
     cmd_buffer.end();
 
-    cmd_buffer.QueueCommandBuffer(&queue);
+    queue.submit(cmd_buffer);
     device.wait();
 
     return top_level_accel_struct;

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -1157,7 +1157,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &de
     return out_build_info;
 }
 
-BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::CommandBuffer &cmd_buffer) {
+BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Queue &queue, vkt::CommandBuffer &cmd_buffer) {
     // Create acceleration structure
     cmd_buffer.begin();
     // Build Bottom Level Acceleration Structure
@@ -1166,7 +1166,7 @@ BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Comma
     bot_level_accel_struct->BuildCmdBuffer(cmd_buffer);
     cmd_buffer.end();
 
-    cmd_buffer.QueueCommandBuffer();
+    cmd_buffer.QueueCommandBuffer(&queue);
     device.wait();
 
     cmd_buffer.begin();
@@ -1176,7 +1176,7 @@ BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device &device, vkt::Comma
     top_level_accel_struct.BuildCmdBuffer(cmd_buffer);
     cmd_buffer.end();
 
-    cmd_buffer.QueueCommandBuffer();
+    cmd_buffer.QueueCommandBuffer(&queue);
     device.wait();
 
     return top_level_accel_struct;

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -279,7 +279,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device& de
                                                            std::shared_ptr<BuildGeometryInfoKHR> on_host_bottom_level_geometry);
 
 // Create and build a top level acceleration structure
-BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device& device, vkt::CommandBuffer& cmd_buffer);
+BuildGeometryInfoKHR BuildOnDeviceTopLevel(const vkt::Device& device, vkt::Queue& queue, vkt::CommandBuffer& cmd_buffer);
 }  // namespace blueprint
 }  // namespace as
 

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -1927,7 +1927,7 @@ class VideoContext {
           cmd_pool_(
               *device, queue_.get_family_index(),
               VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT | (protected_content ? VK_COMMAND_POOL_CREATE_PROTECTED_BIT : 0)),
-          cmd_buffer_(*device, &cmd_pool_, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &queue_),
+          cmd_buffer_(*device, &cmd_pool_, VK_COMMAND_BUFFER_LEVEL_PRIMARY),
           session_(VK_NULL_HANDLE),
           session_memory_(),
           session_params_(VK_NULL_HANDLE),

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1838,7 +1838,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     vkt::CommandPool graphics_pool(*m_device, graphics_queue->get_family_index());
 
-    vkt::CommandBuffer graphics_buffer(*m_device, &graphics_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, graphics_queue);
+    vkt::CommandBuffer graphics_buffer(*m_device, &graphics_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     VkClearValue cv;
     cv.color = VkClearColorValue{};
@@ -1876,7 +1876,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     vkt::CommandPool compute_pool(*m_device, compute_queue->get_family_index());
 
-    vkt::CommandBuffer compute_buffer(*m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, compute_queue);
+    vkt::CommandBuffer compute_buffer(*m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     // Record command buffers without queue transition
 
@@ -1889,7 +1889,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     graphics_buffer.end();
 
-    graphics_buffer.QueueCommandBuffer();
+    graphics_buffer.QueueCommandBuffer(graphics_queue);
 
     // Record compute command buffer
     compute_buffer.begin();
@@ -1905,7 +1905,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     // Warning should trigger as we are potentially accessing undefined resources
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
-    compute_buffer.QueueCommandBuffer();
+    compute_buffer.QueueCommandBuffer(compute_queue);
     m_errorMonitor->VerifyFound();
 
     vk::ResetCommandPool(device(), graphics_pool.handle(), 0);
@@ -1938,7 +1938,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     graphics_buffer.end();
 
-    graphics_buffer.QueueCommandBuffer();
+    graphics_buffer.QueueCommandBuffer(graphics_queue);
 
     // Record compute command buffer
     compute_buffer.begin();
@@ -1957,7 +1957,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     // Warning shouldn't trigger
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
-    compute_buffer.QueueCommandBuffer();
+    compute_buffer.QueueCommandBuffer(compute_queue);
     m_errorMonitor->Finish();
 }
 

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -1889,7 +1889,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     graphics_buffer.end();
 
-    graphics_buffer.QueueCommandBuffer(graphics_queue);
+    graphics_queue->submit(graphics_buffer);
+    graphics_queue->wait();
 
     // Record compute command buffer
     compute_buffer.begin();
@@ -1905,7 +1906,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     // Warning should trigger as we are potentially accessing undefined resources
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
-    compute_buffer.QueueCommandBuffer(compute_queue);
+    compute_queue->submit(compute_buffer);
+    compute_queue->wait();
     m_errorMonitor->VerifyFound();
 
     vk::ResetCommandPool(device(), graphics_pool.handle(), 0);
@@ -1937,8 +1939,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
                            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
 
     graphics_buffer.end();
-
-    graphics_buffer.QueueCommandBuffer(graphics_queue);
+    graphics_queue->submit(graphics_buffer);
+    graphics_queue->wait();
 
     // Record compute command buffer
     compute_buffer.begin();
@@ -1957,7 +1959,8 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     // Warning shouldn't trigger
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "BestPractices-ConcurrentUsageOfExclusiveImage");
-    compute_buffer.QueueCommandBuffer(compute_queue);
+    compute_queue->submit(compute_buffer);
+    compute_queue->wait();
     m_errorMonitor->Finish();
 }
 

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -706,13 +706,13 @@ TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
         "compute opeartions");
 
     RETURN_IF_SKIP(Init());
-    vkt::Queue* queue = m_device->TransferOnlyQueue();
-    if (!queue) {
-        GTEST_SKIP() << "Transfer-only queue not found";
+    auto transfer_family = m_device->TransferOnlyQueueFamily();
+    if (!transfer_family.has_value()) {
+        GTEST_SKIP() << "Transfer-only queue family not found";
     }
 
-    vkt::CommandPool pool(*m_device, queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+    vkt::CommandPool pool(*m_device, transfer_family.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     cb.begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdFillBuffer-apiVersion-07894");

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -26,7 +26,7 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
     }
 
     vkt::CommandPool no_gfx_pool(*m_device, no_gfx_queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, no_gfx_queue);
+    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
     auto buffer_barrier = buffer.buffer_memory_barrier(0, 0, 0, VK_WHOLE_SIZE);
@@ -34,19 +34,19 @@ TEST_F(PositiveBuffer, OwnershipTranfers) {
     // Let gfx own it.
     buffer_barrier.srcQueueFamilyIndex = m_device->graphics_queue_node_index_;
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransferOp(m_errorMonitor, m_commandBuffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                             &buffer_barrier, nullptr);
+    ValidOwnershipTransferOp(m_errorMonitor, m_default_queue, m_commandBuffer, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
+                             VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
 
     // Transfer it to non-gfx
     buffer_barrier.dstQueueFamilyIndex = no_gfx_queue->get_family_index();
-    ValidOwnershipTransfer(m_errorMonitor, m_commandBuffer, &no_gfx_cb, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT,
-                           VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_commandBuffer, no_gfx_queue, &no_gfx_cb,
+                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, &buffer_barrier, nullptr);
 
     // Transfer it to gfx
     buffer_barrier.srcQueueFamilyIndex = no_gfx_queue->get_family_index();
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransfer(m_errorMonitor, &no_gfx_cb, m_commandBuffer, VK_PIPELINE_STAGE_TRANSFER_BIT,
-                           VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, &no_gfx_cb, m_default_queue, m_commandBuffer,
+                           VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, &buffer_barrier, nullptr);
 }
 
 TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -436,13 +436,13 @@ TEST_F(PositiveCommand, FillBufferCmdPoolTransferQueue) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    vkt::Queue *queue = m_device->TransferOnlyQueue();
-    if (!queue) {
-        GTEST_SKIP() << "Transfer-only queue not found";
+    auto tranfer_family = m_device->TransferOnlyQueueFamily();
+    if (!tranfer_family.has_value()) {
+        GTEST_SKIP() << "Transfer-only queue family not found";
     }
 
-    vkt::CommandPool pool(*m_device, queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+    vkt::CommandPool pool(*m_device, tranfer_family.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
+    vkt::CommandBuffer cb(*m_device, &pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
     cb.begin();

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -429,7 +429,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -806,7 +806,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -942,7 +942,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -1285,7 +1285,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -429,7 +429,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -806,7 +806,7 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -942,7 +942,7 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -1285,7 +1285,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -111,7 +111,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -111,7 +111,8 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -85,7 +85,8 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
         m_commandBuffer->begin();
         vk::CmdFillBuffer(m_commandBuffer->handle(), ib.handle(), 0, 16, 5);
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+        m_default_queue->submit(*m_commandBuffer, false);
+        m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
 

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -85,7 +85,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
         m_commandBuffer->begin();
         vk::CmdFillBuffer(m_commandBuffer->handle(), ib.handle(), 0, 16, 5);
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(false);
+        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
         m_errorMonitor->VerifyFound();
     }
 

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -247,7 +247,8 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
                            &mem_barrier, 0, nullptr, 0, nullptr);
     vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_import.handle(), buffer_output.handle(), 1, &copy_info);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveExternalMemorySync, BufferDedicatedAllocation) {

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -247,7 +247,7 @@ TEST_F(PositiveExternalMemorySync, ExternalMemory) {
                            &mem_barrier, 0, nullptr, 0, nullptr);
     vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_import.handle(), buffer_output.handle(), 1, &copy_info);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveExternalMemorySync, BufferDedicatedAllocation) {

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -139,7 +139,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Should not get a warning since shader wasn't instrumented
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     VkValidationFeatureEnableEXT enabled[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
     VkValidationFeaturesEXT features = vku::InitStructHelper();
@@ -163,7 +163,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     // Should get a warning since shader was instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-storageBuffers-06936");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -833,7 +833,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32) {
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
     vk::DeviceWaitIdle(*m_device);
 }
@@ -903,7 +903,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32Vk13) {
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
     vk::DeviceWaitIdle(*m_device);
 }
@@ -961,7 +961,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8) {
 
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 20475 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
     vk::DeviceWaitIdle(*m_device);
 }
@@ -1030,7 +1030,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8Vk13) {
 
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 20475 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
     vk::DeviceWaitIdle(*m_device);
 }

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -139,7 +139,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
     // Should not get a warning since shader wasn't instrumented
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     VkValidationFeatureEnableEXT enabled[] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT};
     VkValidationFeaturesEXT features = vku::InitStructHelper();
@@ -163,7 +163,7 @@ TEST_F(NegativeGpuAV, SelectInstrumentedShaders) {
     // Should get a warning since shader was instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-storageBuffers-06936");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -833,9 +833,9 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32) {
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
-    vk::DeviceWaitIdle(*m_device);
 }
 
 TEST_F(NegativeGpuAV, CopyBufferToImageD32Vk13) {
@@ -903,9 +903,9 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32Vk13) {
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 16376 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
-    vk::DeviceWaitIdle(*m_device);
 }
 
 TEST_F(NegativeGpuAV, CopyBufferToImageD32U8) {
@@ -961,9 +961,9 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8) {
 
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 20475 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
-    vk::DeviceWaitIdle(*m_device);
 }
 
 TEST_F(NegativeGpuAV, CopyBufferToImageD32U8Vk13) {
@@ -1030,7 +1030,7 @@ TEST_F(NegativeGpuAV, CopyBufferToImageD32U8Vk13) {
 
     m_commandBuffer->end();
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "has a float value at offset 20475 that is not in the range [0, 1]");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
-    vk::DeviceWaitIdle(*m_device);
 }

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -79,7 +79,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -94,7 +94,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
 
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -135,7 +135,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -202,7 +202,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
     m_commandBuffer->end();
     vkt::Fence null_fence;
     // use vkQueueSumit2
-    m_commandBuffer->QueueCommandBuffer(null_fence, true, true);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, null_fence, true, true);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -260,7 +260,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                 sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
@@ -276,7 +276,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                 sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -303,7 +303,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
@@ -320,7 +320,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     if (mesh_shader_enabled) {
@@ -359,7 +359,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -374,7 +374,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -442,7 +442,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
                                     (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -450,7 +450,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     draw_ptr[8] = 0;
     draw_ptr[5] = mesh_shader_props.maxMeshWorkGroupCount[1] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07327");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -458,7 +458,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     draw_ptr[5] = 0;
     draw_ptr[2] = mesh_shader_props.maxMeshWorkGroupCount[2] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07328");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[2] = 0;
@@ -470,7 +470,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         draw_ptr[0] = (mesh_shader_props.maxMeshWorkGroupTotalCount + 2) / 2;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07329");
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -503,7 +503,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set x in second draw
     draw_ptr[4] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[4] = 0;
@@ -511,7 +511,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set y in first draw
     draw_ptr[1] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[1] = 0;
@@ -519,7 +519,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set z in third draw
     draw_ptr[10] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[10] = 0;
@@ -531,7 +531,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         draw_ptr[0] = (mesh_shader_props.maxTaskWorkGroupTotalCount + 2) / 2;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07325");
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -581,7 +581,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     vk::CmdDrawIndirect(m_commandBuffer->handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -609,7 +609,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
                                sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -685,7 +685,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 
     // Check again in a 2nd submitted command buffer
@@ -702,7 +702,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 0);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -781,7 +781,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 
     // Check again in a 2nd submitted command buffer
@@ -798,7 +798,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 0);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -79,7 +79,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
 
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -94,7 +94,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
 
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -135,7 +135,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -202,7 +202,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
     m_commandBuffer->end();
     vkt::Fence null_fence;
     // use vkQueueSumit2
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, null_fence, true, true);
+    m_default_queue->submit2(*m_commandBuffer, null_fence);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -260,7 +260,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                 sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
@@ -276,7 +276,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                 sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -303,7 +303,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
@@ -320,7 +320,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     if (mesh_shader_enabled) {
@@ -359,7 +359,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -374,7 +374,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
@@ -442,7 +442,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
                                     (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -450,7 +450,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     draw_ptr[8] = 0;
     draw_ptr[5] = mesh_shader_props.maxMeshWorkGroupCount[1] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07327");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -458,7 +458,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     draw_ptr[5] = 0;
     draw_ptr[2] = mesh_shader_props.maxMeshWorkGroupCount[2] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07328");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[2] = 0;
@@ -470,7 +470,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         draw_ptr[0] = (mesh_shader_props.maxMeshWorkGroupTotalCount + 2) / 2;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07329");
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -503,7 +503,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set x in second draw
     draw_ptr[4] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07322");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[4] = 0;
@@ -511,7 +511,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set y in first draw
     draw_ptr[1] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07323");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[1] = 0;
@@ -519,7 +519,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set z in third draw
     draw_ptr[10] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07324");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     draw_ptr[10] = 0;
@@ -531,7 +531,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         draw_ptr[0] = (mesh_shader_props.maxTaskWorkGroupTotalCount + 2) / 2;
 
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07325");
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_default_queue->wait();
         m_errorMonitor->VerifyFound();
 
@@ -581,7 +581,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     vk::CmdDrawIndirect(m_commandBuffer->handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -609,7 +609,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
                                sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -685,7 +685,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 
     // Check again in a 2nd submitted command buffer
@@ -702,7 +702,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 0);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -781,7 +781,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 
     // Check again in a 2nd submitted command buffer
@@ -798,7 +798,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     vk::CmdDispatchIndirect(m_commandBuffer->handle(), indirect_buffer.handle(), 0);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -83,7 +83,8 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     m_errorMonitor->SetDesiredWarning(
         "Descriptor index 0 access out of bounds. Descriptor size is 4 and highest byte accessed was 19", 3);
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
     data = (uint32_t *)uniform_buffer.memory().map();
     *data = 1;
@@ -91,7 +92,8 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     // normally VUID-vkCmdDraw-storageBuffers-06936
     m_errorMonitor->SetDesiredWarning(
         "Descriptor index 0 access out of bounds. Descriptor size is 16 and highest byte accessed was 35", 3);
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
 
@@ -255,7 +257,7 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
         m_commandBuffer->EndRenderPass();
     }
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     vk::DeviceWaitIdle(*m_device);
     m_errorMonitor->VerifyFound();
     DestroyRenderTarget();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -83,7 +83,7 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     m_errorMonitor->SetDesiredWarning(
         "Descriptor index 0 access out of bounds. Descriptor size is 4 and highest byte accessed was 19", 3);
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
     data = (uint32_t *)uniform_buffer.memory().map();
     *data = 1;
@@ -91,7 +91,7 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     // normally VUID-vkCmdDraw-storageBuffers-06936
     m_errorMonitor->SetDesiredWarning(
         "Descriptor index 0 access out of bounds. Descriptor size is 16 and highest byte accessed was 35", 3);
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
 }
 
@@ -255,7 +255,7 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
         m_commandBuffer->EndRenderPass();
     }
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(true);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     vk::DeviceWaitIdle(*m_device);
     m_errorMonitor->VerifyFound();
     DestroyRenderTarget();

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -722,7 +722,7 @@ TEST_F(PositiveGpuAV, SelectInstrumentedShaders) {
     m_commandBuffer->end();
     // Should not get a warning since buggy vertex shader wasn't instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 }
 
@@ -793,7 +793,7 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
@@ -890,7 +890,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
     vk::CmdDrawIndirect(m_commandBuffer->handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 
     // Now with an offset and indexed draw
@@ -916,7 +916,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
                                sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 }
 
@@ -977,7 +977,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
                              &buffer_image_copy_2);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     vk::DeviceWaitIdle(*m_device);
 }
 
@@ -1033,7 +1033,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
                              &buffer_image_copy);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     vk::DeviceWaitIdle(*m_device);
 }
 
@@ -1126,6 +1126,6 @@ TEST_F(PositiveGpuAV, AliasImageBinding) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     vk::DeviceWaitIdle(*m_device);
 }

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -722,7 +722,7 @@ TEST_F(PositiveGpuAV, SelectInstrumentedShaders) {
     m_commandBuffer->end();
     // Should not get a warning since buggy vertex shader wasn't instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }
 
@@ -793,7 +793,8 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
@@ -890,7 +891,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
     vk::CmdDrawIndirect(m_commandBuffer->handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 
     // Now with an offset and indexed draw
@@ -916,7 +917,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
                                sizeof(VkDrawIndexedIndirectCommand));
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }
 
@@ -977,7 +978,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
                              &buffer_image_copy_2);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     vk::DeviceWaitIdle(*m_device);
 }
 
@@ -1033,7 +1034,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
                              &buffer_image_copy);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     vk::DeviceWaitIdle(*m_device);
 }
 
@@ -1126,6 +1127,6 @@ TEST_F(PositiveGpuAV, AliasImageBinding) {
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     vk::DeviceWaitIdle(*m_device);
 }

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -71,7 +71,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -125,7 +125,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -176,7 +176,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -227,7 +227,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -282,7 +282,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -337,7 +337,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -392,7 +392,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -448,7 +448,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -511,7 +511,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349", gpuav::glsl::kMaxErrorsPerCmd);
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -50,7 +50,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -71,7 +71,7 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -104,7 +104,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -125,7 +125,7 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -156,7 +156,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -176,7 +176,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -207,7 +207,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -227,7 +227,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -261,7 +261,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -282,7 +282,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -316,7 +316,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -337,7 +337,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -372,7 +372,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
                               {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr}};
     pipeline.CreateComputePipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
@@ -392,7 +392,7 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -433,8 +433,8 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
     buffer->memory().unmap();
     pipeline.SetStorageBufferBinding(buffer, 1);
 
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
     pipeline.Build();
 
@@ -448,7 +448,7 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }
@@ -488,7 +488,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
                               {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr}};
     pipeline.CreateGraphicsPipeline();
 
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
@@ -511,7 +511,7 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349", gpuav::glsl::kMaxErrorsPerCmd);
 
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_device->wait();
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -66,7 +66,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -123,7 +123,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     // Ray query with both t_min and t_max dynamically set to 42
@@ -133,7 +133,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
         uniform_buffer_ptr[1] = 42.0f;  // t_max
         uniform_buffer.memory().unmap();
     }
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -187,7 +187,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -242,7 +242,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -285,7 +285,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -331,6 +331,6 @@ TEST_F(PositiveGpuAVRayQuery, RayTracingBasic) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -55,7 +55,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
@@ -66,7 +66,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -99,7 +99,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     // Add uniform buffer binding
@@ -123,7 +123,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     // Ray query with both t_min and t_max dynamically set to 42
@@ -133,7 +133,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
         uniform_buffer_ptr[1] = 42.0f;  // t_max
         uniform_buffer.memory().unmap();
     }
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -164,7 +164,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     // Add uniform buffer binding
@@ -187,7 +187,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -220,7 +220,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     pipeline.CreateComputePipeline();
 
     // Add TLAS binding
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
 
     // Add uniform buffer binding
@@ -242,7 +242,7 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -272,7 +272,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     pipeline.CreateGraphicsPipeline();
 
     // Add TLAS binding
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer);
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer);
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
@@ -285,7 +285,7 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -315,8 +315,8 @@ TEST_F(PositiveGpuAVRayQuery, RayTracingBasic) {
     pipeline.SetRayGenShader(ray_gen);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Build pipeline
@@ -331,6 +331,6 @@ TEST_F(PositiveGpuAVRayQuery, RayTracingBasic) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -169,7 +169,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
         uint64_t(vvl::kU32Max)) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkTraceRaysIndirectCommandKHR-depth-03640");
     }
-    m_commandBuffer->QueueCommandBuffer(true);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_errorMonitor->VerifyFound();
 
     m_device->wait();

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -169,10 +169,9 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
         uint64_t(vvl::kU32Max)) {
         m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "VUID-VkTraceRaysIndirectCommandKHR-depth-03640");
     }
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
-
-    m_device->wait();
 
     vk::DestroyPipeline(device(), raytracing_pipeline, nullptr);
 }

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -96,7 +96,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRays) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -185,7 +185,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultipleStages) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -297,7 +297,7 @@ TEST_F(PositiveGpuAVRayTracing, DynamicTminTmax) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -404,7 +404,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDynamicRayFlags) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -515,6 +515,6 @@ TEST_F(PositiveGpuAVRayTracing, DynamicRayFlagsSkipTriangle) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -80,8 +80,8 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRays) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Build pipeline
@@ -96,7 +96,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRays) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -169,8 +169,8 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultipleStages) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Build pipeline
@@ -185,7 +185,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultipleStages) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -270,8 +270,8 @@ TEST_F(PositiveGpuAVRayTracing, DynamicTminTmax) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Add uniform buffer binding
@@ -297,7 +297,7 @@ TEST_F(PositiveGpuAVRayTracing, DynamicTminTmax) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -378,8 +378,8 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDynamicRayFlags) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Add uniform buffer binding
@@ -404,7 +404,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDynamicRayFlags) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -489,8 +489,8 @@ TEST_F(PositiveGpuAVRayTracing, DynamicRayFlagsSkipTriangle) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Add uniform buffer binding
@@ -515,6 +515,6 @@ TEST_F(PositiveGpuAVRayTracing, DynamicRayFlagsSkipTriangle) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -107,7 +107,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
 
     // Should get a warning since shader was instrumented
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -125,6 +125,6 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
 
     // Should not get a warning since shader was not instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 }

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -107,7 +107,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
 
     // Should get a warning since shader was instrumented
     m_errorMonitor->SetDesiredFailureMsg(kWarningBit, "VUID-vkCmdDraw-None-08613");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
@@ -125,6 +125,6 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
 
     // Should not get a warning since shader was not instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -175,7 +175,8 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &image_barrier);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 
     // Get memory size of tiled image
     VkImageSubresource2KHR subresource = vku::InitStructHelper();

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -175,7 +175,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &image_barrier);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(true);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 
     // Get memory size of tiled image
     VkImageSubresource2KHR subresource = vku::InitStructHelper();

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -5389,7 +5389,8 @@ TEST_F(NegativeImage, ComputeImageLayout) {
         cmd.end();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-        cmd.QueueCommandBuffer(m_default_queue, false);
+        m_default_queue->submit(cmd, false);
+        m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
 
@@ -5403,7 +5404,8 @@ TEST_F(NegativeImage, ComputeImageLayout) {
         cmd.end();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-        cmd.QueueCommandBuffer(m_default_queue, false);
+        m_default_queue->submit(cmd, false);
+        m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
 }
@@ -5446,7 +5448,8 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -5389,7 +5389,7 @@ TEST_F(NegativeImage, ComputeImageLayout) {
         cmd.end();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-        cmd.QueueCommandBuffer(false);
+        cmd.QueueCommandBuffer(m_default_queue, false);
         m_errorMonitor->VerifyFound();
     }
 
@@ -5403,7 +5403,7 @@ TEST_F(NegativeImage, ComputeImageLayout) {
         cmd.end();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-        cmd.QueueCommandBuffer(false);
+        cmd.QueueCommandBuffer(m_default_queue, false);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -5446,7 +5446,7 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     m_commandBuffer->end();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -390,7 +390,8 @@ TEST_F(PositiveImage, SubresourceLayout) {
     vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &barrier);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveImage, ImagelessLayoutTracking) {
@@ -517,8 +518,8 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
 
-    vkt::Fence fence(*m_device);
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, fence);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 
     VkPresentInfoKHR present = vku::InitStructHelper();
     present.waitSemaphoreCount = 1;

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -205,7 +205,7 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
 
     // Submit and verify no validation errors
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveMemory, BindMemory2) {
@@ -263,7 +263,7 @@ TEST_F(PositiveMemory, BindMemory2) {
 
     // Submit and verify no validation errors
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveMemory, NonCoherentMapping) {

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -205,7 +205,8 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
 
     // Submit and verify no validation errors
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveMemory, BindMemory2) {
@@ -263,7 +264,8 @@ TEST_F(PositiveMemory, BindMemory2) {
 
     // Submit and verify no validation errors
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveMemory, NonCoherentMapping) {

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -267,7 +267,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
 
     for (vkt::Queue *queue : queues) {
         vkt::CommandPool compute_pool(*m_device, queue->get_family_index());
-        vkt::CommandBuffer cmd_buffer(*m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue);
+        vkt::CommandBuffer cmd_buffer(*m_device, &compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
         cmd_buffer.begin();
 

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -476,7 +476,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
     // Destroy image attached to framebuffer to invalidate cmd buffer
     // Now attempt to submit cmd buffer and verify error
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyFramebuffer(device(), fb, nullptr);

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -476,7 +476,8 @@ TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
     // Destroy image attached to framebuffer to invalidate cmd buffer
     // Now attempt to submit cmd buffer and verify error
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 
     vk::DestroyFramebuffer(device(), fb, nullptr);

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -211,7 +211,8 @@ TEST_F(NegativePipeline, CmdBufferPipelineDestroyed) {
 
     // Cause error by submitting command buffer that references destroyed pipeline
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -211,7 +211,7 @@ TEST_F(NegativePipeline, CmdBufferPipelineDestroyed) {
 
     // Cause error by submitting command buffer that references destroyed pipeline
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -323,7 +323,7 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
 
-        m_commandBuffer->QueueCommandBuffer(false);
+        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
         m_errorMonitor->VerifyFound();
     }
 }

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -323,7 +323,8 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
         m_commandBuffer->EndRenderPass();
         m_commandBuffer->end();
 
-        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+        m_default_queue->submit(*m_commandBuffer, false);
+        m_default_queue->wait();
         m_errorMonitor->VerifyFound();
     }
 }

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -2730,11 +2730,11 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     RETURN_IF_SKIP(Init());
 
     vkt::Queue *queue0 = m_default_queue;
-    vkt::Queue *queue1 = m_device->ComputeOnlyQueue();
-    if (!queue0 || !queue1) {
+    auto queue1_family = m_device->ComputeOnlyQueueFamily();
+    if (!queue1_family.has_value()) {
         GTEST_SKIP() << "Can't find two different queue families";
     }
-    assert(queue0->get_family_index() != queue1->get_family_index());
+    assert(queue0->family_index != queue1_family.value());
 
     uint32_t counterCount = 0u;
     vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), 0, &counterCount, nullptr, nullptr);
@@ -2764,11 +2764,11 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     vkt::QueryPool query_pool(*m_device, query_pool_ci);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
-    pool_create_info.queueFamilyIndex = queue1->get_family_index();
+    pool_create_info.queueFamilyIndex = queue1_family.value();
     pool_create_info.flags = VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT;
     vkt::CommandPool command_pool(*m_device, pool_create_info);
 
-    vkt::CommandBuffer cb(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, queue1);
+    vkt::CommandBuffer cb(*m_device, &command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     auto acquire_profiling_lock_info = vku::InitStruct<VkAcquireProfilingLockInfoKHR>();
     acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -155,14 +155,14 @@ TEST_F(PositiveQuery, BasicQuery) {
     m_commandBuffer->begin();
     vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool.handle(), 0, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
     vk::ResetCommandBuffer(m_commandBuffer->handle(), 0);
     m_commandBuffer->begin();
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_commandBuffer->handle(), query_pool.handle(), 0);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }
 
@@ -283,7 +283,8 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
         primary_buffer.end();
     }
 
-    primary_buffer.QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(primary_buffer);
+    m_default_queue->wait();
     vk::QueueWaitIdle(queue);
 }
 

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -155,14 +155,14 @@ TEST_F(PositiveQuery, BasicQuery) {
     m_commandBuffer->begin();
     vk::CmdResetQueryPool(m_commandBuffer->handle(), query_pool.handle(), 0, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
     vk::ResetCommandBuffer(m_commandBuffer->handle(), 0);
     m_commandBuffer->begin();
     vk::CmdBeginQuery(m_commandBuffer->handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_commandBuffer->handle(), query_pool.handle(), 0);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 }
 
@@ -283,7 +283,7 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
         primary_buffer.end();
     }
 
-    primary_buffer.QueueCommandBuffer();
+    primary_buffer.QueueCommandBuffer(m_default_queue);
     vk::QueueWaitIdle(queue);
 }
 

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -3283,7 +3283,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadAddress) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
@@ -3317,7 +3317,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadMemory) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
@@ -3381,7 +3381,7 @@ TEST_F(NegativeRayTracing, UpdatedFirstVertex) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3421,7 +3421,7 @@ TEST_F(NegativeRayTracing, UpdatedFirstPrimitiveCount) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3510,7 +3510,7 @@ TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpUpdate) {
     blas.BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3608,7 +3608,7 @@ TEST_F(NegativeRayTracing, TooManyInstances) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -3283,7 +3283,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadAddress) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
@@ -3317,7 +3317,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadMemory) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
@@ -3381,7 +3381,7 @@ TEST_F(NegativeRayTracing, UpdatedFirstVertex) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3421,7 +3421,7 @@ TEST_F(NegativeRayTracing, UpdatedFirstPrimitiveCount) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3510,7 +3510,7 @@ TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpUpdate) {
     blas.BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -3608,7 +3608,7 @@ TEST_F(NegativeRayTracing, TooManyInstances) {
     blas->BuildCmdBuffer(*m_commandBuffer);
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
@@ -3633,8 +3633,8 @@ TEST_F(NegativeRayTracing, PipelineNullMissShader) {
     RETURN_IF_SKIP(InitState());
 
     vkt::rt::Pipeline pipeline(*this, m_device);
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     pipeline.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_NO_NULL_MISS_SHADERS_BIT_KHR);

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -1061,8 +1061,8 @@ TEST_F(NegativeRayTracingPipeline, GetRayTracingShaderGroupStackSizeUnusedGroup)
     RETURN_IF_SKIP(InitState());
 
     vkt::rt::Pipeline pipeline(*this, m_device);
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
     pipeline.SetRayGenShader(kRayTracingMinimalGlsl);
     pipeline.Build();

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -179,8 +179,8 @@ TEST_F(PositiveRayTracingPipeline, GetCaptureReplayShaderGroupHandlesKHR) {
     vkt::rt::Pipeline rt_pipe(*this, m_device);
     rt_pipe.AddCreateInfoFlags(VK_PIPELINE_CREATE_RAY_TRACING_SHADER_GROUP_HANDLE_CAPTURE_REPLAY_BIT_KHR);
     rt_pipe.InitLibraryInfo();
-    auto top_level_accel_struct =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto top_level_accel_struct = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     rt_pipe.AddTopLevelAccelStructBinding(std::move(top_level_accel_struct), 0);
     rt_pipe.SetRayGenShader(kRayTracingMinimalGlsl);
     rt_pipe.AddLibrary(rt_pipe_lib);

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -71,7 +71,7 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     blas->BuildCmdBuffer(m_commandBuffer->handle());
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -80,7 +80,7 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     tlas.BuildCmdBuffer(m_commandBuffer->handle());
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -227,7 +227,7 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, true);
+    m_default_queue->submit(*m_commandBuffer);
 
     m_device->wait();
 
@@ -412,13 +412,13 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
     }
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     m_commandBuffer->begin();
     vkt::as::BuildAccelerationStructuresKHR(m_commandBuffer->handle(), blas_vec);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 
@@ -491,7 +491,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
         vkt::as::BuildAccelerationStructuresKHR(m_commandBuffer->handle(), blas_vec);
         m_commandBuffer->end();
 
-        m_commandBuffer->QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(*m_commandBuffer);
         m_device->wait();
     }
 }
@@ -893,7 +893,7 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 }
 

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -71,7 +71,7 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     blas->BuildCmdBuffer(m_commandBuffer->handle());
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     m_commandBuffer->begin();
@@ -80,7 +80,7 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     tlas.BuildCmdBuffer(m_commandBuffer->handle());
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -227,7 +227,7 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
 
     m_commandBuffer->end();
 
-    m_commandBuffer->QueueCommandBuffer(true);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, true);
 
     m_device->wait();
 
@@ -412,13 +412,13 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
     }
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     m_commandBuffer->begin();
     vkt::as::BuildAccelerationStructuresKHR(m_commandBuffer->handle(), blas_vec);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 
@@ -491,7 +491,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
         vkt::as::BuildAccelerationStructuresKHR(m_commandBuffer->handle(), blas_vec);
         m_commandBuffer->end();
 
-        m_commandBuffer->QueueCommandBuffer();
+        m_commandBuffer->QueueCommandBuffer(m_default_queue);
         m_device->wait();
     }
 }
@@ -877,8 +877,8 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     pipeline.AddClosestHitShader(closest_hit);
 
     // Add TLAS binding
-    auto tlas =
-        std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_commandBuffer));
+    auto tlas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, *m_commandBuffer));
     pipeline.AddTopLevelAccelStructBinding(std::move(tlas), 0);
 
     // Build pipeline
@@ -893,7 +893,7 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     vk::CmdTraceRaysKHR(*m_commandBuffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 }
 

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -199,13 +199,15 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
 
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_image_view.handle(), 100, 100);
-    vkt::Fence fence(*m_device);
 
     m_commandBuffer->begin();
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 100, 100, 1, &clear);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, fence);
+
+    vkt::Fence fence(*m_device);
+    m_default_queue->submit(*m_commandBuffer, fence);
+    m_default_queue->wait();
 
     vkt::Image destImage(*m_device, 100, 100, 1, depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -305,7 +307,8 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveRenderPass, DestroyPipeline) {
@@ -916,7 +919,8 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &imb);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses) {
@@ -1196,7 +1200,8 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
         vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
                                0, nullptr, 0, nullptr, 1, &stencil_barrier);
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+        m_default_queue->submit(*m_commandBuffer, false);
+        m_default_queue->wait();
         m_commandBuffer->reset();
     }
 
@@ -1284,7 +1289,8 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     m_commandBuffer->EndRenderPass();
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveRenderPass, InputResolve) {

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -205,7 +205,7 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 100, 100, 1, &clear);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(fence);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, fence);
 
     vkt::Image destImage(*m_device, 100, 100, 1, depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -305,7 +305,7 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
     m_commandBuffer->BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
 }
 
 TEST_F(PositiveRenderPass, DestroyPipeline) {
@@ -916,7 +916,7 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &imb);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
 }
 
 TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses) {
@@ -1196,7 +1196,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
         vk::CmdPipelineBarrier(m_commandBuffer->handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
                                0, nullptr, 0, nullptr, 1, &stencil_barrier);
         m_commandBuffer->end();
-        m_commandBuffer->QueueCommandBuffer(false);
+        m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
         m_commandBuffer->reset();
     }
 
@@ -1284,7 +1284,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     m_commandBuffer->EndRenderPass();
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
 }
 
 TEST_F(PositiveRenderPass, InputResolve) {

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -194,7 +194,7 @@ TEST_F(NegativeSecondaryCommandBuffer, CascadedInvalidation) {
     vk::DestroyEvent(device(), event, nullptr);
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -194,7 +194,8 @@ TEST_F(NegativeSecondaryCommandBuffer, CascadedInvalidation) {
     vk::DestroyEvent(device(), event, nullptr);
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -34,7 +34,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     }
 
     vkt::CommandPool no_gfx_pool(*m_device, no_gfx_queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, no_gfx_queue);
+    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     // Create an "exclusive" image owned by the graphics queue.
     VkFlags image_use = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
@@ -46,7 +46,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     image_barrier.srcQueueFamilyIndex = m_device->graphics_queue_node_index_;
     image_barrier.dstQueueFamilyIndex = no_gfx_queue->get_family_index();
 
-    ValidOwnershipTransfer(m_errorMonitor, m_commandBuffer, &no_gfx_cb, nullptr, &image_barrier);
+    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_commandBuffer, no_gfx_queue, &no_gfx_cb, nullptr, &image_barrier);
 
     // Change layouts while changing ownership
     image_barrier.srcQueueFamilyIndex = no_gfx_queue->get_family_index();
@@ -61,7 +61,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
         image_barrier.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     }
 
-    ValidOwnershipTransfer(m_errorMonitor, &no_gfx_cb, m_commandBuffer, nullptr, &image_barrier);
+    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, &no_gfx_cb, m_default_queue, m_commandBuffer, nullptr, &image_barrier);
 }
 
 TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
@@ -77,7 +77,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     }
 
     vkt::CommandPool no_gfx_pool(*m_device, no_gfx_queue->get_family_index(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, no_gfx_queue);
+    vkt::CommandBuffer no_gfx_cb(*m_device, &no_gfx_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
     auto buffer_barrier =
@@ -87,11 +87,11 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     // Let gfx own it.
     buffer_barrier.srcQueueFamilyIndex = m_device->graphics_queue_node_index_;
     buffer_barrier.dstQueueFamilyIndex = m_device->graphics_queue_node_index_;
-    ValidOwnershipTransferOp(m_errorMonitor, m_commandBuffer, &buffer_barrier, nullptr);
+    ValidOwnershipTransferOp(m_errorMonitor, m_default_queue, m_commandBuffer, &buffer_barrier, nullptr);
 
     // Transfer it to non-gfx
     buffer_barrier.dstQueueFamilyIndex = no_gfx_queue->get_family_index();
-    ValidOwnershipTransfer(m_errorMonitor, m_commandBuffer, &no_gfx_cb, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_errorMonitor, m_default_queue, m_commandBuffer, no_gfx_queue, &no_gfx_cb, &buffer_barrier, nullptr);
 
     // Transfer it to gfx
     buffer_barrier.srcQueueFamilyIndex = no_gfx_queue->get_family_index();
@@ -99,7 +99,7 @@ TEST_F(PositiveSyncObject, Sync2OwnershipTranfersBuffer) {
     buffer_barrier.srcStageMask = VK_PIPELINE_STAGE_2_TRANSFER_BIT_KHR;
     buffer_barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_GRAPHICS_BIT_KHR;
 
-    ValidOwnershipTransfer(m_errorMonitor, &no_gfx_cb, m_commandBuffer, &buffer_barrier, nullptr);
+    ValidOwnershipTransfer(m_errorMonitor, no_gfx_queue, &no_gfx_cb, m_default_queue, m_commandBuffer, &buffer_barrier, nullptr);
 }
 
 TEST_F(PositiveSyncObject, LayoutFromPresentWithoutAccessMemoryRead) {

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -385,7 +385,8 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
 
         end_render(command_buffer);
         command_buffer.end();
-        command_buffer.QueueCommandBuffer(&queue);
+        queue.submit(command_buffer);
+        queue.wait();
         test.DefaultQueue()->wait();
     }
 
@@ -417,7 +418,8 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
         test.VerifyFound();
 
         command_buffer.end();
-        command_buffer.QueueCommandBuffer(&queue);
+        queue.submit(command_buffer);
+        queue.wait();
         test.DefaultQueue()->wait();
     }
 
@@ -450,7 +452,8 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
         test.VerifyFound();
 
         command_buffer.end();
-        command_buffer.QueueCommandBuffer(&queue);
+        queue.submit(command_buffer);
+        queue.wait();
         test.DefaultQueue()->wait();
     }
 
@@ -480,7 +483,8 @@ void ClearAttachmentHazardHelper::Test(BeginRenderFn& begin_render, EndRenderFn&
         vk::CmdClearAttachments(command_buffer, 1, &clear_attachment, 1, &clear_rect);
         end_render(command_buffer);
         command_buffer.end();
-        command_buffer.QueueCommandBuffer(&queue);
+        queue.submit(command_buffer);
+        queue.wait();
         test.DefaultQueue()->wait();
     }
 }
@@ -4083,7 +4087,7 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     vk::CmdDrawIndexed(m_commandBuffer->handle(), 1, 1, 0, 0, 0);
     m_commandBuffer->EndRenderPass();
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -134,7 +134,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     vk::CmdClearAttachments(*m_commandBuffer, 1, &clear_attachment, 1, &clear_rect);
     vk::CmdEndRenderPass(*m_commandBuffer);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_default_queue->wait();
 }
 
@@ -1601,7 +1601,8 @@ TEST_F(PositiveSyncVal, ThreadedSubmitAndFenceWaitAndPresent) {
                                    nullptr, 1, &transition);
         }
         cmd.end();
-        cmd.QueueCommandBuffer(m_default_queue);
+        m_default_queue->submit(cmd);
+        m_default_queue->wait();
     }
 
     constexpr int N = 1'000;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -134,7 +134,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     vk::CmdClearAttachments(*m_commandBuffer, 1, &clear_attachment, 1, &clear_rect);
     vk::CmdEndRenderPass(*m_commandBuffer);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_default_queue->wait();
 }
 
@@ -1601,7 +1601,7 @@ TEST_F(PositiveSyncVal, ThreadedSubmitAndFenceWaitAndPresent) {
                                    nullptr, 1, &transition);
         }
         cmd.end();
-        cmd.QueueCommandBuffer();
+        cmd.QueueCommandBuffer(m_default_queue);
     }
 
     constexpr int N = 1'000;

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -9691,7 +9691,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     // Will succeed this time as we reset the query
@@ -9704,7 +9704,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 
     // Will succeed again after reset
     context.Queue().submit(cb);
@@ -9964,7 +9964,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
     m_device->wait();
 
     // Will succeed this time as we reset the query
@@ -9977,7 +9977,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 
     // Will succeed again after reset
     context.Queue().submit(cb);

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -9691,7 +9691,7 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     // Will succeed this time as we reset the query
@@ -9704,7 +9704,8 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 
     // Will succeed again after reset
     context.Queue().submit(cb);
@@ -9964,7 +9965,7 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
     m_device->wait();
 
     // Will succeed this time as we reset the query
@@ -9977,7 +9978,8 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
     m_errorMonitor->VerifyFound();
     m_device->wait();
 
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 
     // Will succeed again after reset
     context.Queue().submit(cb);

--- a/tests/unit/video_positive.cpp
+++ b/tests/unit/video_positive.cpp
@@ -51,8 +51,8 @@ TEST_F(PositiveVideo, MultipleCmdBufs) {
     context.CreateResources();
 
     vkt::CommandPool cmd_pool(*m_device, config.QueueFamilyIndex(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
-    vkt::CommandBuffer cb1(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
-    vkt::CommandBuffer cb2(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &context.Queue());
+    vkt::CommandBuffer cb1(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
+    vkt::CommandBuffer cb2(*m_device, &cmd_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
     cb1.begin();
     cb1.BeginVideoCoding(context.Begin());

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -31,7 +31,7 @@ void WsiTest::SetImageLayoutPresentSrc(VkImage image) {
     vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &layout_barrier);
     cmd_buf.end();
-    cmd_buf.QueueCommandBuffer();
+    cmd_buf.QueueCommandBuffer(m_default_queue);
 }
 
 VkImageMemoryBarrier WsiTest::TransitionToPresent(VkImage swapchain_image, VkImageLayout old_layout,
@@ -412,7 +412,7 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer();
+    m_commandBuffer->QueueCommandBuffer(m_default_queue);
 }
 
 TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -31,7 +31,8 @@ void WsiTest::SetImageLayoutPresentSrc(VkImage image) {
     vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &layout_barrier);
     cmd_buf.end();
-    cmd_buf.QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(cmd_buf);
+    m_default_queue->wait();
 }
 
 VkImageMemoryBarrier WsiTest::TransitionToPresent(VkImage swapchain_image, VkImageLayout old_layout,
@@ -412,7 +413,8 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue);
+    m_default_queue->submit(*m_commandBuffer);
+    m_default_queue->wait();
 }
 
 TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -339,7 +339,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
                              &copy_region);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(false);
+    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
 
     // Test to verify that views of multiplanar images have layouts tracked correctly
     // by changing the image's layout then using a view of that image

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -339,7 +339,8 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     vk::CmdCopyBufferToImage(m_commandBuffer->handle(), buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
                              &copy_region);
     m_commandBuffer->end();
-    m_commandBuffer->QueueCommandBuffer(m_default_queue, false);
+    m_default_queue->submit(*m_commandBuffer, false);
+    m_default_queue->wait();
 
     // Test to verify that views of multiplanar images have layouts tracked correctly
     // by changing the image's layout then using a view of that image


### PR DESCRIPTION
Part 1. 
`vkt::CommandBuffer` does not keep a reference to `vkt::Queue` anymore.
`vkt::Queue` is a single helper to submit to the queue (`QueueCommandBuffer` was removed).

Part 2 is going to update `vkt::Queue` submit helpers.