### PR TITLE
layers: Add VK_EXT_legacy_vertex_attributes

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -307,12 +307,14 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
 
                     // first type check before doing 64-bit matching
                     if ((attribute_type & var_numeric_type) == 0) {
-                        skip |= LogError(vuid.vertex_input_08734, vert_spirv_state->handle(), loc,
+                        if (!enabled_features.legacyVertexAttributes || shader64) {
+                            skip |=
+                                LogError(vuid.vertex_input_08734, vert_spirv_state->handle(), loc,
                                          "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32
                                          ") with format %s but the vertex shader input is numeric type %s",
                                          i, description.location, string_VkFormat(description.format),
                                          vert_spirv_state->DescribeType(var_base_type_id).c_str());
-
+                        }
                     } else if (attribute64 && !shader64) {
                         skip |= LogError(vuid.vertex_input_format_08936, vert_spirv_state->handle(), loc,
                                          "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32

--- a/tests/device_profiles/max_profile.json
+++ b/tests/device_profiles/max_profile.json
@@ -668,6 +668,9 @@
                 "VkPhysicalDeviceLegacyDitheringFeaturesEXT": {
                     "legacyDithering": true
                 },
+                "VkPhysicalDeviceLegacyVertexAttributesFeaturesEXT": {
+                    "legacyVertexAttributes": true
+                },
                 "VkPhysicalDeviceMultisampledRenderToSingleSampledFeaturesEXT": {
                     "multisampledRenderToSingleSampled": true
                 },
@@ -1894,6 +1897,7 @@
                 "VK_KHR_index_type_uint8": 1,
                 "VK_EXT_inline_uniform_block": 1,
                 "VK_EXT_legacy_dithering": 1,
+                "VK_EXT_legacy_vertex_attributes": 1,
                 "VK_EXT_line_rasterization": 1,
                 "VK_KHR_line_rasterization": 1,
                 "VK_EXT_load_store_op_none": 1,


### PR DESCRIPTION
Extension is just allowing 1 shader interface VU to be allowed