### PR TITLE
layers: Cleanup Pipeline and ShaderObject Drawtime

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -207,6 +207,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto& last_bound = cmd_state.lastBound[lv_bind_point];
     const auto* pipeline_state = last_bound.pipeline_state;
+    if (!pipeline_state) return skip;
 
     const auto* ia_state = pipeline_state->InputAssemblyState();
     if (ia_state) {
@@ -214,7 +215,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
     }
 
     // no point checking index buffer if the memory is nonexistant/unmapped, or if there is no graphics pipeline bound to this CB
-    if (ib_mem && last_bound.IsUsing()) {
+    if (ib_mem) {
         const uint32_t scan_stride = GetIndexAlignment(ib_type);
         const uint8_t* scan_begin = static_cast<const uint8_t*>(ib_mem) + firstIndex * scan_stride;
         const uint8_t* scan_end = scan_begin + indexCount * scan_stride;

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1606,7 +1606,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
     return skip;
 }
 
-bool CoreChecks::ValidateRayTracingDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const {
+bool CoreChecks::ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const {
     bool skip = false;
     const vvl::CommandBuffer& cb_state = last_bound_state.cb_state;
     const vvl::Pipeline& pipeline = *last_bound_state.pipeline_state;

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1545,16 +1545,18 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
     }
     if (!phys_dev_ext_props.fragment_shading_rate_props.primitiveFragmentShadingRateWithMultipleViewports) {
         for (uint32_t stage = 0; stage < kShaderObjectStageCount; ++stage) {
-            const auto shader_stage = last_bound_state.GetShaderState(static_cast<ShaderObjectStage>(stage));
-            if (shader_stage && shader_stage->entrypoint && shader_stage->entrypoint->written_builtin_primitive_shading_rate_khr) {
+            const auto shader_object = last_bound_state.GetShaderState(static_cast<ShaderObjectStage>(stage));
+            if (shader_object && shader_object->entrypoint &&
+                shader_object->entrypoint->written_builtin_primitive_shading_rate_khr) {
                 skip |= ValidateDynamicStateIsSet(cb_state.dynamic_state_status.cb, CB_DYNAMIC_STATE_VIEWPORT_WITH_COUNT, cb_state,
                                                   objlist, loc, vuid.set_viewport_with_count_08642);
                 if (cb_state.dynamic_state_value.viewport_count != 1) {
-                    skip |= LogError(
-                        vuid.set_viewport_with_count_08642, cb_state.Handle(), loc,
-                        "primitiveFragmentShadingRateWithMultipleViewports is not supported and shader stage %s uses "
-                        "PrimitiveShadingRateKHR, but viewportCount set with vkCmdSetViewportWithCount was %" PRIu32 ".",
-                        string_VkShaderStageFlagBits(shader_stage->create_info.stage), cb_state.dynamic_state_value.viewport_count);
+                    skip |=
+                        LogError(vuid.set_viewport_with_count_08642, cb_state.Handle(), loc,
+                                 "primitiveFragmentShadingRateWithMultipleViewports is not supported and shader stage %s uses "
+                                 "PrimitiveShadingRateKHR, but viewportCount set with vkCmdSetViewportWithCount was %" PRIu32 ".",
+                                 string_VkShaderStageFlagBits(shader_object->create_info.stage),
+                                 cb_state.dynamic_state_value.viewport_count);
                 }
                 break;
             }

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -371,7 +371,7 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                 }
             }
 
-            if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS && cb_state->GetCurrentPipeline(pipelineBindPoint) &&
+            if (cb_state->GetCurrentPipeline(pipelineBindPoint) &&
                 pipeline == cb_state->GetCurrentPipeline(pipelineBindPoint)->VkHandle() && cb_state->dirtyStaticState &&
                 IsBeforeCtsVersion(1, 3, 8)) {
                 const LogObjectList objlist(commandBuffer, pipeline);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -78,7 +78,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index, const Location& loc) const;
     bool ValidateMultiViewShaders(const vvl::Pipeline& pipeline, const Location& multiview_loc, uint32_t view_mask,
                                   bool dynamic_rendering) const;
-    bool ValidateVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline, const Location& loc,
+    bool ValidateVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
                                  const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipeline(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
@@ -94,21 +94,19 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDynamicStateIsSet(const CBDynamicFlags& state_status_cb, CBDynamicState dynamic_state,
                                    const vvl::CommandBuffer& cb_state, const LogObjectList& objlist, const Location& loc,
                                    const char* vuid) const;
-    bool ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateGraphicsDynamicStateValue(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateGraphicsDynamicStateViewportScissor(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateDrawDynamicState(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateDrawDynamicStatePipeline(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateDrawDynamicStateShaderObject(const LastBound& last_bound_state, const Location& loc) const;
+    bool ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateGraphicsDynamicStateValue(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateGraphicsDynamicStateViewportScissor(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawDynamicState(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawDynamicStatePipeline(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawDynamicStateShaderObject(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawRenderingAttachmentLocation(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline_state,
-                                                 const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
+                                                 const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline_state,
-                                                   const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
-    bool ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateDrawPrimitivesGeneratedQuery(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid,
-                                              const Location& loc) const;
-    bool ValidateDrawProtectedMemory(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid,
-                                     const Location& loc) const;
+                                                   const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPrimitivesGeneratedQuery(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawProtectedMemory(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateStageMaskHost(const LogObjectList& objlist, const Location& stage_mask_loc,
                                VkPipelineStageFlags2KHR stageMask) const;
     bool ValidateMapMemory(const vvl::DeviceMemory& mem_info, VkDeviceSize offset, VkDeviceSize size, const Location& offset_loc,
@@ -434,7 +432,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateIndirectCountCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& count_buffer_state,
                                   VkDeviceSize count_buffer_offset, const Location& loc) const;
     bool ValidateCmdDrawFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
-                                    const vvl::DrawDispatchVuid& vuid, const Location& loc) const;
+                                    const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
                                                       const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                       const Location& attachment_loc, const Location& rendering_info_loc) const;
@@ -484,25 +482,24 @@ class CoreChecks : public ValidationStateTracker {
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
     bool ValidatePipelineRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
-                                        const Location& loc) const;
+                                        const vvl::DrawDispatchVuid& vuid) const;
     bool ValidatePipelineDynamicRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
-                                               const Location& loc) const;
+                                               const vvl::DrawDispatchVuid& vuid) const;
     bool ValidatePipelineDynamicRenderpassSampleCount(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
-                                                      const Location& loc) const;
-    bool ValidatePipelineDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline, const Location& loc) const;
+                                                      const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipeline(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                              const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateShaderObjectBoundShader(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
-                                         const Location& loc) const;
-    bool ValidateShaderObjectDraw(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateShaderObjectDrawMesh(const LastBound& last_bound_state, const Location& loc) const;
+                                         const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawShaderObject(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawShaderObjectMesh(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
     bool ValidateActionStateDescriptors(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
-                                        const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid,
-                                        const Location& loc) const;
+                                        const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStatePushConstant(const LastBound& last_bound_state, const vvl::Pipeline* pipeline,
-                                         const vvl::DrawDispatchVuid& vuid, const Location& loc) const;
+                                         const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateProtectedMemory(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
-                                            const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid,
-                                            const Location& loc) const;
+                                            const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid) const;
     static bool ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::CommandBuffer& cb_state, size_t eventCount,
                                            size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
                                            const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc);
@@ -572,7 +569,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineRenderPass(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineLibrary(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineFragmentShadingRateDraw(const vvl::Pipeline& pipeline, const vvl::CommandBuffer& cb_state,
-                                                         const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
+                                                         const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineTessellationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -492,6 +492,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateShaderObjectBoundShader(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
                                          const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObject(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawShaderObjectLinking(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectMesh(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
     bool ValidateActionStateDescriptors(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -78,8 +78,8 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateGraphicsPipelineDerivatives(PipelineStates& pipeline_states, uint32_t pipe_index, const Location& loc) const;
     bool ValidateMultiViewShaders(const vvl::Pipeline& pipeline, const Location& multiview_loc, uint32_t view_mask,
                                   bool dynamic_rendering) const;
-    bool ValidateVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
-                                 const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipelineVertexAttribute(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                             const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipeline(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidImageBufferQueue(const vvl::CommandBuffer& cb_state, const VulkanTypedHandle& object, uint32_t queueFamilyIndex,
                                uint32_t count, const uint32_t* indices, const Location& loc) const;
@@ -431,8 +431,14 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateIndirectCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& buffer_state, const Location& loc) const;
     bool ValidateIndirectCountCmd(const vvl::CommandBuffer& cb_state, const vvl::Buffer& count_buffer_state,
                                   VkDeviceSize count_buffer_offset, const Location& loc) const;
-    bool ValidateCmdDrawFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
-                                    const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipelineFramebuffer(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                         const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipelineVertexBinding(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                           const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipelineFragmentShadingRate(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline,
+                                                 const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawPipelineRasterizationState(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                                                const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateMultisampledRenderToSingleSampleView(VkCommandBuffer commandBuffer, const vvl::ImageView& image_view_state,
                                                       const VkMultisampledRenderToSingleSampledInfoEXT& msrtss_info,
                                                       const Location& attachment_loc, const Location& rendering_info_loc) const;
@@ -481,9 +487,9 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
-    bool ValidatePipelineRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+    bool ValidateDrawPipelineRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                         const vvl::DrawDispatchVuid& vuid) const;
-    bool ValidatePipelineDynamicRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+    bool ValidateDrawPipelineDynamicRenderpass(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                const vvl::DrawDispatchVuid& vuid) const;
     bool ValidatePipelineDynamicRenderpassSampleCount(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
                                                       const vvl::DrawDispatchVuid& vuid) const;
@@ -570,8 +576,6 @@ class CoreChecks : public ValidationStateTracker {
                                            const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineRenderPass(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineLibrary(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
-    bool ValidateGraphicsPipelineFragmentShadingRateDraw(const vvl::Pipeline& pipeline, const vvl::CommandBuffer& cb_state,
-                                                         const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineTessellationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -104,7 +104,11 @@ class CoreChecks : public ValidationStateTracker {
                                                  const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawRenderingInputAttachmentIndex(const vvl::CommandBuffer& cb_state, const vvl::Pipeline& pipeline_state,
                                                    const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
-    bool ValidateRayTracingDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const;
+    bool ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bound_state, const Location& loc) const;
+    bool ValidateDrawPrimitivesGeneratedQuery(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid,
+                                              const Location& loc) const;
+    bool ValidateDrawProtectedMemory(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid,
+                                     const Location& loc) const;
     bool ValidateStageMaskHost(const LogObjectList& objlist, const Location& stage_mask_loc,
                                VkPipelineStageFlags2KHR stageMask) const;
     bool ValidateMapMemory(const vvl::DeviceMemory& mem_info, VkDeviceSize offset, VkDeviceSize size, const Location& offset_loc,
@@ -479,12 +483,26 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidatePrimaryCommandBufferState(const Location& loc, const vvl::CommandBuffer& cb_state, uint32_t current_submit_count,
                                            QFOTransferCBScoreboards<QFOImageTransferBarrier>* qfo_image_scoreboards,
                                            QFOTransferCBScoreboards<QFOBufferTransferBarrier>* qfo_buffer_scoreboards) const;
-    bool ValidatePipelineRenderpassDraw(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidatePipelineDynamicRenderpassDraw(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidatePipelineDrawtimeState(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateShaderObjectDrawtimeState(const LastBound& last_bound_state, const Location& loc) const;
-    bool ValidateShaderObjectGraphicsDrawtimeState(const LastBound& last_bound_state, const Location& loc) const;
+    bool ValidatePipelineRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                                        const Location& loc) const;
+    bool ValidatePipelineDynamicRenderpassDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                                               const Location& loc) const;
+    bool ValidatePipelineDynamicRenderpassSampleCount(const LastBound& last_bound_state, const vvl::Pipeline& pipeline,
+                                                      const Location& loc) const;
+    bool ValidatePipelineDraw(const LastBound& last_bound_state, const vvl::Pipeline& pipeline, const Location& loc) const;
+    bool ValidateShaderObjectBoundShader(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                         const Location& loc) const;
+    bool ValidateShaderObjectDraw(const LastBound& last_bound_state, const Location& loc) const;
+    bool ValidateShaderObjectDrawMesh(const LastBound& last_bound_state, const Location& loc) const;
     bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
+    bool ValidateActionStateDescriptors(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                        const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid,
+                                        const Location& loc) const;
+    bool ValidateActionStatePushConstant(const LastBound& last_bound_state, const vvl::Pipeline* pipeline,
+                                         const vvl::DrawDispatchVuid& vuid, const Location& loc) const;
+    bool ValidateActionStateProtectedMemory(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                            const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid,
+                                            const Location& loc) const;
     static bool ValidateWaitEventsAtSubmit(vvl::Func command, const vvl::CommandBuffer& cb_state, size_t eventCount,
                                            size_t firstEventIndex, VkPipelineStageFlags2 sourceStageMask,
                                            const EventMap& local_event_signal_info, VkQueue waiting_queue, const Location& loc);
@@ -500,7 +518,7 @@ class CoreChecks : public ValidationStateTracker {
     // For given bindings validate state at time of draw is correct, returning false on error and writing error details into string*
     bool ValidateDrawState(const vvl::DescriptorSet& descriptor_set, uint32_t set_index, const BindingVariableMap& bindings,
                            const std::vector<uint32_t>& dynamic_offsets, const vvl::CommandBuffer& cb_state, const Location& loc,
-                           const vvl::DrawDispatchVuid& vuids) const;
+                           const vvl::DrawDispatchVuid& vuid) const;
 
     bool VerifySetLayoutCompatibility(const vvl::DescriptorSetLayout& layout_dsl,
                                       const vvl::DescriptorSetLayout& bound_dsl, std::string& error_msg) const;
@@ -553,8 +571,8 @@ class CoreChecks : public ValidationStateTracker {
                                            const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineRenderPass(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineLibrary(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
-    bool ValidateGraphicsPipelineShaderDynamicState(const vvl::Pipeline& pipeline, const vvl::CommandBuffer& cb_state,
-                                                    const Location& loc, const vvl::DrawDispatchVuid& vuids) const;
+    bool ValidateGraphicsPipelineFragmentShadingRateDraw(const vvl::Pipeline& pipeline, const vvl::CommandBuffer& cb_state,
+                                                         const Location& loc, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsPipelineBlendEnable(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineInputAssemblyState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineTessellationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -22,7 +22,7 @@
 namespace vvl {
 // clang-format off
 struct DispatchVuidsCmdDraw : DrawDispatchVuid {
-    DispatchVuidsCmdDraw() : DrawDispatchVuid() {
+    DispatchVuidsCmdDraw() : DrawDispatchVuid(Func::vkCmdDraw) {
         pipeline_bound_08606                     = "VUID-vkCmdDraw-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDraw-None-08607";
         vertex_binding_04007                     = "VUID-vkCmdDraw-None-04007";
@@ -338,7 +338,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
-    DispatchVuidsCmdDrawMultiEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMultiEXT() : DrawDispatchVuid(Func::vkCmdDrawMultiEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMultiEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMultiEXT-None-08607";
         vertex_binding_04007                     = "VUID-vkCmdDrawMultiEXT-None-04007";
@@ -654,7 +654,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndexed() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndexed() : DrawDispatchVuid(Func::vkCmdDrawIndexed) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndexed-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndexed-None-08607";
         index_binding_07312                      = "VUID-vkCmdDrawIndexed-None-07312";
@@ -971,7 +971,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
-    DispatchVuidsCmdDrawMultiIndexedEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMultiIndexedEXT() : DrawDispatchVuid(Func::vkCmdDrawMultiIndexedEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMultiIndexedEXT-None-08607";
         index_binding_07312                      = "VUID-vkCmdDrawMultiIndexedEXT-None-07312";
@@ -1288,7 +1288,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndirect() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndirect() : DrawDispatchVuid(Func::vkCmdDrawIndirect) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndirect-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndirect-None-08607";
         vertex_binding_04007                     = "VUID-vkCmdDrawIndirect-None-04007";
@@ -1603,7 +1603,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndexedIndirect() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndexedIndirect() : DrawDispatchVuid(Func::vkCmdDrawIndexedIndirect) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndexedIndirect-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndexedIndirect-None-08607";
         index_binding_07312                      = "VUID-vkCmdDrawIndexedIndirect-None-07312";
@@ -1919,7 +1919,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
-    DispatchVuidsCmdDispatch() : DrawDispatchVuid() {
+    DispatchVuidsCmdDispatch() : DrawDispatchVuid(Func::vkCmdDispatch) {
         pipeline_bound_08606                     = "VUID-vkCmdDispatch-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDispatch-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDispatch-None-08600";
@@ -1967,7 +1967,7 @@ struct DispatchVuidsCmdDispatch : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
-    DispatchVuidsCmdDispatchIndirect() : DrawDispatchVuid() {
+    DispatchVuidsCmdDispatchIndirect() : DrawDispatchVuid(Func::vkCmdDispatchIndirect) {
         pipeline_bound_08606                     = "VUID-vkCmdDispatchIndirect-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDispatchIndirect-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDispatchIndirect-None-08600";
@@ -2016,7 +2016,7 @@ struct DispatchVuidsCmdDispatchIndirect : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndirectCount() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndirectCount() : DrawDispatchVuid(Func::vkCmdDrawIndirectCount) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndirectCount-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndirectCount-None-08607";
         vertex_binding_04007                     = "VUID-vkCmdDrawIndirectCount-None-04007";
@@ -2334,7 +2334,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndexedIndirectCount() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndexedIndirectCount() : DrawDispatchVuid(Func::vkCmdDrawIndexedIndirectCount) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndexedIndirectCount-None-08607";
         index_binding_07312                      = "VUID-vkCmdDrawIndexedIndirectCount-None-07312";
@@ -2653,7 +2653,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
-    DispatchVuidsCmdTraceRaysNV() : DrawDispatchVuid() {
+    DispatchVuidsCmdTraceRaysNV() : DrawDispatchVuid(Func::vkCmdTraceRaysNV) {
         pipeline_bound_08606                     = "VUID-vkCmdTraceRaysNV-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdTraceRaysNV-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdTraceRaysNV-None-08600";
@@ -2701,7 +2701,7 @@ struct DispatchVuidsCmdTraceRaysNV: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
-    DispatchVuidsCmdTraceRaysKHR() : DrawDispatchVuid() {
+    DispatchVuidsCmdTraceRaysKHR() : DrawDispatchVuid(Func::vkCmdTraceRaysKHR) {
         pipeline_bound_08606                     = "VUID-vkCmdTraceRaysKHR-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdTraceRaysKHR-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdTraceRaysKHR-None-08600";
@@ -2749,7 +2749,7 @@ struct DispatchVuidsCmdTraceRaysKHR: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
-    DispatchVuidsCmdTraceRaysIndirectKHR() : DrawDispatchVuid() {
+    DispatchVuidsCmdTraceRaysIndirectKHR() : DrawDispatchVuid(Func::vkCmdTraceRaysIndirectKHR) {
         pipeline_bound_08606                     = "VUID-vkCmdTraceRaysIndirectKHR-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdTraceRaysIndirectKHR-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdTraceRaysIndirectKHR-None-08600";
@@ -2799,7 +2799,7 @@ struct DispatchVuidsCmdTraceRaysIndirectKHR: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
-    DispatchVuidsCmdTraceRaysIndirect2KHR() : DrawDispatchVuid() {
+    DispatchVuidsCmdTraceRaysIndirect2KHR() : DrawDispatchVuid(Func::vkCmdTraceRaysIndirect2KHR) {
         pipeline_bound_08606                     = "VUID-vkCmdTraceRaysIndirect2KHR-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdTraceRaysIndirect2KHR-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdTraceRaysIndirect2KHR-None-08600";
@@ -2849,7 +2849,7 @@ struct DispatchVuidsCmdTraceRaysIndirect2KHR: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksNV() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksNV() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksNV) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksNV-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksNV-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksNV-None-08600";
@@ -3148,7 +3148,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksIndirectNV() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksIndirectNV() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksIndirectNV) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08600";
@@ -3450,7 +3450,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksIndirectCountNV() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksIndirectCountNV() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksIndirectCountNV) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08600";
@@ -3755,7 +3755,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksEXT() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksEXT-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksEXT-None-08600";
@@ -4054,7 +4054,7 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksIndirectEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksIndirectEXT() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksIndirectEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08600";
@@ -4356,7 +4356,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
-    DispatchVuidsCmdDrawMeshTasksIndirectCountEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawMeshTasksIndirectCountEXT() : DrawDispatchVuid(Func::vkCmdDrawMeshTasksIndirectCountEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08600";
@@ -4661,7 +4661,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
-    DispatchVuidsCmdDrawIndirectByteCountEXT() : DrawDispatchVuid() {
+    DispatchVuidsCmdDrawIndirectByteCountEXT() : DrawDispatchVuid(Func::vkCmdDrawIndirectByteCountEXT) {
         pipeline_bound_08606                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDrawIndirectByteCountEXT-None-08607";
         vertex_binding_04007                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-04007";
@@ -4976,7 +4976,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
 };
 
 struct DispatchVuidsCmdDispatchBase: DrawDispatchVuid {
-    DispatchVuidsCmdDispatchBase() : DrawDispatchVuid() {
+    DispatchVuidsCmdDispatchBase() : DrawDispatchVuid(Func::vkCmdDispatchBase) {
         pipeline_bound_08606                     = "VUID-vkCmdDispatchBase-None-08606";
         pipeline_or_shaders_bound_08607          = "VUID-vkCmdDispatchBase-None-08607";
         compatible_pipeline_08600                = "VUID-vkCmdDispatchBase-None-08600";
@@ -5052,7 +5052,7 @@ static const std::map<Func, DrawDispatchVuid> kDrawdispatchVuid = {
     {Func::vkCmdDispatchBase, DispatchVuidsCmdDispatchBase()},
     {Func::vkCmdDispatchBaseKHR, DispatchVuidsCmdDispatchBase()},
     // Used if invalid function is used
-    {Func::Empty, DrawDispatchVuid()}
+    {Func::Empty, DrawDispatchVuid(Func::Empty)}
 };
 // clang-format on
 

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -25,6 +25,11 @@ namespace vvl {
 
 // Set of VUID that need to go between drawdispatch_validation.cpp and rest of CoreChecks
 struct DrawDispatchVuid {
+    // Save the action command here for reverse lookup so don't need to pass around both items
+    const Func function;
+    DrawDispatchVuid(Func func) : function(func){};
+    Location loc() const { return Location(function); }
+
     const char* pipeline_bound_08606 = kVUIDUndefined;
     const char* pipeline_or_shaders_bound_08607 = kVUIDUndefined;
     const char* index_binding_07312 = kVUIDUndefined;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1815,9 +1815,7 @@ void CommandBuffer::GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipel
                                                        const std::vector<LastBound::PER_SET> **rtn_sets) const {
     const auto lv_bind_point = ConvertToLvlBindPoint(pipelineBindPoint);
     const auto &last_bound = lastBound[lv_bind_point];
-    if (!last_bound.IsUsing()) {
-        return;
-    }
+    if (!last_bound.pipeline_state) return;
     *rtn_pipe = last_bound.pipeline_state;
     *rtn_sets = &(last_bound.per_set);
 }

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -833,7 +833,7 @@ void LastBound::Reset() {
 }
 
 bool LastBound::IsDepthTestEnable() const {
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE)) {
         return cb_state.dynamic_state_value.depth_test_enable;
     } else {
         if (pipeline_state->DepthStencilState()) {
@@ -844,7 +844,7 @@ bool LastBound::IsDepthTestEnable() const {
 }
 
 bool LastBound::IsDepthBoundTestEnable() const {
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)) {
         return cb_state.dynamic_state_value.depth_bounds_test_enable;
     } else {
         if (pipeline_state->DepthStencilState()) {
@@ -859,12 +859,13 @@ bool LastBound::IsDepthWriteEnable() const {
     if (!IsDepthTestEnable()) {
         return false;
     }
-    return pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE) ? cb_state.dynamic_state_value.depth_write_enable
-                                                                          : pipeline_state->DepthStencilState()->depthWriteEnable;
+    return (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE))
+               ? cb_state.dynamic_state_value.depth_write_enable
+               : pipeline_state->DepthStencilState()->depthWriteEnable;
 }
 
 bool LastBound::IsStencilTestEnable() const {
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE)) {
         return cb_state.dynamic_state_value.stencil_test_enable;
     } else {
         if (pipeline_state->DepthStencilState()) {
@@ -903,7 +904,7 @@ VkStencilOpState LastBound::GetStencilOpStateBack() const {
 VkSampleCountFlagBits LastBound::GetRasterizationSamples() const {
     // For given pipeline, return number of MSAA samples, or one if MSAA disabled
     VkSampleCountFlagBits rasterization_samples = VK_SAMPLE_COUNT_1_BIT;
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT)) {
         rasterization_samples = cb_state.dynamic_state_value.rasterization_samples;
     } else {
         const auto ms_state = pipeline_state->MultisampleState();
@@ -915,13 +916,13 @@ VkSampleCountFlagBits LastBound::GetRasterizationSamples() const {
 }
 
 bool LastBound::IsRasterizationDisabled() const {
-    return pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)
+    return (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE))
                ? cb_state.dynamic_state_value.rasterizer_discard_enable
                : pipeline_state->RasterizationDisabled();
 }
 
 VkColorComponentFlags LastBound::GetColorWriteMask(uint32_t i) const {
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT)) {
         if (i < cb_state.dynamic_state_value.color_write_masks.size()) {
             return cb_state.dynamic_state_value.color_write_masks[i];
         }
@@ -934,7 +935,7 @@ VkColorComponentFlags LastBound::GetColorWriteMask(uint32_t i) const {
 }
 
 bool LastBound::IsColorWriteEnabled(uint32_t i) const {
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT)) {
         return cb_state.dynamic_state_value.color_write_enabled[i];
     } else {
         if (pipeline_state->ColorBlendState()) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -675,8 +675,6 @@ struct LastBound {
 
     void UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorSet> &&ds);
 
-    inline bool IsUsing() const { return pipeline_state != nullptr; }
-
     // Dynamic State helpers that require both the Pipeline and CommandBuffer state are here
     bool IsDepthTestEnable() const;
     bool IsDepthBoundTestEnable() const;

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -309,6 +309,23 @@ TEST_F(NegativePipeline, BadPipelineObject) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativePipeline, NoPipelineDynamicState) {
+    TEST_DESCRIPTION("Call vkCmdDraw when there are no shaders or pipeline bound.");
+    SetTargetApiVersion(VK_API_VERSION_1_3);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+    InitDynamicRenderTarget();
+
+    m_commandBuffer->begin();
+    m_commandBuffer->BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08606");
+    vk::CmdDraw(m_commandBuffer->handle(), 4, 1, 0, 0);
+    m_errorMonitor->VerifyFound();
+    m_commandBuffer->EndRendering();
+    m_commandBuffer->end();
+}
+
 TEST_F(NegativePipeline, ShaderStageName) {
     TEST_DESCRIPTION("Create Pipelines with invalid state set");
 


### PR DESCRIPTION
There was a lot of churn from when we added Shader Object as well as more and more things being moved to draw time... this cleans things up

- Moves things out to functions to avoid massive mega-functions
- For things we know for sure are Pipeline, deference it and pass it around so it is clear we have broke off from the Shader Object code paths
- Consistent naming of functions (ex. `ValidateDraw*`) for draw time things (which implies graphics pipeline bind point)
- Pass around the `vvl::DrawDispatchVuid` instead of `Location` AND `vvl::DrawDispatchVuid` (since we never go more then just the function for that location)