### PR TITLE
Null check all Get<> to state object

### DIFF
--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -139,14 +139,15 @@ bool BestPractices::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryP
                                                        VkQueryResultFlags flags, const ErrorObject& error_obj) const {
     bool skip = false;
 
-    const auto& query_pool_state = *Get<vvl::QueryPool>(queryPool);
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
 
     for (uint32_t i = firstQuery; i < firstQuery + queryCount; ++i) {
-        if (query_pool_state.GetQueryState(i, 0u) == QUERYSTATE_RESET) {
+        if (query_pool_state->GetQueryState(i, 0u) == QUERYSTATE_RESET) {
             const LogObjectList objlist(queryPool);
             skip |= LogWarning(kVUID_BestPractices_QueryPool_Unavailable, objlist, error_obj.location,
                                "QueryPool %s and query %" PRIu32 ": vkCmdBeginQuery() was never called.",
-                               FormatHandle(query_pool_state.Handle()).c_str(), i);
+                               FormatHandle(query_pool_state->Handle()).c_str(), i);
             break;
         }
     }

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -88,7 +88,7 @@ void BestPractices::RecordBindZcullScope(bp_state::CommandBuffer& cmd_state, VkI
     assert((subresource_range.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0U);
 
     auto image_state = Get<vvl::Image>(depth_attachment);
-    assert(image_state);
+    if (!image_state) return;
 
     const uint32_t mip_levels = image_state->create_info.mipLevels;
     const uint32_t array_layers = image_state->create_info.arrayLayers;
@@ -236,9 +236,7 @@ bool BestPractices::ValidateZcull(const bp_state::CommandBuffer& cmd_state, VkIm
     const auto& tree = image_it->second;
 
     auto image_state = Get<vvl::Image>(image);
-    if (!image_state) {
-        return skip;
-    }
+    if (!image_state) return skip;
 
     ForEachSubresource(*image_state, subresource_range, [&](uint32_t layer, uint32_t level) {
         if (is_balanced) {

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -331,7 +331,7 @@ bool BestPractices::ValidateCmdResolveImage(VkCommandBuffer command_buffer, VkIm
     bool skip = false;
     auto src_image_state = Get<vvl::Image>(src_image);
     auto dst_image_state = Get<vvl::Image>(dst_image);
-    if (!src_image_state || dst_image_state) return skip;
+    if (!src_image_state || !dst_image_state) return skip;
 
     auto src_image_type = src_image_state->create_info.imageType;
     auto dst_image_type = dst_image_state->create_info.imageType;

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -203,7 +203,7 @@ bool BestPractices::ValidateBindImageMemory(VkImage image, VkDeviceMemory memory
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     auto mem_state = Get<vvl::DeviceMemory>(memory);
-    if (!mem_state) return skip;
+    if (!mem_state || !image_state) return skip;
 
     if (mem_state->allocate_info.allocationSize == image_state->requirements[0].size &&
         mem_state->allocate_info.allocationSize < kMinDedicatedAllocationSize) {

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -155,7 +155,7 @@ bool BestPractices::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem
     bool skip = false;
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto mem_state = Get<vvl::DeviceMemory>(memory);
-    if (!mem_state) return skip;
+    if (!mem_state || !buffer_state) return skip;
 
     if (mem_state->allocate_info.allocationSize == buffer_state->create_info.size &&
         mem_state->allocate_info.allocationSize < kMinDedicatedAllocationSize) {

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -55,9 +55,8 @@ bool BestPractices::ValidateMultisampledBlendingArm(uint32_t create_info_count, 
         }
 
         auto rp_state = Get<vvl::RenderPass>(create_info->renderPass);
-        if (!rp_state) {
-            continue;
-        }
+        if (!rp_state) continue;
+
         const auto& subpass = rp_state->create_info.pSubpasses[create_info->subpass];
 
         // According to spec, pColorBlendState must be ignored if subpass does not have color attachments.

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -554,6 +554,7 @@ bool BestPractices::PreCallValidateCreatePipelineLayout(VkDevice device, const V
         uint32_t pipeline_size = pCreateInfo->setLayoutCount;  // in DWORDS
         for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; i++) {
             auto descriptor_set_layout_state = Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+            if (!descriptor_set_layout_state) continue;
             pipeline_size += descriptor_set_layout_state->GetDynamicDescriptorCount() * descriptor_size;
         }
 
@@ -578,6 +579,7 @@ bool BestPractices::PreCallValidateCreatePipelineLayout(VkDevice device, const V
 
         for (uint32_t i = 0; i < pCreateInfo->setLayoutCount; ++i) {
             auto descriptor_set_layout_state = Get<vvl::DescriptorSetLayout>(pCreateInfo->pSetLayouts[i]);
+            if (!descriptor_set_layout_state) continue;
             for (const auto& binding : descriptor_set_layout_state->GetBindings()) {
                 if (binding.descriptorType == VK_DESCRIPTOR_TYPE_SAMPLER) {
                     has_separate_sampler = true;

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -436,10 +436,8 @@ void BestPractices::PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, 
     StateTracker::PreCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, record_obj);
 
     auto pipeline_info = Get<vvl::Pipeline>(pipeline);
+    if (!pipeline_info) return;
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-
-    assert(pipeline_info);
-    assert(cb_state);
 
     if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS && VendorCheckEnabled(kBPVendorNVIDIA)) {
         using TessGeometryMeshState = bp_state::CommandBufferStateNV::TessGeometryMesh::State;

--- a/layers/best_practices/bp_ray_tracing.cpp
+++ b/layers/best_practices/bp_ray_tracing.cpp
@@ -68,6 +68,7 @@ bool BestPractices::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice de
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         auto as_state = Get<vvl::AccelerationStructureNV>(pBindInfos[i].accelerationStructure);
+        if (!as_state) continue;
         if (!as_state->memory_requirements_checked) {
             // There's not an explicit requirement in the spec to call vkGetImageMemoryRequirements() prior to calling
             // BindAccelerationStructureMemoryNV but it's implied in that memory being bound must conform with

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -275,6 +275,8 @@ bool BestPractices::ValidateCmdBeginRendering(VkCommandBuffer commandBuffer, con
         const Location color_attachment_info = rendering_info.dot(Field::pColorAttachments, i);
 
         auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
+        if (!image_view_state) continue;
+
         if (VendorCheckEnabled(kBPVendorNVIDIA)) {
             if (color_attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
                 const VkFormat format = image_view_state->create_info.format;
@@ -518,8 +520,10 @@ void BestPractices::RecordCmdBeginRenderingCommon(VkCommandBuffer commandBuffer)
             for (uint32_t i = 0; i < rp->dynamic_rendering_begin_rendering_info.colorAttachmentCount; ++i) {
                 const auto& color_attachment = rp->dynamic_rendering_begin_rendering_info.pColorAttachments[i];
                 if (color_attachment.loadOp == VK_ATTACHMENT_LOAD_OP_CLEAR) {
-                    const VkFormat format = Get<vvl::ImageView>(color_attachment.imageView)->create_info.format;
-                    RecordClearColor(format, color_attachment.clearValue.color);
+                    if (auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView)) {
+                        const VkFormat format = image_view_state->create_info.format;
+                        RecordClearColor(format, color_attachment.clearValue.color);
+                    }
                 }
             }
 

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -317,7 +317,7 @@ bool BestPractices::PreCallValidateCmdPipelineBarrier(
             // general with no storage
             if (VendorCheckEnabled(kBPVendorAMD) && image_barrier.newLayout == VK_IMAGE_LAYOUT_GENERAL) {
                 auto image_state = Get<vvl::Image>(pImageMemoryBarriers[i].image);
-                if (!(image_state->create_info.usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
+                if (image_state && !(image_state->create_info.usage & VK_IMAGE_USAGE_STORAGE_BIT)) {
                     const LogObjectList objlist(commandBuffer, pImageMemoryBarriers[i].image);
                     skip |= LogPerformanceWarning(kVUID_BestPractices_vkImage_AvoidGeneral, objlist, error_obj.location,
                                                   "%s VK_IMAGE_LAYOUT_GENERAL should only be used with "

--- a/layers/best_practices/bp_video.cpp
+++ b/layers/best_practices/bp_video.cpp
@@ -26,9 +26,7 @@ bool BestPractices::PreCallValidateGetVideoSessionMemoryRequirementsKHR(VkDevice
                                                                         VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                                         const ErrorObject& error_obj) const {
     bool skip = false;
-
-    auto vs_state = Get<vvl::VideoSession>(videoSession);
-    if (vs_state) {
+    if (auto vs_state = Get<vvl::VideoSession>(videoSession)) {
         if (pMemoryRequirements != nullptr && !vs_state->memory_binding_count_queried) {
             skip |= LogWarning(kVUID_BestPractices_GetVideoSessionMemReqCountNotRetrieved, videoSession, error_obj.location,
                                "querying list of memory requirements of %s "
@@ -47,8 +45,7 @@ bool BestPractices::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, Vk
                                                              const ErrorObject& error_obj) const {
     bool skip = false;
 
-    auto vs_state = Get<vvl::VideoSession>(videoSession);
-    if (vs_state) {
+    if (auto vs_state = Get<vvl::VideoSession>(videoSession)) {
         if (!vs_state->memory_binding_count_queried) {
             skip |= LogWarning(kVUID_BestPractices_BindVideoSessionMemReqCountNotRetrieved, videoSession, error_obj.location,
                                "binding memory to %s but "

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -137,6 +137,7 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
                                                                       const ErrorObject &error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(pInfo->memory);
+    if (!mem_info) return skip;
 
     // VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID must have been included in
     // VkExportMemoryAllocateInfo::handleTypes when memory was created.

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -572,8 +572,7 @@ bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &cre
         const VkSamplerYcbcrConversionInfo *ycbcr_conv_info =
             vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext);
         if (ycbcr_conv_info != nullptr) {
-            auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conv_info->conversion);
-            if (ycbcr_state) {
+            if (auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conv_info->conversion)) {
                 conv_found = true;
                 external_format = ycbcr_state->external_format;
             }

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -315,9 +315,8 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
     auto buffer_state_ptr = Get<vvl::Buffer>(pCreateInfo->buffer);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     // If this isn't a sparse buffer, it needs to have memory backing it at CreateBufferView time
-    if (!buffer_state_ptr) {
-        return skip;
-    }
+    if (!buffer_state_ptr) return skip;
+
     const auto &buffer_state = *buffer_state_ptr;
     const LogObjectList objlist(device, pCreateInfo->buffer);
 
@@ -429,10 +428,8 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
 
 bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
                                               const ErrorObject &error_obj) const {
-    auto buffer_state = Get<vvl::Buffer>(buffer);
-
     bool skip = false;
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(buffer)) {
         skip |= ValidateObjectNotInUse(buffer_state.get(), error_obj.location, "VUID-vkDestroyBuffer-buffer-00922");
     }
     return skip;
@@ -440,9 +437,8 @@ bool CoreChecks::PreCallValidateDestroyBuffer(VkDevice device, VkBuffer buffer, 
 
 bool CoreChecks::PreCallValidateDestroyBufferView(VkDevice device, VkBufferView bufferView, const VkAllocationCallbacks *pAllocator,
                                                   const ErrorObject &error_obj) const {
-    auto buffer_view_state = Get<vvl::BufferView>(bufferView);
     bool skip = false;
-    if (buffer_view_state) {
+    if (auto buffer_view_state = Get<vvl::BufferView>(bufferView)) {
         skip |= ValidateObjectNotInUse(buffer_view_state.get(), error_obj.location, "VUID-vkDestroyBufferView-bufferView-00936");
     }
     return skip;
@@ -453,9 +449,8 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto buffer_state = Get<vvl::Buffer>(dstBuffer);
-    if (!cb_state_ptr || !buffer_state) {
-        return skip;
-    }
+    if (!cb_state_ptr || !buffer_state) return skip;
+
     const LogObjectList objlist(commandBuffer, dstBuffer);
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
     const Location buffer_loc = error_obj.location.dot(Field::dstBuffer);

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -990,8 +990,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             } else {
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[color_i].imageView);
 
-                                if (image_view_state->create_info.format !=
-                                    inheritance_rendering_info.pColorAttachmentFormats[color_i]) {
+                                if (image_view_state && image_view_state->create_info.format !=
+                                                            inheritance_rendering_info.pColorAttachmentFormats[color_i]) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-imageView-06028", objlist, cb_loc,
@@ -1012,7 +1012,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
                             auto image_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
 
-                            if (image_view_state->create_info.format != inheritance_rendering_info.depthAttachmentFormat) {
+                            if (image_view_state &&
+                                image_view_state->create_info.format != inheritance_rendering_info.depthAttachmentFormat) {
                                 const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pDepthAttachment-06029", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
@@ -1028,7 +1029,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                             rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
                             auto image_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
 
-                            if (image_view_state->create_info.format != inheritance_rendering_info.stencilAttachmentFormat) {
+                            if (image_view_state &&
+                                image_view_state->create_info.format != inheritance_rendering_info.stencilAttachmentFormat) {
                                 const LogObjectList objlist(commandBuffer, pCommandBuffers[i], cb_state.activeRenderPass->Handle());
                                 skip |= LogError("VUID-vkCmdExecuteCommands-pStencilAttachment-06030", objlist, cb_loc,
                                                  "(%s) is executed within a dynamic renderpass "
@@ -1093,7 +1095,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 }
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[index].imageView);
 
-                                if (image_view_state->samples != amd_sample_count->pColorAttachmentSamples[index]) {
+                                if (image_view_state &&
+                                    image_view_state->samples != amd_sample_count->pColorAttachmentSamples[index]) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
@@ -1113,7 +1116,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
 
-                                if (image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
+                                if (image_view_state &&
+                                    image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
@@ -1131,7 +1135,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
 
-                                if (image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
+                                if (image_view_state &&
+                                    image_view_state->samples != amd_sample_count->depthStencilAttachmentSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
@@ -1151,7 +1156,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 }
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[index].imageView);
 
-                                if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
+                                if (image_view_state &&
+                                    image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError(
@@ -1170,7 +1176,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
 
-                                if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
+                                if (image_view_state &&
+                                    image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-pNext-06036", objlist, cb_loc,
@@ -1187,7 +1194,8 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                                 rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
                                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
 
-                                if (image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
+                                if (image_view_state &&
+                                    image_view_state->samples != inheritance_rendering_info.rasterizationSamples) {
                                     const LogObjectList objlist(commandBuffer, pCommandBuffers[i],
                                                                 cb_state.activeRenderPass->Handle());
                                     skip |= LogError("VUID-vkCmdExecuteCommands-pNext-06037", objlist, cb_loc,
@@ -1279,6 +1287,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                     for (auto index = iter->range.begin; index < iter->range.end; index++) {
                         const LogObjectList objlist(commandBuffer, pCommandBuffers[i]);
                         const auto image_state = Get<vvl::Image>(image);
+                        if (!image_state) continue;
                         const auto subresource = image_state->subresource_encoder.Decode(index);
                         // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/issues/2456
                         skip |= LogError("UNASSIGNED-vkCmdExecuteCommands-commandBuffer-00001", objlist, cb_loc,

--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -821,6 +821,7 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
     const QueryObject *active_occlusion_query = nullptr;
     for (const auto &active_query : cb_state.activeQueries) {
         auto query_pool_state = Get<vvl::QueryPool>(active_query.pool);
+        if (!query_pool_state) continue;
         const auto queryType = query_pool_state->create_info.queryType;
         if (queryType == VK_QUERY_TYPE_OCCLUSION) {
             active_occlusion_query = &active_query;

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -874,7 +874,7 @@ bool CoreChecks::ValidateDrawDynamicStatePipeline(const LastBound& last_bound_st
         bool pgq_active = false;
         for (const auto& active_query : cb_state.activeQueries) {
             auto query_pool_state = Get<vvl::QueryPool>(active_query.pool);
-            if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+            if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
                 pgq_active = true;
                 break;
             }

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1829,6 +1829,8 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
+    if (!src_buffer_state || !dst_buffer_state) return;
+
     if (src_buffer_state->sparse || dst_buffer_state->sparse) {
         auto cb_state_ptr = Get<vvl::CommandBuffer>(commandBuffer);
 

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2442,6 +2442,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
     bool skip = false;
     VkImage image = GetImage(*info_ptr);
     auto image_state = Get<vvl::Image>(image);
+    if (!image_state) return skip;
     auto image_layout = GetImageLayout(*info_ptr);
     auto regionCount = info_ptr->regionCount;
     const bool from_image = loc.function == Func::vkCopyImageToMemoryEXT;
@@ -2665,7 +2666,6 @@ bool CoreChecks::PreCallValidateCopyMemoryToImageEXT(VkDevice device, const VkCo
     bool skip = false;
     const Location copy_loc = error_obj.location.dot(Field::pCopyMemoryToImageInfo);
     auto dst_image = pCopyMemoryToImageInfo->dstImage;
-    auto image_state = Get<vvl::Image>(dst_image);
 
     skip |= ValidateMemoryImageCopyCommon(pCopyMemoryToImageInfo, copy_loc);
     auto *props = &phys_dev_ext_props.host_image_copy_props;
@@ -2680,7 +2680,6 @@ bool CoreChecks::PreCallValidateCopyImageToMemoryEXT(VkDevice device, const VkCo
     bool skip = false;
     const Location copy_loc = error_obj.location.dot(Field::pCopyImageToMemoryInfo);
     auto src_image = pCopyImageToMemoryInfo->srcImage;
-    auto image_state = Get<vvl::Image>(src_image);
 
     skip |= ValidateMemoryImageCopyCommon(pCopyImageToMemoryInfo, copy_loc);
     auto *props = &phys_dev_ext_props.host_image_copy_props;
@@ -2745,6 +2744,7 @@ bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCop
     const Location loc = error_obj.location.dot(Field::pCopyImageToImageInfo);
     auto src_image_state = Get<vvl::Image>(info_ptr->srcImage);
     auto dst_image_state = Get<vvl::Image>(info_ptr->dstImage);
+    if (!src_image_state || !dst_image_state) return skip;
     // Formats are required to match, but check each image anyway
     auto src_plane_count = vkuFormatPlaneCount(src_image_state->create_info.format);
     auto dst_plane_count = vkuFormatPlaneCount(dst_image_state->create_info.format);

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -212,9 +212,7 @@ bool CoreChecks::ValidateCmdBindDescriptorSets(const vvl::CommandBuffer &cb_stat
     const bool is_2 = loc.function != Func::vkCmdBindDescriptorSets;
 
     auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
-    if (!pipeline_layout) {
-        return skip;  // dynamicPipelineLayout feature
-    }
+    if (!pipeline_layout) return skip;  // dynamicPipelineLayout feature
 
     // Track total count of dynamic descriptor types to make sure we have an offset for each one
     uint32_t total_dynamic_descriptors = 0;
@@ -2137,12 +2135,10 @@ bool CoreChecks::VerifyWriteUpdateContents(const DescriptorSet &dst_set, const V
 bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer &cb_state, VkPipelineLayout layout,
                                                        uint32_t firstSet, uint32_t setCount, const uint32_t *pBufferIndices,
                                                        const VkDeviceSize *pOffsets, const Location &loc) const {
-    auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
-    if (!pipeline_layout) {
-        return false;  // dynamicPipelineLayout
-    }
-
     bool skip = false;
+    auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
+    if (!pipeline_layout) return skip;  // dynamicPipelineLayout
+
     const bool is_2 = loc.function != Func::vkCmdSetDescriptorBufferOffsetsEXT;
 
     if (!enabled_features.descriptorBuffer) {
@@ -2347,9 +2343,7 @@ bool CoreChecks::ValidateCmdBindDescriptorBufferEmbeddedSamplers(const vvl::Comm
     }
 
     auto pipeline_layout = Get<vvl::PipelineLayout>(layout);
-    if (!pipeline_layout) {
-        return skip;  // dynamicPipelineLayout
-    }
+    if (!pipeline_layout) return skip;  // dynamicPipelineLayout
 
     if (set >= pipeline_layout->set_layouts.size()) {
         const char *vuid = is_2 ? "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-set-08071"
@@ -3489,9 +3483,7 @@ bool CoreChecks::ValidateCmdPushDescriptorSet(const vvl::CommandBuffer &cb_state
     const bool is_2 = loc.function != Func::vkCmdPushDescriptorSetKHR;
 
     auto layout_data = Get<vvl::PipelineLayout>(layout);
-    if (!layout_data) {
-        return skip;  // dynamicPipelineLayout
-    }
+    if (!layout_data) return skip;  // dynamicPipelineLayout
 
     // Validate the set index points to a push descriptor set and is in range
     const LogObjectList objlist(cb_state.Handle(), layout);
@@ -4470,9 +4462,7 @@ bool CoreChecks::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipel
         return skip;
     }
     auto layout_state = Get<vvl::PipelineLayout>(layout);
-    if (!layout_state) {
-        return skip;  // dynamicPipelineLayout feature
-    }
+    if (!layout_state) return skip;  // dynamicPipelineLayout feature
 
     const bool is_2 = loc.function != Func::vkCmdPushConstants;
     const auto &ranges = *layout_state->push_constant_ranges;

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -1606,9 +1606,8 @@ bool CoreChecks::ValidateBufferUpdate(const VkDescriptorBufferInfo &buffer_info,
     bool skip = false;
     // Invalid handles should be caught by the object tracker, but lets make sure not to crash anyways.
     const auto buffer_state = Get<vvl::Buffer>(buffer_info.buffer);
-    if (!buffer_state) {
-        return skip;
-    }
+    if (!buffer_state) return skip;
+
     skip |= ValidateMemoryIsBoundToBuffer(device, *buffer_state, buffer_info_loc.dot(Field::buffer),
                                           "VUID-VkWriteDescriptorSet-descriptorType-00329");
     skip |= ValidateBufferUsage(*buffer_state, type, buffer_info_loc.dot(Field::buffer));
@@ -1759,8 +1758,7 @@ bool CoreChecks::VerifyCopyUpdateContents(const VkCopyDescriptorSet &update, con
                                          "Attempted copy update to texel buffer descriptor with invalid buffer view (%s).",
                                          FormatHandle(buffer_view).c_str());
                     } else {
-                        auto buffer_state = Get<vvl::Buffer>(bv_state->create_info.buffer);
-                        if (buffer_state) {
+                        if (auto buffer_state = Get<vvl::Buffer>(bv_state->create_info.buffer)) {
                             skip |= ValidateBufferUsage(*buffer_state, src_type, copy_loc);
                         }
                     }
@@ -2659,9 +2657,7 @@ bool CoreChecks::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT(VkDevice
                          physical_device_count);
     }
 
-    auto buffer_state = Get<vvl::Buffer>(pInfo->buffer);
-
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(pInfo->buffer)) {
         if (!(buffer_state->create_info.flags & VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
             skip |= LogError("VUID-VkBufferCaptureDescriptorDataInfoEXT-buffer-08075", pInfo->buffer,
                              error_obj.location.dot(Field::pInfo).dot(Field::buffer), "was created with %s.",

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2687,9 +2687,7 @@ bool CoreChecks::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(VkDevice 
                          physical_device_count);
     }
 
-    auto image_state = Get<vvl::Image>(pInfo->image);
-
-    if (image_state) {
+    if (auto image_state = Get<vvl::Image>(pInfo->image)) {
         if (!(image_state->create_info.flags & VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
             skip |= LogError("VUID-VkImageCaptureDescriptorDataInfoEXT-image-08079", pInfo->image,
                              error_obj.location.dot(Field::pInfo).dot(Field::image), "is %s.",

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -759,9 +759,9 @@ bool CoreChecks::PreCallValidateDestroyCommandPool(VkDevice device, VkCommandPoo
                                                    const VkAllocationCallbacks *pAllocator, const ErrorObject &error_obj) const {
     bool skip = false;
     // In case of DEVICE_LOST, all execution is considered over
-    if (is_device_lost) return false;
+    if (is_device_lost) return skip;
     auto cp_state = Get<vvl::CommandPool>(commandPool);
-    if (!cp_state) { return false; }
+    if (!cp_state) return skip;
     // Verify that command buffers in pool are complete (not in-flight)
     for (auto &entry : cp_state->commandBuffers) {
         auto cb_state = entry.second;
@@ -778,7 +778,7 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
                                                  const ErrorObject &error_obj) const {
     bool skip = false;
     auto cp_state = Get<vvl::CommandPool>(commandPool);
-    if (!cp_state) { return false; }
+    if (!cp_state) return skip;
     // Verify that command buffers in pool are complete (not in-flight)
     for (auto &entry : cp_state->commandBuffers) {
         auto cb_state = entry.second;

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -1883,8 +1883,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                         FormatHandle(bind_info.image).c_str(), FormatHandle(image_state->create_from_swapchain).c_str(),
                         FormatHandle(swapchain_info->swapchain).c_str());
                 }
-                auto swapchain_state = Get<vvl::Swapchain>(swapchain_info->swapchain);
-                if (swapchain_state) {
+                if (auto swapchain_state = Get<vvl::Swapchain>(swapchain_info->swapchain)) {
                     if (swapchain_state->images.size() <= swapchain_info->imageIndex) {
                         const LogObjectList objlist(bind_info.image, bind_info.memory);
                         skip |= LogError("VUID-VkBindImageMemorySwapchainInfoKHR-imageIndex-01644", objlist,

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -205,8 +205,7 @@ bool CoreChecks::ValidateCmdDrawIndexedBufferSize(const vvl::CommandBuffer &cb_s
         return skip;
     }
     const auto &index_buffer_binding = cb_state.index_buffer_binding;
-    const auto buffer_state = Get<vvl::Buffer>(index_buffer_binding.buffer);
-    if (buffer_state) {
+    if (const auto buffer_state = Get<vvl::Buffer>(index_buffer_binding.buffer)) {
         const uint32_t index_size = GetIndexAlignment(index_buffer_binding.index_type);
         // This doesn't exactly match the pseudocode of the VUID, but the binding size is the *bound* size, such that the offset
         // has already been accounted for (subtracted from the buffer size), and is consistent with the use of
@@ -300,6 +299,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, V
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
 
@@ -348,6 +348,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBu
     skip |= ValidateGraphicsIndexedCmd(cb_state, error_obj.location);
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
 
@@ -519,6 +520,7 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffe
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-02710", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
@@ -561,6 +563,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
                          "call this command.");
     }
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateCmdDrawStrideWithStruct(cb_state, "VUID-vkCmdDrawIndirectCount-stride-03110", stride,
                                             Struct::VkDrawIndirectCommand, sizeof(VkDrawIndirectCommand), error_obj.location);
     if (maxDrawCount > 1) {
@@ -572,6 +575,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+    if (!count_buffer_state) return skip;
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
     return skip;
@@ -613,6 +617,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
                                             Struct::VkDrawIndexedIndirectCommand, sizeof(VkDrawIndexedIndirectCommand),
                                             error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     if (maxDrawCount > 1) {
         skip |= ValidateCmdDrawStrideWithBuffer(cb_state, "VUID-vkCmdDrawIndexedIndirectCount-maxDrawCount-03143", stride,
                                                 Struct::VkDrawIndexedIndirectCommand, sizeof(VkDrawIndexedIndirectCommand),
@@ -623,6 +628,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+    if (!count_buffer_state) return skip;
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
     return skip;
@@ -1278,6 +1284,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
     if (drawCount > 1) {
@@ -1340,6 +1347,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+    if (!buffer_state || !count_buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateCmdDrawStrideWithStruct(cb_state, "VUID-vkCmdDrawMeshTasksIndirectCountNV-stride-02182", stride,
@@ -1427,6 +1435,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
+    if (!buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
     if (drawCount > 1) {
@@ -1477,6 +1486,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
+    if (!buffer_state || !count_buffer_state) return skip;
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *count_buffer_state, error_obj.location.dot(Field::countBuffer),
                                           vuid.indirect_count_contiguous_memory_02714);

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -139,11 +139,12 @@ bool CoreChecks::ValidateMeshShaderStage(const vvl::CommandBuffer &cb_state, con
     }
     for (const auto &query : cb_state.activeQueries) {
         const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
-        if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
+        if (!query_pool_state) continue;
+        if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT) {
             skip |= LogError(vuid.xfb_queries_07074, cb_state.Handle(), loc, "Query with type %s is active.",
                              string_VkQueryType(query_pool_state->create_info.queryType));
         }
-        if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
+        if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
             skip |= LogError(vuid.pg_queries_07075, cb_state.Handle(), loc, "Query with type %s is active.",
                              string_VkQueryType(query_pool_state->create_info.queryType));
         }
@@ -1761,7 +1762,7 @@ bool CoreChecks::ValidateActionState(const vvl::CommandBuffer &cb_state, const V
                                               VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT | VK_SHADER_STAGE_GEOMETRY_BIT)) != 0) {
             for (const auto &query : cb_state.activeQueries) {
                 const auto query_pool_state = Get<vvl::QueryPool>(query.pool);
-                if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
+                if (query_pool_state && query_pool_state->create_info.queryType == VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT) {
                     const LogObjectList objlist(cb_state.Handle(), query.pool);
                     skip |= LogError(vuid.mesh_shader_queries_07073, objlist, loc,
                                      "Query (slot %" PRIu32 ") with type VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT is active.",

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -466,8 +466,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                     }
                 }
                 if (metal_texture_ptr->bufferView) {
-                    auto buffer_view_info = Get<vvl::BufferView>(metal_texture_ptr->bufferView);
-                    if (buffer_view_info) {
+                    if (auto buffer_view_info = Get<vvl::BufferView>(metal_texture_ptr->bufferView)) {
                         if (!buffer_view_info->metal_bufferview_export) {
                             skip |= LogError(
                                 "VUID-VkExportMetalObjectsInfoEXT-pNext-06797", device, error_obj.location,

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -359,8 +359,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_BUFFER_INFO_EXT: {
                 auto metal_buffer_ptr = reinterpret_cast<const VkExportMetalBufferInfoEXT *>(metal_objects_info_ptr);
-                auto mem_info = Get<vvl::DeviceMemory>(metal_buffer_ptr->memory);
-                if (mem_info) {
+                if (auto mem_info = Get<vvl::DeviceMemory>(metal_buffer_ptr->memory)) {
                     if (!mem_info->metal_buffer_export) {
                         skip |= LogError(
                             "VUID-VkExportMetalObjectsInfoEXT-pNext-06793", device, error_obj.location,

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -383,8 +383,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                                  FormatHandle(metal_texture_ptr->bufferView).c_str());
                 }
                 if (metal_texture_ptr->image) {
-                    auto image_info = Get<vvl::Image>(metal_texture_ptr->image);
-                    if (image_info) {
+                    if (auto image_info = Get<vvl::Image>(metal_texture_ptr->image)) {
                         if (!image_info->metal_image_export) {
                             skip |= LogError(
                                 "VUID-VkExportMetalObjectsInfoEXT-pNext-06795", device, error_obj.location,
@@ -418,8 +417,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
                     }
                 }
                 if (metal_texture_ptr->imageView) {
-                    auto image_view_info = Get<vvl::ImageView>(metal_texture_ptr->imageView);
-                    if (image_view_info) {
+                    if (auto image_view_info = Get<vvl::ImageView>(metal_texture_ptr->imageView)) {
                         if (!image_view_info->metal_imageview_export) {
                             skip |= LogError(
                                 "VUID-VkExportMetalObjectsInfoEXT-pNext-06796", device, error_obj.location,
@@ -491,8 +489,7 @@ bool CoreChecks::PreCallValidateExportMetalObjectsEXT(VkDevice device, VkExportM
 
             case VK_STRUCTURE_TYPE_EXPORT_METAL_IO_SURFACE_INFO_EXT: {
                 auto metal_io_surface_ptr = reinterpret_cast<const VkExportMetalIOSurfaceInfoEXT *>(metal_objects_info_ptr);
-                auto image_info = Get<vvl::Image>(metal_io_surface_ptr->image);
-                if (image_info) {
+                if (auto image_info = Get<vvl::Image>(metal_io_surface_ptr->image)) {
                     if (!image_info->metal_io_surface_export) {
                         skip |= LogError(
                             "VUID-VkExportMetalObjectsInfoEXT-pNext-06803", device, error_obj.location,

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -68,42 +68,41 @@ bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkIm
                                                      const ErrorObject &error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreFdInfo->semaphore);
-    if (sem_state) {
-        const Location info_loc = error_obj.location.dot(Field::pImportSemaphoreFdInfo);
-        skip |=
-            ValidateObjectNotInUse(sem_state.get(), info_loc.dot(Field::semaphore), "VUID-vkImportSemaphoreFdKHR-semaphore-01142");
+    if (!sem_state) return skip;
 
-        if ((pImportSemaphoreFdInfo->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0) {
-            if (sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
-                skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-flags-03323", sem_state->Handle(), info_loc.dot(Field::flags),
-                                 "includes VK_SEMAPHORE_IMPORT_TEMPORARY_BIT and semaphore is VK_SEMAPHORE_TYPE_TIMELINE.");
-            }
-        } else {
-            // only valid type with copy payload transference semantics currently
-            if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT) {
-                skip |=
-                    LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-07307", sem_state->Handle(), info_loc.dot(Field::flags),
+    const Location info_loc = error_obj.location.dot(Field::pImportSemaphoreFdInfo);
+    skip |= ValidateObjectNotInUse(sem_state.get(), info_loc.dot(Field::semaphore), "VUID-vkImportSemaphoreFdKHR-semaphore-01142");
+
+    if ((pImportSemaphoreFdInfo->flags & VK_SEMAPHORE_IMPORT_TEMPORARY_BIT) != 0) {
+        if (sem_state->type == VK_SEMAPHORE_TYPE_TIMELINE) {
+            skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-flags-03323", sem_state->Handle(), info_loc.dot(Field::flags),
+                             "includes VK_SEMAPHORE_IMPORT_TEMPORARY_BIT and semaphore is VK_SEMAPHORE_TYPE_TIMELINE.");
+        }
+    } else {
+        // only valid type with copy payload transference semantics currently
+        if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT) {
+            skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-07307", sem_state->Handle(), info_loc.dot(Field::flags),
                              "is %s and handleType is VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT.",
                              string_VkSemaphoreImportFlags(pImportSemaphoreFdInfo->flags).c_str());
-            }
         }
+    }
 
-        if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT) {
-            if (const auto payload_info = GetOpaqueInfoFromFdHandle(pImportSemaphoreFdInfo->fd)) {
-                if (sem_state->flags != payload_info->semaphore_flags) {
-                    // would use string_VkSemaphoreCreateFlags but no valid flags yet
-                    skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-03263", device, info_loc.dot(Field::semaphore),
-                                     "was created with flags 0x%" PRIx32 " but fd (%d) was exported with 0x%" PRIx32 ".",
-                                     sem_state->flags, pImportSemaphoreFdInfo->fd, payload_info->semaphore_flags);
-                }
-                if (sem_state->type != payload_info->semaphore_type) {
-                    skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-03264", device, info_loc.dot(Field::semaphore),
-                                     "was created with %s but fd (%d) was exported as %s.", string_VkSemaphoreType(sem_state->type),
-                                     pImportSemaphoreFdInfo->fd, string_VkSemaphoreType(payload_info->semaphore_type));
-                }
+    if (pImportSemaphoreFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT) {
+        if (const auto payload_info = GetOpaqueInfoFromFdHandle(pImportSemaphoreFdInfo->fd)) {
+            if (sem_state->flags != payload_info->semaphore_flags) {
+                // would use string_VkSemaphoreCreateFlags but no valid flags yet
+                skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-03263", device, info_loc.dot(Field::semaphore),
+                                 "was created with flags 0x%" PRIx32 " but fd (%d) was exported with 0x%" PRIx32 ".",
+                                 sem_state->flags, pImportSemaphoreFdInfo->fd, payload_info->semaphore_flags);
+            }
+            if (sem_state->type != payload_info->semaphore_type) {
+                skip |= LogError("VUID-VkImportSemaphoreFdInfoKHR-handleType-03264", device, info_loc.dot(Field::semaphore),
+                                 "was created with %s but fd (%d) was exported as %s.", string_VkSemaphoreType(sem_state->type),
+                                 pImportSemaphoreFdInfo->fd, string_VkSemaphoreType(payload_info->semaphore_type));
             }
         }
     }
+
     return skip;
 }
 
@@ -111,33 +110,32 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
                                                   const ErrorObject &error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pGetFdInfo->semaphore);
-    if (sem_state) {
-        const Location info_loc = error_obj.location.dot(Field::pGetFdInfo);
-        if ((pGetFdInfo->handleType & sem_state->exportHandleTypes) == 0) {
-            skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-01132", sem_state->Handle(), info_loc.dot(Field::handleType),
-                             "(%s) is different from VkExportSemaphoreCreateInfo::handleTypes (%s).",
-                             string_VkExternalSemaphoreHandleTypeFlagBits(pGetFdInfo->handleType),
-                             string_VkExternalSemaphoreHandleTypeFlags(sem_state->exportHandleTypes).c_str());
-        }
+    if (!sem_state) return skip;
 
-        if (sem_state->Scope() != vvl::Semaphore::kInternal && sem_state->HasImportedHandleType() &&
-            !CanSemaphoreExportFromImported(physical_device, pGetFdInfo->handleType, sem_state->ImportedHandleType())) {
-            skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-semaphore-01133", sem_state->Handle(), info_loc.dot(Field::handleType),
-                             "(%s) cannot be exported from semaphore with imported payload with handle type %s",
-                             string_VkExternalSemaphoreHandleTypeFlagBits(pGetFdInfo->handleType),
-                             string_VkExternalSemaphoreHandleTypeFlagBits(sem_state->ImportedHandleType()));
-        }
+    const Location info_loc = error_obj.location.dot(Field::pGetFdInfo);
+    if ((pGetFdInfo->handleType & sem_state->exportHandleTypes) == 0) {
+        skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-01132", sem_state->Handle(), info_loc.dot(Field::handleType),
+                         "(%s) is different from VkExportSemaphoreCreateInfo::handleTypes (%s).",
+                         string_VkExternalSemaphoreHandleTypeFlagBits(pGetFdInfo->handleType),
+                         string_VkExternalSemaphoreHandleTypeFlags(sem_state->exportHandleTypes).c_str());
+    }
 
-        if (pGetFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT) {
-            if (sem_state->type != VK_SEMAPHORE_TYPE_BINARY) {
-                skip |=
-                    LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03253", sem_state->Handle(), info_loc.dot(Field::handleType),
+    if (sem_state->Scope() != vvl::Semaphore::kInternal && sem_state->HasImportedHandleType() &&
+        !CanSemaphoreExportFromImported(physical_device, pGetFdInfo->handleType, sem_state->ImportedHandleType())) {
+        skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-semaphore-01133", sem_state->Handle(), info_loc.dot(Field::handleType),
+                         "(%s) cannot be exported from semaphore with imported payload with handle type %s",
+                         string_VkExternalSemaphoreHandleTypeFlagBits(pGetFdInfo->handleType),
+                         string_VkExternalSemaphoreHandleTypeFlagBits(sem_state->ImportedHandleType()));
+    }
+
+    if (pGetFdInfo->handleType == VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT) {
+        if (sem_state->type != VK_SEMAPHORE_TYPE_BINARY) {
+            skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03253", sem_state->Handle(), info_loc.dot(Field::handleType),
                              "is VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT, but semaphore type is %s.",
                              string_VkSemaphoreType(sem_state->type));
-            } else if (!sem_state->CanBinaryBeWaited()) {
-                skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03254", sem_state->Handle(),
-                                 info_loc.dot(Field::semaphore), "must be signaled or have a pending signal operation.");
-            }
+        } else if (!sem_state->CanBinaryBeWaited()) {
+            skip |= LogError("VUID-VkSemaphoreGetFdInfoKHR-handleType-03254", sem_state->Handle(), info_loc.dot(Field::semaphore),
+                             "must be signaled or have a pending signal operation.");
         }
     }
     return skip;
@@ -161,8 +159,7 @@ bool CoreChecks::PreCallValidateImportFenceFdKHR(VkDevice device, const VkImport
 bool CoreChecks::PreCallValidateGetFenceFdKHR(VkDevice device, const VkFenceGetFdInfoKHR *pGetFdInfo, int *pFd,
                                               const ErrorObject &error_obj) const {
     bool skip = false;
-    auto fence_state = Get<vvl::Fence>(pGetFdInfo->fence);
-    if (fence_state) {
+    if (auto fence_state = Get<vvl::Fence>(pGetFdInfo->fence)) {
         const Location info_loc = error_obj.location.dot(Field::pGetFdInfo);
         if ((pGetFdInfo->handleType & fence_state->exportHandleTypes) == 0) {
             skip |= LogError("VUID-VkFenceGetFdInfoKHR-handleType-01453", fence_state->Handle(), info_loc.dot(Field::handleType),
@@ -214,8 +211,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreWin32HandleKHR(
     VkDevice device, const VkImportSemaphoreWin32HandleInfoKHR *pImportSemaphoreWin32HandleInfo,
     const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreWin32HandleInfo->semaphore);
-    if (sem_state) {
+    if (auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreWin32HandleInfo->semaphore)) {
         // Waiting for: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3507
         skip |= ValidateObjectNotInUse(sem_state.get(), error_obj.location, kVUIDUndefined);
 
@@ -233,8 +229,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice device,
                                                            const VkSemaphoreGetWin32HandleInfoKHR *pGetWin32HandleInfo,
                                                            HANDLE *pHandle, const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<vvl::Semaphore>(pGetWin32HandleInfo->semaphore);
-    if (sem_state) {
+    if (auto sem_state = Get<vvl::Semaphore>(pGetWin32HandleInfo->semaphore)) {
         if ((pGetWin32HandleInfo->handleType & sem_state->exportHandleTypes) == 0) {
             skip |= LogError("VUID-VkSemaphoreGetWin32HandleInfoKHR-handleType-01126", sem_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
@@ -265,8 +260,7 @@ bool CoreChecks::PreCallValidateImportFenceWin32HandleKHR(VkDevice device,
 bool CoreChecks::PreCallValidateGetFenceWin32HandleKHR(VkDevice device, const VkFenceGetWin32HandleInfoKHR *pGetWin32HandleInfo,
                                                        HANDLE *pHandle, const ErrorObject &error_obj) const {
     bool skip = false;
-    auto fence_state = Get<vvl::Fence>(pGetWin32HandleInfo->fence);
-    if (fence_state) {
+    if (auto fence_state = Get<vvl::Fence>(pGetWin32HandleInfo->fence)) {
         if ((pGetWin32HandleInfo->handleType & fence_state->exportHandleTypes) == 0) {
             skip |= LogError("VUID-VkFenceGetWin32HandleInfoKHR-handleType-01448", fence_state->Handle(),
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::handleType),
@@ -293,8 +287,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(
     VkDevice device, const VkImportSemaphoreZirconHandleInfoFUCHSIA *pImportSemaphoreZirconHandleInfo,
     const ErrorObject &error_obj) const {
     bool skip = false;
-    auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreZirconHandleInfo->semaphore);
-    if (sem_state) {
+    if (auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreZirconHandleInfo->semaphore)) {
         skip |= ValidateObjectNotInUse(sem_state.get(), error_obj.location,
                                        "VUID-vkImportSemaphoreZirconHandleFUCHSIA-semaphore-04764");
 

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -449,9 +449,8 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
     }
 
     const auto swapchain_create_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(pCreateInfo->pNext);
-    if (swapchain_create_info != nullptr) {
-        if (swapchain_create_info->swapchain != VK_NULL_HANDLE) {
-            auto swapchain_state = Get<vvl::Swapchain>(swapchain_create_info->swapchain);
+    if (swapchain_create_info != nullptr && swapchain_create_info->swapchain != VK_NULL_HANDLE) {
+        if (auto swapchain_state = Get<vvl::Swapchain>(swapchain_create_info->swapchain)) {
             const VkSwapchainCreateFlagsKHR swapchain_flags = swapchain_state->create_info.flags;
 
             // Validate rest of Swapchain Image create check that require swapchain state

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -2304,7 +2304,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     const auto ycbcr_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
     if (ycbcr_conversion && ycbcr_conversion->conversion != VK_NULL_HANDLE) {
         auto ycbcr_state = Get<vvl::SamplerYcbcrConversion>(ycbcr_conversion->conversion);
-        if (pCreateInfo->format != ycbcr_state->format) {
+        if (ycbcr_state && (pCreateInfo->format != ycbcr_state->format)) {
             skip |= LogError("VUID-VkImageViewCreateInfo-pNext-06658", pCreateInfo->image,
                              create_info_loc.pNext(Struct::VkSamplerYcbcrConversionInfo, Field::conversion),
                              "was created with format %s which is different than pCreateInfo->format %s.",

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -476,6 +476,7 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
                                                        const Location &rp_begin_loc) const {
     bool skip = false;
     auto render_pass_state = Get<vvl::RenderPass>(begin_info.renderPass);
+    if (!render_pass_state) return skip;
     const auto *render_pass_info = render_pass_state->create_info.ptr();
     const VkRenderPass render_pass = render_pass_state->VkHandle();
     auto const &framebuffer_info = framebuffer_state.create_info;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -198,9 +198,8 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
     for (const auto &layout_map_entry : cb_state.image_layout_map) {
         const auto image = layout_map_entry.first;
         const auto image_state = Get<vvl::Image>(image);
-        if (!image_state) {
-            continue;
-        }
+        if (!image_state) continue;
+
         const auto &layout_map = layout_map_entry.second.map->GetLayoutMap();
         // Validate the initial_uses for each subresource referenced
         if (layout_map.empty()) continue;
@@ -629,18 +628,19 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
             if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
                 const Location input_loc = subpass_loc.dot(Field::pInputAttachments, k);
                 auto image_view = attachments[attachment_ref.attachment];
-                auto view_state = Get<vvl::ImageView>(image_view);
 
-                if (view_state) {
+                if (auto view_state = Get<vvl::ImageView>(image_view)) {
                     skip |= ValidateRenderPassLayoutAgainstFramebufferImageUsage(attachment_ref.layout, *view_state, framebuffer,
                                                                                  render_pass, attachment_ref.attachment, rp_loc,
                                                                                  input_loc.dot(Field::layout));
-                }
-                if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
-                    if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
-                        skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
-                            framebuffer, render_pass, *view_state->image_state, ms_rendered_to_single_sampled->rasterizationSamples,
-                            subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+
+                    if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
+                        if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
+                            skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
+                                framebuffer, render_pass, *view_state->image_state,
+                                ms_rendered_to_single_sampled->rasterizationSamples,
+                                subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+                        }
                     }
                 }
             }
@@ -651,9 +651,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
             if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
                 const Location color_loc = subpass_loc.dot(Field::pColorAttachments, k);
                 auto image_view = attachments[attachment_ref.attachment];
-                auto view_state = Get<vvl::ImageView>(image_view);
 
-                if (view_state) {
+                if (auto view_state = Get<vvl::ImageView>(image_view)) {
                     skip |= ValidateRenderPassLayoutAgainstFramebufferImageUsage(attachment_ref.layout, *view_state, framebuffer,
                                                                                  render_pass, attachment_ref.attachment, rp_loc,
                                                                                  color_loc.dot(Field::layout));
@@ -662,12 +661,14 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
                             attachment_ref.layout, *view_state, framebuffer, render_pass, attachment_ref.attachment, rp_loc,
                             subpass_loc.dot(Field::pResolveAttachments, k).dot(Field::layout));
                     }
-                }
-                if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
-                    if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
-                        skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
-                            framebuffer, render_pass, *view_state->image_state, ms_rendered_to_single_sampled->rasterizationSamples,
-                            subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+
+                    if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
+                        if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
+                            skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
+                                framebuffer, render_pass, *view_state->image_state,
+                                ms_rendered_to_single_sampled->rasterizationSamples,
+                                subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+                        }
                     }
                 }
             }
@@ -678,9 +679,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
             if (attachment_ref.attachment != VK_ATTACHMENT_UNUSED) {
                 const Location ds_loc = subpass_loc.dot(Field::pDepthStencilAttachment);
                 auto image_view = attachments[attachment_ref.attachment];
-                auto view_state = Get<vvl::ImageView>(image_view);
 
-                if (view_state) {
+                if (auto view_state = Get<vvl::ImageView>(image_view)) {
                     skip |= ValidateRenderPassLayoutAgainstFramebufferImageUsage(attachment_ref.layout, *view_state, framebuffer,
                                                                                  render_pass, attachment_ref.attachment, rp_loc,
                                                                                  ds_loc.dot(Field::layout));
@@ -691,12 +691,14 @@ bool CoreChecks::VerifyFramebufferAndRenderPassLayouts(const vvl::CommandBuffer 
                             stencil_layout->stencilLayout, *view_state, framebuffer, render_pass,
                             ds_loc.pNext(Struct::VkAttachmentReferenceStencilLayout, Field::stencilLayout));
                     }
-                }
-                if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
-                    if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
-                        skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
-                            framebuffer, render_pass, *view_state->image_state, ms_rendered_to_single_sampled->rasterizationSamples,
-                            subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+
+                    if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
+                        if (render_pass_info->pAttachments[attachment_ref.attachment].samples == VK_SAMPLE_COUNT_1_BIT) {
+                            skip |= ValidateMultipassRenderedToSingleSampledSampleCount(
+                                framebuffer, render_pass, *view_state->image_state,
+                                ms_rendered_to_single_sampled->rasterizationSamples,
+                                subpass_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT, Field::rasterizationSamples));
+                        }
                     }
                 }
             }
@@ -826,9 +828,8 @@ bool CoreChecks::UpdateCommandBufferImageLayoutMap(const vvl::CommandBuffer &cb_
                                                    vvl::CommandBuffer::ImageLayoutMap &layout_updates) const {
     bool skip = false;
     auto image_state = Get<vvl::Image>(img_barrier.image);
-    if (!image_state) {
-        return skip;
-    }
+    if (!image_state) return skip;
+
     std::shared_ptr<ImageSubresourceLayoutMap> write_subresource_map;
     auto iter = layout_updates.find(image_state->VkHandle());
     bool new_write = false;
@@ -910,9 +911,8 @@ void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const
         }
     }
     auto image_state = Get<vvl::Image>(mem_barrier.image);
-    if (!image_state) {
-        return;
-    }
+    if (!image_state) return;
+
     auto normalized_isr = image_state->NormalizeSubresourceRange(mem_barrier.subresourceRange);
 
     VkImageLayout initial_layout = NormalizeSynchronization2Layout(mem_barrier.subresourceRange.aspectMask, mem_barrier.oldLayout);

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -194,7 +194,7 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice devi
                                            "VUID-vkGetPipelineExecutableStatisticsKHR-pipelineExecutableInfo-03272");
 
     auto pipeline_state = Get<vvl::Pipeline>(pExecutableInfo->pipeline);
-    if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR)) {
+    if (pipeline_state && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR)) {
         skip |= LogError("VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03274", pExecutableInfo->pipeline, error_obj.location,
                          "called on a pipeline created without the "
                          "VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR flag set.");
@@ -211,7 +211,7 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
                                            "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipelineExecutableInfo-03276");
 
     auto pipeline_state = Get<vvl::Pipeline>(pExecutableInfo->pipeline);
-    if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR)) {
+    if (pipeline_state && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR)) {
         skip |= LogError("VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03278", pExecutableInfo->pipeline,
                          error_obj.location,
                          "called on a pipeline created without the "
@@ -223,9 +223,8 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
 
 bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
                                                 const ErrorObject &error_obj) const {
-    auto pipeline_state = Get<vvl::Pipeline>(pipeline);
     bool skip = false;
-    if (pipeline_state) {
+    if (auto pipeline_state = Get<vvl::Pipeline>(pipeline)) {
         skip |= ValidateObjectNotInUse(pipeline_state.get(), error_obj.location, "VUID-vkDestroyPipeline-pipeline-00765");
     }
     return skip;
@@ -240,9 +239,9 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
     skip |= ValidateCmd(*cb_state, error_obj.location);
     skip |= ValidatePipelineBindPoint(*cb_state, pipelineBindPoint, error_obj.location);
 
-    auto pPipeline = Get<vvl::Pipeline>(pipeline);
-    assert(pPipeline);
-    const vvl::Pipeline &pipeline_state = *pPipeline;
+    auto pipeline_ptr = Get<vvl::Pipeline>(pipeline);
+    if (!pipeline_ptr) return skip;
+    const vvl::Pipeline &pipeline_state = *pipeline_ptr;
 
     if (pipelineBindPoint != pipeline_state.pipeline_type) {
         if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -219,6 +219,7 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
         // Validate color attachments
         const uint32_t subpass = pipeline.Subpass();
         auto render_pass = Get<vvl::RenderPass>(pipeline.GraphicsCreateInfo().renderPass);
+        if (!render_pass) return skip;
         const bool ignore_color_blend_state =
             raster_state_ci->rasterizerDiscardEnable ||
             (pipeline.rendering_create_info ? (pipeline.rendering_create_info->colorAttachmentCount == 0)

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3223,14 +3223,13 @@ bool CoreChecks::ValidatePipelineDrawtimeState(const LastBound &last_bound_state
     // Because vertex & index buffer is read only, it doesn't need to care protected command buffer case.
     if (enabled_features.protectedMemory == VK_TRUE) {
         for (const auto &vertex_buffer_binding : cb_state.current_vertex_buffer_binding_info) {
-            const auto buffer_state = Get<vvl::Buffer>(vertex_buffer_binding.second.buffer);
-            if (buffer_state) {
+            if (const auto buffer_state = Get<vvl::Buffer>(vertex_buffer_binding.second.buffer)) {
                 skip |= ValidateProtectedBuffer(cb_state, *buffer_state, loc, vuid.unprotected_command_buffer_02707,
                                                 "Buffer is vertex buffer");
             }
         }
-        const auto buffer_state = Get<vvl::Buffer>(cb_state.index_buffer_binding.buffer);
-        if (buffer_state) {
+
+        if (const auto buffer_state = Get<vvl::Buffer>(cb_state.index_buffer_binding.buffer)) {
             skip |= ValidateProtectedBuffer(cb_state, *buffer_state, loc, vuid.unprotected_command_buffer_02707,
                                             "Buffer is index buffer");
         }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -270,9 +270,8 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
 
     for (uint32_t i = 0; i < library_create_info.libraryCount; ++i) {
         const auto lib = Get<vvl::Pipeline>(library_create_info.pLibraries[i]);
-        if (!lib) {
-            continue;
-        }
+        if (!lib) continue;
+
         const Location &library_loc = create_info_loc.pNext(Struct::VkPipelineLibraryCreateInfoKHR, Field::pLibraries, i);
         const VkPipelineCreateFlags2KHR lib_pipeline_flags = lib->create_flags;
 
@@ -406,6 +405,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
             if (flags_count >= 1 && flags_count <= 2) {
                 for (uint32_t i = 0; i < library_create_info.libraryCount; ++i) {
                     const auto lib = Get<vvl::Pipeline>(library_create_info.pLibraries[i]);
+                    if (!lib) continue;
                     const auto lib_gpl_info =
                         vku::FindStructInPNextChain<VkGraphicsPipelineLibraryCreateInfoEXT>(lib->GraphicsCreateInfo().pNext);
                     if (!lib_gpl_info) {
@@ -425,6 +425,7 @@ bool CoreChecks::ValidatePipelineLibraryCreateInfo(const vvl::Pipeline &pipeline
         }
         for (uint32_t i = 0; i < library_create_info.libraryCount; ++i) {
             const auto lib = Get<vvl::Pipeline>(library_create_info.pLibraries[i]);
+            if (!lib) continue;
             const auto lib_rendering_struct = lib->GetPipelineRenderingCreateInfo();
             skip |= ValidatePipelineLibraryFlags(lib->graphics_lib_type, library_create_info, lib_rendering_struct, create_info_loc,
                                                  i, "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06627");
@@ -690,9 +691,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
 
         for (uint32_t i = 0; i < pipeline.library_create_info->libraryCount; ++i) {
             const auto lib = Get<vvl::Pipeline>(pipeline.library_create_info->pLibraries[i]);
-            if (!lib) {
-                continue;
-            }
+            if (!lib) continue;
+
             const auto &lib_ci = lib->GraphicsCreateInfo();
             if (lib->graphics_lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {
                 pre_raster_info.init = GPLInitType::link_libraries;
@@ -3547,7 +3547,7 @@ bool CoreChecks::ValidateShaderObjectDrawtimeState(const LastBound &last_bound_s
                 prev_stage = stage;
                 for (const auto &linked_shader : state->linked_shaders) {
                     const auto &linked_state = Get<vvl::ShaderObject>(linked_shader);
-                    if (linked_state->create_info.stage == state->create_info.nextStage) {
+                    if (linked_state && linked_state->create_info.stage == state->create_info.nextStage) {
                         next_stage = static_cast<VkShaderStageFlagBits>(state->create_info.nextStage);
                         break;
                     }
@@ -4280,6 +4280,8 @@ bool CoreChecks::ValidatePipelineLibraryFlags(const VkGraphicsPipelineLibraryFla
         // loop
         for (int i = lib_index + 1; i < static_cast<int>(link_info.libraryCount); ++i) {
             const auto lib = Get<vvl::Pipeline>(link_info.pLibraries[i]);
+            if (!lib) continue;
+
             const auto lib_rendering_struct = lib->GetPipelineRenderingCreateInfo();
             const bool other_flag = (lib->graphics_lib_type & flags) && (lib->graphics_lib_type & ~lib_flags);
             if (!other_flag) {

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -44,6 +44,7 @@ bool CoreChecks::ValidateRayTracingPipeline(const vvl::Pipeline &pipeline,
                 const Location library_info_loc = create_info_loc.dot(Field::pLibraryInfo);
                 const Location library_loc = library_info_loc.dot(Field::pLibraries, i);
                 const auto library_pipelinestate = Get<vvl::Pipeline>(create_info.pLibraryInfo->pLibraries[i]);
+                if (!library_pipelinestate) continue;
                 const auto &library_create_info = library_pipelinestate->RayTracingCreateInfo();
                 if (library_create_info.maxPipelineRayRecursionDepth != create_info.maxPipelineRayRecursionDepth) {
                     skip |= LogError("VUID-VkRayTracingPipelineCreateInfoKHR-pLibraries-03591", device, library_loc,
@@ -266,6 +267,8 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                 const Location library_info_loc = create_info_loc.dot(Field::pLibraryInfo);
                 const Location library_loc = library_info_loc.dot(Field::pLibraries, j);
                 const auto lib = Get<vvl::Pipeline>(create_info.pLibraryInfo->pLibraries[j]);
+                if (!lib) continue;
+
                 if ((lib->create_flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) == 0) {
                     skip |= LogError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-03381", device, library_loc,
                                      "was created with %s.", string_VkPipelineCreateFlags2KHR(lib->create_flags).c_str());

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -40,11 +40,12 @@ static QueryState GetLocalQueryState(const QueryMap *localQueryToStateMap, VkQue
 
 bool CoreChecks::PreCallValidateDestroyQueryPool(VkDevice device, VkQueryPool queryPool, const VkAllocationCallbacks *pAllocator,
                                                  const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
-    if (queryPool == VK_NULL_HANDLE) return false;
-    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
-
     bool skip = false;
+    if (disabled[query_validation]) return skip;
+    if (queryPool == VK_NULL_HANDLE) return skip;
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
     bool completed_by_get_results = true;
     for (uint32_t i = 0; i < query_pool_state->create_info.queryCount; ++i) {
         auto state = query_pool_state->GetQueryState(i, 0);
@@ -138,21 +139,23 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
                          "is %" PRIu32 " but stride is zero.", queryCount);
     }
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    skip |= ValidateQueryPoolIndex(device, query_pool_state, firstQuery, queryCount, error_obj.location,
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    skip |= ValidateQueryPoolIndex(device, *query_pool_state, firstQuery, queryCount, error_obj.location,
                                    "VUID-vkGetQueryPoolResults-firstQuery-09436", "VUID-vkGetQueryPoolResults-firstQuery-09437");
 
-    if (query_pool_state.create_info.queryType != VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
+    if (query_pool_state->create_info.queryType != VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         skip |= ValidateQueryPoolStride("VUID-vkGetQueryPoolResults-flags-02828", "VUID-vkGetQueryPoolResults-flags-00815", stride,
                                         Field::dataSize, dataSize, flags, device, error_obj.location.dot(Field::stride));
     }
-    if ((query_pool_state.create_info.queryType == VK_QUERY_TYPE_TIMESTAMP) && (flags & VK_QUERY_RESULT_PARTIAL_BIT)) {
+    if ((query_pool_state->create_info.queryType == VK_QUERY_TYPE_TIMESTAMP) && (flags & VK_QUERY_RESULT_PARTIAL_BIT)) {
         skip |= LogError("VUID-vkGetQueryPoolResults-queryType-09439", queryPool, error_obj.location.dot(Field::flags),
                          "(%s) includes VK_QUERY_RESULT_PARTIAL_BIT, but queryPool (%s) was created with a queryType of "
                          "VK_QUERY_TYPE_TIMESTAMP.",
                          string_VkQueryResultFlags(flags).c_str(), FormatHandle(queryPool).c_str());
     }
-    if (query_pool_state.create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
+    if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
         (flags & VK_QUERY_RESULT_WITH_STATUS_BIT_KHR) == 0) {
         skip |= LogError("VUID-vkGetQueryPoolResults-queryType-09442", queryPool, error_obj.location.dot(Field::flags),
                          "(%s) doesn't have VK_QUERY_RESULT_WITH_STATUS_BIT_KHR, but queryPool %s was created with "
@@ -170,7 +173,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
     uint32_t query_items = 0;
     uint32_t query_size = 0;
 
-    switch (query_pool_state.create_info.queryType) {
+    switch (query_pool_state->create_info.queryType) {
         case VK_QUERY_TYPE_OCCLUSION:
             // Occlusion queries write one integer value - the number of samples passed.
             query_items = 1;
@@ -181,7 +184,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
             // Pipeline statistics queries write one integer value for each bit that is enabled in the pipelineStatistics
             // when the pool is created
             {
-                query_items = GetBitSetCount(query_pool_state.create_info.pipelineStatistics);
+                query_items = GetBitSetCount(query_pool_state->create_info.pipelineStatistics);
                 query_size = query_size_in_bytes * (query_items + query_avail_data);
             }
             break;
@@ -207,13 +210,13 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
         case VK_QUERY_TYPE_VIDEO_ENCODE_FEEDBACK_KHR:
             // Video encode feedback queries write one integer value for each bit that is enabled in
             // VkQueryPoolVideoEncodeFeedbackCreateInfoKHR::encodeFeedbackFlags when the pool is created
-            query_items = GetBitSetCount(query_pool_state.video_encode_feedback_flags);
+            query_items = GetBitSetCount(query_pool_state->video_encode_feedback_flags);
             query_size = query_size_in_bytes * (query_items + query_avail_data);
             break;
 
         case VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR:
             // Performance queries store results in a tightly packed array of VkPerformanceCounterResultsKHR
-            query_items = query_pool_state.perf_counter_index_count;
+            query_items = query_pool_state->perf_counter_index_count;
             query_size = sizeof(VkPerformanceCounterResultKHR) * query_items;
             if (query_size > stride) {
                 skip |= LogError("VUID-vkGetQueryPoolResults-queryType-04519", queryPool, error_obj.location.dot(Field::queryPool),
@@ -231,7 +234,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
                                  "size of VkPerformanceCounterResultKHR.",
                                  FormatHandle(queryPool).c_str());
             }
-            skip |= ValidatePerformanceQueryResults(query_pool_state, firstQuery, queryCount, flags, error_obj.location);
+            skip |= ValidatePerformanceQueryResults(*query_pool_state, firstQuery, queryCount, flags, error_obj.location);
 
             break;
 
@@ -251,7 +254,7 @@ bool CoreChecks::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryPool
                          FormatHandle(queryPool).c_str(), dataSize);
     }
 
-    skip |= ValidateQueryPoolWasReset(query_pool_state, firstQuery, queryCount, error_obj.location, nullptr, 0u);
+    skip |= ValidateQueryPoolWasReset(*query_pool_state, firstQuery, queryCount, error_obj.location, nullptr, 0u);
 
     return skip;
 }
@@ -427,6 +430,7 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     bool skip = false;
     const bool is_indexed = loc.function == Func::vkCmdBeginQueryIndexedEXT;
     auto query_pool_state = Get<vvl::QueryPool>(query_obj.pool);
+    if (!query_pool_state) return skip;
     const auto &query_pool_ci = query_pool_state->create_info;
 
     switch (query_pool_ci.queryType) {
@@ -627,7 +631,8 @@ bool CoreChecks::ValidateBeginQuery(const vvl::CommandBuffer &cb_state, const Qu
     // Check for nested queries
     for (const auto &active_query_obj : cb_state.activeQueries) {
         auto active_query_pool_state = Get<vvl::QueryPool>(active_query_obj.pool);
-        if (active_query_pool_state->create_info.queryType == query_pool_ci.queryType && active_query_obj.index == index) {
+        if (active_query_pool_state && (active_query_pool_state->create_info.queryType == query_pool_ci.queryType) &&
+            (active_query_obj.index == index)) {
             const char *vuid =
                 is_indexed ? "VUID-vkCmdBeginQueryIndexedEXT-queryPool-04753" : "VUID-vkCmdBeginQuery-queryPool-01922";
             const LogObjectList objlist(cb_state.Handle(), query_obj.pool, active_query_obj.pool);
@@ -761,8 +766,9 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
-    QueryObject query_obj = {queryPool, slot};
-    auto query_pool_state = Get<vvl::QueryPool>(query_obj.pool);
+    auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
     if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
         if (!enabled_features.primitivesGeneratedQuery) {
             const LogObjectList objlist(commandBuffer, queryPool);
@@ -771,6 +777,7 @@ bool CoreChecks::PreCallValidateCmdBeginQuery(VkCommandBuffer commandBuffer, VkQ
                              "primitivesGeneratedQuery feature was not enabled.");
         }
     }
+    QueryObject query_obj = {queryPool, slot};
     skip |= ValidateBeginQuery(*cb_state, query_obj, flags, 0, error_obj.location);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     return skip;
@@ -782,6 +789,7 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
     const auto &state_data = cb_state.dev_data;
 
     auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
+    if (!query_pool_state) return skip;
     const auto &query_pool_ci = query_pool_state->create_info;
 
     QueryState state = GetLocalQueryState(localQueryToStateMap, query_obj.pool, query_obj.slot, perfPass);
@@ -829,14 +837,15 @@ bool CoreChecks::VerifyQueryIsReset(const vvl::CommandBuffer &cb_state, const Qu
 
 bool CoreChecks::ValidatePerformanceQuery(const vvl::CommandBuffer &cb_state, const QueryObject &query_obj, Func command,
                                           VkQueryPool &firstPerfQueryPool, uint32_t perfPass, QueryMap *localQueryToStateMap) {
+    bool skip = false;
     const auto &state_data = cb_state.dev_data;
     auto query_pool_state = state_data.Get<vvl::QueryPool>(query_obj.pool);
+    if (!query_pool_state) return skip;
+
     const auto &query_pool_ci = query_pool_state->create_info;
     const Location loc(command);
 
-    if (query_pool_ci.queryType != VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) return false;
-
-    bool skip = false;
+    if (query_pool_ci.queryType != VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) return skip;
 
     if (perfPass >= query_pool_state->n_performance_passes) {
         const LogObjectList objlist(cb_state.Handle(), query_obj.pool);
@@ -911,6 +920,7 @@ void CoreChecks::EnqueueVerifyEndQuery(vvl::CommandBuffer &cb_state, const Query
         bool skip = false;
         // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
         auto query_pool_state = cb_state_arg.dev_data.Get<vvl::QueryPool>(query_obj.pool);
+        if (!query_pool_state) return skip;
         if (query_pool_state->has_perf_scope_command_buffer && (cb_state_arg.command_count - 1) != query_obj.end_command_index) {
             const LogObjectList objlist(cb_state_arg.Handle(), query_pool_state->Handle());
             const Location loc(command);
@@ -936,6 +946,8 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
                          slot);
     }
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
     const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         if (query_pool_state->has_perf_scope_render_pass && cb_state.activeRenderPass) {
@@ -989,13 +1001,15 @@ bool CoreChecks::ValidateCmdEndQuery(const vvl::CommandBuffer &cb_state, VkQuery
 
 bool CoreChecks::PreCallValidateCmdEndQuery(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                             const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
     bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    const uint32_t available_query_count = query_pool_state.create_info.queryCount;
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    const uint32_t available_query_count = query_pool_state->create_info.queryCount;
     // Only continue validating if the slot is even within range
     if (slot >= available_query_count) {
         const LogObjectList objlist(commandBuffer, queryPool);
@@ -1056,14 +1070,16 @@ bool CoreChecks::ValidateQueriesNotActive(const vvl::CommandBuffer &cb_state, Vk
 
 bool CoreChecks::PreCallValidateCmdResetQueryPool(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t firstQuery,
                                                   uint32_t queryCount, const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
 
-    bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    skip |= ValidateQueryPoolIndex(commandBuffer, query_pool_state, firstQuery, queryCount, error_obj.location,
+
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+    skip |= ValidateQueryPoolIndex(commandBuffer, *query_pool_state, firstQuery, queryCount, error_obj.location,
                                    "VUID-vkCmdResetQueryPool-firstQuery-09436", "VUID-vkCmdResetQueryPool-firstQuery-09437");
     skip |= ValidateQueriesNotActive(*cb_state, queryPool, firstQuery, queryCount, error_obj.location,
                                      "VUID-vkCmdResetQueryPool-None-02841");
@@ -1075,8 +1091,10 @@ void CoreChecks::PreCallRecordCmdResetQueryPool(VkCommandBuffer commandBuffer, V
                                                 uint32_t queryCount, const RecordObject &record_obj) {
     if (disabled[query_validation]) return;
     auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    if (query_pool_state.create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return;
+
+    if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
         cb_state->queryUpdates.emplace_back([queryPool, firstQuery, queryCount, record_obj](
                                                 vvl::CommandBuffer &cb_state_arg, bool do_validate, VkQueryPool &firstPerfQueryPool,
                                                 uint32_t perfPass, QueryMap *localQueryToStateMap) {
@@ -1129,13 +1147,13 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
                                                         uint32_t queryCount, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                                         VkDeviceSize stride, VkQueryResultFlags flags,
                                                         const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto dst_buff_state = Get<vvl::Buffer>(dstBuffer);
     assert(cb_state);
     assert(dst_buff_state);
     const LogObjectList buffer_objlist(commandBuffer, dstBuffer);
-    bool skip = false;
     skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buff_state, error_obj.location.dot(Field::dstBuffer),
                                           "VUID-vkCmdCopyQueryPoolResults-dstBuffer-00826");
     skip |=
@@ -1169,15 +1187,17 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
                          "is %" PRIu32 " but stride is zero.", queryCount);
     }
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    skip |= ValidateQueryPoolIndex(commandBuffer, query_pool_state, firstQuery, queryCount, error_obj.location,
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    skip |= ValidateQueryPoolIndex(commandBuffer, *query_pool_state, firstQuery, queryCount, error_obj.location,
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-09436",
                                    "VUID-vkCmdCopyQueryPoolResults-firstQuery-09437");
     skip |= ValidateQueriesNotActive(*cb_state, queryPool, firstQuery, queryCount, error_obj.location,
                                      "VUID-vkCmdCopyQueryPoolResults-None-07429");
 
-    if (query_pool_state.create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
-        skip |= ValidatePerformanceQueryResults(query_pool_state, firstQuery, queryCount, flags, error_obj.location);
+    if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR) {
+        skip |= ValidatePerformanceQueryResults(*query_pool_state, firstQuery, queryCount, flags, error_obj.location);
         if (!phys_dev_ext_props.performance_query_props.allowCommandBufferQueryCopies) {
             const LogObjectList objlist(commandBuffer, queryPool);
             skip |= LogError("VUID-vkCmdCopyQueryPoolResults-queryType-03232", objlist, error_obj.location.dot(Field::queryPool),
@@ -1186,18 +1206,18 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
                              FormatHandle(queryPool).c_str());
         }
     }
-    if ((query_pool_state.create_info.queryType == VK_QUERY_TYPE_TIMESTAMP) && ((flags & VK_QUERY_RESULT_PARTIAL_BIT) != 0)) {
+    if ((query_pool_state->create_info.queryType == VK_QUERY_TYPE_TIMESTAMP) && ((flags & VK_QUERY_RESULT_PARTIAL_BIT) != 0)) {
         const LogObjectList objlist(commandBuffer, queryPool);
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-queryType-09439", objlist, error_obj.location.dot(Field::flags),
                          "(%s) includes VK_QUERY_RESULT_PARTIAL_BIT, but %s was created with VK_QUERY_TYPE_TIMESTAMP.",
                          string_VkQueryResultFlags(flags).c_str(), FormatHandle(queryPool).c_str());
     }
-    if (query_pool_state.create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL) {
+    if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL) {
         const LogObjectList objlist(commandBuffer, queryPool);
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-queryType-02734", objlist, error_obj.location.dot(Field::queryPool),
                          "(%s) was created with queryType VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL.", FormatHandle(queryPool).c_str());
     }
-    if (query_pool_state.create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
+    if (query_pool_state->create_info.queryType == VK_QUERY_TYPE_RESULT_STATUS_ONLY_KHR &&
         (flags & VK_QUERY_RESULT_WITH_STATUS_BIT_KHR) == 0) {
         const LogObjectList objlist(commandBuffer, queryPool);
         skip |= LogError("VUID-vkCmdCopyQueryPoolResults-queryType-09442", objlist, error_obj.location.dot(Field::flags),
@@ -1235,8 +1255,10 @@ void CoreChecks::PreCallRecordCmdCopyQueryPoolResults(VkCommandBuffer commandBuf
 
         // NOTE: dev_data == this, but the compiler "Visual Studio 16" complains Get is ambiguous if dev_data isn't used
         auto query_pool_state = cb_state_arg.dev_data.Get<vvl::QueryPool>(queryPool);
-        skip |= ValidateQueryPoolWasReset(*query_pool_state, firstQuery, queryCount, record_obj.location, localQueryToStateMap,
-                                          perfPass);
+        if (query_pool_state) {
+            skip |= ValidateQueryPoolWasReset(*query_pool_state, firstQuery, queryCount, record_obj.location, localQueryToStateMap,
+                                              perfPass);
+        }
 
         return skip;
     });
@@ -1258,30 +1280,32 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
                          FormatHandle(queryPool).c_str(), cb_state.command_pool->queueFamilyIndex);
     }
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    if (query_pool_state.create_info.queryType != VK_QUERY_TYPE_TIMESTAMP) {
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    if (query_pool_state->create_info.queryType != VK_QUERY_TYPE_TIMESTAMP) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-queryPool-03861" : "VUID-vkCmdWriteTimestamp-queryPool-01416";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc, "Query Pool %s was not created with VK_QUERY_TYPE_TIMESTAMP.",
                          FormatHandle(queryPool).c_str());
     }
 
-    if (slot >= query_pool_state.create_info.queryCount) {
+    if (slot >= query_pool_state->create_info.queryCount) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-04903" : "VUID-vkCmdWriteTimestamp-query-04904";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc,
                          "query (%" PRIu32 ") is not lower than the number of queries (%" PRIu32 ") in Query pool %s.", slot,
-                         query_pool_state.create_info.queryCount, FormatHandle(queryPool).c_str());
+                         query_pool_state->create_info.queryCount, FormatHandle(queryPool).c_str());
     }
     if (cb_state.activeRenderPass &&
-        slot + cb_state.activeRenderPass->GetViewMaskBits(cb_state.GetActiveSubpass()) > query_pool_state.create_info.queryCount) {
+        slot + cb_state.activeRenderPass->GetViewMaskBits(cb_state.GetActiveSubpass()) > query_pool_state->create_info.queryCount) {
         const char *vuid = is_2 ? "VUID-vkCmdWriteTimestamp2-query-03865" : "VUID-vkCmdWriteTimestamp-query-00831";
         const LogObjectList objlist(cb_state.Handle(), queryPool);
         skip |= LogError(vuid, objlist, loc,
                          "query (%" PRIu32 ") + number of bits in current subpass (%" PRIu32
                          ") is not lower than the number of queries (%" PRIu32 ") in Query pool %s.",
                          slot, cb_state.activeRenderPass->GetViewMaskBits(cb_state.GetActiveSubpass()),
-                         query_pool_state.create_info.queryCount, FormatHandle(queryPool).c_str());
+                         query_pool_state->create_info.queryCount, FormatHandle(queryPool).c_str());
     }
 
     return skip;
@@ -1289,10 +1313,10 @@ bool CoreChecks::ValidateCmdWriteTimestamp(const vvl::CommandBuffer &cb_state, V
 
 bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer, VkPipelineStageFlagBits pipelineStage,
                                                   VkQueryPool queryPool, uint32_t slot, const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
-    bool skip = false;
     skip |= ValidateCmdWriteTimestamp(*cb_state, queryPool, slot, error_obj.location);
 
     const Location stage_loc = error_obj.location.dot(Field::pipelineStage);
@@ -1302,10 +1326,10 @@ bool CoreChecks::PreCallValidateCmdWriteTimestamp(VkCommandBuffer commandBuffer,
 
 bool CoreChecks::PreCallValidateCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage,
                                                    VkQueryPool queryPool, uint32_t slot, const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
-    bool skip = false;
     skip |= ValidateCmdWriteTimestamp(*cb_state, queryPool, slot, error_obj.location);
 
     if (!enabled_features.synchronization2) {
@@ -1360,17 +1384,19 @@ void CoreChecks::PreCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, 
 bool CoreChecks::PreCallValidateCmdBeginQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                                         VkQueryControlFlags flags, uint32_t index,
                                                         const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
     QueryObject query_obj = {queryPool, slot, flags, 0, true, index};
-    bool skip = false;
     skip |= ValidateBeginQuery(*cb_state, query_obj, flags, index, error_obj.location);
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     // Extension specific VU's
-    const auto &query_pool_state = *Get<vvl::QueryPool>(query_obj.pool);
-    const auto &query_pool_ci = query_pool_state.create_info;
+    const auto query_pool_state = Get<vvl::QueryPool>(query_obj.pool);
+    if (!query_pool_state) return skip;
+
+    const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType == VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT) {
         if (!enabled_features.primitivesGeneratedQuery) {
             const LogObjectList objlist(commandBuffer, queryPool);
@@ -1405,7 +1431,7 @@ bool CoreChecks::PreCallValidateCmdBeginQueryIndexedEXT(VkCommandBuffer commandB
                 index, phys_dev_ext_props.transform_feedback_props.maxTransformFeedbackStreams);
         }
     } else if (index != 0) {
-        const LogObjectList objlist(commandBuffer, query_pool_state.Handle());
+        const LogObjectList objlist(commandBuffer, query_pool_state->Handle());
         skip |= LogError("VUID-vkCmdBeginQueryIndexedEXT-queryType-06692", objlist, error_obj.location.dot(Field::index),
                          "(%" PRIu32
                          ") must be zero if %s was not created with type VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT or "
@@ -1433,16 +1459,18 @@ void CoreChecks::PreCallRecordCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffe
 
 bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuffer, VkQueryPool queryPool, uint32_t slot,
                                                       uint32_t index, const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
+    bool skip = false;
+    if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     assert(cb_state);
-    bool skip = false;
     skip |= ValidateCmdEndQuery(*cb_state, queryPool, slot, index, error_obj.location);
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    const auto &query_pool_ci = query_pool_state.create_info;
-    const uint32_t available_query_count = query_pool_state.create_info.queryCount;
+    const auto &query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    const auto &query_pool_ci = query_pool_state->create_info;
+    const uint32_t available_query_count = query_pool_ci.queryCount;
     if (slot >= available_query_count) {
         const LogObjectList objlist(commandBuffer, queryPool);
         skip |= LogError("VUID-vkCmdEndQueryIndexedEXT-query-02343", objlist, error_obj.location.dot(Field::index),
@@ -1483,25 +1511,26 @@ bool CoreChecks::PreCallValidateCmdEndQueryIndexedEXT(VkCommandBuffer commandBuf
 
 bool CoreChecks::PreCallValidateResetQueryPool(VkDevice device, VkQueryPool queryPool, uint32_t firstQuery, uint32_t queryCount,
                                                const ErrorObject &error_obj) const {
-    if (disabled[query_validation]) return false;
-
     bool skip = false;
+    if (disabled[query_validation]) return skip;
 
     if (!enabled_features.hostQueryReset) {
         skip |= LogError("VUID-vkResetQueryPool-None-02665", device, error_obj.location, "hostQueryReset feature was not enabled.");
     }
 
-    const auto &query_pool_state = *Get<vvl::QueryPool>(queryPool);
-    if (firstQuery >= query_pool_state.create_info.queryCount) {
+    const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
+
+    if (firstQuery >= query_pool_state->create_info.queryCount) {
         skip |= LogError("VUID-vkResetQueryPool-firstQuery-09436", queryPool, error_obj.location.dot(Field::firstQuery),
                          "(%" PRIu32 ") is greater than or equal to query pool count (%" PRIu32 ") for %s.", firstQuery,
-                         query_pool_state.create_info.queryCount, FormatHandle(queryPool).c_str());
+                         query_pool_state->create_info.queryCount, FormatHandle(queryPool).c_str());
     }
 
-    if ((firstQuery + queryCount) > query_pool_state.create_info.queryCount) {
+    if ((firstQuery + queryCount) > query_pool_state->create_info.queryCount) {
         skip |= LogError("VUID-vkResetQueryPool-firstQuery-09437", queryPool, error_obj.location,
                          "Query range [%" PRIu32 ", %" PRIu32 ") goes beyond query pool count (%" PRIu32 ") for %s.", firstQuery,
-                         firstQuery + queryCount, query_pool_state.create_info.queryCount, FormatHandle(queryPool).c_str());
+                         firstQuery + queryCount, query_pool_state->create_info.queryCount, FormatHandle(queryPool).c_str());
     }
 
     return skip;
@@ -1539,6 +1568,8 @@ void CoreChecks::PostCallRecordGetQueryPoolResults(VkDevice device, VkQueryPool 
         return;
     }
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return;
+
     if ((flags & VK_QUERY_RESULT_PARTIAL_BIT) == 0) {
         for (uint32_t i = firstQuery; i < queryCount; ++i) {
             query_pool_state->SetQueryState(i, 0, QUERYSTATE_AVAILABLE);

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -1151,8 +1151,8 @@ bool CoreChecks::PreCallValidateCmdCopyQueryPoolResults(VkCommandBuffer commandB
     if (disabled[query_validation]) return skip;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto dst_buff_state = Get<vvl::Buffer>(dstBuffer);
-    assert(cb_state);
-    assert(dst_buff_state);
+    if (!dst_buff_state) return skip;
+
     const LogObjectList buffer_objlist(commandBuffer, dstBuffer);
     skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *dst_buff_state, error_obj.location.dot(Field::dstBuffer),
                                           "VUID-vkCmdCopyQueryPoolResults-dstBuffer-00826");

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -681,6 +681,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const VkSparseImageOpaqueMemoryBindInfo &image_opaque_bind = bind_info.pImageOpaqueBinds[image_opaque_idx];
                 if (image_opaque_bind.pBinds) {
                     auto image_state = Get<vvl::Image>(image_opaque_bind.image);
+                    if (!image_state) continue;
                     for (uint32_t image_opaque_bind_idx = 0; image_opaque_bind_idx < image_opaque_bind.bindCount;
                          ++image_opaque_bind_idx) {
                         const VkSparseMemoryBind &memory_bind = image_opaque_bind.pBinds[image_opaque_bind_idx];
@@ -701,9 +702,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const Location bind_loc = bind_info_loc.dot(Field::pImageBinds, image_idx);
                 const VkSparseImageMemoryBindInfo &image_bind = bind_info.pImageBinds[image_idx];
                 auto image_state = Get<vvl::Image>(image_bind.image);
-                if (!image_state) {
-                    continue;
-                }
+                if (!image_state) continue;
 
                 if (!image_state->sparse_residency) {
                     skip |=

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -668,6 +668,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const VkSparseBufferMemoryBindInfo &buffer_bind = bind_info.pBufferBinds[buffer_idx];
                 if (buffer_bind.pBinds) {
                     auto buffer_state = Get<vvl::Buffer>(buffer_bind.buffer);
+                    if (!buffer_state) continue;
                     for (uint32_t buffer_bind_idx = 0; buffer_bind_idx < buffer_bind.bindCount; ++buffer_bind_idx) {
                         const VkSparseMemoryBind &memory_bind = buffer_bind.pBinds[buffer_bind_idx];
                         const Location buffer_loc = bind_info_loc.dot(Field::pBufferBinds, buffer_idx);

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -89,7 +89,7 @@ struct CommandBufferSubmitState {
         for (const auto &it : cb_state.video_session_updates) {
             auto video_session_state = core.Get<vvl::VideoSession>(it.first);
             auto local_state_it = local_video_session_state.find(it.first);
-            if (local_state_it == local_video_session_state.end()) {
+            if (video_session_state && (local_state_it == local_video_session_state.end())) {
                 local_state_it = local_video_session_state.insert({it.first, video_session_state->DeviceStateCopy()}).first;
             }
             for (const auto &function : it.second) {

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -1468,6 +1468,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
     const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType != queryType) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryPool-02493", commandBuffer,
@@ -1506,6 +1507,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
+    if (!query_pool_state) return skip;
     const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType != queryType) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesNV-queryPool-03755", commandBuffer,

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -723,11 +723,12 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
 
             const VkImageView *image_views = cb_state.activeFramebuffer.get()->create_info.pAttachments;
             for (uint32_t i = 0; i < rpci->attachmentCount; ++i) {
-                const auto &view_state = *Get<vvl::ImageView>(image_views[i]);
-                const auto &ici = view_state.image_state->create_info;
+                const auto view_state = Get<vvl::ImageView>(image_views[i]);
+                if (!view_state) continue;
+                const auto &ici = view_state->image_state->create_info;
 
                 if ((fdm_non_zero_offsets == true) && ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                     skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-06502", objlist, error_obj.location,
                                      "pAttachments[%" PRIu32
                                      "] is not created with flag value"
@@ -742,7 +743,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
                     if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
                         if ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityMapAttachment-06504",
                                              objlist, error_obj.location,
                                              "Fragment density map attachment %" PRIu32
@@ -753,18 +754,19 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         }
 
                         if ((subpass.viewMask != 0) &&
-                            (view_state.create_info.subresourceRange.layerCount != fdm_offset_info->fragmentDensityOffsetCount)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
-                            skip |= LogError(
-                                "VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06510", objlist,
-                                error_obj.location,
-                                "fragmentDensityOffsetCount %" PRIu32
-                                " does not match the fragment density map attachment (%" PRIu32 ") view layer count (%" PRIu32 ").",
-                                fdm_offset_info->fragmentDensityOffsetCount, i, view_state.create_info.subresourceRange.layerCount);
+                            (view_state->create_info.subresourceRange.layerCount != fdm_offset_info->fragmentDensityOffsetCount)) {
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
+                            skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06510",
+                                             objlist, error_obj.location,
+                                             "fragmentDensityOffsetCount %" PRIu32
+                                             " does not match the fragment density map attachment (%" PRIu32
+                                             ") view layer count (%" PRIu32 ").",
+                                             fdm_offset_info->fragmentDensityOffsetCount, i,
+                                             view_state->create_info.subresourceRange.layerCount);
                         }
 
                         if ((subpass.viewMask == 0) && (fdm_offset_info->fragmentDensityOffsetCount != 1)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-fragmentDensityOffsetCount-06511",
                                              objlist, error_obj.location,
                                              "fragmentDensityOffsetCount %" PRIu32 " should be 1 when multiview is not enabled.",
@@ -777,7 +779,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                 if (subpass.pDepthStencilAttachment && (subpass.pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) &&
                     (subpass.pDepthStencilAttachment->attachment == i) &&
                     ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                    const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                     skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pDepthStencilAttachment-06505", objlist,
                                      error_obj.location,
                                      "pDepthStencilAttachment[%" PRIu32
@@ -792,7 +794,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pInputAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pInputAttachments-06506", objlist,
                                          error_obj.location,
                                          "pInputAttachments[%" PRIu32
@@ -808,7 +810,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pColorAttachments[k].attachment;
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pColorAttachments-06507", objlist,
                                          error_obj.location,
                                          "pColorAttachments[%" PRIu32
@@ -825,7 +827,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                         const auto attachment = subpass.pResolveAttachments[k].attachment;
                         if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                             ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                            const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                             skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pResolveAttachments-06508", objlist,
                                              error_obj.location,
                                              "pResolveAttachments[%" PRIu32
@@ -842,7 +844,7 @@ bool CoreChecks::ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const V
                     const auto attachment = subpass.pPreserveAttachments[k];
                     if ((attachment != VK_ATTACHMENT_UNUSED) && (attachment == i) &&
                         ((ici.flags & VK_IMAGE_CREATE_FRAGMENT_DENSITY_MAP_OFFSET_BIT_QCOM) == 0)) {
-                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state.Handle());
+                        const LogObjectList objlist(commandBuffer, rp_state.Handle(), view_state->Handle());
                         skip |= LogError("VUID-VkSubpassFragmentDensityMapOffsetEndInfoQCOM-pPreserveAttachments-06509", objlist,
                                          error_obj.location,
                                          "pPreserveAttachments[%" PRIu32
@@ -1033,6 +1035,8 @@ bool CoreChecks::VerifyFramebufferAndRenderPassImageViews(const VkRenderPassBegi
     for (uint32_t i = 0; i < render_pass_attachment_begin_info->attachmentCount; ++i) {
         const Location attachment_loc = begin_info_loc.pNext(Struct::VkRenderPassAttachmentBeginInfo, Field::pAttachments, i);
         auto image_view_state = Get<vvl::ImageView>(render_pass_attachment_begin_info->pAttachments[i]);
+        if (!image_view_state) continue;
+
         const VkImageViewCreateInfo *image_view_create_info = &image_view_state->create_info;
         const auto &subresource_range = image_view_state->normalized_subresource_range;
         const VkFramebufferAttachmentImageInfo *framebuffer_attachment_image_info =
@@ -2869,31 +2873,30 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
     if (attachment_info.imageView == VK_NULL_HANDLE) {
         return false;
     }
-    const auto &image_view_state = *Get<vvl::ImageView>(attachment_info.imageView);
+    const auto image_view_state = Get<vvl::ImageView>(attachment_info.imageView);
+    if (!image_view_state) return skip;
 
+    const auto &create_info = image_view_state->create_info;
+    const VkFormat image_view_format = create_info.format;
     if (attachment_info.imageLayout == VK_IMAGE_LAYOUT_PRESENT_SRC_KHR) {
         skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06145", commandBuffer, attachment_loc.dot(Field::imageLayout),
                          "must not be VK_IMAGE_LAYOUT_PRESENT_SRC_KHR");
     }
 
-    if ((!vkuFormatIsSINT(image_view_state.create_info.format) && !vkuFormatIsUINT(image_view_state.create_info.format)) &&
-        vkuFormatIsColor(image_view_state.create_info.format) &&
+    if ((!vkuFormatIsSINT(image_view_format) && !vkuFormatIsUINT(image_view_format)) && vkuFormatIsColor(image_view_format) &&
         !(attachment_info.resolveMode == VK_RESOLVE_MODE_NONE || attachment_info.resolveMode == VK_RESOLVE_MODE_AVERAGE_BIT)) {
         const LogObjectList objlist(commandBuffer, attachment_info.imageView);
         skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06129", objlist, attachment_loc.dot(Field::resolveMode),
                          "(%s) must be VK_RESOLVE_MODE_NONE or VK_RESOLVE_MODE_AVERAGE_BIT for non-integer formats (%s)",
-                         string_VkResolveModeFlags(attachment_info.resolveMode).c_str(),
-                         string_VkFormat(image_view_state.create_info.format));
+                         string_VkResolveModeFlags(attachment_info.resolveMode).c_str(), string_VkFormat(image_view_format));
     }
 
-    if ((vkuFormatIsSINT(image_view_state.create_info.format) || vkuFormatIsUINT(image_view_state.create_info.format)) &&
-        vkuFormatIsColor(image_view_state.create_info.format) &&
+    if ((vkuFormatIsSINT(image_view_format) || vkuFormatIsUINT(image_view_format)) && vkuFormatIsColor(image_view_format) &&
         !(attachment_info.resolveMode == VK_RESOLVE_MODE_NONE || attachment_info.resolveMode == VK_RESOLVE_MODE_SAMPLE_ZERO_BIT)) {
         const LogObjectList objlist(commandBuffer, attachment_info.imageView);
         skip |= LogError("VUID-VkRenderingAttachmentInfo-imageView-06130", objlist, attachment_loc.dot(Field::resolveMode),
                          "(%s) must be VK_RESOLVE_MODE_NONE or VK_RESOLVE_MODE_SAMPLE_ZERO_BIT for integer formats (%s)",
-                         string_VkResolveModeFlags(attachment_info.resolveMode).c_str(),
-                         string_VkFormat(image_view_state.create_info.format));
+                         string_VkResolveModeFlags(attachment_info.resolveMode).c_str(), string_VkFormat(image_view_format));
     }
 
     if (attachment_info.imageLayout == VK_IMAGE_LAYOUT_FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR) {
@@ -2910,7 +2913,7 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
                          "must not be VK_IMAGE_LAYOUT_FRAGMENT_DENSITY_MAP_OPTIMAL_EXT");
     }
 
-    if (attachment_info.resolveMode != VK_RESOLVE_MODE_NONE && image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) {
+    if (attachment_info.resolveMode != VK_RESOLVE_MODE_NONE && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
         const auto msrtss_info = vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(pRenderingInfo->pNext);
         if (!msrtss_info || !msrtss_info->multisampledRenderToSingleSampledEnable) {
             const LogObjectList objlist(commandBuffer, attachment_info.imageView);
@@ -2976,12 +2979,12 @@ bool CoreChecks::ValidateRenderingAttachmentInfo(VkCommandBuffer commandBuffer, 
                              attachment_loc.dot(Field::resolveImageLayout), "must not be VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL_KHR");
         }
 
-        if (resolve_view_state && (image_view_state.create_info.format != resolve_view_state->create_info.format)) {
+        if (resolve_view_state && (image_view_format != resolve_view_state->create_info.format)) {
             const LogObjectList objlist(commandBuffer, attachment_info.resolveImageView);
-            skip |= LogError(
-                "VUID-VkRenderingAttachmentInfo-imageView-06865", objlist, attachment_loc.dot(Field::resolveImageView),
-                "format (%s) and %s format (%s) are different.", string_VkFormat(resolve_view_state->create_info.format),
-                attachment_loc.dot(Field::imageView).Fields().c_str(), string_VkFormat(image_view_state.create_info.format));
+            skip |=
+                LogError("VUID-VkRenderingAttachmentInfo-imageView-06865", objlist, attachment_loc.dot(Field::resolveImageView),
+                         "format (%s) and %s format (%s) are different.", string_VkFormat(resolve_view_state->create_info.format),
+                         attachment_loc.dot(Field::imageView).Fields().c_str(), string_VkFormat(image_view_format));
         }
 
         if (IsValueIn(attachment_info.resolveImageLayout,
@@ -3025,7 +3028,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         for (uint32_t j = 0; j < rendering_info.colorAttachmentCount; ++j) {
             if (rendering_info.pColorAttachments[j].imageView != VK_NULL_HANDLE) {
                 auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView);
-                if (!(image_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
+                if (image_view_state && !(image_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
                     const LogObjectList objlist(commandBuffer, rendering_info.pColorAttachments[j].imageView);
                     skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
                                      rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView),
@@ -3036,7 +3039,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
 
         if (rendering_info.pDepthAttachment && (rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE)) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-            if (!(depth_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
+            if (depth_view_state && !(depth_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
                 const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView);
                 skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
@@ -3046,7 +3049,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
 
         if (rendering_info.pStencilAttachment && (rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE)) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-            if (!(stencil_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
+            if (stencil_view_state && !(stencil_view_state->image_state->create_info.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT)) {
                 const LogObjectList objlist(commandBuffer, rendering_info.pStencilAttachment->imageView);
                 skip |= LogError("VUID-VkRenderingInfo-imageView-06107", objlist,
                                  rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView),
@@ -3059,6 +3062,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
         const Location view_loc =
             rendering_info_loc.pNext(Struct::VkRenderingFragmentDensityMapAttachmentInfoEXT, Field::imageView);
         auto fragment_density_map_view_state = Get<vvl::ImageView>(fragment_density_map_attachment_info->imageView);
+        if (!fragment_density_map_view_state) return skip;
         if ((fragment_density_map_view_state->inherited_usage & VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT) == 0) {
             const LogObjectList objlist(commandBuffer, fragment_density_map_attachment_info->imageView);
             skip |= LogError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158", objlist, view_loc,
@@ -3117,6 +3121,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentDensityMap(VkCommandBuffer comman
                                               static_cast<int64_t>(rendering_info.renderArea.extent.height);
 
             auto view_state = Get<vvl::ImageView>(fragment_density_map_attachment_info->imageView);
+            if (!view_state) return skip;
             vvl::Image *image_state = view_state->image_state.get();
             if (image_state->create_info.extent.width <
                 vvl::GetQuotientCeil(
@@ -3164,6 +3169,7 @@ bool CoreChecks::ValidateBeginRenderingFragmentShadingRate(VkCommandBuffer comma
     }
 
     auto view_state = Get<vvl::ImageView>(rendering_fragment_shading_rate_attachment_info->imageView);
+    if (!view_state) return skip;
     const LogObjectList objlist(commandBuffer, view_state->Handle());
     if (rendering_info.viewMask == 0) {
         if (view_state->create_info.subresourceRange.layerCount != 1 &&
@@ -3335,6 +3341,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
                 continue;
             }
             auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView);
+            if (!image_view_state) continue;
             vvl::Image *image_state = image_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
@@ -3358,6 +3365,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
 
         if (rendering_info.pDepthAttachment != VK_NULL_HANDLE) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
+            if (!depth_view_state) return skip;
             vvl::Image *image_state = depth_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
@@ -3381,6 +3389,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
 
         if (rendering_info.pStencilAttachment != VK_NULL_HANDLE) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
+            if (!stencil_view_state) return skip;
             vvl::Image *image_state = stencil_view_state->image_state.get();
             if (image_state->create_info.extent.width < offset_x + width) {
                 const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
@@ -3406,6 +3415,7 @@ bool CoreChecks::ValidateBeginRenderingDeviceGroup(VkCommandBuffer commandBuffer
             vku::FindStructInPNextChain<VkRenderingFragmentDensityMapAttachmentInfoEXT>(rendering_info.pNext);
         if (fragment_density_map_attachment_info && fragment_density_map_attachment_info->imageView != VK_NULL_HANDLE) {
             auto view_state = Get<vvl::ImageView>(fragment_density_map_attachment_info->imageView);
+            if (!view_state) return skip;
             vvl::Image *image_state = view_state->image_state.get();
             if (image_state->create_info.extent.width <
                 vvl::GetQuotientCeil(offset_x + width,
@@ -3452,23 +3462,26 @@ bool CoreChecks::ValidateBeginRenderingMultisampledRenderToSingleSampled(VkComma
     }
     for (uint32_t j = 0; j < rendering_info.colorAttachmentCount; ++j) {
         if (rendering_info.pColorAttachments[j].imageView != VK_NULL_HANDLE) {
-            const auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView);
-            skip |= ValidateMultisampledRenderToSingleSampleView(
-                commandBuffer, image_view_state, *msrtss_info,
-                rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView), rendering_info_loc);
+            if (const auto image_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[j].imageView)) {
+                skip |= ValidateMultisampledRenderToSingleSampleView(
+                    commandBuffer, *image_view_state, *msrtss_info,
+                    rendering_info_loc.dot(Field::pColorAttachments, j).dot(Field::imageView), rendering_info_loc);
+            }
         }
     }
     if (rendering_info.pDepthAttachment && rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE) {
-        const auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-        skip |= ValidateMultisampledRenderToSingleSampleView(commandBuffer, depth_view_state, *msrtss_info,
-                                                             rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView),
-                                                             rendering_info_loc);
+        if (const auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView)) {
+            skip |= ValidateMultisampledRenderToSingleSampleView(
+                commandBuffer, *depth_view_state, *msrtss_info,
+                rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::imageView), rendering_info_loc);
+        }
     }
     if (rendering_info.pStencilAttachment && rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE) {
-        const auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-        skip |= ValidateMultisampledRenderToSingleSampleView(
-            commandBuffer, stencil_view_state, *msrtss_info,
-            rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView), rendering_info_loc);
+        if (const auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView)) {
+            skip |= ValidateMultisampledRenderToSingleSampleView(
+                commandBuffer, *stencil_view_state, *msrtss_info,
+                rendering_info_loc.dot(Field::pStencilAttachment).dot(Field::imageView), rendering_info_loc);
+        }
     }
     if (msrtss_info->rasterizationSamples == VK_SAMPLE_COUNT_1_BIT) {
         skip |= LogError("VUID-VkMultisampledRenderToSingleSampledInfoEXT-rasterizationSamples-06878", commandBuffer,
@@ -3515,6 +3528,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
         for (uint32_t j = 0; j < pRenderingInfo->colorAttachmentCount; ++j) {
             if (pRenderingInfo->pColorAttachments[j].imageView != VK_NULL_HANDLE) {
                 const auto image_view = Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[j].imageView);
+                if (!image_view) continue;
                 first_sample_count_attachment = (first_sample_count_attachment == VK_ATTACHMENT_UNUSED)
                                                     ? static_cast<uint32_t>(image_view->samples)
                                                     : first_sample_count_attachment;
@@ -3532,6 +3546,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
         }
         if (pRenderingInfo->pDepthAttachment && pRenderingInfo->pDepthAttachment->imageView != VK_NULL_HANDLE) {
             const auto image_view = Get<vvl::ImageView>(pRenderingInfo->pDepthAttachment->imageView);
+            if (!image_view) return skip;
             first_sample_count_attachment = (first_sample_count_attachment == VK_ATTACHMENT_UNUSED)
                                                 ? static_cast<uint32_t>(image_view->samples)
                                                 : first_sample_count_attachment;
@@ -3547,6 +3562,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
         }
         if (pRenderingInfo->pStencilAttachment && pRenderingInfo->pStencilAttachment->imageView != VK_NULL_HANDLE) {
             const auto image_view = Get<vvl::ImageView>(pRenderingInfo->pStencilAttachment->imageView);
+            if (!image_view) return skip;
             first_sample_count_attachment = (first_sample_count_attachment == VK_ATTACHMENT_UNUSED)
                                                 ? static_cast<uint32_t>(image_view->samples)
                                                 : first_sample_count_attachment;
@@ -3662,6 +3678,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
         if (pRenderingInfo->pColorAttachments[j].imageView != VK_NULL_HANDLE) {
             auto image_view_state = Get<vvl::ImageView>(pRenderingInfo->pColorAttachments[j].imageView);
+            if (!image_view_state) continue;
             vvl::Image *image_state = image_view_state->image_state.get();
             if (!(image_state->create_info.usage & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT)) {
                 const LogObjectList objlist(commandBuffer, image_view_state->Handle(), image_state->Handle());
@@ -3733,8 +3750,8 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                                      "was created with subresourceRange.layerCount of %" PRIu32 ".",
                                      resolve_view_state->create_info.subresourceRange.layerCount);
                 }
-                auto color_view_state = Get<vvl::ImageView>(attachment_info.imageView);
-                if (color_view_state) {
+
+                if (auto color_view_state = Get<vvl::ImageView>(attachment_info.imageView)) {
                     if (android_external_format_resolve_null_color_attachment_prop) {
                         skip |= LogError("VUID-VkRenderingAttachmentInfo-resolveMode-09328", commandBuffer,
                                          color_loc.dot(Field::imageView), "is not null (%s).",
@@ -3761,8 +3778,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
         }
 
         if (attachment_info.resolveMode != VK_RESOLVE_MODE_NONE) {
-            auto resolve_view_state = Get<vvl::ImageView>(attachment_info.resolveImageView);
-            if (resolve_view_state) {
+            if (auto resolve_view_state = Get<vvl::ImageView>(attachment_info.resolveImageView)) {
                 const VkComponentMapping components = resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
                     const LogObjectList objlist(commandBuffer, resolve_view_state->Handle());
@@ -3796,6 +3812,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
         if (depth_attachment_info.imageView != VK_NULL_HANDLE) {
             auto depth_view_state = Get<vvl::ImageView>(depth_attachment_info.imageView);
+            if (!depth_view_state) return skip;
             vvl::Image *image_state = depth_view_state->image_state.get();
             if (!(image_state->create_info.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
                 const LogObjectList objlist(commandBuffer, depth_view_state->Handle(), image_state->Handle());
@@ -3833,8 +3850,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                                  rendering_info_loc.dot(Field::pDepthAttachment).dot(Field::resolveMode),
                                  "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID.");
             }
-            auto depth_resolve_view_state = Get<vvl::ImageView>(depth_attachment_info.resolveImageView);
-            if (depth_resolve_view_state) {
+            if (auto depth_resolve_view_state = Get<vvl::ImageView>(depth_attachment_info.resolveImageView)) {
                 const VkComponentMapping components = depth_resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
                     const LogObjectList objlist(commandBuffer, depth_resolve_view_state->Handle());
@@ -3867,6 +3883,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
 
         if (stencil_attachment_info.imageView != VK_NULL_HANDLE) {
             auto stencil_view_state = Get<vvl::ImageView>(stencil_attachment_info.imageView);
+            if (!stencil_view_state) return skip;
             vvl::Image *image_state = stencil_view_state->image_state.get();
             if (!(image_state->create_info.usage & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
                 const LogObjectList objlist(commandBuffer, stencil_view_state->Handle(), image_state->Handle());
@@ -3904,8 +3921,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
                                  "is VK_RESOLVE_MODE_EXTERNAL_FORMAT_DOWNSAMPLE_ANDROID.");
             }
 
-            auto stencil_resolve_view_state = Get<vvl::ImageView>(stencil_attachment_info.resolveImageView);
-            if (stencil_resolve_view_state) {
+            if (auto stencil_resolve_view_state = Get<vvl::ImageView>(stencil_attachment_info.resolveImageView)) {
                 const VkComponentMapping components = stencil_resolve_view_state->create_info.components;
                 if (!IsIdentitySwizzle(components)) {
                     const LogObjectList objlist(commandBuffer, stencil_resolve_view_state->Handle());
@@ -3991,8 +4007,7 @@ bool CoreChecks::PreCallValidateCmdEndRenderingKHR(VkCommandBuffer commandBuffer
     return PreCallValidateCmdEndRendering(commandBuffer, error_obj);
 }
 
-bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer,
-                                                              const std::shared_ptr<const vvl::ImageView> &image_view_state,
+bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView &image_view_state,
                                                               const VkMultisampledRenderToSingleSampledInfoEXT &msrtss_info,
                                                               const Location &attachment_loc,
                                                               const Location &rendering_info_loc) const {
@@ -4000,17 +4015,17 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
     if (!msrtss_info.multisampledRenderToSingleSampledEnable) {
         return false;
     }
-    const LogObjectList objlist(commandBuffer, image_view_state->Handle());
-    if ((image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) && (image_view_state->samples != msrtss_info.rasterizationSamples)) {
+    const LogObjectList objlist(commandBuffer, image_view_state.Handle());
+    if ((image_view_state.samples != VK_SAMPLE_COUNT_1_BIT) && (image_view_state.samples != msrtss_info.rasterizationSamples)) {
         skip |= LogError("VUID-VkRenderingInfo-imageView-06858", objlist,
                          rendering_info_loc.pNext(Struct::VkMultisampledRenderToSingleSampledInfoEXT,
                                                   Field::multisampledRenderToSingleSampledEnable),
                          "is %s, but %s was created with %s, which is not VK_SAMPLE_COUNT_1_BIT.",
                          string_VkSampleCountFlagBits(msrtss_info.rasterizationSamples), attachment_loc.Fields().c_str(),
-                         string_VkSampleCountFlagBits(image_view_state->samples));
+                         string_VkSampleCountFlagBits(image_view_state.samples));
     }
-    vvl::Image *image_state = image_view_state->image_state.get();
-    if ((image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) &&
+    vvl::Image *image_state = image_view_state.image_state.get();
+    if ((image_view_state.samples == VK_SAMPLE_COUNT_1_BIT) &&
         !(image_state->create_info.flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
         skip |= LogError("VUID-VkRenderingInfo-imageView-06859", objlist, attachment_loc,
                          "was created with VK_SAMPLE_COUNT_1_BIT but "
@@ -4030,7 +4045,7 @@ bool CoreChecks::ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer co
             "is %s, but %s format %s does not support sample count %s from an image with imageType: %s, tiling: "
             "%s, usage: %s, flags: %s.",
             string_VkSampleCountFlagBits(msrtss_info.rasterizationSamples), attachment_loc.Fields().c_str(),
-            string_VkFormat(image_view_state->create_info.format), string_VkSampleCountFlagBits(msrtss_info.rasterizationSamples),
+            string_VkFormat(image_view_state.create_info.format), string_VkSampleCountFlagBits(msrtss_info.rasterizationSamples),
             string_VkImageType(image_state->create_info.imageType), string_VkImageTiling(image_state->create_info.tiling),
             string_VkImageUsageFlags(image_state->create_info.usage).c_str(),
             string_VkImageCreateFlags(image_state->create_info.flags).c_str());
@@ -4131,8 +4146,7 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
         }
         if ((fbci->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
             const VkImageView *image_view = &fbci->pAttachments[fb_attachment];
-            auto view_state = Get<vvl::ImageView>(*image_view);
-            if (view_state) {
+            if (auto view_state = Get<vvl::ImageView>(*image_view)) {
                 const auto &ici = view_state->image_state->create_info;
                 auto creation_usage = ici.usage;
                 const auto stencil_usage_info = vku::FindStructInPNextChain<VkImageStencilUsageCreateInfo>(ici.pNext);
@@ -4177,6 +4191,7 @@ bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, 
         if (renderpass_samples == VK_SAMPLE_COUNT_1_BIT) {
             const VkImageView *image_view = &fbci->pAttachments[fb_attachment];
             auto view_state = Get<vvl::ImageView>(*image_view);
+            if (!view_state) continue;
             auto image_state = view_state->image_state;
             if (!(image_state->create_info.flags & VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT)) {
                 skip |= LogError("VUID-VkFramebufferCreateInfo-samples-06881", device, create_info_loc,
@@ -4306,6 +4321,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
         for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
             const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
             auto view_state = Get<vvl::ImageView>(image_views[i]);
+            if (!view_state) continue;
             auto &ivci = view_state->create_info;
             auto &subresource_range = view_state->normalized_subresource_range;
             if (ivci.format != rpci->pAttachments[i].format) {
@@ -4339,10 +4355,11 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
             }
 
             // Verify that image memory is valid
-            auto image_data = Get<vvl::Image>(ivci.image);
-            // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5598
-            skip |= ValidateMemoryIsBoundToImage(LogObjectList(ivci.image), *image_data, attachment_loc,
-                                                 "UNASSIGNED-VkFramebufferCreateInfo-BoundResourceFreedMemoryAccess");
+            if (auto image_data = Get<vvl::Image>(ivci.image)) {
+                // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5598
+                skip |= ValidateMemoryIsBoundToImage(LogObjectList(ivci.image), *image_data, attachment_loc,
+                                                     "UNASSIGNED-VkFramebufferCreateInfo-BoundResourceFreedMemoryAccess");
+            }
 
             // Verify that view only has a single mip level
             if (subresource_range.levelCount != 1) {
@@ -4586,7 +4603,7 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
             }
             if ((ivci.viewType == VK_IMAGE_VIEW_TYPE_2D) || (ivci.viewType == VK_IMAGE_VIEW_TYPE_2D)) {
                 auto image_state = Get<vvl::Image>(ivci.image);
-                if (image_state->create_info.imageType == VK_IMAGE_TYPE_3D) {
+                if (image_state && image_state->create_info.imageType == VK_IMAGE_TYPE_3D) {
                     if (vkuFormatIsDepthOrStencil(ivci.format)) {
                         LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
                         skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00891", objlist, attachment_loc,

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -366,8 +366,7 @@ bool CoreChecks::PreCallValidateDestroyShaderEXT(VkDevice device, VkShaderEXT sh
             LogError("VUID-vkDestroyShaderEXT-None-08481", device, error_obj.location, "the shaderObject feature was not enabled.");
     }
 
-    const auto shader_state = Get<vvl::ShaderObject>(shader);
-    if (shader_state) {
+    if (const auto shader_state = Get<vvl::ShaderObject>(shader)) {
         skip |= ValidateObjectNotInUse(shader_state.get(), error_obj.location.dot(Field::shader),
                                        "VUID-vkDestroyShaderEXT-shader-08482");
     }
@@ -480,7 +479,7 @@ bool CoreChecks::PreCallValidateCmdBindShadersEXT(VkCommandBuffer commandBuffer,
         }
         if (shader != VK_NULL_HANDLE) {
             const auto shader_state = Get<vvl::ShaderObject>(shader);
-            if (shader_state->create_info.stage != stage) {
+            if (shader_state && shader_state->create_info.stage != stage) {
                 skip |=
                     LogError("VUID-vkCmdBindShadersEXT-pShaders-08469", commandBuffer, stage_loc,
                              "is %s, but pShaders[%" PRIu32 "] was created with shader stage %s.",

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2434,6 +2434,7 @@ uint32_t CoreChecks::CalcShaderStageCount(const vvl::Pipeline &pipeline, VkShade
     if (pipeline.ray_tracing_library_ci) {
         for (uint32_t i = 0; i < pipeline.ray_tracing_library_ci->libraryCount; ++i) {
             auto library_pipeline = Get<vvl::Pipeline>(pipeline.ray_tracing_library_ci->pLibraries[i]);
+            if (!library_pipeline) continue;
             total += CalcShaderStageCount(*library_pipeline, stageBit);
         }
     }
@@ -2456,6 +2457,7 @@ bool CoreChecks::GroupHasValidIndex(const vvl::Pipeline &pipeline, uint32_t grou
     if (pipeline.ray_tracing_library_ci) {
         for (uint32_t i = 0; i < pipeline.ray_tracing_library_ci->libraryCount; ++i) {
             auto library_pipeline = Get<vvl::Pipeline>(pipeline.ray_tracing_library_ci->pLibraries[i]);
+            if (!library_pipeline) continue;
             const uint32_t stage_count = static_cast<uint32_t>(library_pipeline->shader_stages_ci.size());
             if (group < stage_count) {
                 return (library_pipeline->shader_stages_ci[group].stage & stage) != 0;

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2291,8 +2291,7 @@ bool CoreChecks::ValidateBufferBarrier(const LogObjectList &objects, const Locat
     skip |= ValidateQFOTransferBarrierUniqueness(barrier_loc, cb_state, mem_barrier, cb_state.qfo_transfer_buffer_barriers);
 
     // Validate buffer barrier queue family indices
-    auto buffer_state = Get<vvl::Buffer>(mem_barrier.buffer);
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(mem_barrier.buffer)) {
         auto buf_loc = barrier_loc.dot(Field::buffer);
         const auto &mem_vuid = GetBufferBarrierVUID(buf_loc, BufferError::kNoMemory);
         skip |= ValidateMemoryIsBoundToBuffer(cb_state.VkHandle(), *buffer_state, buf_loc, mem_vuid.c_str());

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1579,9 +1579,8 @@ bool CoreChecks::ValidateBarriersToImages(const Location &barrier_loc, const vvl
 
     {
         auto image_state = Get<vvl::Image>(img_barrier.image);
-        if (!image_state) {
-            return skip;
-        }
+        if (!image_state) return skip;
+
         auto image_loc = barrier_loc.dot(Field::image);
 
         if ((img_barrier.srcQueueFamilyIndex != img_barrier.dstQueueFamilyIndex) ||
@@ -1683,7 +1682,8 @@ bool CoreChecks::ValidateBarriersToImages(const Location &barrier_loc, const vvl
                 if (color_attachment.imageView == VK_NULL_HANDLE) {
                     continue;
                 }
-                const auto &image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
+                const auto image_view_state = Get<vvl::ImageView>(color_attachment.imageView);
+                if (!image_view_state) continue;
                 const auto &image_view_image_state = image_view_state->image_state;
 
                 if (img_barrier_image == image_view_image_state->VkHandle()) {
@@ -2363,8 +2363,7 @@ bool CoreChecks::ValidateImageBarrier(const LogObjectList &objects, const Locati
         }
     }
 
-    auto image_data = Get<vvl::Image>(mem_barrier.image);
-    if (image_data) {
+    if (auto image_data = Get<vvl::Image>(mem_barrier.image)) {
         auto image_loc = barrier_loc.dot(Field::image);
         // TODO - use LocationVuidAdapter
         const auto &vuid_no_memory = sync_vuid_maps::GetImageBarrierVUID(barrier_loc, sync_vuid_maps::ImageError::kNoMemory);

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -3722,55 +3722,54 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
 
     const auto &profile_caps = vs_state->profile->GetCapabilities();
 
-    auto buffer_state = Get<vvl::Buffer>(pDecodeInfo->srcBuffer);
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(pDecodeInfo->srcBuffer)) {
         const char *where = " Buffer referenced in pDecodeInfo->srcBuffer.";
         skip |= ValidateProtectedBuffer(*cb_state, *buffer_state, error_obj.location,
                                         "VUID-vkCmdDecodeVideoKHR-commandBuffer-07136", where);
         skip |= ValidateUnprotectedBuffer(*cb_state, *buffer_state, error_obj.location,
                                           "VUID-vkCmdDecodeVideoKHR-commandBuffer-07137", where);
-    }
 
-    if ((buffer_state->usage & VK_BUFFER_USAGE_VIDEO_DECODE_SRC_BIT_KHR) == 0) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
-        skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBuffer-07165", objlist, decode_info_loc.dot(Field::srcBuffer),
-                         "(%s) was not created with "
-                         "VK_BUFFER_USAGE_VIDEO_DECODE_SRC_BIT_KHR.",
-                         FormatHandle(pDecodeInfo->srcBuffer).c_str());
-    }
+        if ((buffer_state->usage & VK_BUFFER_USAGE_VIDEO_DECODE_SRC_BIT_KHR) == 0) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
+            skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBuffer-07165", objlist, decode_info_loc.dot(Field::srcBuffer),
+                             "(%s) was not created with "
+                             "VK_BUFFER_USAGE_VIDEO_DECODE_SRC_BIT_KHR.",
+                             FormatHandle(pDecodeInfo->srcBuffer).c_str());
+        }
 
-    if (!IsBufferCompatibleWithVideoProfile(*buffer_state, vs_state->profile)) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
-        skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07135", objlist, decode_info_loc.dot(Field::srcBuffer),
-                         "(%s) is not compatible "
-                         "with the video profile %s was created with.",
-                         FormatHandle(pDecodeInfo->srcBuffer).c_str(), FormatHandle(*vs_state).c_str());
-    }
+        if (!IsBufferCompatibleWithVideoProfile(*buffer_state, vs_state->profile)) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
+            skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07135", objlist, decode_info_loc.dot(Field::srcBuffer),
+                             "(%s) is not compatible "
+                             "with the video profile %s was created with.",
+                             FormatHandle(pDecodeInfo->srcBuffer).c_str(), FormatHandle(*vs_state).c_str());
+        }
 
-    if (pDecodeInfo->srcBufferOffset >= buffer_state->create_info.size) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
-        skip |=
-            LogError("VUID-VkVideoDecodeInfoKHR-srcBufferOffset-07166", objlist, decode_info_loc.dot(Field::srcBufferOffset),
-                     "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
-                     pDecodeInfo->srcBufferOffset, buffer_state->create_info.size, FormatHandle(pDecodeInfo->srcBuffer).c_str());
-    }
+        if (pDecodeInfo->srcBufferOffset >= buffer_state->create_info.size) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
+            skip |= LogError(
+                "VUID-VkVideoDecodeInfoKHR-srcBufferOffset-07166", objlist, decode_info_loc.dot(Field::srcBufferOffset),
+                "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
+                pDecodeInfo->srcBufferOffset, buffer_state->create_info.size, FormatHandle(pDecodeInfo->srcBuffer).c_str());
+        }
 
-    if (!IsIntegerMultipleOf(pDecodeInfo->srcBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle());
-        skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07138", objlist, decode_info_loc.dot(Field::srcBufferOffset),
-                         "(%" PRIu64 ") is not an integer multiple of the minBitstreamBufferOffsetAlignment (%" PRIu64
-                         ") required by the video profile %s was created with.",
-                         pDecodeInfo->srcBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment,
-                         FormatHandle(*vs_state).c_str());
-    }
+        if (!IsIntegerMultipleOf(pDecodeInfo->srcBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle());
+            skip |= LogError("VUID-vkCmdDecodeVideoKHR-pDecodeInfo-07138", objlist, decode_info_loc.dot(Field::srcBufferOffset),
+                             "(%" PRIu64 ") is not an integer multiple of the minBitstreamBufferOffsetAlignment (%" PRIu64
+                             ") required by the video profile %s was created with.",
+                             pDecodeInfo->srcBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment,
+                             FormatHandle(*vs_state).c_str());
+        }
 
-    if (pDecodeInfo->srcBufferOffset + pDecodeInfo->srcBufferRange > buffer_state->create_info.size) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
-        skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBufferRange-07167", objlist, decode_info_loc.dot(Field::srcBufferOffset),
-                         "(%" PRIu64 ") plus pDecodeInfo->srcBufferRange (%" PRIu64
-                         ") must be less than or equal to the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
-                         pDecodeInfo->srcBufferOffset, pDecodeInfo->srcBufferRange, buffer_state->create_info.size,
-                         FormatHandle(pDecodeInfo->srcBuffer).c_str());
+        if (pDecodeInfo->srcBufferOffset + pDecodeInfo->srcBufferRange > buffer_state->create_info.size) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pDecodeInfo->srcBuffer);
+            skip |= LogError("VUID-VkVideoDecodeInfoKHR-srcBufferRange-07167", objlist, decode_info_loc.dot(Field::srcBufferOffset),
+                             "(%" PRIu64 ") plus pDecodeInfo->srcBufferRange (%" PRIu64
+                             ") must be less than or equal to the size (%" PRIu64 ") of pDecodeInfo->srcBuffer (%s).",
+                             pDecodeInfo->srcBufferOffset, pDecodeInfo->srcBufferRange, buffer_state->create_info.size,
+                             FormatHandle(pDecodeInfo->srcBuffer).c_str());
+        }
     }
 
     if (!IsIntegerMultipleOf(pDecodeInfo->srcBufferRange, profile_caps.base.minBitstreamBufferSizeAlignment)) {
@@ -4153,55 +4152,54 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
 
     const auto &profile_caps = vs_state->profile->GetCapabilities();
 
-    auto buffer_state = Get<vvl::Buffer>(pEncodeInfo->dstBuffer);
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(pEncodeInfo->dstBuffer)) {
         const char *where = " Buffer referenced in pEncodeInfo->dstBuffer.";
         skip |= ValidateProtectedBuffer(*cb_state, *buffer_state, error_obj.location,
                                         "VUID-vkCmdEncodeVideoKHR-commandBuffer-08202", where);
         skip |= ValidateUnprotectedBuffer(*cb_state, *buffer_state, error_obj.location,
                                           "VUID-vkCmdEncodeVideoKHR-commandBuffer-08203", where);
-    }
 
-    if ((buffer_state->usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
-        skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBuffer-08236", objlist, encode_info_loc.dot(Field::dstBuffer),
-                         "(%s) was not created with "
-                         "VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR.",
-                         FormatHandle(pEncodeInfo->dstBuffer).c_str());
-    }
+        if ((buffer_state->usage & VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR) == 0) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
+            skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBuffer-08236", objlist, encode_info_loc.dot(Field::dstBuffer),
+                             "(%s) was not created with "
+                             "VK_BUFFER_USAGE_VIDEO_ENCODE_DST_BIT_KHR.",
+                             FormatHandle(pEncodeInfo->dstBuffer).c_str());
+        }
 
-    if (!IsBufferCompatibleWithVideoProfile(*buffer_state, vs_state->profile)) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
-        skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08201", objlist, encode_info_loc.dot(Field::dstBuffer),
-                         " (%s) is not compatible "
-                         "with the video profile %s was created with.",
-                         FormatHandle(pEncodeInfo->dstBuffer).c_str(), FormatHandle(*vs_state).c_str());
-    }
+        if (!IsBufferCompatibleWithVideoProfile(*buffer_state, vs_state->profile)) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
+            skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08201", objlist, encode_info_loc.dot(Field::dstBuffer),
+                             " (%s) is not compatible "
+                             "with the video profile %s was created with.",
+                             FormatHandle(pEncodeInfo->dstBuffer).c_str(), FormatHandle(*vs_state).c_str());
+        }
 
-    if (pEncodeInfo->dstBufferOffset >= buffer_state->create_info.size) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
-        skip |=
-            LogError("VUID-VkVideoEncodeInfoKHR-dstBufferOffset-08237", objlist, encode_info_loc.dot(Field::dstBufferOffset),
-                     "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
-                     pEncodeInfo->dstBufferOffset, buffer_state->create_info.size, FormatHandle(pEncodeInfo->dstBuffer).c_str());
-    }
+        if (pEncodeInfo->dstBufferOffset >= buffer_state->create_info.size) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
+            skip |= LogError(
+                "VUID-VkVideoEncodeInfoKHR-dstBufferOffset-08237", objlist, encode_info_loc.dot(Field::dstBufferOffset),
+                "(%" PRIu64 ") must be less than the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
+                pEncodeInfo->dstBufferOffset, buffer_state->create_info.size, FormatHandle(pEncodeInfo->dstBuffer).c_str());
+        }
 
-    if (!IsIntegerMultipleOf(pEncodeInfo->dstBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle());
-        skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08204", objlist, encode_info_loc.dot(Field::dstBufferOffset),
-                         "(%" PRIu64 ") is not an integer multiple of the minBitstreamBufferOffsetAlignment (%" PRIu64
-                         ") required by the video profile %s was created with.",
-                         pEncodeInfo->dstBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment,
-                         FormatHandle(*vs_state).c_str());
-    }
+        if (!IsIntegerMultipleOf(pEncodeInfo->dstBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment)) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle());
+            skip |= LogError("VUID-vkCmdEncodeVideoKHR-pEncodeInfo-08204", objlist, encode_info_loc.dot(Field::dstBufferOffset),
+                             "(%" PRIu64 ") is not an integer multiple of the minBitstreamBufferOffsetAlignment (%" PRIu64
+                             ") required by the video profile %s was created with.",
+                             pEncodeInfo->dstBufferOffset, profile_caps.base.minBitstreamBufferOffsetAlignment,
+                             FormatHandle(*vs_state).c_str());
+        }
 
-    if (pEncodeInfo->dstBufferOffset + pEncodeInfo->dstBufferRange > buffer_state->create_info.size) {
-        const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
-        skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBufferRange-08238", objlist, encode_info_loc.dot(Field::dstBufferOffset),
-                         "(%" PRIu64 ") plus pEncodeInfo->dstBufferRange (%" PRIu64
-                         ") must be less than or equal to the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
-                         pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange, buffer_state->create_info.size,
-                         FormatHandle(pEncodeInfo->dstBuffer).c_str());
+        if (pEncodeInfo->dstBufferOffset + pEncodeInfo->dstBufferRange > buffer_state->create_info.size) {
+            const LogObjectList objlist(commandBuffer, vs_state->Handle(), pEncodeInfo->dstBuffer);
+            skip |= LogError("VUID-VkVideoEncodeInfoKHR-dstBufferRange-08238", objlist, encode_info_loc.dot(Field::dstBufferOffset),
+                             "(%" PRIu64 ") plus pEncodeInfo->dstBufferRange (%" PRIu64
+                             ") must be less than or equal to the size (%" PRIu64 ") of pEncodeInfo->dstBuffer (%s).",
+                             pEncodeInfo->dstBufferOffset, pEncodeInfo->dstBufferRange, buffer_state->create_info.size,
+                             FormatHandle(pEncodeInfo->dstBuffer).c_str());
+        }
     }
 
     if (!IsIntegerMultipleOf(pEncodeInfo->dstBufferRange, profile_caps.base.minBitstreamBufferSizeAlignment)) {

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -2637,8 +2637,7 @@ bool CoreChecks::PreCallValidateBindVideoSessionMemoryKHR(VkDevice device, VkVid
             const auto &bind_info = pBindSessionMemoryInfos[i];
             const auto &mem_binding_info = vs_state->GetMemoryBindingInfo(bind_info.memoryBindIndex);
             if (mem_binding_info != nullptr) {
-                auto mem_state = Get<vvl::DeviceMemory>(bind_info.memory);
-                if (mem_state) {
+                if (auto mem_state = Get<vvl::DeviceMemory>(bind_info.memory)) {
                     if (((1 << mem_state->allocate_info.memoryTypeIndex) & mem_binding_info->requirements.memoryTypeBits) == 0) {
                         const LogObjectList objlist(videoSession, mem_state->Handle());
                         skip |=

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -969,8 +969,7 @@ bool CoreChecks::PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentIn
 
             for (uint32_t i = 0; i < swapchain_present_fence_info->swapchainCount; i++) {
                 if (swapchain_present_fence_info->pFences[i]) {
-                    const auto fence_state = Get<vvl::Fence>(swapchain_present_fence_info->pFences[i]);
-                    if (fence_state) {
+                    if (const auto fence_state = Get<vvl::Fence>(swapchain_present_fence_info->pFences[i])) {
                         const LogObjectList objlist(queue, swapchain_present_fence_info->pFences[i]);
                         skip |= ValidateFenceForSubmit(
                             *fence_state, "VUID-VkSwapchainPresentFenceInfoEXT-pFences-07759",
@@ -1070,8 +1069,7 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
                                           VkFence fence, const Location &loc, const char *semaphore_type_vuid) const {
     bool skip = false;
     const bool version_2 = loc.function != Func::vkAcquireNextImageKHR;
-    auto semaphore_state = Get<vvl::Semaphore>(semaphore);
-    if (semaphore_state) {
+    if (auto semaphore_state = Get<vvl::Semaphore>(semaphore)) {
         if (semaphore_state->type != VK_SEMAPHORE_TYPE_BINARY) {
             skip |= LogError(semaphore_type_vuid, semaphore, loc, "%s is not a VK_SEMAPHORE_TYPE_BINARY.",
                              FormatHandle(semaphore).c_str());
@@ -1094,15 +1092,13 @@ bool CoreChecks::ValidateAcquireNextImage(VkDevice device, VkSwapchainKHR swapch
         }
     }
 
-    auto fence_state = Get<vvl::Fence>(fence);
-    if (fence_state) {
+    if (auto fence_state = Get<vvl::Fence>(fence)) {
         const LogObjectList objlist(device, fence);
         skip |= ValidateFenceForSubmit(*fence_state, "VUID-vkAcquireNextImageKHR-fence-01287",
                                        "VUID-vkAcquireNextImageKHR-fence-01287", objlist, loc);
     }
 
-    auto swapchain_data = Get<vvl::Swapchain>(swapchain);
-    if (swapchain_data) {
+    if (auto swapchain_data = Get<vvl::Swapchain>(swapchain)) {
         if (swapchain_data->retired) {
             const char *vuid =
                 version_2 ? "VUID-VkAcquireNextImageInfoKHR-swapchain-01675" : "VUID-vkAcquireNextImageKHR-swapchain-01285";

--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -1367,7 +1367,8 @@ bool CoreChecks::PreCallValidateAcquireFullScreenExclusiveModeEXT(VkDevice devic
                                                                   const ErrorObject &error_obj) const {
     bool skip = false;
 
-    auto swapchain_state = Get<vvl::Swapchain>(swapchain) if (!swapchain_state) return skip;
+    auto swapchain_state = Get<vvl::Swapchain>(swapchain);
+    if (!swapchain_state) return skip;
 
     if (swapchain_state->retired) {
         skip |= LogError("VUID-vkAcquireFullScreenExclusiveModeEXT-swapchain-02674", device, error_obj.location,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -421,8 +421,7 @@ class CoreChecks : public ValidationStateTracker {
                                   VkDeviceSize count_buffer_offset, const Location& loc) const;
     bool ValidateCmdDrawFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
                                     const vvl::DrawDispatchVuid& vuid, const Location& loc) const;
-    bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer,
-                                                      const std::shared_ptr<const vvl::ImageView>& image_view_state,
+    bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
                                                       const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                       const Location& attachment_loc, const Location& rendering_info_loc) const;
 

--- a/layers/gpu_validation/gpu_image_layout.cpp
+++ b/layers/gpu_validation/gpu_image_layout.cpp
@@ -101,9 +101,8 @@ void Validator::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const 
         }
     }
     auto image_state = Get<vvl::Image>(mem_barrier.image);
-    if (!image_state) {
-        return;
-    }
+    if (!image_state) return;
+
     auto normalized_isr = image_state->NormalizeSubresourceRange(mem_barrier.subresourceRange);
 
     VkImageLayout initial_layout = NormalizeSynchronization2Layout(mem_barrier.subresourceRange.aspectMask, mem_barrier.oldLayout);
@@ -155,15 +154,15 @@ void Validator::PostCallRecordCreateImage(VkDevice device, const VkImageCreateIn
     BaseClass::PostCallRecordCreateImage(device, pCreateInfo, pAllocator, pImage, record_obj);
     if ((pCreateInfo->flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) != 0) {
         // non-sparse images set up their layout maps when memory is bound
-        auto image_state = Get<vvl::Image>(*pImage);
-        image_state->SetInitialLayoutMap();
+        if (auto image_state = Get<vvl::Image>(*pImage)) {
+            image_state->SetInitialLayoutMap();
+        }
     }
 }
 
 void Validator::PreCallRecordDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator,
                                           const RecordObject &record_obj) {
     // Clean up validation specific data
-    auto image_state = Get<vvl::Image>(image);
     // Clean up generic image state
     BaseClass::PreCallRecordDestroyImage(device, image, pAllocator, record_obj);
 }
@@ -427,8 +426,7 @@ void Validator::PostCallRecordBindImageMemory(VkDevice device, VkImage image, Vk
     if (VK_SUCCESS != record_obj.result) return;
     BaseClass::PostCallRecordBindImageMemory(device, image, memory, memoryOffset, record_obj);
 
-    auto image_state = Get<vvl::Image>(image);
-    if (image_state) {
+    if (auto image_state = Get<vvl::Image>(image)) {
         image_state->SetInitialLayoutMap();
     }
 }
@@ -439,8 +437,7 @@ void Validator::PostCallRecordBindImageMemory2(VkDevice device, uint32_t bindInf
     BaseClass::PostCallRecordBindImageMemory2(device, bindInfoCount, pBindInfos, record_obj);
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        auto image_state = Get<vvl::Image>(pBindInfos[i].image);
-        if (image_state) {
+        if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             image_state->SetInitialLayoutMap();
         }
     }
@@ -452,8 +449,7 @@ void Validator::PostCallRecordBindImageMemory2KHR(VkDevice device, uint32_t bind
     BaseClass::PostCallRecordBindImageMemory2KHR(device, bindInfoCount, pBindInfos, record_obj);
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
-        auto image_state = Get<vvl::Image>(pBindInfos[i].image);
-        if (image_state) {
+        if (auto image_state = Get<vvl::Image>(pBindInfos[i].image)) {
             image_state->SetInitialLayoutMap();
         }
     }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1591,6 +1591,7 @@ void CommandBuffer::Submit(VkQueue queue, uint32_t perf_submit_pass, const Locat
         }
         for (const auto &query_state_pair : local_query_to_state_map) {
             auto query_pool_state = dev_data.Get<vvl::QueryPool>(query_state_pair.first.pool);
+            if (!query_pool_state) continue;
             query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, query_state_pair.second);
         }
     }
@@ -1636,10 +1637,8 @@ void CommandBuffer::Retire(uint32_t perf_submit_pass, const std::function<bool(c
     for (const auto &query_state_pair : local_query_to_state_map) {
         if (query_state_pair.second == QUERYSTATE_ENDED && !is_query_updated_after(query_state_pair.first)) {
             auto query_pool_state = dev_data.Get<vvl::QueryPool>(query_state_pair.first.pool);
-            if (query_pool_state) {
-                query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass,
-                                                QUERYSTATE_AVAILABLE);
-            }
+            if (!query_pool_state) continue;
+            query_pool_state->SetQueryState(query_state_pair.first.slot, query_state_pair.first.perf_pass, QUERYSTATE_AVAILABLE);
         }
     }
 }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -510,8 +510,7 @@ void ValidationStateTracker::PreCallRecordDestroyImageView(VkDevice device, VkIm
 
 void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator,
                                                         const RecordObject &record_obj) {
-    auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(buffer)) {
         WriteLockGuard guard(buffer_address_lock_);
 
         const VkBufferUsageFlags descriptor_buffer_usages =
@@ -1278,17 +1277,13 @@ void ValidationStateTracker::PostCallRecordAllocateMemory(VkDevice device, const
     if (const auto dedicated = vku::FindStructInPNextChain<VkMemoryDedicatedAllocateInfo>(pAllocateInfo->pNext)) {
         if (dedicated->buffer) {
             auto buffer_state = Get<vvl::Buffer>(dedicated->buffer);
-            assert(buffer_state);
-            if (!buffer_state) {
-                return;
-            }
+            if (!buffer_state) return;
+
             dedicated_binding.emplace(dedicated->buffer, buffer_state->create_info);
         } else if (dedicated->image) {
             auto image_state = Get<vvl::Image>(dedicated->image);
-            assert(image_state);
-            if (!image_state) {
-                return;
-            }
+            if (!image_state) return;
+
             dedicated_binding.emplace(dedicated->image, image_state->create_info);
         }
     }
@@ -1616,8 +1611,7 @@ void ValidationStateTracker::PreCallRecordDestroyQueryPool(VkDevice device, VkQu
 }
 
 void ValidationStateTracker::UpdateBindBufferMemoryState(VkBuffer buffer, VkDeviceMemory mem, VkDeviceSize memoryOffset) {
-    auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (buffer_state) {
+    if (auto buffer_state = Get<vvl::Buffer>(buffer)) {
         // Track objects tied to memory
         if (auto mem_state = Get<vvl::DeviceMemory>(mem)) {
             buffer_state->BindMemory(buffer_state.get(), mem_state, memoryOffset, 0u, buffer_state->requirements.size);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1453,8 +1453,7 @@ void ValidationStateTracker::PostCallRecordSignalSemaphoreKHR(VkDevice device, c
 }
 
 void ValidationStateTracker::RecordMappedMemory(VkDeviceMemory mem, VkDeviceSize offset, VkDeviceSize size, void **ppData) {
-    auto mem_info = Get<vvl::DeviceMemory>(mem);
-    if (mem_info) {
+    if (auto mem_info = Get<vvl::DeviceMemory>(mem)) {
         mem_info->mapped_range.offset = offset;
         mem_info->mapped_range.size = size;
         mem_info->p_driver_data = *ppData;
@@ -1620,8 +1619,7 @@ void ValidationStateTracker::UpdateBindBufferMemoryState(VkBuffer buffer, VkDevi
     auto buffer_state = Get<vvl::Buffer>(buffer);
     if (buffer_state) {
         // Track objects tied to memory
-        auto mem_state = Get<vvl::DeviceMemory>(mem);
-        if (mem_state) {
+        if (auto mem_state = Get<vvl::DeviceMemory>(mem)) {
             buffer_state->BindMemory(buffer_state.get(), mem_state, memoryOffset, 0u, buffer_state->requirements.size);
         }
     }
@@ -2537,8 +2535,7 @@ void ValidationStateTracker::PostCallRecordBindAccelerationStructureMemoryNV(
         auto as_state = Get<vvl::AccelerationStructureNV>(info.accelerationStructure);
         if (as_state) {
             // Track objects tied to memory
-            auto mem_state = Get<vvl::DeviceMemory>(info.memory);
-            if (mem_state) {
+            if (auto mem_state = Get<vvl::DeviceMemory>(info.memory)) {
                 as_state->BindMemory(as_state.get(), mem_state, info.memoryOffset, 0u, as_state->memory_requirements.size);
             }
 
@@ -3435,8 +3432,7 @@ void ValidationStateTracker::PostCallRecordMapMemory2KHR(VkDevice device, const 
 }
 
 void ValidationStateTracker::PreCallRecordUnmapMemory(VkDevice device, VkDeviceMemory mem, const RecordObject &record_obj) {
-    auto mem_info = Get<vvl::DeviceMemory>(mem);
-    if (mem_info) {
+    if (auto mem_info = Get<vvl::DeviceMemory>(mem)) {
         mem_info->mapped_range = vvl::MemRange();
         mem_info->p_driver_data = nullptr;
     }
@@ -3444,8 +3440,7 @@ void ValidationStateTracker::PreCallRecordUnmapMemory(VkDevice device, VkDeviceM
 
 void ValidationStateTracker::PreCallRecordUnmapMemory2KHR(VkDevice device, const VkMemoryUnmapInfoKHR *pMemoryUnmapInfo,
                                                           const RecordObject &record_obj) {
-    auto mem_info = Get<vvl::DeviceMemory>(pMemoryUnmapInfo->memory);
-    if (mem_info) {
+    if (auto mem_info = Get<vvl::DeviceMemory>(pMemoryUnmapInfo->memory)) {
         mem_info->mapped_range = vvl::MemRange();
         mem_info->p_driver_data = nullptr;
     }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -2450,7 +2450,7 @@ void ValidationStateTracker::PostCallRecordBuildAccelerationStructuresKHR(
     const VkAccelerationStructureBuildRangeInfoKHR *const *ppBuildRangeInfos, const RecordObject &record_obj) {
     for (uint32_t i = 0; i < infoCount; ++i) {
         auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfos[i].dstAccelerationStructure);
-        if (dst_as_state != nullptr) {
+        if (dst_as_state) {
             dst_as_state->Build(&pInfos[i], true, *ppBuildRangeInfos);
         }
     }
@@ -2520,7 +2520,7 @@ void ValidationStateTracker::PostCallRecordGetAccelerationStructureMemoryRequire
     VkDevice device, const VkAccelerationStructureMemoryRequirementsInfoNV *pInfo, VkMemoryRequirements2 *pMemoryRequirements,
     const RecordObject &record_obj) {
     auto as_state = Get<vvl::AccelerationStructureNV>(pInfo->accelerationStructure);
-    if (as_state != nullptr) {
+    if (as_state) {
         if (pInfo->type == VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_OBJECT_NV) {
             as_state->memory_requirements_checked = true;
         } else if (pInfo->type == VK_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_TYPE_BUILD_SCRATCH_NV) {
@@ -2620,10 +2620,10 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureNV(VkComm
     if (cb_state) {
         auto src_as_state = Get<vvl::AccelerationStructureNV>(src);
         auto dst_as_state = Get<vvl::AccelerationStructureNV>(dst);
-        if (!disabled[command_buffer_state]) {
-            cb_state->RecordTransferCmd(record_obj.location.function, src_as_state, dst_as_state);
-        }
-        if (dst_as_state != nullptr && src_as_state != nullptr) {
+        if (dst_as_state && src_as_state) {
+            if (!disabled[command_buffer_state]) {
+                cb_state->RecordTransferCmd(record_obj.location.function, src_as_state, dst_as_state);
+            }
             dst_as_state->built = true;
             dst_as_state->build_info = src_as_state->build_info;
         }
@@ -4831,7 +4831,7 @@ void ValidationStateTracker::PostCallRecordCopyAccelerationStructureKHR(VkDevice
                                                                         const RecordObject &record_obj) {
     auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
     auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
-    if (dst_as_state != nullptr && src_as_state != nullptr) {
+    if (dst_as_state && src_as_state) {
         dst_as_state->built = true;
         dst_as_state->build_info_khr = src_as_state->build_info_khr;
     }
@@ -4845,7 +4845,7 @@ void ValidationStateTracker::PostCallRecordCmdCopyAccelerationStructureKHR(VkCom
         cb_state->RecordCmd(record_obj.location.function);
         auto src_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->src);
         auto dst_as_state = Get<vvl::AccelerationStructureKHR>(pInfo->dst);
-        if (dst_as_state != nullptr && src_as_state != nullptr) {
+        if (dst_as_state && src_as_state) {
             dst_as_state->built = true;
             dst_as_state->build_info_khr = src_as_state->build_info_khr;
             if (!disabled[command_buffer_state]) {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -596,9 +596,7 @@ bool CommandBufferAccessContext::ValidateDrawVertexIndex(const std::optional<uin
     bool skip = false;
     const auto &index_binding = cb_state_->index_buffer_binding;
     const auto index_buf_state = sync_state_->Get<vvl::Buffer>(index_binding.buffer);
-    if (!index_buf_state) {
-        return skip;
-    }
+    if (!index_buf_state) return skip;
 
     const auto index_size = GetIndexAlignment(index_binding.index_type);
     const ResourceAccessRange range = MakeRange(index_binding, firstIndex, index_count, index_size);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7975

This was me going through every `Get<vvl::*>` to make sure we are null-checking them
