### PR TITLE
gpu: Have InternalError disconnect from chassis

### DIFF
--- a/layers/gpu_validation/debug_printf.h
+++ b/layers/gpu_validation/debug_printf.h
@@ -87,8 +87,6 @@ class Validator : public GpuShaderInstrumentor {
         desired_features.fragmentStoresAndAtomics = true;
     }
 
-    void ReportSetupProblemPrintF(LogObjectList objlist, const Location& loc, const char* const specific_message,
-                                  bool vma_fail) const;
     void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
     bool InstrumentShader(const vvl::span<const uint32_t>& input, std::vector<uint32_t>& instrumented_spirv,
                           uint32_t unique_shader_id, const Location& loc) override;

--- a/layers/gpu_validation/gpu_error_message.cpp
+++ b/layers/gpu_validation/gpu_error_message.cpp
@@ -873,21 +873,3 @@ bool PreCopyBufferToImageResources::LogCustomValidationMessage(Validator &valida
     return error_logged;
 }
 }  // namespace gpuav
-
-void GpuShaderInstrumentor::ReportSetupProblem(LogObjectList objlist, const Location &loc, const char *const specific_message,
-                                               bool vma_fail) const {
-    std::string error_message = specific_message;
-    if (vma_fail) {
-        char *stats_string;
-        vmaBuildStatsString(vmaAllocator, &stats_string, false);
-        error_message += " VMA statistics = ";
-        error_message += stats_string;
-        vmaFreeStatsString(vmaAllocator, stats_string);
-    }
-
-    char const *layer_name = container_type == LayerObjectTypeDebugPrintf ? "Debug PrintF" : "GPU-AV";
-    char const *vuid =
-        container_type == LayerObjectTypeDebugPrintf ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
-
-    LogError(vuid, objlist, loc, "Setup Error, %s is being disabled. Detail: (%s)", layer_name, error_message.c_str());
-}

--- a/layers/gpu_validation/gpu_setup.cpp
+++ b/layers/gpu_validation/gpu_setup.cpp
@@ -112,17 +112,13 @@ void Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Locati
     BaseClass::CreateDevice(pCreateInfo, loc);
 
     if (api_version < VK_API_VERSION_1_1) {
-        ReportSetupProblem(device, loc, "GPU-Assisted validation requires Vulkan 1.1 or later.  GPU-Assisted Validation disabled.");
-        aborted = true;
+        InternalError(device, loc, "GPU-Assisted validation requires Vulkan 1.1 or later.");
         return;
     }
 
     DispatchGetPhysicalDeviceFeatures(physical_device, &supported_features);
     if (!supported_features.fragmentStoresAndAtomics || !supported_features.vertexPipelineStoresAndAtomics) {
-        ReportSetupProblem(device, loc,
-                           "GPU-Assisted validation requires fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics.  "
-                           "GPU-Assisted Validation disabled.");
-        aborted = true;
+        InternalError(device, loc, "GPU-Assisted validation requires fragmentStoresAndAtomics and vertexPipelineStoresAndAtomics.");
         return;
     }
 
@@ -207,8 +203,7 @@ void Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Locati
     VkResult result =
         vmaFindMemoryTypeIndexForBufferInfo(vmaAllocator, &output_buffer_create_info, &alloc_create_info, &mem_type_index);
     if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, loc, "Unable to find memory type index");
-        aborted = true;
+        InternalError(device, loc, "Unable to find memory type index");
         return;
     }
     VmaPoolCreateInfo pool_create_info = {};
@@ -220,8 +215,7 @@ void Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Locati
     }
     result = vmaCreatePool(vmaAllocator, &pool_create_info, &output_buffer_pool);
     if (result != VK_SUCCESS) {
-        ReportSetupProblem(device, loc, "Unable to create VMA memory pool");
-        aborted = true;
+        InternalError(device, loc, "Unable to create VMA memory pool");
         return;
     }
 
@@ -268,17 +262,14 @@ void Validator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Locati
         result =
             vmaCreateBuffer(vmaAllocator, &buffer_info, &alloc_info, &indices_buffer.buffer, &indices_buffer.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, loc, "Unable to allocate device memory for command indices. Device could become unstable.",
-                               true);
-            aborted = true;
+            InternalError(device, loc, "Unable to allocate device memory for command indices.", true);
             return;
         }
 
         uint32_t *indices_ptr = nullptr;
         result = vmaMapMemory(vmaAllocator, indices_buffer.allocation, reinterpret_cast<void **>(&indices_ptr));
         if (result != VK_SUCCESS) {
-            ReportSetupProblem(device, loc, "Unable to map device memory for command indices buffer.");
-            aborted = true;
+            InternalError(device, loc, "Unable to map device memory for command indices buffer.");
             return;
         }
 

--- a/layers/gpu_validation/gpu_shader_instrumentor.h
+++ b/layers/gpu_validation/gpu_shader_instrumentor.h
@@ -138,8 +138,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
                                       const RecordObject &record_obj) override;
 
-    void ReportSetupProblem(LogObjectList objlist, const Location &loc, const char *const specific_message,
-                            bool vma_fail = false) const;
+    void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message, bool vma_fail = false) const;
     bool CheckForGpuAvEnabled(const void *pNext);
 
   protected:
@@ -164,7 +163,12 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     VkPipelineLayout GetDebugPipelineLayout() { return debug_pipeline_layout_; }
 
   public:
+    // When aborting we will disconnect all future chassis calls.
+    // If we are deep into a call stack, we can use this to return up to the chassis call.
+    // It should only be used after calls that might abort, not to be used for guarding a function (unless a case is found that make
+    // sense too)
     mutable bool aborted = false;
+
     bool force_buffer_device_address;
     vvl::unordered_map<uint32_t, std::pair<size_t, std::vector<uint32_t>>> instrumented_shaders;
     PFN_vkSetDeviceLoaderData vkSetDeviceLoaderData;

--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -53,7 +53,7 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
         pool_create_info.queueFamilyIndex = queueFamilyIndex;
         result = DispatchCreateCommandPool(shader_instrumentor_.device, &pool_create_info, nullptr, &barrier_command_pool_);
         if (result != VK_SUCCESS) {
-            shader_instrumentor_.ReportSetupProblem(vvl::Queue::VkHandle(), loc, "Unable to create command pool for barrier CB.");
+            shader_instrumentor_.InternalError(vvl::Queue::VkHandle(), loc, "Unable to create command pool for barrier CB.");
             barrier_command_pool_ = VK_NULL_HANDLE;
             return;
         }
@@ -64,7 +64,7 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
         buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
         result = DispatchAllocateCommandBuffers(shader_instrumentor_.device, &buffer_alloc_info, &barrier_command_buffer_);
         if (result != VK_SUCCESS) {
-            shader_instrumentor_.ReportSetupProblem(vvl::Queue::VkHandle(), loc, "Unable to create barrier command buffer.");
+            shader_instrumentor_.InternalError(vvl::Queue::VkHandle(), loc, "Unable to create barrier command buffer.");
             DispatchDestroyCommandPool(shader_instrumentor_.device, barrier_command_pool_, nullptr);
             barrier_command_pool_ = VK_NULL_HANDLE;
             barrier_command_buffer_ = VK_NULL_HANDLE;
@@ -79,7 +79,7 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
 
         result = DispatchCreateSemaphore(shader_instrumentor_.device, &semaphore_create_info, nullptr, &barrier_sem_);
         if (result != VK_SUCCESS) {
-            shader_instrumentor_.ReportSetupProblem(shader_instrumentor_.device, loc, "Unable to create barrier semaphore.");
+            shader_instrumentor_.InternalError(shader_instrumentor_.device, loc, "Unable to create barrier semaphore.");
             DispatchDestroyCommandPool(shader_instrumentor_.device, barrier_command_pool_, nullptr);
             barrier_command_pool_ = VK_NULL_HANDLE;
             barrier_command_buffer_ = VK_NULL_HANDLE;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2234,6 +2234,7 @@ class ValidationObject {
     bool is_device_lost = false;
 
     std::vector<ValidationObject*> object_dispatch;
+    std::vector<ValidationObject*> aborted_object_dispatch;
     LayerObjectTypeId container_type;
     void ReleaseDeviceDispatchObject(LayerObjectTypeId type_id) const;
 

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -57,9 +57,23 @@ TEST_F(NegativeGpuAV, ValidationAbort) {
     features.vertexPipelineStoresAndAtomics = false;
     features.fragmentStoresAndAtomics = false;
     fpvkSetPhysicalDeviceFeaturesEXT(gpu(), features);
-    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "GPU-Assisted Validation disabled");
+    m_errorMonitor->SetDesiredFailureMsg(kErrorBit, "GPU-AV is being disabled");
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->VerifyFound();
+
+    // Still make sure we can use Vulkan as expected without errors
+    InitRenderTarget();
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.CreateComputePipeline();
+
+    m_commandBuffer->begin();
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+    vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
+    m_commandBuffer->end();
+
+    m_default_queue->Submit(*m_commandBuffer);
+    m_default_queue->Wait();
 }
 
 TEST_F(NegativeGpuAV, ValidationFeatures) {


### PR DESCRIPTION
- rename `ReportSetupProblem` to `InternalError` (as it does more then just during setup)
- Call `ReleaseDeviceDispatchObject` that will prevent any more `Pre/Post` chassis calls from getting called

For `aborted` we still need it, but not to "gaurd" a function, but to get out of a function, example

```
void DeepDownFunction() {
    AllocationOfThing();
    if (aborted) return;
}
```

We might decide in the future to do a `[[no-discard]]` bool return from these functions, but that is orthogonal to the scope of this change