### PR TITLE
layers: Fix accessing RasterizationState

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -28,10 +28,8 @@
 bool BestPractices::ValidateCmdDrawType(VkCommandBuffer cmd_buffer, const Location& loc) const {
     bool skip = false;
     const auto cb_state = GetRead<bp_state::CommandBuffer>(cmd_buffer);
-    const auto* pipe = cb_state->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    if (pipe) {
-        const auto& rp_state = pipe->RenderPassState();
-        if (rp_state) {
+    if (const auto* pipe = cb_state->GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS)) {
+        if (const auto rp_state = pipe->RenderPassState()) {
             for (uint32_t i = 0; i < rp_state->create_info.subpassCount; ++i) {
                 const auto& subpass = rp_state->create_info.pSubpasses[i];
                 const auto* ds_state = pipe->DepthStencilState();

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1899,7 +1899,7 @@ bool CoreChecks::ValidateDrawPrimitivesGeneratedQuery(const LastBound &last_boun
         const vvl::Pipeline *pipeline = last_bound_state.pipeline_state;
         if (!with_non_zero_streams && pipeline) {
             const auto rasterization_state_stream_ci =
-                vku::FindStructInPNextChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(pipeline->RasterizationState()->pNext);
+                vku::FindStructInPNextChain<VkPipelineRasterizationStateStreamCreateInfoEXT>(pipeline->RasterizationStatePNext());
             if (rasterization_state_stream_ci && rasterization_state_stream_ci->rasterizationStream != 0) {
                 skip |= LogError(vuid.primitives_generated_streams_06709, cb_state.GetObjectList(VK_PIPELINE_BIND_POINT_GRAPHICS),
                                  vuid.loc(),

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -271,11 +271,11 @@ bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, V
                 if (last_bound.pipeline_state) {
                     auto last_bound_provoking_vertex_state_ci =
                         vku::FindStructInPNextChain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(
-                            last_bound.pipeline_state->RasterizationState()->pNext);
+                            last_bound.pipeline_state->RasterizationStatePNext());
 
                     auto current_provoking_vertex_state_ci =
                         vku::FindStructInPNextChain<VkPipelineRasterizationProvokingVertexStateCreateInfoEXT>(
-                            pipeline_state.RasterizationState()->pNext);
+                            pipeline_state.RasterizationStatePNext());
 
                     if (last_bound_provoking_vertex_state_ci && !current_provoking_vertex_state_ci) {
                         const LogObjectList objlist(cb_state->Handle(), pipeline);

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -641,10 +641,7 @@ bool CoreChecks::ValidateFsOutputsAgainstRenderPass(const spirv::Module &module_
     bool skip = false;
 
     // Don't check any color attachments if rasterization is disabled
-    const auto raster_state = pipeline.RasterizationState();
-    if (!raster_state || raster_state->rasterizerDiscardEnable) {
-        return skip;
-    }
+    if (pipeline.RasterizationDisabled()) return skip;
 
     struct Attachment {
         const VkAttachmentReference2 *reference = nullptr;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -290,6 +290,15 @@ class Pipeline : public StateObject {
         return nullptr;
     }
 
+    const void *RasterizationStatePNext() const {
+        if (const auto *raster_state = RasterizationState()) {
+            return raster_state->pNext;
+        }
+        return nullptr;
+    }
+
+    // Lack of a rasterization state can be from various things (dynamic state, GPL, etc)
+    // For this case, act as if (rasterizerDiscardEnable == false)
     bool RasterizationDisabled() const {
         if (pre_raster_state && pre_raster_state->raster_state) {
             return pre_raster_state->raster_state->rasterizerDiscardEnable == VK_TRUE;

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -302,8 +302,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
     using TexelDescriptor = vvl::TexelDescriptor;
 
     for (const auto &stage_state : pipe->stage_states) {
-        const auto raster_state = pipe->RasterizationState();
-        if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
+        if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && pipe->RasterizationDisabled()) {
             continue;
         } else if (!stage_state.entrypoint) {
             continue;
@@ -447,8 +446,7 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
     using TexelDescriptor = vvl::TexelDescriptor;
 
     for (const auto &stage_state : pipe->stage_states) {
-        const auto raster_state = pipe->RasterizationState();
-        if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && raster_state && raster_state->rasterizerDiscardEnable) {
+        if (stage_state.GetStage() == VK_SHADER_STAGE_FRAGMENT_BIT && pipe->RasterizationDisabled()) {
             continue;
         } else if (!stage_state.entrypoint) {
             continue;
@@ -645,14 +643,7 @@ bool CommandBufferAccessContext::ValidateDrawDynamicRenderingAttachment(const Lo
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto &last_bound_state = cb_state_->lastBound[lv_bind_point];
     const auto *pipe = last_bound_state.pipeline_state;
-    if (!pipe) {
-        return skip;
-    }
-
-    const auto raster_state = pipe->RasterizationState();
-    if (raster_state && raster_state->rasterizerDiscardEnable) {
-        return skip;
-    }
+    if (!pipe || pipe->RasterizationDisabled()) return skip;
 
     const auto &list = pipe->fragmentShader_writable_output_location_list;
     const auto &access_context = *GetCurrentAccessContext();
@@ -714,10 +705,7 @@ void CommandBufferAccessContext::RecordDrawDynamicRenderingAttachment(ResourceUs
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto &last_bound_state = cb_state_->lastBound[lv_bind_point];
     const auto *pipe = last_bound_state.pipeline_state;
-    if (!pipe) return;
-
-    const auto raster_state = pipe->RasterizationState();
-    if (raster_state && raster_state->rasterizerDiscardEnable) return;
+    if (!pipe || pipe->RasterizationDisabled()) return;
 
     const auto &list = pipe->fragmentShader_writable_output_location_list;
     auto &access_context = *GetCurrentAccessContext();

--- a/layers/sync/sync_renderpass.cpp
+++ b/layers/sync/sync_renderpass.cpp
@@ -486,14 +486,8 @@ bool RenderPassAccessContext::ValidateDrawSubpassAttachment(const CommandExecuti
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto &last_bound_state = cmd_buffer.lastBound[lv_bind_point];
     const auto *pipe = last_bound_state.pipeline_state;
-    if (!pipe) {
-        return skip;
-    }
+    if (!pipe || pipe->RasterizationDisabled()) return skip;
 
-    const auto raster_state = pipe->RasterizationState();
-    if (raster_state && raster_state->rasterizerDiscardEnable) {
-        return skip;
-    }
     const auto &list = pipe->fragmentShader_writable_output_location_list;
     const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 
@@ -576,14 +570,8 @@ void RenderPassAccessContext::RecordDrawSubpassAttachment(const vvl::CommandBuff
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto &last_bound_state = cmd_buffer.lastBound[lv_bind_point];
     const auto *pipe = last_bound_state.pipeline_state;
-    if (!pipe) {
-        return;
-    }
+    if (!pipe || pipe->RasterizationDisabled()) return;
 
-    const auto *raster_state = pipe->RasterizationState();
-    if (raster_state && raster_state->rasterizerDiscardEnable) {
-        return;
-    }
     const auto &list = pipe->fragmentShader_writable_output_location_list;
     const auto &subpass = rp_state_->create_info.pSubpasses[current_subpass_];
 

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "810074ebb68dfec81dee79f279b78f88d6c5c24f",
+            "commit": "8bc338928b5c92489d953e049018eab2359d437a",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -3612,3 +3612,34 @@ TEST_F(NegativePipeline, GetPipelinePropertiesEXT) {
     vk::GetPipelinePropertiesEXT(device(), &pipeline_info, nullptr);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(NegativePipeline, NoRasterizationState) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8051");
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    CreatePipelineHelper pipe(*this);
+    pipe.gp_ci_.pRasterizationState = nullptr;
+    m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-06601");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativePipeline, NoRasterizationStateDynamicRendering) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8051");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    RETURN_IF_SKIP(Init());
+
+    VkFormat color_formats = VK_FORMAT_UNDEFINED;
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.gp_ci_.pRasterizationState = nullptr;
+    m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-06601");
+    pipe.CreateGraphicsPipeline();
+    m_errorMonitor->VerifyFound();
+}

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -1717,10 +1717,16 @@ TEST_F(PositivePipeline, AttachmentCountIgnored) {
     pipe.CreateGraphicsPipeline();
 }
 
-TEST_F(PositivePipeline, DynamicRasterizationState) {
+TEST_F(PositivePipeline, NoRasterizationState) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7899");
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8051");
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState);
     AddRequiredFeature(vkt::Feature::extendedDynamicState2);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState3DepthClampEnable);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState3PolygonMode);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
@@ -1731,8 +1737,55 @@ TEST_F(PositivePipeline, DynamicRasterizationState) {
     ms_ci.pSampleMask = nullptr;
 
     CreatePipelineHelper pipe(*this);
-    pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
     pipe.gp_ci_.pRasterizationState = nullptr;
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_POLYGON_MODE_EXT);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_CULL_MODE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_FRONT_FACE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
+    pipe.ms_ci_ = ms_ci;
+    pipe.CreateGraphicsPipeline();
+}
+
+TEST_F(PositivePipeline, NoRasterizationStateDynamicRendering) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7899");
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8051");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_3_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState2);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState3DepthClampEnable);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState3PolygonMode);
+    RETURN_IF_SKIP(Init());
+
+    VkFormat color_formats = VK_FORMAT_UNDEFINED;
+    VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
+    pipeline_rendering_info.colorAttachmentCount = 1;
+    pipeline_rendering_info.pColorAttachmentFormats = &color_formats;
+
+    VkPipelineMultisampleStateCreateInfo ms_ci = vku::InitStructHelper();
+    ms_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    ms_ci.sampleShadingEnable = 0;
+    ms_ci.minSampleShading = 1.0;
+    ms_ci.pSampleMask = nullptr;
+
+    CreatePipelineHelper pipe(*this, &pipeline_rendering_info);
+    pipe.gp_ci_.pRasterizationState = nullptr;
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_POLYGON_MODE_EXT);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_CULL_MODE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_FRONT_FACE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BIAS);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
     pipe.ms_ci_ = ms_ci;
     pipe.CreateGraphicsPipeline();
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8051

Change from https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/212 included

Spec change for VU in https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6674

This change hopefully fixes all things `rasterizerDiscardEnable`/`pRasterizationState` related