### PR TITLE
gpuav: Fix crash in dota2

### DIFF
--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -286,6 +286,10 @@ void gpuav::Validator::UpdateBoundPipeline(VkCommandBuffer commandBuffer, VkPipe
         if (last_bound.per_set[i].bound_descriptor_set) {
             auto slot = last_bound.pipeline_state->active_slots.find(i);
             if (slot != last_bound.pipeline_state->active_slots.end()) {
+                if (update_index >= descriptor_set_buffers.size()) {
+                    // TODO - Hit crash running with Dota2, this shouldn't happen, need to look into
+                    continue;
+                }
                 descriptor_set_buffers[update_index++].binding_req = slot->second;
             }
         }


### PR DESCRIPTION
This crashes Dota2, I added this logic in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7838 but clearly something is not 100% correct

There was no false positive given when doing this with Dota2, so seemed safe for now to just remove the crashing