### PR TITLE
layers: Option to print application name

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1449,6 +1449,27 @@
                     "default": []
                 },
                 {
+                    "key": "message_format",
+                    "label": "Message Format",
+                    "description": "Specifies how error messages are reported",
+                    "type": "GROUP",
+                    "expanded": true,
+                    "settings": [
+                        {
+                            "key": "message_format_display_application_name",
+                            "label": "Display Application Name",
+                            "description": "Useful when running multiple instances to know which instance the message is from.","type": "BOOL",
+                            "default": false,
+                            "platforms": [
+                                "WINDOWS",
+                                "LINUX",
+                                "MACOS",
+                                "ANDROID"
+                            ]
+                        }
+                    ]
+                },
+                {
                     "key": "disables",
                     "label": "Disables",
                     "description": "Specify areas of validation to be disabled",

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -187,6 +187,10 @@ bool DebugReport::DebugLogMsg(VkFlags msg_flags, const LogObjectList &objects, c
     oss << "Self ";
 #endif
 
+    if (message_format_settings.display_application_name && !message_format_settings.application_name.empty()) {
+        oss << "[AppName: " << message_format_settings.application_name << "] ";
+    }
+
     if (msg_flags & kErrorBit) {
         oss << "Validation Error: ";
     } else if (msg_flags & kWarningBit) {

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -179,6 +179,11 @@ class TypedHandleWrapper {
 
 struct Location;
 
+struct MessageFormatSettings {
+    bool display_application_name = false;
+    std::string application_name;
+};
+
 class DebugReport {
   public:
     std::vector<VkLayerDbgFunctionState> debug_callback_list;
@@ -191,6 +196,7 @@ class DebugReport {
     const void *instance_pnext_chain{};
     bool force_default_log_callback{false};
     uint32_t device_created = 0;
+    MessageFormatSettings message_format_settings;
 
     void SetUtilsObjectName(const VkDebugUtilsObjectNameInfoEXT *pNameInfo);
     void SetMarkerObjectName(const VkDebugMarkerObjectNameInfoEXT *pNameInfo);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -21,6 +21,7 @@
 #include <vulkan/layer/vk_layer_settings.hpp>
 
 #include "gpu_validation/gpu_settings.h"
+#include "error_message/logging.h"
 
 // Include new / delete overrides if using mimalloc. This needs to be include exactly once in a file that is
 // part of the VVL but not the layer utils library.
@@ -89,6 +90,9 @@ const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+
+// Message Formatting
+const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 
 // These were deprecated after the 1.3.280 SDK release
 const char *DEPRECATED_VK_LAYER_GPUAV_VALIDATE_COPIES = "gpuav_validate_copies";
@@ -570,6 +574,16 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (gpuav_settings.debug_validate_instrumented_shaders || gpuav_settings.debug_dump_instrumented_shaders) {
         // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
         gpuav_settings.cache_instrumented_shaders = false;
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME,
+                                settings_data->message_format_settings->display_application_name);
+    }
+    // Grab application name here while we have access to it and know if to save it or not
+    if (settings_data->message_format_settings->display_application_name) {
+        settings_data->message_format_settings->application_name =
+            settings_data->create_info->pApplicationInfo ? settings_data->create_info->pApplicationInfo->pApplicationName : "";
     }
 
     const auto *validation_features_ext = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(settings_data->create_info);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -90,6 +90,7 @@ using CHECK_ENABLED = std::array<bool, kMaxEnableFlags>;
 
 struct GpuAVSettings;
 struct DebugPrintfSettings;
+struct MessageFormatSettings;
 struct ConfigAndEnvSettings {
     const char *layer_description;
     const VkInstanceCreateInfo *create_info;
@@ -97,6 +98,7 @@ struct ConfigAndEnvSettings {
     CHECK_DISABLED &disables;
     vvl::unordered_set<uint32_t> &message_filter_list;
     uint32_t *duplicate_message_limit;
+    MessageFormatSettings *message_format_settings;
     bool *fine_grained_locking;
     GpuAVSettings *gpuav_settings;
     DebugPrintfSettings *printf_settings;

--- a/layers/vk_layer_settings.txt
+++ b/layers/vk_layer_settings.txt
@@ -135,6 +135,12 @@ khronos_validation.enables =
 # performance in multithreaded applications.
 khronos_validation.fine_grained_locking = true
 
+# Display Application Name
+# =====================
+# <LayerIdentifier>.message_format_display_application_name
+# Useful when running multiple instances to know which instance the message is from
+#khronos_validation.message_format_display_application_name = false
+
 # Best Practices
 # =====================
 # Enable best practices layer

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -422,6 +422,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
                                                       local_disables,
                                                       debug_report->filter_message_ids,
                                                       &debug_report->duplicate_message_limit,
+                                                      &debug_report->message_format_settings,
                                                       &lock_setting,
                                                       &local_gpuav_settings,
                                                       &local_printf_settings};

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1097,6 +1097,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                                                                 local_disables,
                                                                 debug_report->filter_message_ids,
                                                                 &debug_report->duplicate_message_limit,
+                                                                &debug_report->message_format_settings,
                                                                 &lock_setting,
                                                                 &local_gpuav_settings,
                                                                 &local_printf_settings};


### PR DESCRIPTION
successor of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7943

The whole formatting of the error messages needs to be reworked, I am using this as energy to start to foundation for that future change.

This adds a simple way to print the `pApplicationName` which is helpful for something like Android which now has many processes (such as surface flinger and skia) using Vulkan to know which app is printing the error messages