### PR TITLE
layers: Fix Image/Buffer comparing

### DIFF
--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -573,13 +573,19 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                      "is %s but %s (%d) was not created with a dedicated image.",
                                      FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd);
 
-                } else if (payload_info->dedicated_image != dedicated_image) {
-                    const LogObjectList objlist(payload_info->dedicated_image, dedicated_image);
-                    skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01878", objlist,
-                                     allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
-                                     "is %s but %s (%d) was created with a dedicated image %s.",
-                                     FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd,
-                                     FormatHandle(payload_info->dedicated_image).c_str());
+                } else {
+                    auto dedicated_image_state = Get<vvl::Image>(dedicated_image);
+                    auto payload_image_state = Get<vvl::Image>(payload_info->dedicated_image);
+                    if (!dedicated_image_state || !payload_image_state ||
+                        !dedicated_image_state->CompareCreateInfo(*payload_image_state)) {
+                        // TODO - Print out info about image creation info
+                        const LogObjectList objlist(payload_info->dedicated_image, dedicated_image);
+                        skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01878", objlist,
+                                         allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
+                                         "is %s but %s (%d) was created with a dedicated image %s.",
+                                         FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(),
+                                         import_memory_fd_info->fd, FormatHandle(payload_info->dedicated_image).c_str());
+                    }
                 }
             }
             if (dedicated_buffer != VK_NULL_HANDLE) {
@@ -590,13 +596,19 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                  "is %s but %s (%d) was not created with a dedicated buffer.",
                                  FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd);
 
-                } else if (payload_info->dedicated_buffer != dedicated_buffer) {
-                    const LogObjectList objlist(payload_info->dedicated_buffer, dedicated_buffer);
-                    skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879", objlist,
-                                     allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer),
-                                     "is %s but %s (%d) was created with a dedicated buffer %s.",
-                                     FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(), import_memory_fd_info->fd,
-                                     FormatHandle(payload_info->dedicated_buffer).c_str());
+                } else {
+                    auto dedicated_buffer_state = Get<vvl::Buffer>(dedicated_buffer);
+                    auto payload_buffer_state = Get<vvl::Buffer>(payload_info->dedicated_buffer);
+                    if (!dedicated_buffer_state || !payload_buffer_state ||
+                        !dedicated_buffer_state->CompareCreateInfo(*payload_buffer_state)) {
+                        // TODO - Print out info about buffer creation info
+                        const LogObjectList objlist(payload_info->dedicated_buffer, dedicated_buffer);
+                        skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879", objlist,
+                                         allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer),
+                                         "is %s but %s (%d) was created with a dedicated buffer %s.",
+                                         FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(),
+                                         import_memory_fd_info->fd, FormatHandle(payload_info->dedicated_buffer).c_str());
+                    }
                 }
             }
         }
@@ -662,14 +674,20 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                          "is %s but %s (0x%" PRIxPTR ") was not created with a dedicated image.",
                                          FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(),
                                          reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle));
-                    } else if (payload_info->dedicated_image != dedicated_image) {
-                        const LogObjectList objlist(payload_info->dedicated_image, dedicated_image);
-                        skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01876", objlist,
-                                         allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
-                                         "is %s but %s (0x%" PRIxPTR ") was created with a dedicated image %s.",
-                                         FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(),
-                                         reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
-                                         FormatHandle(payload_info->dedicated_image).c_str());
+                    } else {
+                        auto dedicated_image_state = Get<vvl::Image>(dedicated_image);
+                        auto payload_image_state = Get<vvl::Image>(payload_info->dedicated_image);
+                        if (!dedicated_image_state || !payload_image_state ||
+                            !dedicated_image_state->CompareCreateInfo(*payload_image_state)) {
+                            // TODO - Print out info about image creation info
+                            const LogObjectList objlist(payload_info->dedicated_image, dedicated_image);
+                            skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-image-01876", objlist,
+                                             allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::image),
+                                             "is %s but %s (0x%" PRIxPTR ") was created with a dedicated image %s.",
+                                             FormatHandle(dedicated_image).c_str(), import_loc.Fields().c_str(),
+                                             reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
+                                             FormatHandle(payload_info->dedicated_image).c_str());
+                        }
                     }
                 }
             }
@@ -688,15 +706,22 @@ bool CoreChecks::PreCallValidateAllocateMemory(VkDevice device, const VkMemoryAl
                                      reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
                                      string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType));
 
-                    } else if (payload_info->dedicated_buffer != dedicated_buffer) {
-                        const LogObjectList objlist(payload_info->dedicated_buffer, dedicated_buffer);
-                        skip |= LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01877", objlist,
+                    } else {
+                        auto dedicated_buffer_state = Get<vvl::Buffer>(dedicated_buffer);
+                        auto payload_buffer_state = Get<vvl::Buffer>(payload_info->dedicated_buffer);
+                        if (!dedicated_buffer_state || !payload_buffer_state ||
+                            !dedicated_buffer_state->CompareCreateInfo(*payload_buffer_state)) {
+                            // TODO - Print out info about buffer creation info
+                            const LogObjectList objlist(payload_info->dedicated_buffer, dedicated_buffer);
+                            skip |=
+                                LogError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01877", objlist,
                                          allocate_info_loc.pNext(Struct::VkMemoryDedicatedAllocateInfo, Field::buffer),
                                          "is %s but %s (0x%" PRIxPTR ") was created with a dedicated buffer %s with handleType %s.",
                                          FormatHandle(dedicated_buffer).c_str(), import_loc.Fields().c_str(),
                                          reinterpret_cast<std::uintptr_t>(import_memory_win32_info->handle),
                                          FormatHandle(payload_info->dedicated_buffer).c_str(),
                                          string_VkExternalMemoryHandleTypeFlagBits(import_memory_win32_info->handleType));
+                        }
                     }
                 }
             }

--- a/layers/state_tracker/buffer_state.h
+++ b/layers/state_tracker/buffer_state.h
@@ -69,6 +69,8 @@ class Buffer : public Bindable {
         return {deviceAddress, deviceAddress + create_info.size};
     }
 
+    bool CompareCreateInfo(const Buffer &other) const;
+
   private:
     std::variant<std::monostate, BindableLinearMemoryTracker, BindableSparseMemoryTracker> tracker_;
 };

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -371,6 +371,35 @@ void Image::SetSwapchain(std::shared_ptr<vvl::Swapchain> &swapchain, uint32_t sw
     bind_swapchain->AddParent(this);
 }
 
+// This function is only used for comparing Imported External Dedicated Memory
+bool Image::CompareCreateInfo(const Image &other) const {
+    bool valid_queue_family = true;
+    if (create_info.sharingMode == VK_SHARING_MODE_CONCURRENT) {
+        if (create_info.queueFamilyIndexCount != other.create_info.queueFamilyIndexCount) {
+            valid_queue_family = false;
+        } else {
+            for (uint32_t i = 0; i < create_info.queueFamilyIndexCount; i++) {
+                if (create_info.pQueueFamilyIndices[i] != other.create_info.pQueueFamilyIndices[i]) {
+                    valid_queue_family = false;
+                    break;
+                }
+            }
+        }
+    }
+
+    // There are limitations what actually needs to be compared, so for simplicity (until found otherwise needed), we only need to
+    // check the ExternalHandleType and not other pNext chains
+    const bool valid_external = GetExternalHandleTypes(&create_info) == GetExternalHandleTypes(&other.create_info);
+
+    return (create_info.flags == other.create_info.flags) && (create_info.imageType == other.create_info.imageType) &&
+           (create_info.format == other.create_info.format) && (create_info.extent.width == other.create_info.extent.width) &&
+           (create_info.extent.height == other.create_info.extent.height) &&
+           (create_info.extent.depth == other.create_info.extent.depth) && (create_info.mipLevels == other.create_info.mipLevels) &&
+           (create_info.arrayLayers == other.create_info.arrayLayers) && (create_info.samples == other.create_info.samples) &&
+           (create_info.tiling == other.create_info.tiling) && (create_info.usage == other.create_info.usage) &&
+           (create_info.initialLayout == other.create_info.initialLayout) && valid_queue_family && valid_external;
+}
+
 }  // namespace vvl
 
 static VkSamplerYcbcrConversion GetSamplerConversion(const VkImageViewCreateInfo *ci) {

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -219,6 +219,8 @@ class Image : public Bindable {
     void SetInitialLayoutMap();
     void SetImageLayout(const VkImageSubresourceRange &range, VkImageLayout layout);
 
+    bool CompareCreateInfo(const Image &other) const;
+
   protected:
     void NotifyInvalidate(const StateObject::NodeList &invalid_nodes, bool unlink) override;
 

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -2135,6 +2135,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     HANDLE handle = NULL;
     vk::GetMemoryWin32HandleKHR(device(), &get_handle_info, &handle);
 
+    buffer_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     vkt::Buffer buffer2(*m_device, buffer_info, vkt::no_mem);
     dedicated_info.buffer = buffer2.handle();
 
@@ -2336,6 +2337,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     int fd;
     vk::GetMemoryFdKHR(device(), &mgfi, &fd);
 
+    buffer_info.usage |= VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     vkt::Buffer buffer2(*m_device, buffer_info, vkt::no_mem);
 
     dedicated_info.buffer = buffer2.handle();


### PR DESCRIPTION
from https://gitlab.khronos.org/vulkan/Vulkan-ValidationLayers/-/issues/35

These VUs say `identical` but it didn't mean the VkHandle, but the creation was the same

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/0780910e-533b-4463-97cf-fa3d5722498c)

There is still a discussion which pNext this is suppose to account for, but for now covered the main cases