### PR TITLE
sync: Add SignaledSemaphoresUpdate

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -1047,6 +1047,48 @@ bool Contains(const Container &container, const Key &key) {
     return container.find(key) != container.cend();
 }
 
+//
+// if (auto [found, it] = vvl::Find(map, key); found) { it->jump(); }
+//
+template <typename Container, typename Key = typename Container::key_type>
+std::pair<bool, typename Container::iterator> Find(Container &container, const Key &key) {
+    auto it = container.find(key);
+    return std::make_pair(it != container.end(), it);
+}
+template <typename Container, typename Key = typename Container::key_type>
+std::pair<bool, typename Container::const_iterator> Find(const Container &container, const Key &key) {
+    auto it = container.find(key);
+    return std::make_pair(it != container.cend(), it);
+}
+
+//
+// if (auto it_holder = vvl::FindIt(map, key); it_holder) { it_holder->jump(); }
+//
+template <typename Container>
+struct IteratorHolder {
+    typename Container::iterator it;
+    typename Container::iterator end_it;
+    typename Container::value_type &operator*() { return *it; }
+    typename Container::value_type *operator->() { return &*it; }
+    operator bool() { return it != end_it; }
+};
+template <typename Container>
+struct ConstIteratorHolder {
+    typename Container::const_iterator it;
+    typename Container::const_iterator end_it;
+    const typename Container::value_type &operator*() { return *it; }
+    const typename Container::value_type *operator->() { return &*it; }
+    operator bool() { return it != end_it; }
+};
+template <typename Container, typename Key = typename Container::key_type>
+IteratorHolder<Container> FindIt(Container &container, const Key &key) {
+    return {container.find(key), container.end()};
+}
+template <typename Container, typename Key = typename Container::key_type>
+ConstIteratorHolder<Container> FindIt(const Container &container, const Key &key) {
+    return {container.find(key), container.cend()};
+}
+
 // EraseIf is not implemented as std::erase(std::remove_if(...), ...) for two reasons:
 //   1) Robin Hood containers don't support two-argument erase functions
 //   2) STL remove_if requires the predicate to be const w.r.t the value-type, and std::erase_if doesn't AFAICT

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -51,15 +51,19 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
 
     vvl::unordered_map<VkQueue, std::shared_ptr<QueueSyncState>> queue_sync_states_;
     QueueId queue_id_limit_ = kQueueIdBase;
+
     SignaledSemaphores signaled_semaphores_;
 
     using SignaledFences = vvl::unordered_map<VkFence, FenceSyncState>;
-    using SignaledFence = SignaledFences::value_type;
     SignaledFences waitable_fences_;
 
     uint32_t debug_command_number = vvl::kU32Max;
     uint32_t debug_reset_count = 1;
     std::string debug_cmdbuf_pattern;
+
+    // Applies information from update object to signaled_semaphores_.
+    // The update object is mutable to be able to std::move SignalInfo from it.
+    void UpdateSignaledSemaphores(SignaledSemaphoresUpdate &update, const std::shared_ptr<QueueBatchContext> &last_batch);
 
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
     void ApplyAcquireWait(const AcquiredImage &acquired);


### PR DESCRIPTION
This splits `SignaledSemaphores` into two parts. The part that is
repsonsible for collecting updates is put into a separate type -
`SignaledSemaphoresUpdate`. The pars that is left that's the new
`SignaledSemaphores` and is just a map.

This simplifies design and restricts possible operations that can
be done with each type since they are used in different contexts
and have different interfaces.