### PR TITLE
tests: Add second command pool/buffer

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1635,8 +1635,19 @@ DescriptorSet::~DescriptorSet() noexcept { destroy(); }
 
 NON_DISPATCHABLE_HANDLE_DTOR(CommandPool, vk::DestroyCommandPool)
 
-void CommandPool::init(const Device &dev, const VkCommandPoolCreateInfo &info) {
+void CommandPool::Init(const Device &dev, const VkCommandPoolCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateCommandPool, dev, &info);
+}
+
+void CommandPool::Init(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
+    VkCommandPoolCreateInfo pool_ci = vku::InitStructHelper();
+    pool_ci.flags = flags;
+    pool_ci.queueFamilyIndex = queue_family_index;
+    Init(dev, pool_ci);
+}
+
+CommandPool::CommandPool(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
+    Init(dev, queue_family_index, flags);
 }
 
 void CommandBuffer::destroy() noexcept {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1014,22 +1014,11 @@ class CommandPool : public internal::NonDispHandle<VkCommandPool> {
     void destroy() noexcept;
 
     explicit CommandPool() : NonDispHandle() {}
-    explicit CommandPool(const Device &dev, const VkCommandPoolCreateInfo &info) { init(dev, info); }
-    explicit CommandPool(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags = 0) {
-        init(dev, CommandPool::create_info(queue_family_index, flags));
-    }
-
-    void init(const Device &dev, const VkCommandPoolCreateInfo &info);
-
-    static VkCommandPoolCreateInfo create_info(uint32_t queue_family_index, VkCommandPoolCreateFlags flags);
+    explicit CommandPool(const Device &dev, const VkCommandPoolCreateInfo &info) { Init(dev, info); }
+    explicit CommandPool(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags = 0);
+    void Init(const Device &dev, const VkCommandPoolCreateInfo &info);
+    void Init(const Device &dev, uint32_t queue_family_index, VkCommandPoolCreateFlags flags = 0);
 };
-
-inline VkCommandPoolCreateInfo CommandPool::create_info(uint32_t queue_family_index, VkCommandPoolCreateFlags flags) {
-    VkCommandPoolCreateInfo info = vku::InitStructHelper();
-    info.queueFamilyIndex = queue_family_index;
-    info.flags = flags;
-    return info;
-}
 
 class CommandBuffer : public internal::Handle<VkCommandBuffer> {
   public:

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -64,7 +64,7 @@ QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Que
     first_to_second = {0, half_size, half_size};
     second_to_first = {half_size, 0, half_size};
 
-    pool.init(*device, vkt::CommandPool::create_info(q_fam, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
+    pool.Init(*device, q_fam, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
 
     h_cba = InitFromPool(cba);
     h_cbb = InitFromPool(cbb);

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -195,8 +195,10 @@ class VkRenderFramework : public VkTestFramework {
 
     uint32_t m_gpu_index;
     vkt::Device *m_device;
-    vkt::CommandPool *m_commandPool;
-    vkt::CommandBuffer *m_commandBuffer;
+    vkt::CommandPool *m_commandPool;  // DEPRECATED: use m_command_pool
+    vkt::CommandPool m_command_pool;
+    vkt::CommandBuffer *m_commandBuffer;  // DEPRECATED: use m_command_buffer
+    vkt::CommandBuffer m_command_buffer;
     VkRenderPass m_renderPass = VK_NULL_HANDLE;
 
     // WSI items
@@ -224,6 +226,9 @@ class VkRenderFramework : public VkTestFramework {
     // It is null if implementation provides the only queue. Capabilities should be checked if necessary (m_second_queue_caps).
     vkt::Queue *m_second_queue = nullptr;
     VkQueueFlags m_second_queue_caps = 0;
+
+    vkt::CommandPool m_second_command_pool;  // associated with a queue family of the second command queue
+    vkt::CommandBuffer m_second_command_buffer;
 
     // Requested extensions to enable at device creation time
     std::vector<const char *> m_required_extensions;

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -659,8 +659,8 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
         m_commandBuffer->end();
 
         {
-            delete m_commandBuffer;
-            m_commandBuffer = new vkt::CommandBuffer(*m_device, m_commandPool);
+            m_command_buffer.destroy();
+            m_command_buffer.Init(*m_device, &m_command_pool);
 
             std::unique_ptr<vkt::CommandBuffer> secondary_cmd_buffer(
                 new vkt::CommandBuffer(*m_device, m_commandPool, VK_COMMAND_BUFFER_LEVEL_SECONDARY));
@@ -740,8 +740,8 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
 
     clear_cmd_test(true);
 
-    delete m_commandBuffer;
-    m_commandBuffer = new vkt::CommandBuffer(*m_device, m_commandPool);
+    m_command_buffer.destroy();
+    m_command_buffer.Init(*m_device, &m_command_pool);
     clear_cmd_test(false);
 }
 


### PR DESCRIPTION
When the second queue is used, an associated command pool/buffer is often needed.
