### PR TITLE
tests: Fix DeviceIDPropertiesExtensions tests

### DIFF
--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -96,7 +96,7 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     if (DeviceValidationVersion() != VK_API_VERSION_1_0) {
@@ -104,8 +104,8 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
     }
 
     VkPhysicalDeviceIDProperties id_props =  vku::InitStructHelper();
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&id_props);
-    vk::GetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
+    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
 }
 
 TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -533,9 +533,7 @@ TEST_F(VkLayerTest, SpecLinks) {
     CreateImageViewTest(*this, &imgViewInfo, "Vulkan-Docs/search");
 }
 
-// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5600
-// Should be printing an error
-TEST_F(VkLayerTest, DISABLED_DeviceIDPropertiesExtensions) {
+TEST_F(VkLayerTest, DeviceIDPropertiesExtensions) {
     TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -547,8 +545,10 @@ TEST_F(VkLayerTest, DISABLED_DeviceIDPropertiesExtensions) {
     }
 
     VkPhysicalDeviceIDProperties id_props =  vku::InitStructHelper();
-    VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&id_props);
-    vk::GetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
+    m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
+    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, UsePnextOnlyStructWithoutExtensionEnabled) {


### PR DESCRIPTION
Both tests were wrong (from https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2457)