### PR TITLE
layers: Refactor RequiredQueueFlags check

### DIFF
--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -481,8 +481,12 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     }
 
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance1)) {
-        skip |= ValidateCmdQueueFlags(cb_state, error_obj.location, VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT,
-                                      "VUID-vkCmdFillBuffer-apiVersion-07894");
+        const VkQueueFlags required_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT;
+        if (!HasRequiredQueueFlags(cb_state, *physical_device_state, required_flags)) {
+            const LogObjectList objlist_pool(cb_state.Handle(), cb_state.command_pool->Handle());
+            skip |= LogError("VUID-vkCmdFillBuffer-apiVersion-07894", objlist_pool, error_obj.location, "%s",
+                             DescribeRequiredQueueFlag(cb_state, *physical_device_state, required_flags).c_str());
+        }
     }
 
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -305,8 +305,10 @@ class CoreChecks : public ValidationStateTracker {
                                       const char* vuid) const;
 
     bool ValidateObjectNotInUse(const vvl::StateObject* obj_node, const Location& loc, const char* error_code) const;
-    bool ValidateCmdQueueFlags(const vvl::CommandBuffer& cb_state, const Location& loc, VkQueueFlags flags, const char* vuid,
-                               const char* extra_message = "") const;
+    bool HasRequiredQueueFlags(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
+                               VkQueueFlags required_flags) const;
+    std::string DescribeRequiredQueueFlag(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
+                                          VkQueueFlags required_flags) const;
     bool ValidateSampleLocationsInfo(const VkSampleLocationsInfoEXT& sample_location_info, const Location& loc) const;
     bool MatchSampleLocationsInfo(const VkSampleLocationsInfoEXT& info_1, const VkSampleLocationsInfoEXT& info_2) const;
     bool InsideRenderPass(const vvl::CommandBuffer& cb_state, const Location& loc, const char* vuid) const;

--- a/layers/vulkan/generated/command_validation.cpp
+++ b/layers/vulkan/generated/command_validation.cpp
@@ -1847,7 +1847,11 @@ bool CoreChecks::ValidateCmd(const vvl::CommandBuffer& cb_state, const Location&
     }
 
     // Validate the command pool from which the command buffer is from that the command is allowed for queue type
-    skip |= ValidateCmdQueueFlags(cb_state, loc, info.queue_flags, info.queue_vuid);
+    if (!HasRequiredQueueFlags(cb_state, *physical_device_state, info.queue_flags)) {
+        const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+        skip |= LogError(info.queue_vuid, objlist, loc, "%s",
+                         DescribeRequiredQueueFlag(cb_state, *physical_device_state, info.queue_flags).c_str());
+    }
 
     // Validate if command is inside or outside a render pass if applicable
     if (info.render_pass == CMD_SCOPE_INSIDE) {

--- a/scripts/generators/command_validation_generator.py
+++ b/scripts/generators/command_validation_generator.py
@@ -178,7 +178,11 @@ class CommandValidationOutputGenerator(BaseGenerator):
                 }
 
                 // Validate the command pool from which the command buffer is from that the command is allowed for queue type
-                skip |= ValidateCmdQueueFlags(cb_state, loc, info.queue_flags, info.queue_vuid);
+                if (!HasRequiredQueueFlags(cb_state, *physical_device_state, info.queue_flags)) {
+                    const LogObjectList objlist(cb_state.Handle(), cb_state.command_pool->Handle());
+                    skip |= LogError(info.queue_vuid, objlist, loc,
+                                "%s", DescribeRequiredQueueFlag(cb_state, *physical_device_state, info.queue_flags).c_str());
+                }
 
                 // Validate if command is inside or outside a render pass if applicable
                 if (info.render_pass == CMD_SCOPE_INSIDE) {


### PR DESCRIPTION
Instead of passing ad-hoc strings down, this separates `ValidateCmdQueueFlags` into a  `HasRequiredQueueFlags` and `DescribeRequiredQueueFlag` logic

While it seems like more code, it prevents having to pass strings around while we are still validating and saves that until we need to print the error out