### PR TITLE
scripts: Fix VkPhysicalDeviceIDProperties extension check

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -4184,7 +4184,9 @@ bool StatelessValidation::ValidatePnextPropertyStructContents(const Location& lo
         // Validation code for VkPhysicalDeviceIDProperties structure members
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES: {  // Covers VUID-VkPhysicalDeviceIDProperties-sType-sType
 
-            if (!IsExtEnabled(instance_extensions.vk_khr_external_fence_capabilities)) {
+            if (!IsExtEnabled(instance_extensions.vk_khr_external_fence_capabilities) &&
+                !IsExtEnabled(instance_extensions.vk_khr_external_memory_capabilities) &&
+                !IsExtEnabled(instance_extensions.vk_khr_external_semaphore_capabilities)) {
                 skip |= LogError(pnext_vuid, instance, loc.dot(Field::pNext),
                                  "includes a pointer to a VkStructureType (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES), but "
                                  "its parent extension "

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -1015,7 +1015,15 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             # Dependent on enabled extension
             extension = self.vk.extensions[ext_name]
             extension_check = ''
-            if extension.device:
+            if len(struct.extensions) > 1:
+                # There are very few edge cases that get here with multiple extensions, so just handle by hand
+                if struct.name == 'VkPipelineShaderStageRequiredSubgroupSizeCreateInfo':
+                    extension_check = 'if ((is_physdev_api && !SupportedByPdev(physical_device, vvl::Extension::_VK_EXT_subgroup_size_control)) || (!is_physdev_api && !IsExtEnabled(device_extensions.vk_ext_subgroup_size_control))) {'
+                elif struct.name == 'VkPhysicalDeviceIDProperties':
+                    extension_check = 'if (!IsExtEnabled(instance_extensions.vk_khr_external_fence_capabilities) && !IsExtEnabled(instance_extensions.vk_khr_external_memory_capabilities) && !IsExtEnabled(instance_extensions.vk_khr_external_semaphore_capabilities)) {'
+                else:
+                    print(f'WARNING - special case not handled for {extension.name} - {struct.name}')
+            elif extension.device:
                 extension_check = f'if ((is_physdev_api && !SupportedByPdev(physical_device, vvl::Extension::_{extension.name})) || (!is_physdev_api && !IsExtEnabled(device_extensions.{extension.name.lower()}))) {{'
             else:
                 extension_check = f'if (!IsExtEnabled(instance_extensions.{extension.name.lower()})) {{'

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -91,7 +91,7 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     vk::FreeMemory(device(), buffer_memory, NULL);
 }
 
-TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
+TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensionsFence) {
     TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
@@ -104,6 +104,40 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
     }
 
     VkPhysicalDeviceIDProperties id_props =  vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
+    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
+}
+
+TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensionsMemory) {
+    TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
+
+    SetTargetApiVersion(VK_API_VERSION_1_0);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework());
+
+    if (DeviceValidationVersion() != VK_API_VERSION_1_0) {
+        GTEST_SKIP() << "Tests for 1.0 only";
+    }
+
+    VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
+    VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
+    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
+}
+
+TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensionsSemaphore) {
+    TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
+
+    SetTargetApiVersion(VK_API_VERSION_1_0);
+    AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_CAPABILITIES_EXTENSION_NAME);
+    RETURN_IF_SKIP(InitFramework());
+
+    if (DeviceValidationVersion() != VK_API_VERSION_1_0) {
+        GTEST_SKIP() << "Tests for 1.0 only";
+    }
+
+    VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
     vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
 }


### PR DESCRIPTION
Actually now closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/2457

`VkPhysicalDeviceIDProperties` is be used in Vulkan 1.0 with only one of `VK_KHR_external_fence_capabilities`, `VK_KHR_external_memory_capabilities`, `VK_KHR_external_semaphore_capabilities`