### PR TITLE
layers: Retire present operation when waiting on present fence

### DIFF
--- a/layers/gpu_validation/gpu_state_tracker.cpp
+++ b/layers/gpu_validation/gpu_state_tracker.cpp
@@ -119,7 +119,7 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
     }
 }
 
-uint64_t Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
+vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
     for (const auto &submission : submissions) {
         for (auto &cb : submission.cbs) {
             auto gpu_cb = std::static_pointer_cast<CommandBuffer>(cb);

--- a/layers/gpu_validation/gpu_state_tracker.h
+++ b/layers/gpu_validation/gpu_state_tracker.h
@@ -29,7 +29,7 @@ class Queue : public vvl::Queue {
     virtual ~Queue();
 
   protected:
-    uint64_t PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
+    vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
     void PostSubmit(vvl::QueueSubmission &) override;
     void SubmitBarrier(const Location &loc, uint64_t seq);
     void Retire(vvl::QueueSubmission &) override;

--- a/layers/gpu_validation/gpu_subclasses.cpp
+++ b/layers/gpu_validation/gpu_subclasses.cpp
@@ -523,7 +523,7 @@ void CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
 Queue::Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp)
     : gpu_tracker::Queue(state, q, index, flags, qfp) {}
 
-uint64_t Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
+vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
     return gpu_tracker::Queue::PreSubmit(std::move(submissions));
 }
 

--- a/layers/gpu_validation/gpu_subclasses.h
+++ b/layers/gpu_validation/gpu_subclasses.h
@@ -152,7 +152,7 @@ class Queue : public gpu_tracker::Queue {
     Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp);
 
   protected:
-    uint64_t PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
+    vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
 };
 
 class Buffer : public vvl::Buffer {

--- a/layers/state_tracker/fence_state.cpp
+++ b/layers/state_tracker/fence_state.cpp
@@ -34,6 +34,9 @@ bool vvl::Fence::EnqueueSignal(vvl::Queue *queue_state, uint64_t next_seq) {
 
 void vvl::Fence::SetPresentSync(const PresentSync &present_sync) {
     auto guard = WriteLock();
+    // Attempt to overwrite not yet comitted present sync data with a new one is a bug
+    assert(present_sync.submissions.empty() || present_sync_.submissions.empty());
+
     present_sync_ = present_sync;
 }
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -76,6 +76,13 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
     return std::chrono::steady_clock::now() + std::chrono::seconds(10);
 }
 
+struct PreSubmitResult {
+    uint64_t last_submission_seq = 0;
+
+    bool has_external_fence = false;
+    uint64_t submission_with_external_fence_seq = 0;
+};
+
 class Queue: public StateObject {
   public:
     Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
@@ -92,7 +99,7 @@ class Queue: public StateObject {
     VkQueue VkHandle() const { return handle_.Cast<VkQueue>(); }
 
     // called from the various PreCallRecordQueueSubmit() methods
-    virtual uint64_t PreSubmit(std::vector<QueueSubmission> &&submissions);
+    virtual PreSubmitResult PreSubmit(std::vector<QueueSubmission> &&submissions);
     // called from the various PostCallRecordQueueSubmit() methods
     void PostSubmit();
 

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -671,7 +671,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
     dispatch_key key = GetDispatchKey(device);
     auto layer_data = GetLayerDataPtr(key, layer_data_map);
-    ErrorObject error_obj(vvl::Func::vkCreateDevice, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
+    ErrorObject error_obj(vvl::Func::vkDestroyDevice, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
         intercept->PreCallValidateDestroyDevice(device, pAllocator, error_obj);

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1347,7 +1347,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
             VKAPI_ATTR void VKAPI_CALL DestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator) {
                 dispatch_key key = GetDispatchKey(device);
                 auto layer_data = GetLayerDataPtr(key, layer_data_map);
-                ErrorObject error_obj(vvl::Func::vkCreateDevice, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
+                ErrorObject error_obj(vvl::Func::vkDestroyDevice, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();
                     intercept->PreCallValidateDestroyDevice(device, pAllocator, error_obj);

--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -800,6 +800,12 @@ VkMemoryAllocateInfo DeviceMemory::get_resource_alloc_info(const Device &dev, co
 
 NON_DISPATCHABLE_HANDLE_DTOR(Fence, vk::DestroyFence)
 
+Fence &Fence::operator=(Fence &&rhs) noexcept {
+    destroy();
+    NonDispHandle<VkFence>::operator=(std::move(rhs));
+    return *this;
+}
+
 void Fence::init(const Device &dev, const VkFenceCreateInfo &info) { NON_DISPATCHABLE_HANDLE_INIT(vk::CreateFence, dev, &info); }
 
 VkResult Fence::wait(uint64_t timeout) const {
@@ -858,6 +864,12 @@ Semaphore::Semaphore(const Device &dev, VkSemaphoreType type, uint64_t initial_v
         VkSemaphoreCreateInfo semaphore_ci = vku::InitStructHelper(&semaphore_type_ci);
         init(dev, semaphore_ci);
     }
+}
+
+Semaphore &Semaphore::operator=(Semaphore &&rhs) noexcept {
+    destroy();
+    NonDispHandle<VkSemaphore>::operator=(std::move(rhs));
+    return *this;
 }
 
 void Semaphore::init(const Device &dev, const VkSemaphoreCreateInfo &info) {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -147,6 +147,15 @@ class NonDispHandle : public Handle<T> {
 
     void destroy() noexcept { dev_handle_ = VK_NULL_HANDLE; }
 
+  public:
+    void SetName(const char *name) {
+        VkDebugUtilsObjectNameInfoEXT name_info = vku::InitStructHelper();
+        name_info.objectType = vku::GetObjectType<T>();
+        name_info.objectHandle = reinterpret_cast<uint64_t>(Handle<T>::handle());
+        name_info.pObjectName = name;
+        vk::SetDebugUtilsObjectNameEXT(dev_handle_, &name_info);
+    }
+
   private:
     VkDevice dev_handle_;
 };
@@ -354,6 +363,7 @@ class Fence : public internal::NonDispHandle<VkFence> {
     Fence(const Device &dev) { init(dev, create_info()); }
     Fence(const Device &dev, const VkFenceCreateInfo &info) { init(dev, info); }
     Fence(Fence &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
+    Fence &operator=(Fence &&) noexcept;
     ~Fence() noexcept;
     void destroy() noexcept;
 
@@ -385,6 +395,7 @@ class Semaphore : public internal::NonDispHandle<VkSemaphore> {
     Semaphore(const Device &dev, VkSemaphoreType type = VK_SEMAPHORE_TYPE_BINARY, uint64_t initial_value = 0);
     Semaphore(const Device &dev, const VkSemaphoreCreateInfo &info) { init(dev, info); }
     Semaphore(Semaphore &&rhs) noexcept : NonDispHandle(std::move(rhs)) {}
+    Semaphore &operator=(Semaphore &&) noexcept;
     ~Semaphore() noexcept;
     void destroy() noexcept;
 


### PR DESCRIPTION
Fixes defect in this solution: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/7694

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8047
