### PR TITLE
sync: Simplify SignaledSemaphores::Unsignal v2

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -91,13 +91,25 @@ bool SignaledSemaphores::SignalSemaphore(const std::shared_ptr<const vvl::Semaph
 }
 
 std::shared_ptr<const SignaledSemaphores::Signal> SignaledSemaphores::Unsignal(VkSemaphore sem) {
-    assert(signaled_.find(sem) == signaled_.end());
-    assert(prev_ != nullptr);
-
-    // We can't unsignal prev_ because it's const * by design.
-    // We put in an empty placeholder
-    signaled_.emplace(sem, std::shared_ptr<Signal>());
-    std::shared_ptr<const Signal> unsignaled = GetPrev(sem);
+    std::shared_ptr<const Signal> unsignaled;
+    const auto found_it = signaled_.find(sem);
+    if (found_it != signaled_.end()) {
+        // Move the unsignaled singal out from the signaled list, but keep the shared_ptr as the caller needs the contents for
+        // a bit.
+        unsignaled = std::move(found_it->second);
+        if (!prev_) {
+            // No parent, not need to keep the entry
+            // IFF (prev_)  leave the entry in the leaf table as we use it to export unsignal to prev_ during record phase
+            signaled_.erase(found_it);
+        }
+    } else if (prev_) {
+        // We can't unsignal prev_ because it's const * by design.
+        // We put in an empty placeholder
+        signaled_.emplace(sem, std::shared_ptr<Signal>());
+        unsignaled = GetPrev(sem);
+    }
+    // NOTE: No else clause. Because if we didn't find it, and there's no previous, this indicates an error,
+    // but CoreChecks should have reported it
 
     // If unsignaled is null, there was a missing pending semaphore, and that's also issue CoreChecks reports
     return unsignaled;

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -89,7 +89,6 @@ class SignaledSemaphores {
   private:
     void Import(VkSemaphore sem, std::shared_ptr<Signal> &&move_from);
     void Reset();
-    std::shared_ptr<const Signal> GetPrev(VkSemaphore sem) const;
 
   private:
     vvl::unordered_map<VkSemaphore, std::shared_ptr<Signal>> signaled_;

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -1677,3 +1677,29 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC3) {
     vk::CmdCopyBufferToImage(*m_commandBuffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
     m_commandBuffer->end();
 }
+
+TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOneQueueSubmit) {
+    TEST_DESCRIPTION("Signal and wait semaphore using one submit command");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredFeature(vkt::Feature::synchronization2);
+    RETURN_IF_SKIP(InitSyncValFramework());
+    RETURN_IF_SKIP(InitState());
+
+    vkt::Semaphore semaphore(*m_device);
+
+    VkSemaphoreSubmitInfo semaphore_info = vku::InitStructHelper();
+    semaphore_info.semaphore = semaphore;
+    semaphore_info.stageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
+
+    VkSubmitInfo2 submits[2];
+    submits[0] = vku::InitStructHelper();
+    submits[0].signalSemaphoreInfoCount = 1;
+    submits[0].pSignalSemaphoreInfos = &semaphore_info;
+
+    submits[1] = vku::InitStructHelper();
+    submits[1].waitSemaphoreInfoCount = 1;
+    submits[1].pWaitSemaphoreInfos = &semaphore_info;
+
+    vk::QueueSubmit2(*m_default_queue, 2, submits, VK_NULL_HANDLE);
+    m_default_queue->Wait();
+}


### PR DESCRIPTION
Made mistake here: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7985. Of course it's possible to signal and then wait on the semaphore in the same submission (was confused by my own pseudocode which was not detailed enough).

This PR reverts that change, adds regression test, and makes one more less ambitious change.

