### PR TITLE
WIP printf: Split apart ReportSetupProblem

### DIFF
--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -81,14 +81,13 @@ class Validator : public gpu_tracker::Validator {
   public:
     using BaseClass = gpu_tracker::Validator;
     Validator() {
-        setup_vuid = "UNASSIGNED-DEBUG-PRINTF";
         container_type = LayerObjectTypeDebugPrintf;
         desired_features.vertexPipelineStoresAndAtomics = true;
         desired_features.fragmentStoresAndAtomics = true;
     }
 
-    void ReportSetupProblemPrintF(LogObjectList objlist, const Location& loc, const char* const specific_message,
-                                  bool vma_fail) const;
+    void ReportSetupProblem(LogObjectList objlist, const Location& loc, const char* const specific_message,
+                            bool vma_fail = false) const;
     void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
     bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& instrumented_spirv,
                           uint32_t unique_shader_id, const Location& loc) override;

--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -885,7 +885,6 @@ void gpu_tracker::Validator::ReportSetupProblem(LogObjectList objlist, const Loc
         vmaFreeStatsString(vmaAllocator, stats_string);
     }
 
-    char const *layer_name = container_type == LayerObjectTypeDebugPrintf ? "Debug PrintF" : "GPU-AV";
-
-    LogError(setup_vuid, objlist, loc, "Setup Error, %s is being disabled. Detail: (%s)", layer_name, logit.c_str());
+    LogError("UNASSIGNED-GPU-Assisted-Validation", objlist, loc, "Setup Error, GPU-AV is being disabled. Detail: (%s)",
+             logit.c_str());
 }

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -200,7 +200,6 @@ class Validator : public ValidationStateTracker {
     bool force_buffer_device_address;
     vvl::unordered_map<uint32_t, std::pair<size_t, std::vector<uint32_t>>> instrumented_shaders;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;
-    const char *setup_vuid;
     VkPhysicalDeviceFeatures supported_features{};
     VkPhysicalDeviceFeatures desired_features{};
     uint32_t adjusted_max_desc_sets = 0;

--- a/layers/gpu_validation/gpu_validation.h
+++ b/layers/gpu_validation/gpu_validation.h
@@ -93,7 +93,6 @@ class Validator : public gpu_tracker::Validator {
 
   public:
     Validator() {
-        setup_vuid = "UNASSIGNED-GPU-Assisted-Validation";
         container_type = LayerObjectTypeGpuAssisted;
         desired_features.vertexPipelineStoresAndAtomics = true;
         desired_features.fragmentStoresAndAtomics = true;


### PR DESCRIPTION
In effort to de-couple GPU-AV and  DebugPrintf, this is a simple removing of `ReportSetupProblem` as it this logic might quickly change between the two