### PR TITLE
layers: Fix crash from null pCreateInfo

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -856,14 +856,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreatePipelineLayout(VkDevice device, const VkPip
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreatePipelineLayout, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    chassis::CreatePipelineLayout chassis_state{};
-    chassis_state.modified_create_info = *pCreateInfo;
-
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreatePipelineLayout]) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
+
+    chassis::CreatePipelineLayout chassis_state{};
+    chassis_state.modified_create_info = *pCreateInfo;
 
     RecordObject record_obj(vvl::Func::vkCreatePipelineLayout);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
@@ -888,14 +888,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateShaderModule, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    chassis::CreateShaderModule chassis_state{};
-    chassis_state.instrumented_create_info = *pCreateInfo;
-
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
+
+    chassis::CreateShaderModule chassis_state{};
+    chassis_state.instrumented_create_info = *pCreateInfo;
 
     RecordObject record_obj(vvl::Func::vkCreateShaderModule);
     for (ValidationObject* intercept : layer_data->object_dispatch) {
@@ -996,14 +996,14 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateBuffer(VkDevice device, const VkBufferCreat
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateBuffer, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    chassis::CreateBuffer chassis_state{};
-    chassis_state.modified_create_info = *pCreateInfo;
-
     for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateBuffer]) {
         auto lock = intercept->ReadLock();
         skip |= intercept->PreCallValidateCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, error_obj);
         if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
     }
+
+    chassis::CreateBuffer chassis_state{};
+    chassis_state.modified_create_info = *pCreateInfo;
 
     RecordObject record_obj(vvl::Func::vkCreateBuffer);
     for (ValidationObject* intercept : layer_data->object_dispatch) {

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1525,14 +1525,14 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool skip = false;
                 ErrorObject error_obj(vvl::Func::vkCreatePipelineLayout, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-                chassis::CreatePipelineLayout chassis_state{};
-                chassis_state.modified_create_info = *pCreateInfo;
-
                 for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreatePipelineLayout]) {
                     auto lock = intercept->ReadLock();
                     skip |= intercept->PreCallValidateCreatePipelineLayout(device, pCreateInfo, pAllocator, pPipelineLayout, error_obj);
                     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
                 }
+
+                chassis::CreatePipelineLayout chassis_state{};
+                chassis_state.modified_create_info = *pCreateInfo;
 
                 RecordObject record_obj(vvl::Func::vkCreatePipelineLayout);
                 for (ValidationObject* intercept : layer_data->object_dispatch) {
@@ -1557,14 +1557,14 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool skip = false;
                 ErrorObject error_obj(vvl::Func::vkCreateShaderModule, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-                chassis::CreateShaderModule chassis_state{};
-                chassis_state.instrumented_create_info = *pCreateInfo;
-
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();
                     skip |= intercept->PreCallValidateCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, error_obj);
                     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
                 }
+
+                chassis::CreateShaderModule chassis_state{};
+                chassis_state.instrumented_create_info = *pCreateInfo;
 
                 RecordObject record_obj(vvl::Func::vkCreateShaderModule);
                 for (ValidationObject* intercept : layer_data->object_dispatch) {
@@ -1664,14 +1664,14 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool skip = false;
                 ErrorObject error_obj(vvl::Func::vkCreateBuffer, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-                chassis::CreateBuffer chassis_state{};
-                chassis_state.modified_create_info = *pCreateInfo;
-
                 for (const ValidationObject* intercept : layer_data->intercept_vectors[InterceptIdPreCallValidateCreateBuffer]) {
                     auto lock = intercept->ReadLock();
                     skip |= intercept->PreCallValidateCreateBuffer(device, pCreateInfo, pAllocator, pBuffer, error_obj);
                     if (skip) return VK_ERROR_VALIDATION_FAILED_EXT;
                 }
+
+                chassis::CreateBuffer chassis_state{};
+                chassis_state.modified_create_info = *pCreateInfo;
 
                 RecordObject record_obj(vvl::Func::vkCreateBuffer);
                 for (ValidationObject* intercept : layer_data->object_dispatch) {

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -401,12 +401,6 @@ TEST_F(VkLayerTest, RequiredParameter) {
     vk::CmdSetViewport(m_commandBuffer->handle(), 0, 0, &viewport);
     m_errorMonitor->VerifyFound();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCreateImage-pCreateInfo-parameter");
-    // Specify a null pImageCreateInfo struct pointer
-    VkImage test_image;
-    vk::CreateImage(device(), NULL, NULL, &test_image);
-    m_errorMonitor->VerifyFound();
-
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-pViewports-parameter");
     // Specify NULL for a required array
     // Expected to trigger an error with StatelessValidation::ValidateArray
@@ -468,11 +462,6 @@ TEST_F(VkLayerTest, RequiredParameter) {
     submitInfo.pWaitSemaphores = &semaphore;
     submitInfo.pWaitDstStageMask = nullptr;
     vk::QueueSubmit(m_default_queue->handle(), 1, &submitInfo, VK_NULL_HANDLE);
-    m_errorMonitor->VerifyFound();
-
-    m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass-pCreateInfo-parameter");
-    VkRenderPass render_pass;
-    vk::CreateRenderPass(device(), nullptr, nullptr, &render_pass);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2048,6 +2037,120 @@ TEST_F(VkLayerTest, Features11WithoutVulkan12) {
         vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
         m_errorMonitor->VerifyFound();
     }
+}
+
+TEST_F(VkLayerTest, MissingCreateInfo) {
+    RETURN_IF_SKIP(Init());
+
+    VkBuffer buffer;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateBuffer-pCreateInfo-parameter");
+    vk::CreateBuffer(device(), nullptr, nullptr, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    VkImage image;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateImage-pCreateInfo-parameter");
+    vk::CreateImage(device(), nullptr, nullptr, &image);
+    m_errorMonitor->VerifyFound();
+
+    VkBufferView buffer_view;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateBufferView-pCreateInfo-parameter");
+    vk::CreateBufferView(device(), nullptr, nullptr, &buffer_view);
+    m_errorMonitor->VerifyFound();
+
+    VkImageView image_view;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateImageView-pCreateInfo-parameter");
+    vk::CreateImageView(device(), nullptr, nullptr, &image_view);
+    m_errorMonitor->VerifyFound();
+
+    VkRenderPass render_pass;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateRenderPass-pCreateInfo-parameter");
+    vk::CreateRenderPass(device(), nullptr, nullptr, &render_pass);
+    m_errorMonitor->VerifyFound();
+
+    VkFramebuffer framebuffer;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateFramebuffer-pCreateInfo-parameter");
+    vk::CreateFramebuffer(device(), nullptr, nullptr, &framebuffer);
+    m_errorMonitor->VerifyFound();
+
+    VkQueryPool query_pool;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateQueryPool-pCreateInfo-parameter");
+    vk::CreateQueryPool(device(), nullptr, nullptr, &query_pool);
+    m_errorMonitor->VerifyFound();
+
+    VkPipelineLayout pipeline_layout;
+    m_errorMonitor->SetDesiredError("VUID-vkCreatePipelineLayout-pCreateInfo-parameter");
+    vk::CreatePipelineLayout(device(), nullptr, nullptr, &pipeline_layout);
+    m_errorMonitor->VerifyFound();
+
+    VkPipelineCache pipeline_cache;
+    m_errorMonitor->SetDesiredError("VUID-vkCreatePipelineCache-pCreateInfo-parameter");
+    vk::CreatePipelineCache(device(), nullptr, nullptr, &pipeline_cache);
+    m_errorMonitor->VerifyFound();
+
+    VkShaderModule shader_module;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateShaderModule-pCreateInfo-parameter");
+    vk::CreateShaderModule(device(), nullptr, nullptr, &shader_module);
+    m_errorMonitor->VerifyFound();
+
+    VkFence fence;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateFence-pCreateInfo-parameter");
+    vk::CreateFence(device(), nullptr, nullptr, &fence);
+    m_errorMonitor->VerifyFound();
+
+    VkSemaphore semaphore;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateSemaphore-pCreateInfo-parameter");
+    vk::CreateSemaphore(device(), nullptr, nullptr, &semaphore);
+    m_errorMonitor->VerifyFound();
+
+    VkEvent event;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateEvent-pCreateInfo-parameter");
+    vk::CreateEvent(device(), nullptr, nullptr, &event);
+    m_errorMonitor->VerifyFound();
+
+    VkSampler sampler;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateSampler-pCreateInfo-parameter");
+    vk::CreateSampler(device(), nullptr, nullptr, &sampler);
+    m_errorMonitor->VerifyFound();
+
+    VkCommandPool command_pool;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateCommandPool-pCreateInfo-parameter");
+    vk::CreateCommandPool(device(), nullptr, nullptr, &command_pool);
+    m_errorMonitor->VerifyFound();
+
+    VkDescriptorSetLayout set_layout;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDescriptorSetLayout-pCreateInfo-parameter");
+    vk::CreateDescriptorSetLayout(device(), nullptr, nullptr, &set_layout);
+    m_errorMonitor->VerifyFound();
+
+    VkDescriptorPool descriptor_pool;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateDescriptorPool-pCreateInfo-parameter");
+    vk::CreateDescriptorPool(device(), nullptr, nullptr, &descriptor_pool);
+    m_errorMonitor->VerifyFound();
+
+    VkCommandBuffer command_buffer;
+    m_errorMonitor->SetDesiredError("VUID-vkAllocateCommandBuffers-pAllocateInfo-parameter");
+    vk::AllocateCommandBuffers(device(), nullptr, &command_buffer);
+    m_errorMonitor->VerifyFound();
+
+    // TODO - vvl::AllocateDescriptorSetsData currently doesn't null check pAllocateInfo
+    // VkDescriptorSet descriptor_set;
+    // m_errorMonitor->SetDesiredError("VUID-vkAllocateDescriptorSets-pAllocateInfo-parameter");
+    // vk::AllocateDescriptorSets(device(), nullptr, &descriptor_set);
+    // m_errorMonitor->VerifyFound();
+
+    VkDeviceMemory device_memory;
+    m_errorMonitor->SetDesiredError("VUID-vkAllocateMemory-pAllocateInfo-parameter");
+    vk::AllocateMemory(device(), nullptr, nullptr, &device_memory);
+    m_errorMonitor->VerifyFound();
+
+    VkPipeline pipeline;
+    m_errorMonitor->SetDesiredError("VUID-vkCreateGraphicsPipelines-pCreateInfos-parameter");
+    vk::CreateGraphicsPipelines(device(), VK_NULL_HANDLE, 1, nullptr, nullptr, &pipeline);
+    m_errorMonitor->VerifyFound();
+
+    m_errorMonitor->SetDesiredError("VUID-vkCreateComputePipelines-pCreateInfos-parameter");
+    vk::CreateComputePipelines(device(), VK_NULL_HANDLE, 1, nullptr, nullptr, &pipeline);
+    m_errorMonitor->VerifyFound();
 }
 
 // Android loader returns an error in this case, so never makes it to the VVL

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -2141,15 +2141,6 @@ TEST_F(NegativeQuery, DISABLED_MultiviewEndQuery) {
     }
 }
 
-TEST_F(NegativeQuery, NullQueryPoolCreateInfo) {
-    TEST_DESCRIPTION("Invalid usage without meshShaderQueries enabled");
-    RETURN_IF_SKIP(Init());
-    VkQueryPool pool = VK_NULL_HANDLE;
-    m_errorMonitor->SetDesiredError("VUID-vkCreateQueryPool-pCreateInfo-parameter");
-    vk::CreateQueryPool(m_device->handle(), nullptr, nullptr, &pool);
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(NegativeQuery, MeshShaderQueries) {
     TEST_DESCRIPTION("Invalid usage without meshShaderQueries enabled");
 


### PR DESCRIPTION
Hit this by accident, but currently a null `pCreateInfo` in `vkCreateBuffer` crashed from where the chassis deference it

added tests for all Vulkan 1.0 creation of objects (which probably should have been done years ago)