### PR TITLE
gpuav: Use internal stream out constants

### DIFF
--- a/layers/gpu_validation/gpu_constants.h
+++ b/layers/gpu_validation/gpu_constants.h
@@ -24,5 +24,29 @@ namespace cst {
 
 // Number of indices held in the buffer used to index commands and validation resources
 inline constexpr uint32_t indices_count = 16384;
+
+// Stream Output Buffer Offsets
+//
+// The following values provide offsets into the output buffer struct
+// ------------------------------
+
+// The 1st member of the debug output buffer contains a set of flags
+// controlling the behavior of instrumentation code.
+inline constexpr uint32_t stream_output_flags_offset = 0;
+
+// Values stored at output_flags_offset
+inline constexpr uint32_t inst_buffer_oob_enabled = 0x1;
+
+// The 2nd member of the debug output buffer contains the next available word
+// in the data stream to be written. Shaders will atomically read and update
+// this value so as not to overwrite each others records. This value must be
+// initialized to zero
+inline constexpr uint32_t stream_output_size_offset = 1;
+
+// The 3rd member of the output buffer is the start of the stream of records
+// written by the instrumented shaders. Each record represents a validation
+// error. The format of the records is documented below.
+inline constexpr uint32_t stream_output_data_offset = 2;
+
 }  // namespace cst
 }  // namespace gpuav

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -173,7 +173,7 @@ void gpuav::Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const
                    "Use of descriptor buffers will result in no descriptor checking");
     }
 
-    output_buffer_byte_size = gpuav::glsl::kErrorBufferByteSize;
+    output_buffer_byte_size = glsl::kErrorBufferByteSize;
 
     if (gpuav_settings.validate_descriptors && !force_buffer_device_address) {
         gpuav_settings.validate_descriptors = false;

--- a/layers/gpu_validation/gpu_validation.cpp
+++ b/layers/gpu_validation/gpu_validation.cpp
@@ -616,7 +616,7 @@ bool gpuav::Validator::AllocateOutputMem(DeviceMemoryBlock &output_mem, const Lo
     if (result == VK_SUCCESS) {
         memset(output_buffer_ptr, 0, output_buffer_byte_size);
         if (gpuav_settings.validate_descriptors) {
-            output_buffer_ptr[spvtools::kDebugOutputFlagsOffset] = spvtools::kInstBufferOOBEnable;
+            output_buffer_ptr[cst::stream_output_flags_offset] = cst::inst_buffer_oob_enabled;
         }
         vmaUnmapMemory(vmaAllocator, output_mem.allocation);
     } else {
@@ -749,8 +749,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndire
             draw_resources->indirect_buffer_size = bufsize;
 
             assert(phys_dev_props.limits.maxDrawIndirectCount > 0);
-            push_constants[0] =
-                (is_mesh_call) ? gpuav::glsl::kPreDrawSelectMeshCountBuffer : gpuav::glsl::kPreDrawSelectCountBuffer;
+            push_constants[0] = (is_mesh_call) ? glsl::kPreDrawSelectMeshCountBuffer : glsl::kPreDrawSelectCountBuffer;
             push_constants[1] = phys_dev_props.limits.maxDrawIndirectCount;
             push_constants[2] = max_count;
             push_constants[3] = static_cast<uint32_t>((count_buffer_offset / sizeof(uint32_t)));
@@ -774,7 +773,7 @@ std::unique_ptr<gpuav::CommandResources> gpuav::Validator::AllocatePreDrawIndire
             phys_dev_props.limits.maxPushConstantsSize >= PreDrawResources::push_constant_words * sizeof(uint32_t)) {
             if (!is_count_call) {
                 // Select was set in count check for count call
-                push_constants[0] = gpuav::glsl::kPreDrawSelectMeshNoCount;
+                push_constants[0] = glsl::kPreDrawSelectMeshNoCount;
             }
             const VkShaderStageFlags stages = pipeline_state->create_info_shaders;
             push_constants[4] = static_cast<uint32_t>(indirect_offset / sizeof(uint32_t));


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7957

These use to live in spirv-tools `instrument.hpp` but we can now safely move to VVL