### PR TITLE
Check attachment depending on type

### DIFF
--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -396,7 +396,7 @@ void BestPractices::PostCallRecordCmdNextSubpass(VkCommandBuffer commandBuffer, 
         if (depth_attachment) {
             const uint32_t attachment_index = depth_attachment->attachment;
             if (attachment_index != VK_ATTACHMENT_UNUSED) {
-                depth_image_view = (*cb_state->active_attachments)[attachment_index];
+                depth_image_view = cb_state->active_attachments[attachment_index].image_view;
             }
         }
         if (depth_image_view && (depth_image_view->create_info.subresourceRange.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0U) {
@@ -536,7 +536,7 @@ void BestPractices::RecordCmdBeginRenderingCommon(VkCommandBuffer commandBuffer)
                         const uint32_t attachment_index = depth_attachment->attachment;
                         if (attachment_index != VK_ATTACHMENT_UNUSED) {
                             load_op.emplace(rp->create_info.pAttachments[attachment_index].loadOp);
-                            depth_image_view = (*cb_state->active_attachments)[attachment_index];
+                            depth_image_view = cb_state->active_attachments[attachment_index].image_view;
                         }
                     }
                 }

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -847,13 +847,16 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         if (!IsExtEnabled(device_extensions.vk_amd_mixed_attachment_samples) &&
             !IsExtEnabled(device_extensions.vk_nv_framebuffer_mixed_samples)) {
             for (uint32_t i = 0; i < cb_state.active_attachments.size(); ++i) {
-                const auto* attachment = cb_state.active_attachments[i].image_view;
-                if (attachment && cb_state.dynamic_state_value.rasterization_samples != attachment->samples) {
-                    skip |= LogError(vuid.rasterization_sampled_07474, cb_state.Handle(), loc,
-                                     "Render pass attachment %" PRIu32
-                                     " samples %s does not match samples %s set with vkCmdSetRasterizationSamplesEXT().",
-                                     i, string_VkSampleCountFlagBits(attachment->samples),
-                                     string_VkSampleCountFlagBits(cb_state.dynamic_state_value.rasterization_samples));
+                const AttachmentInfo& attachment_info = cb_state.active_attachments[i];
+                const auto* attachment = attachment_info.image_view;
+                if (attachment && !attachment_info.IsInput() && !attachment_info.IsResolve() &&
+                    cb_state.dynamic_state_value.rasterization_samples != attachment->samples) {
+                    skip |=
+                        LogError(vuid.rasterization_sampled_07474, cb_state.Handle(), loc,
+                                 "%s attachment samples %s does not match samples %s set with vkCmdSetRasterizationSamplesEXT().",
+                                 attachment_info.Describe(cb_state.attachment_source, i).c_str(),
+                                 string_VkSampleCountFlagBits(attachment->samples),
+                                 string_VkSampleCountFlagBits(cb_state.dynamic_state_value.rasterization_samples));
                 }
             }
         }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1841,9 +1841,9 @@ bool CoreChecks::ValidateCmdDrawFramebuffer(const vvl::CommandBuffer &cb_state, 
                                             const vvl::DrawDispatchVuid &vuid, const Location &loc) const {
     bool skip = false;
     // Verify attachments for unprotected/protected command buffer.
-    if (enabled_features.protectedMemory == VK_TRUE && cb_state.active_attachments) {
-        uint32_t i = 0;
-        for (const auto &view_state : *cb_state.active_attachments.get()) {
+    if (enabled_features.protectedMemory == VK_TRUE) {
+        for (uint32_t i = 0; i < cb_state.active_attachments.size(); i++) {
+            const auto *view_state = cb_state.active_attachments[i].image_view;
             const auto &subpass = cb_state.active_subpasses[i];
             if (subpass.used && view_state && !view_state->Destroyed()) {
                 std::string image_desc = "Image is ";
@@ -1857,7 +1857,6 @@ bool CoreChecks::ValidateCmdDrawFramebuffer(const vvl::CommandBuffer &cb_state, 
                 skip |= ValidateProtectedImage(cb_state, *view_state->image_state, loc, vuid.unprotected_command_buffer_02707,
                                                image_desc.c_str());
             }
-            ++i;
         }
     }
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -517,11 +517,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     }
 
     // Verify if attachments are used in DescriptorSet
-    const std::vector<vvl::ImageView *> *attachments = cb_state.active_attachments.get();
-    if (attachments && attachments->size() > 0 && !cb_state.active_subpasses.empty() &&
+    if (!cb_state.active_attachments.empty() && !cb_state.active_subpasses.empty() &&
         (descriptor_type != VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT)) {
-        for (uint32_t att_index = 0; att_index < attachments->size(); ++att_index) {
-            const auto &view_state = (*attachments)[att_index];
+        for (uint32_t att_index = 0; att_index < cb_state.active_attachments.size(); ++att_index) {
+            const auto *view_state = cb_state.active_attachments[att_index].image_view;
             const SubpassInfo &subpass = cb_state.active_subpasses[att_index];
             if (!view_state || view_state->Destroyed()) {
                 continue;

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -68,6 +68,12 @@ enum class CbState {
     InvalidIncomplete,  // fouled before recording was completed
 };
 
+struct AttachmentInfo {
+    vvl::ImageView *image_view;
+
+    AttachmentInfo() : image_view(nullptr) {}
+};
+
 struct SubpassInfo {
     bool used;
     VkImageUsageFlagBits usage;
@@ -360,9 +366,7 @@ class CommandBuffer : public RefcountedStateObject {
     // The RenderPass created from vkCmdBeginRenderPass or vkCmdBeginRendering
     std::shared_ptr<vvl::RenderPass> activeRenderPass;
     // Used for both type of renderPass
-    // TOOD - Tried to get rid of this shared_ptr as it didn't seem to be needed, but would hit "Assertion failed: vector subscript
-    // out of range" on Windows and couldn't figure out where the lifetime of the ImageView pointer went wrong.
-    std::shared_ptr<std::vector<vvl::ImageView *>> active_attachments;
+    std::vector<AttachmentInfo> active_attachments;
     vvl::unordered_set<uint32_t> active_color_attachments_index;
     uint32_t active_render_pass_device_mask;
     bool has_render_pass_striped;

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -1088,7 +1088,6 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-vkCmdDraw-None-09363");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09365");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-rasterizationSamples-07474");
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-rasterizationSamples-07474");
     vk::CmdDraw(m_commandBuffer->handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
 

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -5620,8 +5620,7 @@ TEST_F(NegativeDynamicState, SetColorBlendWriteMaskArrayLength) {
     m_commandBuffer->end();
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7327
-TEST_F(NegativeDynamicState, DISABLED_RasterizationSamplesDynamicRendering) {
+TEST_F(NegativeDynamicState, RasterizationSamplesDynamicRendering) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState3RasterizationSamples);

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -966,8 +966,7 @@ TEST_F(PositiveDynamicState, RasterizationSamplesDynamicRendering) {
     m_commandBuffer->end();
 }
 
-// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7327
-TEST_F(PositiveDynamicState, DISABLED_RasterizationSamples) {
+TEST_F(PositiveDynamicState, RasterizationSamples) {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::extendedDynamicState3RasterizationSamples);
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7327 (and the CTS tests in `dEQP-VK.pipeline.monolithic.extended_dynamic_state.misc.`)

We never had a way to know which attachments where depth vs stencil vs resolve vs color when it came to dynamic rendering

with some cleanup of the code, this logic is now all contained