### PR TITLE
gpu: Rework settings

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -406,7 +406,7 @@
                             "value": "GPU_BASED_GPU_ASSISTED"
                         },
                         {
-                            "key": "reserve_binding_slot",
+                            "key": "gpuav_reserve_binding_slot",
                             "value": true
                         },
                         {
@@ -815,50 +815,9 @@
                                     ],
                                     "settings": [
                                         {
-                                            "key": "reserve_binding_slot",
-                                            "label": "Reserve Descriptor Set Binding Slot",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_vma_linear_output",
-                                            "label": "Linear Memory Allocation Mode",
-                                            "description": "Use VMA linear memory allocations for GPU-AV output buffers instead of finding best place for new allocations among free regions to optimize memory usage. Enabling this setting reduces performance cost but disabling this method minimizes memory usage.",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "status": "STABLE",
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_descriptor_checks",
-                                            "label": "Descriptor and OOB Checks",
-                                            "description": "Enable descriptor and buffer out of bounds checking",
+                                            "key": "gpuav_shader_instrumentation",
+                                            "label": "Shader instrumentation",
+                                            "description": "Instrument shaders to validate descriptors, descriptor indexing, buffer device addresses and ray queries. Warning: will considerably slow down shader executions.",
                                             "type": "BOOL",
                                             "default": true,
                                             "platforms": [
@@ -876,9 +835,9 @@
                                             },
                                             "settings": [
                                                 {
-                                                    "key": "gpuav_warn_on_robust_oob",
-                                                    "label": "Generate warning on out of bounds accesses even if buffer robustness is enabled",
-                                                    "description": "Warn on out of bounds accesses even if robustness is enabled",
+                                                    "key": "gpuav_descriptor_checks",
+                                                    "label": "Descriptors indexing",
+                                                    "description": "Enable descriptors and buffer out of bounds validation when using descriptor indexing",
                                                     "type": "BOOL",
                                                     "default": true,
                                                     "platforms": [
@@ -889,7 +848,135 @@
                                                         "mode": "ALL",
                                                         "settings": [
                                                             {
-                                                                "key": "gpuav_descriptor_checks",
+                                                                "key": "gpuav_shader_instrumentation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    },
+                                                    "settings": [
+                                                        {
+                                                            "key": "gpuav_warn_on_robust_oob",
+                                                            "label": "Generate warning on out of bounds accesses even if buffer robustness is enabled",
+                                                            "description": "Warn on out of bounds accesses even if robustness is enabled",
+                                                            "type": "BOOL",
+                                                            "default": true,
+                                                            "platforms": [
+                                                                "WINDOWS",
+                                                                "LINUX"
+                                                            ],
+                                                            "dependence": {
+                                                                "mode": "ALL",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "gpuav_shader_instrumentation",
+                                                                        "value": true
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "key": "gpuav_buffer_address_oob",
+                                                    "label": "Out of bounds buffer device addresses",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Check for ",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_shader_instrumentation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    },
+                                                    "settings": [
+                                                        {
+                                                            "key": "gpuav_max_buffer_device_addresses",
+                                                            "label": "Maximum number of buffer device addresses in use at one time",
+                                                            "description": "",
+                                                            "type": "INT",
+                                                            "default": 10000,
+                                                            "range": {
+                                                                "min": 100,
+                                                                "max": 10000000
+                                                            },
+                                                            "platforms": [
+                                                                "WINDOWS",
+                                                                "LINUX"
+                                                            ],
+                                                            "dependence": {
+                                                                "mode": "ALL",
+                                                                "settings": [
+                                                                    {
+                                                                        "key": "gpuav_shader_instrumentation",
+                                                                        "value": true
+                                                                    }
+                                                                ]
+                                                            }
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "key": "gpuav_validate_ray_query",
+                                                    "label": "RayQuery SPIR-V Instructions",
+                                                    "description": "Enable shader instrumentation on OpRayQueryInitializeKHR",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_shader_instrumentation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "key": "gpuav_cache_instrumented_shaders",
+                                                    "label": "Cache instrumented shaders rather than instrumenting them on every run",
+                                                    "description": "Enable instrumented shader caching",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_shader_instrumentation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "key": "gpuav_select_instrumented_shaders",
+                                                    "label": "Enable instrumenting shaders selectively",
+                                                    "description": "Select which shaders to instrument passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext",
+                                                    "type": "BOOL",
+                                                    "default": false,
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_shader_instrumentation",
                                                                 "value": true
                                                             }
                                                         ]
@@ -898,9 +985,9 @@
                                             ]
                                         },
                                         {
-                                            "key": "gpuav_validate_indirect_buffer",
-                                            "label": "Check Draw/Dispatch/TraceRays Indirect buffers",
-                                            "description": "Enable draw/dispatch/traceRays indirect checking",
+                                            "key": "gpuav_buffers_validation",
+                                            "label": "Buffer content validation",
+                                            "description": "Validate buffers containing parameters used in indirect Vulkan commands, or used in copy commands",
                                             "type": "BOOL",
                                             "default": true,
                                             "platforms": [
@@ -915,14 +1002,96 @@
                                                         "value": "GPU_BASED_GPU_ASSISTED"
                                                     }
                                                 ]
-                                            }
+                                            },
+                                            "settings": [
+                                                {
+                                                    "key": "gpuav_indirect_draws_buffers",
+                                                    "label": "Indirect draws parameters",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Validate buffers containing draw parameters used in indirect draw commands",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_buffers_validation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "key": "indirect_dispatches",
+                                                    "label": "Indirect dispatches parameters",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Validate buffers containing dispatch parameters used in indirect dispatch commands",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_buffers_validation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "key": "indirect_trace_rays",
+                                                    "label": "Indirect trace rays parameters",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Validate buffers containing ray tracing parameters used in indirect ray tracing commands",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_buffers_validation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
+                                                    "key": "gpuav_buffer_copies",
+                                                    "label": "Buffer copies",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Validate copies involving a VkBuffer. Right now only validates copy buffer to image.",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "gpuav_buffers_validation",
+                                                                "value": true
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            ]
                                         },
                                         {
-                                            "key": "gpuav_validate_copies",
-                                            "label": "Check copy commands",
-                                            "description": "Enable copy commands checking",
-                                            "type": "BOOL",
-                                            "default": true,
+                                            "key": "gpuav_advanced_settings",
+                                            "label": "Advanced Settings",
+                                            "description": "GPU-AV advanced settings",
+                                            "type": "GROUP",
+                                            "view": "ADVANCED",
                                             "platforms": [
                                                 "WINDOWS",
                                                 "LINUX"
@@ -935,87 +1104,49 @@
                                                         "value": "GPU_BASED_GPU_ASSISTED"
                                                     }
                                                 ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_validate_ray_query",
-                                            "label": "Validate RayQuery SPIR-V Instructions",
-                                            "description": "Enable shader instrumentation on SPV_KHR_ray_query",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
+                                            },
+                                            "settings": [
+                                                {
+                                                    "key": "gpuav_reserve_binding_slot",
+                                                    "label": "Reserve Descriptor Set Binding Slot",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "description": "Specifies that the validation layers reserve a descriptor set binding slot for their own use. The layer reports a value for VkPhysicalDeviceLimits::maxBoundDescriptorSets that is one less than the value reported by the device. If the device supports the binding of only one descriptor set, the validation layer does not perform GPU-assisted validation.",
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "validate_gpu_based",
+                                                                "value": "GPU_BASED_GPU_ASSISTED"
+                                                            }
+                                                        ]
                                                     }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_cache_instrumented_shaders",
-                                            "label": "Cache instrumented shaders rather than instrumenting them on every run",
-                                            "description": "Enable instrumented shader caching",
-                                            "type": "BOOL",
-                                            "default": true,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
+                                                },
+                                                {
+                                                    "key": "gpuav_vma_linear_output",
+                                                    "label": "Linear Memory Allocation Mode",
+                                                    "description": "Use VMA linear memory allocations for GPU-AV output buffers instead of finding best place for new allocations among free regions to optimize memory usage. Enabling this setting reduces performance cost but disabling this method minimizes memory usage.",
+                                                    "type": "BOOL",
+                                                    "default": true,
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "validate_gpu_based",
+                                                                "value": "GPU_BASED_GPU_ASSISTED"
+                                                            }
+                                                        ]
                                                     }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_select_instrumented_shaders",
-                                            "label": "Enable instrumenting shaders selectively",
-                                            "description": "Select which shaders to instrument passing a VkValidationFeaturesEXT struct with GPU-AV enabled in the VkShaderModuleCreateInfo pNext",
-                                            "type": "BOOL",
-                                            "default": false,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
-                                        },
-                                        {
-                                            "key": "gpuav_max_buffer_device_addresses",
-                                            "label": "Specify the maximum number of buffer device addresses in use at one time",
-                                            "description": "Specify maximum number of buffer device addresses",
-                                            "type": "INT",
-                                            "default": 10000,
-                                            "platforms": [
-                                                "WINDOWS",
-                                                "LINUX"
-                                            ],
-                                            "dependence": {
-                                                "mode": "ALL",
-                                                "settings": [
-                                                    {
-                                                        "key": "validate_gpu_based",
-                                                        "value": "GPU_BASED_GPU_ASSISTED"
-                                                    }
-                                                ]
-                                            }
+                                                }
+                                            ]
                                         },
                                         {
                                             "key": "gpuav_debug_settings",

--- a/layers/gpu_validation/gpu_record.cpp
+++ b/layers/gpu_validation/gpu_record.cpp
@@ -44,7 +44,8 @@ void gpuav::Validator::PreCallRecordCreateBuffer(VkDevice device, const VkBuffer
     }
 
     // Indirect buffers will require validation shader to bind the indirect buffers as a storage buffer.
-    if (gpuav_settings.validate_indirect_buffer && chassis_state.modified_create_info.usage & VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT) {
+    if (gpuav_settings.IsBufferValidationEnabled() &&
+        chassis_state.modified_create_info.usage & VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT) {
         chassis_state.modified_create_info.usage |= VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     }
 

--- a/layers/gpu_validation/gpu_settings.h
+++ b/layers/gpu_validation/gpu_settings.h
@@ -18,17 +18,44 @@
 #pragma once
 struct GpuAVSettings {
     bool validate_descriptors = true;
-    bool validate_indirect_buffer = true;
-    bool validate_copies = true;
-    bool validate_ray_query = true;
-    bool vma_linear_output = true;
     bool warn_on_robust_oob = true;
+    bool validate_bda = true;
+    uint32_t max_bda_in_use = 10000;
+    bool validate_ray_query = true;
     bool cache_instrumented_shaders = true;
     bool select_instrumented_shaders = false;
-    uint32_t max_buffer_device_addresses = 10000;
+
+    bool validate_indirect_draws_buffers = true;
+    bool validate_indirect_dispatches_buffers = true;
+    bool validate_indirect_trace_rays_buffers = true;
+    bool validate_buffer_copies = true;
+
+    bool vma_linear_output = true;
 
     bool debug_validate_instrumented_shaders = false;
     bool debug_dump_instrumented_shaders = false;
+
+    bool IsShaderInstrumentationEnabled() const { return validate_descriptors || validate_bda || validate_ray_query; }
+    // Also disables shader caching and select shader instrumentation
+    void DisableShaderInstrumentationAndOptions() {
+        validate_descriptors = false;
+        warn_on_robust_oob = false;
+        validate_bda = false;
+        validate_ray_query = false;
+        // Because of those 2 settings, cannot really have an "enabled" parameter to pass to this method
+        cache_instrumented_shaders = false;
+        select_instrumented_shaders = false;
+    }
+    bool IsBufferValidationEnabled() const {
+        return validate_indirect_draws_buffers || validate_indirect_dispatches_buffers || validate_indirect_trace_rays_buffers ||
+               validate_buffer_copies;
+    }
+    void SetBufferValidationEnabled(bool enabled) {
+        validate_indirect_draws_buffers = enabled;
+        validate_indirect_dispatches_buffers = enabled;
+        validate_indirect_trace_rays_buffers = enabled;
+        validate_buffer_copies = enabled;
+    }
 };
 
 struct DebugPrintfSettings {

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -43,9 +43,9 @@
 #include "generated/gpu_pre_copy_buffer_to_image_comp.h"
 
 VkDeviceAddress gpuav::Validator::GetBufferDeviceAddress(VkBuffer buffer, const Location &loc) const {
-    if (!buffer_device_address_enabled) {
+    if (!enabled_features.bufferDeviceAddress) {
         assert(false);
-        ReportSetupProblem(buffer, loc, "Buffer device address feature not enabled, calling GetBufferDeviceAddress is invalid");
+        ReportSetupProblem(buffer, loc, "bufferDeviceAddress feature not enabled, calling GetBufferDeviceAddress is invalid.");
         aborted = true;
         return 0;
     }
@@ -143,13 +143,11 @@ bool gpuav::Validator::InstrumentShader(const vvl::span<const uint32_t> &input, 
         module.RunPassBindlessDescriptor();
     }
 
-    if ((IsExtEnabled(device_extensions.vk_ext_buffer_device_address) ||
-         IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) &&
-        shaderInt64 && enabled_features.bufferDeviceAddress) {
+    if (gpuav_settings.validate_bda) {
         module.RunPassBufferDeviceAddress();
     }
 
-    if (enabled_features.rayQuery && gpuav_settings.validate_ray_query) {
+    if (gpuav_settings.validate_ray_query) {
         module.RunPassRayQuery();
     }
 
@@ -501,7 +499,7 @@ gpuav::CommandResources gpuav::Validator::AllocateActionCommandResources(
 
         // Buffer device addresses buffer
         VkDescriptorBufferInfo bda_input_desc_buffer_info = {};
-        if (buffer_device_address_enabled) {
+        if (bda_validation_possible) {
             bda_input_desc_buffer_info.range = VK_WHOLE_SIZE;
             bda_input_desc_buffer_info.buffer = cmd_buffer->GetBdaRangesSnapshot().buffer;
             bda_input_desc_buffer_info.offset = 0;
@@ -639,7 +637,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndire
         return nullptr;
     }
 
-    if (!gpuav_settings.validate_indirect_buffer) {
+    if (!gpuav_settings.validate_indirect_draws_buffers) {
         CommandResources cmd_resources = AllocateActionCommandResources(cb_node, VK_PIPELINE_BIND_POINT_GRAPHICS, loc);
         auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
         return cmd_resources_ptr;
@@ -922,7 +920,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDispatchIn
         return nullptr;
     }
 
-    if (!gpuav_settings.validate_indirect_buffer) {
+    if (!gpuav_settings.validate_indirect_dispatches_buffers) {
         CommandResources cmd_resources = AllocateActionCommandResources(cb_node, VK_PIPELINE_BIND_POINT_COMPUTE, loc);
         auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
         return cmd_resources_ptr;
@@ -1121,7 +1119,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreTraceRaysV
         return nullptr;
     }
 
-    if (!gpuav_settings.validate_indirect_buffer) {
+    if (!gpuav_settings.validate_indirect_trace_rays_buffers) {
         CommandResources cmd_resources = AllocateActionCommandResources(cb_node, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, loc);
         auto cmd_resources_ptr = std::make_unique<CommandResources>(cmd_resources);
         return cmd_resources_ptr;
@@ -1347,7 +1345,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreCopyBuffer
         return nullptr;
     }
 
-    if (!gpuav_settings.validate_copies) {
+    if (!gpuav_settings.validate_buffer_copies) {
         return nullptr;
     }
 

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -477,9 +477,6 @@ class Validator : public gpu_tracker::Validator {
                            VkImageLayout explicit_layout, const Location& image_loc, const char* mismatch_layout_vuid,
                            bool* error) const override;
 
-  public:
-    bool IsBufferDeviceAddressEnabled() const { return buffer_device_address_enabled; }
-
   private:
     VkPipeline GetDrawValidationPipeline(VkRenderPass render_pass);
 
@@ -492,7 +489,7 @@ class Validator : public gpu_tracker::Validator {
     std::string instrumented_shader_cache_path{};
     AccelerationStructureBuildValidationState acceleration_structure_validation_state{};
 
-    bool buffer_device_address_enabled = false;
+    bool bda_validation_possible = false;
 
     std::optional<DescriptorHeap> desc_heap{};  // optional only to defer construction
 };

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -20,6 +20,8 @@
 #include "utils/hash_util.h"
 #include <vulkan/layer/vk_layer_settings.hpp>
 
+#include "gpu_validation/gpu_settings.h"
+
 // Include new / delete overrides if using mimalloc. This needs to be include exactly once in a file that is
 // part of the VVL but not the layer utils library.
 #if defined(USE_MIMALLOC) && defined(_WIN64)
@@ -41,7 +43,6 @@ const char *VK_LAYER_VALIDATE_BEST_PRACTICES_IMG = "validate_best_practices_img"
 const char *VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_nvidia";
 const char *VK_LAYER_VALIDATE_SYNC = "validate_sync";
 const char *VK_LAYER_VALIDATE_GPU_BASED = "validate_gpu_based";
-const char *VK_LAYER_RESERVE_BINDING_SLOT = "reserve_binding_slot";
 
 const char *VK_LAYER_DISABLES = "disables";
 const char *VK_LAYER_STATELESS_PARAM = "stateless_param";
@@ -66,19 +67,33 @@ const char *VK_LAYER_PRINTF_TO_STDOUT = "printf_to_stdout";
 const char *VK_LAYER_PRINTF_VERBOSE = "printf_verbose";
 const char *VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
 
+// GPU-AV
+// ---
+const char *VK_LAYER_GPUAV_SHADER_INSTRUMENTATION = "gpuav_shader_instrumentation";
 const char *VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS = "gpuav_descriptor_checks";
-const char *VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
-const char *VK_LAYER_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
-const char *VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
-const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 const char *VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB = "gpuav_warn_on_robust_oob";
+const char *VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB = "gpuav_buffer_address_oob";
+const char *VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS = "gpuav_max_buffer_device_addresses";
+const char *VK_LAYER_GPUAV_VALIDATE_RAY_QUERY = "gpuav_validate_ray_query";
 const char *VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS = "gpuav_cache_instrumented_shaders";
 const char *VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS = "gpuav_select_instrumented_shaders";
-const char *VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS = "gpuav_max_buffer_device_addresses";
-const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "debug_validate_instrumented_shaders";
+
+const char *VK_LAYER_GPUAV_BUFFERS_VALIDATION = "gpuav_buffers_validation";
+const char *VK_LAYER_GPUAV_VALIDATE_INDIRECT_DRAWS_BUFFERS = "gpuav_indirect_draws_buffers";
+const char *VK_LAYER_GPUAV_VALIDATE_INDIRECT_DISPATCHES_BUFFERS = "gpuav_indirect_dispatches_buffers";
+const char *VK_LAYER_GPUAV_VALIDATE_INDIRECT_TRACE_RAYS_BUFFERS = "gpuav_indirect_trace_rays_buffers";
+const char *VK_LAYER_GPUAV_VALIDATE_BUFFER_COPIES = "gpuav_buffer_copies";
+
+const char *VK_LAYER_GPUAV_RESERVE_BINDING_SLOT = "gpuav_reserve_binding_slot";
+const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
+
+const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
 
 // These were deprecated after the 1.3.280 SDK release
+const char *DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
+const char *DEPRECATED_VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER = "gpuav_validate_indirect_buffer";
+const char *DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT = "reserve_binding_slot";
 const char *DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
 const char *DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
 const char *DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
@@ -436,21 +451,102 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     }
 
     GpuAVSettings &gpuav_settings = *settings_data->gpuav_settings;
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS, gpuav_settings.validate_descriptors);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SHADER_INSTRUMENTATION)) {
+        bool shader_instrumentation_enabled;
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SHADER_INSTRUMENTATION, shader_instrumentation_enabled);
+        if (!shader_instrumentation_enabled) {
+            gpuav_settings.DisableShaderInstrumentationAndOptions();
+        } else {
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_DESCRIPTORS,
+                                        gpuav_settings.validate_descriptors);
+            }
+
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.warn_on_robust_oob);
+            } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB)) {
+                vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.warn_on_robust_oob);
+                printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+                       DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB);
+            }
+
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_BUFFER_ADDRESS_OOB, gpuav_settings.validate_bda);
+            }
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS,
+                                        gpuav_settings.max_bda_in_use);
+            }
+
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY, gpuav_settings.validate_ray_query);
+            }
+
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS,
+                                        gpuav_settings.cache_instrumented_shaders);
+            } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE)) {
+                vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE,
+                                        gpuav_settings.cache_instrumented_shaders);
+                printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+                       DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS);
+            }
+
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS,
+                                        gpuav_settings.select_instrumented_shaders);
+            } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS,
+                                        gpuav_settings.select_instrumented_shaders);
+                printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+                       DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS);
+            }
+
+            // No need to enable shader instrumentation options is no instrumentation is done
+            if (!gpuav_settings.IsShaderInstrumentationEnabled()) {
+                gpuav_settings.DisableShaderInstrumentationAndOptions();
+            }
+        }
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_BUFFER,
-                                gpuav_settings.validate_indirect_buffer);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_BUFFERS_VALIDATION)) {
+        bool buffers_validation_enabled;
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_BUFFERS_VALIDATION, buffers_validation_enabled);
+        if (!buffers_validation_enabled) {
+            gpuav_settings.SetBufferValidationEnabled(false);
+        } else {
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_DRAWS_BUFFERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_DRAWS_BUFFERS,
+                                        gpuav_settings.validate_indirect_draws_buffers);
+            }
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_DISPATCHES_BUFFERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_DISPATCHES_BUFFERS,
+                                        gpuav_settings.validate_indirect_dispatches_buffers);
+            }
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_TRACE_RAYS_BUFFERS)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_INDIRECT_TRACE_RAYS_BUFFERS,
+                                        gpuav_settings.validate_indirect_trace_rays_buffers);
+            }
+            if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_BUFFER_COPIES)) {
+                vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_BUFFER_COPIES,
+                                        gpuav_settings.validate_buffer_copies);
+            } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES)) {
+                vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES,
+                                        gpuav_settings.validate_buffer_copies);
+                printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+                       DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES, VK_LAYER_GPUAV_VALIDATE_BUFFER_COPIES);
+            }
+        }
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_COPIES)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_COPIES, gpuav_settings.validate_copies);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_VALIDATE_RAY_QUERY, gpuav_settings.validate_ray_query);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_RESERVE_BINDING_SLOT)) {
+        SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
+                             VK_LAYER_GPUAV_RESERVE_BINDING_SLOT);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT)) {
+        SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
+                             DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+               DEPRECATED_VK_LAYER_RESERVE_BINDING_SLOT, VK_LAYER_GPUAV_RESERVE_BINDING_SLOT);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT)) {
@@ -459,38 +555,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT, gpuav_settings.vma_linear_output);
         printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n", DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT,
                VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.warn_on_robust_oob);
-    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB, gpuav_settings.vma_linear_output);
-        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n", DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB,
-               VK_LAYER_GPUAV_WARN_ON_ROBUST_OOB);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS,
-                                gpuav_settings.cache_instrumented_shaders);
-    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE,
-                                gpuav_settings.vma_linear_output);
-        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
-               DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE, VK_LAYER_GPUAV_CACHE_INSTRUMENTED_SHADERS);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS,
-                                gpuav_settings.select_instrumented_shaders);
-    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, gpuav_settings.vma_linear_output);
-        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
-               DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS, VK_LAYER_GPUAV_SELECT_INSTRUMENTED_SHADERS);
-    }
-
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_MAX_BUFFER_DEVICE_ADDRESS_BUFFERS,
-                                gpuav_settings.max_buffer_device_addresses);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS)) {
@@ -536,9 +600,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
             settings_data->enables[gpu_validation] = setting_value == "GPU_BASED_GPU_ASSISTED";
             settings_data->enables[debug_printf_validation] = setting_value == "GPU_BASED_DEBUG_PRINTF";
         }
-
-        SetValidationSetting(layer_setting_set, settings_data->enables, gpu_validation_reserve_binding_slot,
-                             VK_LAYER_RESERVE_BINDING_SLOT);
     }
 
     // Only read the legacy disables flags when used, not their replacement.

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -23,37 +23,36 @@
 #include <cstdint>
 #include <vulkan/vulkan.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
-#include "gpu_validation/gpu_settings.h"
 #include "containers/custom_containers.h"
 
 #define OBJECT_LAYER_NAME "VK_LAYER_KHRONOS_validation"
 
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
 
-typedef enum ValidationCheckDisables {
+enum ValidationCheckDisables {
     VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE,
     VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
     VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
     VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
     VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
-} ValidationCheckDisables;
+};
 
-typedef enum ValidationCheckEnables {
+enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA,
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
-} ValidationCheckEnables;
+};
 
-typedef enum VkValidationFeatureEnable {
+enum VkValidationFeatureEnable {
     VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
-} VkValidationFeatureEnable;
+};
 
 // CHECK_DISABLED and CHECK_ENABLED vectors are containers for bools that can opt in or out of specific classes of validation
 // checks. Enum values can be specified via the vk_layer_settings.txt config file or at CreateInstance time via the
 // VK_EXT_validation_features extension that can selectively disable or enable checks.
-typedef enum DisableFlags {
+enum DisableFlags {
     command_buffer_state,
     object_in_use,
     query_validation,
@@ -68,9 +67,9 @@ typedef enum DisableFlags {
     sync_validation_queue_submit,
     // Insert new disables above this line
     kMaxDisableFlags,
-} DisableFlags;
+};
 
-typedef enum EnableFlags {
+enum EnableFlags {
     gpu_validation,
     gpu_validation_reserve_binding_slot,
     best_practices,
@@ -82,14 +81,16 @@ typedef enum EnableFlags {
     sync_validation,
     // Insert new enables above this line
     kMaxEnableFlags,
-} EnableFlags;
+};
 
-typedef std::array<bool, kMaxDisableFlags> CHECK_DISABLED;
-typedef std::array<bool, kMaxEnableFlags> CHECK_ENABLED;
+using CHECK_DISABLED = std::array<bool, kMaxDisableFlags>;
+using CHECK_ENABLED = std::array<bool, kMaxEnableFlags>;
 
 // Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 
-typedef struct {
+struct GpuAVSettings;
+struct DebugPrintfSettings;
+struct ConfigAndEnvSettings {
     const char *layer_description;
     const VkInstanceCreateInfo *create_info;
     CHECK_ENABLED &enables;
@@ -99,7 +100,7 @@ typedef struct {
     bool *fine_grained_locking;
     GpuAVSettings *gpuav_settings;
     DebugPrintfSettings *printf_settings;
-} ConfigAndEnvSettings;
+};
 
 static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {
     {"VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT", VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT},


### PR DESCRIPTION
New settings as seen in VkConfig:

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/111733687/1781b953-193a-4224-bafb-d92ed724c8d1)

Also cleaned up `layer_options.h` a bit, most important thing was to remove `#include "gpu_validation/gpu_settings.h"`
