### PR TITLE
tests: Remove operator bool

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -92,7 +92,6 @@ class Handle {
     bool initialized() const noexcept { return (handle_ != T{}); }
 
     operator T() const noexcept { return handle(); }
-    operator bool() const noexcept { return initialized(); }
 
   protected:
     typedef T handle_type;


### PR DESCRIPTION
It's unsafe. Can hide errors when an argument is of a wrong type but conversion operator finds a way. 