### PR TITLE
layers: Add Shader Val Cache for ShaderObject

### DIFF
--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -288,16 +288,8 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
         }
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
 
-        const uint32_t hash = cache ? hash_util::ShaderHash(create_info.pCode, create_info.codeSize) : 0;
-        if (!cache || !cache->Contains(hash)) {
-            spv_const_binary_t binary{static_cast<const uint32_t*>(create_info.pCode), create_info.codeSize / sizeof(uint32_t)};
-            skip |= RunSpirvValidation(binary, create_info_loc);
-        }
-
-        // No point to cache anything that is not valid
-        if (!skip && cache) {
-            cache->Insert(hash);
-        }
+        spv_const_binary_t binary{static_cast<const uint32_t*>(create_info.pCode), create_info.codeSize / sizeof(uint32_t)};
+        skip |= RunSpirvValidation(binary, create_info_loc, cache);
 
         const StageCreateInfo stage_create_info(pCreateInfos[i]);
         const auto spirv = std::make_shared<spirv::Module>(create_info.codeSize, static_cast<const uint32_t*>(create_info.pCode));

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -596,7 +596,7 @@ class CoreChecks : public ValidationStateTracker {
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
                                        const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
                                        const RecordObject& record_obj, chassis::ShaderObject& chassis_state) override;
-    bool RunSpirvValidation(spv_const_binary_t& binary, const Location& loc) const;
+    bool RunSpirvValidation(spv_const_binary_t& binary, const Location& loc, ValidationCache* cache) const;
     bool ValidateSpirvStateless(const spirv::Module& module_state, const spirv::StatelessData& stateless_data,
                                 const Location& loc) const;
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -588,6 +588,8 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                                                VkShaderModuleIdentifierEXT* pIdentifier,
                                                                const ErrorObject& error_obj) const override;
+    bool ValidateCreateShadersLinking(uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
+                                      const Location& loc) const;
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                          const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                          const RecordObject& record_obj, chassis::CreateShaderModule& chassis_state) override;


### PR DESCRIPTION
Adds `ValidationCache` to Shader Object so we don't repeat running `spirv-val` on binaries across multiple runs