### PR TITLE
layers: Fix Shader Cache to account for settings

### DIFF
--- a/docs/shader_validation.md
+++ b/docs/shader_validation.md
@@ -12,6 +12,14 @@ VUIDs that can be validated on a single shader module and require no runtime inf
 
 All of these validations are passed off to `spirv-val` in [SPIRV-Tools](https://github.com/KhronosGroup/SPIRV-Tools/).
 
+## Validation Cache
+
+To improve performance from run-to-run we make use of the `VK_EXT_validation_cache` extension.
+
+During `vkCreateShaderModule` time the user can pass in a `VkShaderModuleValidationCacheCreateInfoEXT` object. Realistically, most apps will not do this, so the Validation Layers do this for apps. At `vkCreateDevice`/`vkDestroyDevice` we load/save a `uint32_t` hash of every `VkShaderModuleCreateInfo::pCode`. Before running validation on it, we check if it is a known/valid shader and if so, skip checking it again.
+
+There are a few settings in `spirv-val` (ex. you can use `--allow-localsizeid` with `VK_KHR_maintenance4`) that change if the `SPIR-V` is legal or not. Because of this, we use both the `SPIRV-Tools` commit version, as well as the device features/extensions, to determine if the cache is valid or not. In practice, it will not matter too much for real apps as they normally don't toggle these few features on/off between runs.
+
 ## spirv-opt
 
 There are a few special places where `spirv-opt` is run to reduce recreating work already done in `SPIRV-Tools`.
@@ -24,8 +32,8 @@ Currently these are
   - Some checks require the runtime spec constant values
 - Flatten OpGroupDecorations
   - Detects if group decorations were used; however, group decorations were [deprecated](https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#OpGroupDecorate) early on in the development of the SPIR-v specification.
-- GPU-AV and Debug Printf
-  - instruments the shaders - see [GPU-Assisted Validation](gpu_validation.md) and [GPU-AV Shader Instrumentation](gpu_av_shader_instrumentation.md).
+- Debug Printf
+  - instruments the shaders to write the `printf` values out to a buffer
 
 ## Different sections
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -25,6 +25,7 @@
 #include "error_message/error_location.h"
 #include "error_message/record_object.h"
 #include "containers/qfo_transfer.h"
+#include <spirv-tools/libspirv.hpp>
 
 typedef vvl::unordered_map<const vvl::Image*, std::optional<GlobalImageLayoutRangeMap>> GlobalImageLayoutMap;
 
@@ -55,6 +56,12 @@ class CoreChecks : public ValidationStateTracker {
     GlobalQFOTransferBarrierMap<QFOBufferTransferBarrier> qfo_release_buffer_barrier_map;
     VkValidationCacheEXT core_validation_cache = VK_NULL_HANDLE;
     std::string validation_cache_path;
+
+    // The options are set from extensions/features only, so only need ot create once.
+    // This also is needed for shader caching (You can have the same SPIR-V, but different Vulkan features making it legal/illegal
+    // the second time).
+    spvtools::ValidatorOptions spirv_val_options;
+    uint32_t spirv_val_option_hash;
 
     CoreChecks() { container_type = LayerObjectTypeCoreValidation; }
 

--- a/layers/gpu_validation/debug_printf.cpp
+++ b/layers/gpu_validation/debug_printf.cpp
@@ -89,7 +89,7 @@ bool debug_printf::Validator::InstrumentShader(const vvl::span<const uint32_t> &
     using namespace spvtools;
     spv_target_env target_env = PickSpirvEnv(api_version, IsExtEnabled(device_extensions.vk_khr_spirv_1_4));
     spvtools::ValidatorOptions val_options;
-    AdjustValidatorOptions(device_extensions, enabled_features, val_options);
+    AdjustValidatorOptions(device_extensions, enabled_features, val_options, nullptr);
     spvtools::OptimizerOptions opt_options;
     opt_options.set_run_validator(true);
     opt_options.set_validator_options(val_options);

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -24,6 +24,95 @@
 #include "generated/vk_extension_helper.h"
 #include "state_tracker/shader_module.h"
 #include "state_tracker/shader_instruction.h"
+#include "utils/hash_util.h"
+
+#include "generated/spirv_tools_commit_id.h"
+
+void ValidationCache::GetUUID(uint8_t *uuid) {
+    const char *sha1_str = SPIRV_TOOLS_COMMIT_ID;
+    // Convert sha1_str from a hex string to binary. We only need VK_UUID_SIZE bytes of
+    // output, so pad with zeroes if the input string is shorter than that, and truncate
+    // if it's longer.
+#if defined(__GNUC__) && (__GNUC__ > 8)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wstringop-truncation"
+#endif
+    char padded_sha1_str[2 * VK_UUID_SIZE + 1] = {};  // 2 hex digits == 1 byte
+    std::strncpy(padded_sha1_str, sha1_str, 2 * VK_UUID_SIZE);
+#if defined(__GNUC__) && (__GNUC__ > 8)
+#pragma GCC diagnostic pop
+#endif
+    for (uint32_t i = 0; i < VK_UUID_SIZE; ++i) {
+        const char byte_str[] = {padded_sha1_str[2 * i + 0], padded_sha1_str[2 * i + 1], '\0'};
+        uuid[i] = static_cast<uint8_t>(std::strtoul(byte_str, nullptr, 16));
+    }
+
+    // Replace the last 4 bytes (likely padded with zero anyway)
+    std::memcpy(uuid + (VK_UUID_SIZE - sizeof(uint32_t)), &spirv_val_option_hash_, sizeof(uint32_t));
+}
+
+void ValidationCache::Load(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
+    const auto headerSize = 2 * sizeof(uint32_t) + VK_UUID_SIZE;
+    auto size = headerSize;
+    if (!pCreateInfo->pInitialData || pCreateInfo->initialDataSize < size) return;
+
+    uint32_t const *data = (uint32_t const *)pCreateInfo->pInitialData;
+    if (data[0] != size) return;
+    if (data[1] != VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT) return;
+    uint8_t expected_uuid[VK_UUID_SIZE];
+    GetUUID(expected_uuid);
+    if (memcmp(&data[2], expected_uuid, VK_UUID_SIZE) != 0) return;  // different version
+
+    data = (uint32_t const *)(reinterpret_cast<uint8_t const *>(data) + headerSize);
+
+    auto guard = WriteLock();
+    for (; size < pCreateInfo->initialDataSize; data++, size += sizeof(uint32_t)) {
+        good_shader_hashes_.insert(*data);
+    }
+}
+
+void ValidationCache::Write(size_t *pDataSize, void *pData) {
+    const auto headerSize = 2 * sizeof(uint32_t) + VK_UUID_SIZE;  // 4 bytes for header size + 4 bytes for version number + UUID
+    if (!pData) {
+        *pDataSize = headerSize + good_shader_hashes_.size() * sizeof(uint32_t);
+        return;
+    }
+
+    if (*pDataSize < headerSize) {
+        *pDataSize = 0;
+        return;  // Too small for even the header!
+    }
+
+    uint32_t *out = (uint32_t *)pData;
+    size_t actualSize = headerSize;
+
+    // Write the header
+    *out++ = headerSize;
+    *out++ = VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT;
+    GetUUID(reinterpret_cast<uint8_t *>(out));
+    out = (uint32_t *)(reinterpret_cast<uint8_t *>(out) + VK_UUID_SIZE);
+
+    {
+        auto guard = ReadLock();
+        for (auto it = good_shader_hashes_.begin(); it != good_shader_hashes_.end() && actualSize < *pDataSize;
+             it++, out++, actualSize += sizeof(uint32_t)) {
+            *out = *it;
+        }
+    }
+
+    *pDataSize = actualSize;
+}
+
+void ValidationCache::Merge(ValidationCache const *other) {
+    // self-merging is invalid, but avoid deadlock below just in case.
+    if (other == this) {
+        return;
+    }
+    auto other_guard = other->ReadLock();
+    auto guard = WriteLock();
+    good_shader_hashes_.reserve(good_shader_hashes_.size() + other->good_shader_hashes_.size());
+    for (auto h : other->good_shader_hashes_) good_shader_hashes_.insert(h);
+}
 
 spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4) {
     if (api_version >= VK_API_VERSION_1_3) {
@@ -42,36 +131,53 @@ spv_target_env PickSpirvEnv(const APIVersion &api_version, bool spirv_1_4) {
 
 // Some Vulkan extensions/features are just all done in spirv-val behind optional settings
 void AdjustValidatorOptions(const DeviceExtensions &device_extensions, const DeviceFeatures &enabled_features,
-                            spvtools::ValidatorOptions &options) {
+                            spvtools::ValidatorOptions &out_options, uint32_t *out_hash) {
+    struct Settings {
+        bool relax_block_layout;
+        bool uniform_buffer_standard_layout;
+        bool scalar_block_layout;
+        bool workgroup_scalar_block_layout;
+        bool allow_local_size_id;
+    } settings;
+
     // VK_KHR_relaxed_block_layout never had a feature bit so just enabling the extension allows relaxed layout
     // Was promotoed in Vulkan 1.1 so anyone using Vulkan 1.1 also gets this for free
-    if (IsExtEnabled(device_extensions.vk_khr_relaxed_block_layout)) {
-        // --relax-block-layout
-        options.SetRelaxBlockLayout(true);
-    }
-
+    settings.relax_block_layout = IsExtEnabled(device_extensions.vk_khr_relaxed_block_layout);
     // The rest of the settings are controlled from a feature bit, which are set correctly in the state tracking. Regardless of
     // Vulkan version used, the feature bit is needed (also described in the spec).
+    settings.uniform_buffer_standard_layout = enabled_features.uniformBufferStandardLayout == VK_TRUE;
+    settings.scalar_block_layout = enabled_features.scalarBlockLayout == VK_TRUE;
+    settings.workgroup_scalar_block_layout = enabled_features.workgroupMemoryExplicitLayoutScalarBlockLayout == VK_TRUE;
+    settings.allow_local_size_id = enabled_features.maintenance4 == VK_TRUE;
 
-    if (enabled_features.uniformBufferStandardLayout == VK_TRUE) {
+    if (settings.relax_block_layout) {
+        // --relax-block-layout
+        out_options.SetRelaxBlockLayout(true);
+    }
+    if (settings.uniform_buffer_standard_layout) {
         // --uniform-buffer-standard-layout
-        options.SetUniformBufferStandardLayout(true);
+        out_options.SetUniformBufferStandardLayout(true);
     }
-    if (enabled_features.scalarBlockLayout == VK_TRUE) {
+    if (settings.scalar_block_layout) {
         // --scalar-block-layout
-        options.SetScalarBlockLayout(true);
+        out_options.SetScalarBlockLayout(true);
     }
-    if (enabled_features.workgroupMemoryExplicitLayoutScalarBlockLayout) {
+    if (settings.workgroup_scalar_block_layout) {
         // --workgroup-scalar-block-layout
-        options.SetWorkgroupScalarBlockLayout(true);
+        out_options.SetWorkgroupScalarBlockLayout(true);
     }
-    if (enabled_features.maintenance4) {
+    if (settings.allow_local_size_id) {
         // --allow-localsizeid
-        options.SetAllowLocalSizeId(true);
+        out_options.SetAllowLocalSizeId(true);
     }
 
     // Faster validation without friendly names.
-    options.SetFriendlyNames(false);
+    out_options.SetFriendlyNames(false);
+
+    // The spv_validator_options_t in libspirv.h is hidden so we can't just hash that struct, so instead need to create our own.
+    if (out_hash) {
+        *out_hash = hash_util::ShaderHash(&settings, sizeof(Settings));
+    }
 }
 
 void GetActiveSlots(ActiveSlotMap &active_slots, const std::shared_ptr<const spirv::EntryPoint> &entrypoint) {

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include "spirv-tools/libspirv.h"
-#include "glslang/Public/ShaderLang.h"
+#include <spirv-tools/libspirv.hpp>
+#include <glslang/Public/ShaderLang.h>
 
 #include "render.h"
 #include "test_framework.h"

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -17,8 +17,8 @@
  */
 #pragma once
 
-#include "spirv-tools/libspirv.h"
-#include "glslang/Public/ShaderLang.h"
+#include <spirv-tools/libspirv.hpp>
+#include <glslang/Public/ShaderLang.h>
 #include "test_common.h"
 
 #include <fstream>

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -2268,3 +2268,40 @@ TEST_F(NegativeShaderSpirv, FPFastMathMode) {
     VkShaderObj cs(this, spv_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativeShaderSpirv, ScalarBlockLayoutShaderCache) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8031");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddDisabledFeature(vkt::Feature::scalarBlockLayout);  // will NOT set --scalar-block-layout
+    RETURN_IF_SKIP(Init());
+
+    // Matches glsl from other ScalarBlockLayoutShaderCache test
+    char const *cs_source = R"glsl(
+        #version 460
+        #extension GL_EXT_buffer_reference : require
+        #extension GL_EXT_scalar_block_layout : require
+
+        struct Transform {
+            mat3x3 rotScaMatrix; //  0, 36
+            vec3 pos;            // 36, 12
+            vec3 pos_err;        // 48, 12
+            float padding;       // 60, 4
+        };
+
+        layout(scalar, buffer_reference, buffer_reference_align = 64) readonly buffer Transforms {
+            Transform transforms[];
+        };
+        layout(std430, push_constant) uniform PushConstant {
+            Transforms pTransforms;
+        };
+
+        void main() {
+            Transform transform = pTransforms.transforms[0];
+        }
+    )glsl";
+
+    m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08737");
+    VkShaderObj cs(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8031

Before we cached the `spirv-val` run by the version of `SPIRV-Tools`, but as shown from the tests added, the output of `spirv-val` is determined by the `spvtools::ValidatorOptions` we pass in, so we need to also account for that when handling the caching