### PR TITLE
layers: Fix typo in VUID 00344

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -410,7 +410,7 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (!descriptor_set.IsPushDescriptor()) {
                 msg << "Descriptor set " << FormatHandle(set)
                     << " Image layout specified by vkCmdBindDescriptorSets doesn't match actual image layout at time "
-                       "descriptor is used.";
+                       "descriptor is used";
             } else {
                 msg << "Image layout specified by vkCmdPushDescriptorSetKHR doesn't match actual image layout at time "
                        "descriptor is used";


### PR DESCRIPTION
Avoids printing dot twice as LogError adds one in string interpolation, matching `vkCmdPushDescriptorSetKHR` case, fixing the typo in current output of: vkCmdBindDescriptorSets doesn't match actual image layout at time descriptor is used..