### PR TITLE
build: Fix incremental builds using wrong VK_LAYER_PATH

### DIFF
--- a/docs/creating_tests.md
+++ b/docs/creating_tests.md
@@ -8,7 +8,7 @@ This is an "up-to-speed" document for writing tests to validate the Validation L
 
 The first rule is to make sure you are actually running the tests on the built version of the Validation Layers you want. Set the environment variable `VK_LOADER_DEBUG` to `layer` and check that the output of the tests report that the path of the validation layer matches what is expected.
 
-The tests automatically set `VK_LAYER_PATH` to the validation layer in the build tree. However if you wish to use a different validation layer than the one that was built, or if you wish to use multiple layers in the tests at the same time, you must set `VK_LAYER_PATH` to include each path to the desired layers, including the validation layer.
+The tests automatically set `VK_LAYER_PATH` to the validation layer in the build tree. However if you wish to use a different validation layer than the one that was built, or if you wish to use multiple layers in the tests at the same time, you must set `VK_LAYER_PATH` or `VK_ADD_LAYER_PATH` to include each path to the desired layers, including the validation layer.
 
 Make sure you have the correct `VK_LAYER_PATH` set on Windows or Linux (on Android the layers are baked into the APK so there is nothing to worry about)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -271,21 +271,12 @@ target_link_libraries(vk_layer_validation_tests PRIVATE
 )
 
 # setup framework/config.h using framework/config.h.in as a source
-file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/framework/config.h.in")
+file(GENERATE OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h" INPUT "${CMAKE_CURRENT_SOURCE_DIR}/framework/config.h.in")
 
-# copy config$<CONFIG>.h to the build directory
-add_custom_command(
-    PRE_BUILD
-    COMMAND ${CMAKE_COMMAND} "-E" "copy_if_different" "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h" "${CMAKE_CURRENT_BINARY_DIR}/config.h"
-    VERBATIM
-    DEPENDS  "${CMAKE_CURRENT_BINARY_DIR}/config$<CONFIG>.h"
-    OUTPUT   "${CMAKE_CURRENT_BINARY_DIR}/config.h"
-    COMMENT  "creating config.h file ({event: PRE_BUILD}, {filename: config.h })"
-    )
-add_custom_target (generate_framework_config DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/config.h")
-add_dependencies (generate_framework_config vk_layer_validation_tests)
+# Since config_$<CONFIG>.h differs per build, set a compiler definition that files can use to include it
+target_compile_definitions(vk_layer_validation_tests PRIVATE CONFIG_HEADER_FILE="config_$<CONFIG>.h")
 
-target_sources(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config.h)
+target_sources(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/config_$<CONFIG>.h)
 target_include_directories(vk_layer_validation_tests PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 # More details in tests/android/mock/README.md

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -18,7 +18,7 @@
 
 #include "test_framework.h"
 #include "render.h"
-#include "config.h"
+#include CONFIG_HEADER_FILE
 #include <filesystem>
 #include <cmath>
 #include <cstdarg>


### PR DESCRIPTION
Occassionally when switching between different build types in a multi-config build system would the config.h file not get copied properly. This is an inhenrent flaw in the solution used to locate build artifacts. By using a compiler definition, the correct header will always be used no matter what.