### PR TITLE
Feature request: Add ApplicationName information to the log messages

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -106,6 +106,9 @@ bool DebugReport::UpdateLogMsgCounts(int32_t vuid_hash) const {
     }
 }
 
+// Global instance name, set to the last created instance's name
+std::string instance_application_name = "";
+
 bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, const char *message, const char *text_vuid) const {
     bool bail = false;
     std::vector<VkDebugUtilsLabelEXT> queue_labels;
@@ -182,6 +185,9 @@ bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, c
     callback_data.pObjects = object_name_infos.data();
 
     std::ostringstream oss;
+    if (instance_application_name.size()) {
+        oss << "[AppName: " << instance_application_name << "] ";
+    }
     if (msg_flags & kErrorBit) {
         oss << "Validation Error: ";
     } else if (msg_flags & kWarningBit) {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -348,6 +348,9 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     // If not cleared, garbage has been seen in some Android run effecting the error message
     custom_stype_info.clear();
 
+    assert(settings_data->create_info);
+    instance_application_name = settings_data->create_info->pApplicationInfo ? settings_data->create_info->pApplicationInfo->pApplicationName : "";
+
     VkuLayerSettingSet layer_setting_set = VK_NULL_HANDLE;
     vkuCreateLayerSettingSet(OBJECT_LAYER_NAME, vkuFindLayerSettingsCreateInfo(settings_data->create_info), nullptr, nullptr,
                              &layer_setting_set);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -23,6 +23,7 @@
 #define OBJECT_LAYER_NAME "VK_LAYER_KHRONOS_validation"
 
 extern std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info;
+extern std::string instance_application_name;
 
 // Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 


### PR DESCRIPTION
Hi, 
Adding this draft CL as a feature request to check if it'd be possible to add application names from InstanceInfo to the log messages. This would be very helpful for debugging issues where multiple Vulkan instances are being created from different applications, such as in emulators. 
To avoid clutter and changing the default behavior, names can be printed out only when there are multiple instances with VVL in flight, or the feature can be put behind a global flag. 
Thanks

Example output with [AppName: ..]:  
`
UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout(ERROR / SPEC): msgNum: 1303270965 - [AppName: com.android.systemui] Validation Error: [ UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout ] Object 0: handle = 0x562767ac4740, type = VK_OBJECT_TYPE_COMMAND_BUFFER; Object 1: handle = 0xc88e49000000081d, type = VK_OBJECT_TYPE_IMAGE; | MessageID = 0x4dae5635 | vkQueueSubmit(): 
...
`
