### PR TITLE
Fix VkPhysicalDeviceIDProperties sType validation

### DIFF
--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -4184,11 +4184,14 @@ bool StatelessValidation::ValidatePnextPropertyStructContents(const Location& lo
         // Validation code for VkPhysicalDeviceIDProperties structure members
         case VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES: {  // Covers VUID-VkPhysicalDeviceIDProperties-sType-sType
 
-            if (!IsExtEnabled(instance_extensions.vk_khr_external_fence_capabilities)) {
+            if (!IsExtEnabled(instance_extensions.vk_khr_external_fence_capabilities) &&
+                !IsExtEnabled(instance_extensions.vk_khr_external_memory_capabilities) &&
+                !IsExtEnabled(instance_extensions.vk_khr_external_semaphore_capabilities)) {
                 skip |= LogError(pnext_vuid, instance, loc.dot(Field::pNext),
                                  "includes a pointer to a VkStructureType (VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ID_PROPERTIES), but "
                                  "its parent extension "
-                                 "VK_KHR_external_fence_capabilities has not been enabled.");
+                                 "VK_KHR_external_fence_capabilities, VK_KHR_external_memory_capabilities, or "
+                                 "VK_KHR_external_semaphore_capabilities has not been enabled.");
             }
         } break;
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -96,14 +96,14 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_EXTERNAL_FENCE_CAPABILITIES_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_EXTERNAL_MEMORY_CAPABILITIES_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     if (DeviceValidationVersion() != VK_API_VERSION_1_0) {
-        GTEST_SKIP() << "Tests for 1.0 only";
+        GTEST_SKIP() << "Test's for 1.0 only";
     }
 
-    VkPhysicalDeviceIDProperties id_props =  vku::InitStructHelper();
+    VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
     vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
 }

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -533,18 +533,18 @@ TEST_F(VkLayerTest, SpecLinks) {
     CreateImageViewTest(*this, &imgViewInfo, "Vulkan-Docs/search");
 }
 
-TEST_F(VkLayerTest, DeviceIDPropertiesExtensions) {
-    TEST_DESCRIPTION("VkPhysicalDeviceIDProperties can be enabled from 1 of 3 extensions");
+TEST_F(VkLayerTest, DeviceIDPropertiesUnsupported) {
+    TEST_DESCRIPTION("VkPhysicalDeviceIDProperties cannot be used without extensions in 1.0");
 
     SetTargetApiVersion(VK_API_VERSION_1_0);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
     if (DeviceValidationVersion() != VK_API_VERSION_1_0) {
-        GTEST_SKIP() << "Tests for 1.0 only";
+        GTEST_SKIP() << "Test's for 1.0 only";
     }
 
-    VkPhysicalDeviceIDProperties id_props =  vku::InitStructHelper();
+    VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
     vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);


### PR DESCRIPTION
`VkPhysicalDeviceIDProperties` is provided from multiple extensions. Add handling of this cornercase into layers. Fix tests that were defective to discover it.