### PR TITLE
bp: Report signaling already signaled event

### DIFF
--- a/layers/best_practices/best_practices_error_enums.h
+++ b/layers/best_practices/best_practices_error_enums.h
@@ -124,6 +124,7 @@
 [[maybe_unused]] static const char *kVUID_BestPractices_Shader_MissingInputAttachment =
     "BestPractices-Shader-MissingInputAttachment";
 [[maybe_unused]] static const char *kVUID_BestPractices_RenderingInfo_ResolveModeNone = "BestPractices-VkRenderingInfo-ResolveModeNone";
+[[maybe_unused]] static const char *kVUID_BestPractices_Event_SignalSignaledEvent = "BestPractices-Event-SignalSignaledEvent";
 
 // Arm-specific best practice
 [[maybe_unused]] static const char *kVUID_BestPractices_AllocateDescriptorSets_SuboptimalReuse =

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -316,18 +316,33 @@ class BestPractices : public ValidationStateTracker {
                                          const RecordObject& record_obj) override;
     bool PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer, const VkCommandBufferBeginInfo* pBeginInfo,
                                            const ErrorObject& error_obj) const override;
+    bool CheckEventSignalingState(const bp_state::CommandBuffer& command_buffer, VkEvent event, const Location& cb_loc) const;
+    void RecordCmdSetEvent(bp_state::CommandBuffer& command_buffer, VkEvent event);
+    void RecordCmdResetEvent(bp_state::CommandBuffer& command_buffer, VkEvent event);
     bool PreCallValidateCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                     const ErrorObject& error_obj) const override;
+    void PreCallRecordCmdSetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
+                                  const RecordObject& record_obj) override;
     bool PreCallValidateCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR* pDependencyInfo,
                                         const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
                                      const ErrorObject& error_obj) const override;
+    void PreCallRecordCmdSetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfoKHR* pDependencyInfo,
+                                      const RecordObject& record_obj) override;
+    void PreCallRecordCmdSetEvent2(VkCommandBuffer commandBuffer, VkEvent event, const VkDependencyInfo* pDependencyInfo,
+                                   const RecordObject& record_obj) override;
     bool PreCallValidateCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
                                       const ErrorObject& error_obj) const override;
+    void PreCallRecordCmdResetEvent(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags stageMask,
+                                    const RecordObject& record_obj) override;
     bool PreCallValidateCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
                                           const ErrorObject& error_obj) const override;
     bool PreCallValidateCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
                                        const ErrorObject& error_obj) const override;
+    void PreCallRecordCmdResetEvent2KHR(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2KHR stageMask,
+                                        const RecordObject& record_obj) override;
+    void PreCallRecordCmdResetEvent2(VkCommandBuffer commandBuffer, VkEvent event, VkPipelineStageFlags2 stageMask,
+                                     const RecordObject& record_obj) override;
     bool PreCallValidateCmdWaitEvents(VkCommandBuffer commandBuffer, uint32_t eventCount, const VkEvent* pEvents,
                                       VkPipelineStageFlags srcStageMask, VkPipelineStageFlags dstStageMask,
                                       uint32_t memoryBarrierCount, const VkMemoryBarrier* pMemoryBarriers,

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -200,6 +200,20 @@ class CommandBuffer : public vvl::CommandBuffer {
 
     std::vector<uint8_t> push_constant_data_set;
     void UnbindResources() { push_constant_data_set.clear(); }
+
+    struct SignalingInfo {
+        // True, if the event's first state change within a command buffer is a signal (SetEvent)
+        // rather than an unsignal (ResetEvent). It is used to do validation on the boundary
+        // between two command buffers.
+        const bool first_state_change_is_signal = false;
+
+        // Tracks how the event signaling state changes as the command buffer recording progresses.
+        // When recording is finished, this is the event state "at the end of the command buffer".
+        bool signaled = false;
+
+        SignalingInfo(bool signal) : first_state_change_is_signal(signal), signaled(signal) {}
+    };
+    vvl::unordered_map<VkEvent, SignalingInfo> event_signaling_state;
 };
 
 class DescriptorPool : public vvl::DescriptorPool {

--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -1048,45 +1048,17 @@ bool Contains(const Container &container, const Key &key) {
 }
 
 //
-// if (auto [found, it] = vvl::Find(map, key); found) { it->jump(); }
+// if (auto* thing = vvl::Find(map, key)) { thing->jump(); }
 //
-template <typename Container, typename Key = typename Container::key_type>
-std::pair<bool, typename Container::iterator> Find(Container &container, const Key &key) {
+template <typename Container, typename Key = typename Container::key_type, typename Value = typename Container::mapped_type>
+Value *Find(Container &container, const Key &key) {
     auto it = container.find(key);
-    return std::make_pair(it != container.end(), it);
+    return (it != container.end()) ? &it->second : nullptr;
 }
-template <typename Container, typename Key = typename Container::key_type>
-std::pair<bool, typename Container::const_iterator> Find(const Container &container, const Key &key) {
+template <typename Container, typename Key = typename Container::key_type, typename Value = typename Container::mapped_type>
+const Value *Find(const Container &container, const Key &key) {
     auto it = container.find(key);
-    return std::make_pair(it != container.cend(), it);
-}
-
-//
-// if (auto it_holder = vvl::FindIt(map, key); it_holder) { it_holder->jump(); }
-//
-template <typename Container>
-struct IteratorHolder {
-    typename Container::iterator it;
-    typename Container::iterator end_it;
-    typename Container::value_type &operator*() { return *it; }
-    typename Container::value_type *operator->() { return &*it; }
-    operator bool() { return it != end_it; }
-};
-template <typename Container>
-struct ConstIteratorHolder {
-    typename Container::const_iterator it;
-    typename Container::const_iterator end_it;
-    const typename Container::value_type &operator*() { return *it; }
-    const typename Container::value_type *operator->() { return &*it; }
-    operator bool() { return it != end_it; }
-};
-template <typename Container, typename Key = typename Container::key_type>
-IteratorHolder<Container> FindIt(Container &container, const Key &key) {
-    return {container.find(key), container.end()};
-}
-template <typename Container, typename Key = typename Container::key_type>
-ConstIteratorHolder<Container> FindIt(const Container &container, const Key &key) {
-    return {container.find(key), container.cend()};
+    return (it != container.cend()) ? &it->second : nullptr;
 }
 
 // EraseIf is not implemented as std::erase(std::remove_if(...), ...) for two reasons:

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -45,7 +45,7 @@ struct CommandBufferSubmitState {
     // (accross all command buffers of that submission), as opposed to globally
     // tracking state accross *all* submissions to the same queue.
     QueryMap local_query_to_state_map;
-    EventToStageMap local_event_signal_info;
+    EventMap local_event_signal_info;
     vvl::unordered_map<VkVideoSessionKHR, vvl::VideoSessionDeviceState> local_video_session_state{};
 
     CommandBufferSubmitState(const CoreChecks &c, const vvl::Queue *q) : core(c), queue_state(q) {

--- a/layers/core_checks/cc_state_tracker.cpp
+++ b/layers/core_checks/cc_state_tracker.cpp
@@ -45,13 +45,13 @@ void core::CommandBuffer::RecordWaitEvents(vvl::Func command, uint32_t eventCoun
     auto first_event_index = events.size();
     vvl::CommandBuffer::RecordWaitEvents(command, eventCount, pEvents, srcStageMask);
     auto event_added_count = events.size() - first_event_index;
-    eventUpdates.emplace_back([command, event_added_count, first_event_index, srcStageMask](
-                                  vvl::CommandBuffer& cb_state, bool do_validate, EventToStageMap& local_event_signal_info,
-                                  VkQueue queue, const Location& loc) {
-        if (!do_validate) return false;
-        return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, srcStageMask,
-                                                      local_event_signal_info, queue, loc);
-    });
+    eventUpdates.emplace_back(
+        [command, event_added_count, first_event_index, srcStageMask](
+            vvl::CommandBuffer& cb_state, bool do_validate, EventMap& local_event_signal_info, VkQueue queue, const Location& loc) {
+            if (!do_validate) return false;
+            return CoreChecks::ValidateWaitEventsAtSubmit(command, cb_state, event_added_count, first_event_index, srcStageMask,
+                                                          local_event_signal_info, queue, loc);
+        });
 }
 
 std::shared_ptr<vvl::CommandBuffer> CoreChecks::CreateCmdBufferState(VkCommandBuffer handle,

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -1035,8 +1035,7 @@ bool CoreChecks::ValidateAccessMask(const LogObjectList &objlist, const Location
 
 bool CoreChecks::ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::CommandBuffer &cb_state, size_t eventCount,
                                             size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
-                                            const EventToStageMap &local_event_signal_info, VkQueue waiting_queue,
-                                            const Location &loc) {
+                                            const EventMap &local_event_signal_info, VkQueue waiting_queue, const Location &loc) {
     bool skip = false;
     const ValidationStateTracker &state_data = cb_state.dev_data;
     VkPipelineStageFlags2KHR stage_mask = 0;
@@ -1051,8 +1050,8 @@ bool CoreChecks::ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::Comman
         // conveniently stored in the vvl::Event object itself (after each queue
         // submit, vvl::CommandBuffer::Submit() updates vvl::Event, so it contains
         // the last src_stage from that submission).
-        if (auto signal_info = local_event_signal_info.find(event); signal_info != local_event_signal_info.end()) {
-            stage_mask |= signal_info->second;
+        if (const auto *event_info = vvl::Find(local_event_signal_info, event)) {
+            stage_mask |= event_info->src_stage_mask;
             // The "set event" is found in the current submission (the same queue); there can't be inter-queue usage errors
         } else {
             auto event_state = state_data.Get<vvl::Event>(event);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -477,8 +477,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
     static bool ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::CommandBuffer& cb_state, size_t eventCount,
                                            size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
-                                           const EventToStageMap& local_event_signal_info, VkQueue waiting_queue,
-                                           const Location& loc);
+                                           const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc);
     bool ValidateQueueFamilyIndices(const Location& loc, const vvl::CommandBuffer& cb_state, const vvl::Queue& queue_state) const;
     VkResult CoreLayerCreateValidationCacheEXT(VkDevice device, const VkValidationCacheCreateInfoEXT* pCreateInfo,
                                                const VkAllocationCallbacks* pAllocator, VkValidationCacheEXT* pValidationCache);

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -3504,6 +3504,7 @@ void ValidationStateTracker::PostCallRecordBindImageMemory2KHR(VkDevice device, 
 void ValidationStateTracker::PreCallRecordSetEvent(VkDevice device, VkEvent event, const RecordObject &record_obj) {
     auto event_state = Get<vvl::Event>(event);
     if (event_state) {
+        event_state->signaled = true;
         event_state->signal_src_stage_mask = VK_PIPELINE_STAGE_HOST_BIT;
         event_state->signaling_queue = VK_NULL_HANDLE;
     }

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -62,11 +62,11 @@ std::optional<SignalInfo> SignaledSemaphoresUpdate::OnUnsignal(VkSemaphore semap
     assert(!vvl::Contains(signals_to_add, semaphore) || !vvl::Contains(signals_to_remove, semaphore));
     std::optional<SignalInfo> unsignaled;
 
-    if (auto local_it = vvl::FindIt(signals_to_add, semaphore)) {
-        unsignaled.emplace(std::move(local_it->second));
-        signals_to_add.erase(local_it.it);
-    } else if (auto global_it = vvl::FindIt(sync_validator_.signaled_semaphores_, semaphore)) {
-        unsignaled.emplace(std::move(global_it->second));
+    if (auto add_it = signals_to_add.find(semaphore); add_it != signals_to_add.end()) {
+        unsignaled.emplace(std::move(add_it->second));
+        signals_to_add.erase(add_it);
+    } else if (auto* p_global_info = vvl::Find(sync_validator_.signaled_semaphores_, semaphore)) {
+        unsignaled.emplace(*p_global_info);
     }
     signals_to_remove.emplace(semaphore);
 

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -1804,6 +1804,8 @@ void CommandBuffer::Copy(const Buffer &src, const Buffer &dst) {
     vk::CmdCopyBuffer(handle(), src.handle(), dst.handle(), 1, &region);
 }
 
+void CommandBuffer::ExecuteCommands(const CommandBuffer &secondary) { vk::CmdExecuteCommands(handle(), 1, &secondary.handle()); }
+
 void RenderPass::init(const Device &dev, const VkRenderPassCreateInfo &info) {
     NON_DISPATCHABLE_HANDLE_INIT(vk::CreateRenderPass, dev, &info);
 }

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -1081,6 +1081,7 @@ class CommandBuffer : public internal::Handle<VkCommandBuffer> {
     }
 
     void Copy(const Buffer &src, const Buffer &dst);
+    void ExecuteCommands(const CommandBuffer &secondary);
 
   private:
     VkDevice dev_handle_;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -237,8 +237,8 @@ class VkPositiveLayerTest : public VkLayerTest {
 
 class VkBestPracticesLayerTest : public VkLayerTest {
   public:
-    void InitBestPracticesFramework();
-    void InitBestPracticesFramework(const char* ValidationChecksToEnable);
+    void InitBestPracticesFramework(const char *ValidationChecksToEnable = "");
+    void InitBestPractices(const char *ValidationChecksToEnable = "");
 
   protected:
     VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT};


### PR DESCRIPTION
This tracks event state within a single command buffer, in the secondary command buffers, and between queue submissions. Some parts of this can migrate later to core validation when needed for event related validation.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8004
