### PR TITLE
layers: Add semaphore tracking to LatencySleepNV

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5633,3 +5633,20 @@ void ValidationStateTracker::PostCallRecordCmdBindTransformFeedbackBuffersEXT(Vk
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     cb_state->transform_feedback_buffers_bound = bindingCount;
 }
+
+void ValidationStateTracker::PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain,
+                                                         const VkLatencySleepInfoNV *pSleepInfo, const RecordObject &record_obj) {
+    auto semaphore_state = Get<vvl::Semaphore>(pSleepInfo->signalSemaphore);
+    if (semaphore_state) {
+        auto value = pSleepInfo->value;
+        semaphore_state->EnqueueSignal(vvl::SubmissionReference{}, value);
+    }
+}
+
+void ValidationStateTracker::PostCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain,
+                                                          const VkLatencySleepInfoNV *pSleepInfo, const RecordObject &record_obj) {
+    auto semaphore_state = Get<vvl::Semaphore>(pSleepInfo->signalSemaphore);
+    if (semaphore_state) {
+        semaphore_state->Retire(nullptr, record_obj.location, pSleepInfo->value);
+    }
+}

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1378,6 +1378,10 @@ class ValidationStateTracker : public ValidationObject {
                                                                 const RecordObject& record_obj) override;
     void PostCallRecordCmdSetCoverageReductionModeNV(VkCommandBuffer commandBuffer, VkCoverageReductionModeNV coverageReductionMode,
                                                      const RecordObject& record_obj) override;
+    void PreCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
+                                     const RecordObject& record_obj) override;
+    void PostCallRecordLatencySleepNV(VkDevice device, VkSwapchainKHR swapchain, const VkLatencySleepInfoNV* pSleepInfo,
+                                      const RecordObject& record_obj) override;
 
     VkFormatFeatureFlags2KHR GetExternalFormatFeaturesANDROID(const void* pNext) const;
 #ifdef VK_USE_PLATFORM_ANDROID_KHR


### PR DESCRIPTION
vkLatencySleepNV will trigger a semaphore signaling which is waited on by an application with vkWaitSemaphores. Currently when applications with Low Latency 2 support are run with VVL, due to the lack of semaphore tracking in vkLatencySleepNV, vkWaitSemaphores will timeout. This Pull Request adds tracking to vkLatencySleepNV which resolves the issue.