### PR TITLE
layer: Add ASSERT_AND_RETURN

### DIFF
--- a/layers/best_practices/bp_cmd_buffer.cpp
+++ b/layers/best_practices/bp_cmd_buffer.cpp
@@ -41,7 +41,7 @@ bool BestPractices::PreCallValidateAllocateCommandBuffers(VkDevice device, const
     bool skip = false;
 
     auto cp_state = Get<vvl::CommandPool>(pAllocateInfo->commandPool);
-    if (!cp_state) return false;
+    ASSERT_AND_RETURN_SKIP(cp_state);
 
     const VkQueueFlags queue_flags = physical_device_state->queue_family_properties[cp_state->queueFamilyIndex].queueFlags;
     const VkQueueFlags sec_cmd_buf_queue_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
@@ -63,7 +63,6 @@ void BestPractices::PreCallRecordBeginCommandBuffer(VkCommandBuffer commandBuffe
     StateTracker::PreCallRecordBeginCommandBuffer(commandBuffer, pBeginInfo, record_obj);
 
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-    if (!cb_state) return;
 
     // reset
     cb_state->num_submits = 0;
@@ -140,7 +139,7 @@ bool BestPractices::PreCallValidateGetQueryPoolResults(VkDevice device, VkQueryP
     bool skip = false;
 
     const auto query_pool_state = Get<vvl::QueryPool>(queryPool);
-    if (!query_pool_state) return skip;
+    ASSERT_AND_RETURN_SKIP(query_pool_state);
 
     for (uint32_t i = firstQuery; i < firstQuery + queryCount; ++i) {
         if (query_pool_state->GetQueryState(i, 0u) == QUERYSTATE_RESET) {
@@ -160,7 +159,6 @@ void BestPractices::PreCallRecordCmdSetDepthCompareOp(VkCommandBuffer commandBuf
     StateTracker::PreCallRecordCmdSetDepthCompareOp(commandBuffer, depthCompareOp, record_obj);
 
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         RecordSetDepthTestState(*cb_state, depthCompareOp, cb_state->nv.depth_test_enable);
@@ -177,7 +175,6 @@ void BestPractices::PreCallRecordCmdSetDepthTestEnable(VkCommandBuffer commandBu
     StateTracker::PreCallRecordCmdSetDepthTestEnable(commandBuffer, depthTestEnable, record_obj);
 
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         RecordSetDepthTestState(*cb_state, cb_state->nv.depth_compare_op, depthTestEnable != VK_FALSE);

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -88,7 +88,7 @@ void BestPractices::RecordBindZcullScope(bp_state::CommandBuffer& cmd_state, VkI
     assert((subresource_range.aspectMask & VK_IMAGE_ASPECT_DEPTH_BIT) != 0U);
 
     auto image_state = Get<vvl::Image>(depth_attachment);
-    if (!image_state) return;
+    ASSERT_AND_RETURN(image_state);
 
     const uint32_t mip_levels = image_state->create_info.mipLevels;
     const uint32_t array_layers = image_state->create_info.arrayLayers;
@@ -147,7 +147,7 @@ void BestPractices::RecordResetZcullDirection(bp_state::CommandBuffer& cmd_state
     auto& tree = image_it->second;
 
     auto image = Get<vvl::Image>(depth_image);
-    if (!image) return;
+    ASSERT_AND_RETURN(image);
 
     ForEachSubresource(*image, subresource_range, [&tree](uint32_t layer, uint32_t level) {
         auto& subresource = tree.GetState(layer, level);
@@ -174,7 +174,7 @@ void BestPractices::RecordSetZcullDirection(bp_state::CommandBuffer& cmd_state, 
     auto& tree = image_it->second;
 
     auto image = Get<vvl::Image>(depth_image);
-    if (!image) return;
+    ASSERT_AND_RETURN(image);
 
     ForEachSubresource(*image, subresource_range, [&tree, &cmd_state](uint32_t layer, uint32_t level) {
         tree.GetState(layer, level).direction = cmd_state.nv.zcull_direction;
@@ -188,7 +188,7 @@ void BestPractices::RecordZcullDraw(bp_state::CommandBuffer& cmd_state) {
     auto& scope = cmd_state.nv.zcull_scope;
 
     auto image = Get<vvl::Image>(scope.image);
-    if (!image) return;
+    ASSERT_AND_RETURN(image);
 
     ForEachSubresource(*image, scope.range, [&scope](uint32_t layer, uint32_t level) {
         auto& subresource = scope.tree->GetState(layer, level);
@@ -196,7 +196,7 @@ void BestPractices::RecordZcullDraw(bp_state::CommandBuffer& cmd_state) {
         switch (subresource.direction) {
             case ZcullDirection::Unknown:
                 // Unreachable
-                assert(0);
+                assert(false);
                 break;
             case ZcullDirection::Less:
                 ++subresource.num_less_draws;
@@ -236,7 +236,7 @@ bool BestPractices::ValidateZcull(const bp_state::CommandBuffer& cmd_state, VkIm
     const auto& tree = image_it->second;
 
     auto image_state = Get<vvl::Image>(image);
-    if (!image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(image_state);
 
     ForEachSubresource(*image_state, subresource_range, [&](uint32_t layer, uint32_t level) {
         if (is_balanced) {

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -199,7 +199,6 @@ bool BestPractices::PreCallValidateCmdClearAttachments(VkCommandBuffer commandBu
                                                        const VkClearRect* pRects, const ErrorObject& error_obj) const {
     bool skip = false;
     const auto cb_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
-    if (!cb_state) return skip;
 
     if (cb_state->IsSeconary()) {
         // Defer checks to ExecuteCommands.
@@ -331,7 +330,7 @@ bool BestPractices::ValidateCmdResolveImage(VkCommandBuffer command_buffer, VkIm
     bool skip = false;
     auto src_image_state = Get<vvl::Image>(src_image);
     auto dst_image_state = Get<vvl::Image>(dst_image);
-    if (!src_image_state || !dst_image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
     auto src_image_type = src_image_state->create_info.imageType;
     auto dst_image_type = dst_image_state->create_info.imageType;
@@ -554,7 +553,7 @@ bool BestPractices::PreCallValidateCmdClearColorImage(VkCommandBuffer commandBuf
     bool skip = false;
 
     auto dst_image = Get<bp_state::Image>(image);
-    if (!dst_image) return skip;
+    ASSERT_AND_RETURN_SKIP(dst_image);
 
     if (VendorCheckEnabled(kBPVendorAMD)) {
         skip |= LogPerformanceWarning(kVUID_BestPractices_ClearAttachment_ClearImage, commandBuffer, error_obj.location,
@@ -582,7 +581,6 @@ bool BestPractices::PreCallValidateCmdClearDepthStencilImage(VkCommandBuffer com
                                       VendorSpecificTag(kBPVendorAMD));
     }
     const auto cb_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         for (uint32_t i = 0; i < rangeCount; i++) {
             skip |= ValidateZcull(*cb_state, image, pRanges[i], error_obj.location);

--- a/layers/best_practices/bp_descriptor.cpp
+++ b/layers/best_practices/bp_descriptor.cpp
@@ -30,7 +30,7 @@ bool BestPractices::PreCallValidateAllocateDescriptorSets(VkDevice device, const
     if (skip) return skip;
 
     const auto pool_state = Get<bp_state::DescriptorPool>(pAllocateInfo->descriptorPool);
-    if (!pool_state) return skip;
+    ASSERT_AND_RETURN_SKIP(pool_state);
 
     // if the number of freed sets > 0, it implies they could be recycled instead if desirable
     // this warning is specific to Arm

--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -116,7 +116,7 @@ void BestPractices::PreCallRecordFreeMemory(VkDevice device, VkDeviceMemory memo
                                             const RecordObject& record_obj) {
     if (memory != VK_NULL_HANDLE && VendorCheckEnabled(kBPVendorNVIDIA)) {
         auto mem_info = Get<vvl::DeviceMemory>(memory);
-        if (!mem_info) return;
+        ASSERT_AND_RETURN(mem_info);
 
         // Exclude memory free events on dedicated allocations, or imported/exported allocations.
         if (!mem_info->IsDedicatedBuffer() && !mem_info->IsDedicatedImage() && !mem_info->IsExport() && !mem_info->IsImport()) {
@@ -139,7 +139,7 @@ bool BestPractices::PreCallValidateFreeMemory(VkDevice device, VkDeviceMemory me
     if (memory == VK_NULL_HANDLE) return skip;
 
     auto mem_info = Get<vvl::DeviceMemory>(memory);
-    if (!mem_info) return skip;
+    ASSERT_AND_RETURN_SKIP(mem_info);
 
     for (const auto& item : mem_info->ObjectBindings()) {
         const auto& obj = item.first;
@@ -155,7 +155,7 @@ bool BestPractices::ValidateBindBufferMemory(VkBuffer buffer, VkDeviceMemory mem
     bool skip = false;
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto mem_state = Get<vvl::DeviceMemory>(memory);
-    if (!mem_state || !buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(mem_state && buffer_state);
 
     if (mem_state->allocate_info.allocationSize == buffer_state->create_info.size &&
         mem_state->allocate_info.allocationSize < kMinDedicatedAllocationSize) {
@@ -203,7 +203,7 @@ bool BestPractices::ValidateBindImageMemory(VkImage image, VkDeviceMemory memory
     bool skip = false;
     auto image_state = Get<vvl::Image>(image);
     auto mem_state = Get<vvl::DeviceMemory>(memory);
-    if (!mem_state || !image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(mem_state && image_state);
 
     if (mem_state->allocate_info.allocationSize == image_state->requirements[0].size &&
         mem_state->allocate_info.allocationSize < kMinDedicatedAllocationSize) {

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -67,7 +67,6 @@ bool BestPractices::ValidatePushConstants(VkCommandBuffer cmd_buffer, const Loca
 
 void BestPractices::RecordCmdDrawType(VkCommandBuffer cmd_buffer, uint32_t draw_count) {
     auto cb_state = GetWrite<bp_state::CommandBuffer>(cmd_buffer);
-    assert(cb_state);
     if (VendorCheckEnabled(kBPVendorArm)) {
         RecordCmdDrawTypeArm(*cb_state, draw_count);
     }
@@ -195,7 +194,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
 
     // check for sparse/underutilised index buffer, and post-transform cache thrashing
     const auto ib_state = Get<vvl::Buffer>(cmd_state.index_buffer_binding.buffer);
-    if (!ib_state) return skip;
+    ASSERT_AND_RETURN_SKIP(ib_state);
 
     const VkIndexType ib_type = cmd_state.index_buffer_binding.index_type;
     const auto& ib_mem_state = *ib_state->MemState();
@@ -205,7 +204,7 @@ bool BestPractices::ValidateIndexBufferArm(const bp_state::CommandBuffer& cmd_st
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
     const auto& last_bound = cmd_state.lastBound[lv_bind_point];
     const auto* pipeline_state = last_bound.pipeline_state;
-    if (!pipeline_state) return skip;
+    ASSERT_AND_RETURN_SKIP(pipeline_state);
 
     const auto* ia_state = pipeline_state->InputAssemblyState();
     if (ia_state) {

--- a/layers/best_practices/bp_framebuffer.cpp
+++ b/layers/best_practices/bp_framebuffer.cpp
@@ -38,7 +38,7 @@ bool BestPractices::ValidateAttachments(const VkRenderPassCreateInfo2* rpci, uin
         }
 
         auto view_state = Get<vvl::ImageView>(attachments[i]);
-        if (!view_state) continue;
+        ASSERT_AND_CONTINUE(view_state);
 
         const auto& ici = view_state->image_state->create_info;
 
@@ -81,7 +81,8 @@ bool BestPractices::PreCallValidateCreateFramebuffer(VkDevice device, const VkFr
     bool skip = false;
 
     auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
-    if (rp_state && !(pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
+    ASSERT_AND_RETURN_SKIP(rp_state);
+    if (!(pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT)) {
         skip |= ValidateAttachments(rp_state->create_info.ptr(), pCreateInfo->attachmentCount, pCreateInfo->pAttachments,
                                     error_obj.location);
     }

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -435,11 +435,11 @@ void BestPractices::PreCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, 
                                                  VkPipeline pipeline, const RecordObject& record_obj) {
     StateTracker::PreCallRecordCmdBindPipeline(commandBuffer, pipelineBindPoint, pipeline, record_obj);
 
-    auto pipeline_info = Get<vvl::Pipeline>(pipeline);
-    if (!pipeline_info) return;
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
 
     if (pipelineBindPoint == VK_PIPELINE_BIND_POINT_GRAPHICS && VendorCheckEnabled(kBPVendorNVIDIA)) {
+        auto pipeline_info = Get<vvl::Pipeline>(pipeline);
+        ASSERT_AND_RETURN(pipeline_info);
         using TessGeometryMeshState = bp_state::CommandBufferStateNV::TessGeometryMesh::State;
         auto& tgm = cb_state->nv.tess_geometry_mesh;
 
@@ -490,7 +490,6 @@ void BestPractices::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer,
         // check for depth/blend state tracking
         if (auto pipeline_state = Get<bp_state::Pipeline>(pipeline)) {
             auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-            assert(cb_state);
             auto& render_pass_state = cb_state->render_pass_state;
 
             render_pass_state.nextDrawTouchesAttachments = pipeline_state->access_framebuffer_attachments;

--- a/layers/best_practices/bp_ray_tracing.cpp
+++ b/layers/best_practices/bp_ray_tracing.cpp
@@ -46,11 +46,10 @@ bool BestPractices::PreCallValidateCmdBuildAccelerationStructuresKHR(
 
 bool BestPractices::ValidateBuildAccelerationStructure(VkCommandBuffer commandBuffer, const Location& loc) const {
     bool skip = false;
-    auto cb_node = GetRead<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_node);
+    auto cb_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
-        if ((cb_node->GetQueueFlags() & VK_QUEUE_GRAPHICS_BIT) != 0) {
+        if ((cb_state->GetQueueFlags() & VK_QUEUE_GRAPHICS_BIT) != 0) {
             skip |= LogPerformanceWarning(kVUID_BestPractices_AccelerationStructure_NotAsync, commandBuffer, loc,
                                           "%s Prefer building acceleration structures on an asynchronous "
                                           "compute queue, instead of using the universal graphics queue.",
@@ -68,7 +67,7 @@ bool BestPractices::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice de
 
     for (uint32_t i = 0; i < bindInfoCount; i++) {
         auto as_state = Get<vvl::AccelerationStructureNV>(pBindInfos[i].accelerationStructure);
-        if (!as_state) continue;
+        ASSERT_AND_CONTINUE(as_state);
         if (!as_state->memory_requirements_checked) {
             // There's not an explicit requirement in the spec to call vkGetImageMemoryRequirements() prior to calling
             // BindAccelerationStructureMemoryNV but it's implied in that memory being bound must conform with

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -430,7 +430,6 @@ bool BestPractices::ValidateCmdPipelineBarrierImageBarrier(VkCommandBuffer comma
     bool skip = false;
 
     const auto cb_state = GetRead<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         if (barrier.oldLayout == VK_IMAGE_LAYOUT_UNDEFINED && barrier.newLayout != VK_IMAGE_LAYOUT_UNDEFINED) {
@@ -460,13 +459,12 @@ static void ForEachSubresource(const vvl::Image& image, const VkImageSubresource
 template <typename ImageMemoryBarrier>
 void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer commandBuffer, const ImageMemoryBarrier& barrier) {
     auto cb_state = Get<bp_state::CommandBuffer>(commandBuffer);
-    assert(cb_state);
 
     // Is a queue ownership acquisition barrier
     if (barrier.srcQueueFamilyIndex != barrier.dstQueueFamilyIndex &&
         barrier.dstQueueFamilyIndex == cb_state->command_pool->queueFamilyIndex) {
         auto image = Get<bp_state::Image>(barrier.image);
-        if (!image) return;
+        ASSERT_AND_RETURN(image);
         auto subresource_range = barrier.subresourceRange;
         cb_state->queue_submit_functions.push_back([image, subresource_range](const ValidationStateTracker& vst,
                                                                               const vvl::Queue& qs,

--- a/layers/best_practices/bp_wsi.cpp
+++ b/layers/best_practices/bp_wsi.cpp
@@ -71,7 +71,7 @@ bool BestPractices::PreCallValidateGetSwapchainImagesKHR(VkDevice device, VkSwap
     bool skip = false;
 
     auto swapchain_state = Get<bp_state::Swapchain>(swapchain);
-    if (!swapchain_state || !pSwapchainImages) return skip;
+    ASSERT_AND_RETURN_SKIP(swapchain_state);
 
     // Compare the preliminary value of *pSwapchainImageCount with the value this time:
     if (swapchain_state->vkGetSwapchainImagesKHRState == UNCALLED) {

--- a/layers/chassis/layer_chassis_dispatch_manual.cpp
+++ b/layers/chassis/layer_chassis_dispatch_manual.cpp
@@ -106,9 +106,10 @@ void DispatchExportMetalObjectsEXT(VkDevice device, VkExportMetalObjectsInfoEXT 
 // copy the returned data to the caller before freeing the copy's data.
 void CopyCreatePipelineFeedbackData(const void *src_chain, const void *dst_chain) {
     auto src_feedback_struct = vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfoEXT>(src_chain);
-    if (!src_feedback_struct) return;
     auto dst_feedback_struct = const_cast<VkPipelineCreationFeedbackCreateInfoEXT *>(
         vku::FindStructInPNextChain<VkPipelineCreationFeedbackCreateInfoEXT>(dst_chain));
+    if (!src_feedback_struct || !dst_feedback_struct) return;
+
     *dst_feedback_struct->pPipelineCreationFeedback = *src_feedback_struct->pPipelineCreationFeedback;
     for (uint32_t i = 0; i < src_feedback_struct->pipelineStageCreationFeedbackCount; i++) {
         dst_feedback_struct->pPipelineStageCreationFeedbacks[i] = src_feedback_struct->pPipelineStageCreationFeedbacks[i];
@@ -708,7 +709,7 @@ void *BuildUnwrappedUpdateTemplateBuffer(ValidationObject *layer_data, uint64_t 
                                                   0);
                 } break;
                 default:
-                    assert(0);
+                    assert(false);
                     break;
             }
         }
@@ -748,7 +749,7 @@ void *BuildUnwrappedUpdateTemplateBuffer(ValidationObject *layer_data, uint64_t 
                         CastFromUint64<VkAccelerationStructureNV>(source);
                     break;
                 default:
-                    assert(0);
+                    assert(false);
                     break;
             }
         }
@@ -1352,7 +1353,6 @@ void DispatchGetDescriptorEXT(VkDevice device, const VkDescriptorGetInfoEXT *pDe
     VkDescriptorImageInfo image_info;
     vku::safe_VkDescriptorAddressInfoEXT address_info;
 
-    assert(pDescriptorInfo);
     switch (pDescriptorInfo->type) {
         case VK_DESCRIPTOR_TYPE_SAMPLER: {
             // if using null descriptors can be null

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -137,7 +137,7 @@ bool CoreChecks::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(VkDevice d
                                                                       const ErrorObject &error_obj) const {
     bool skip = false;
     auto mem_info = Get<vvl::DeviceMemory>(pInfo->memory);
-    if (!mem_info) return skip;
+    ASSERT_AND_RETURN_SKIP(mem_info);
 
     // VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID must have been included in
     // VkExportMemoryAllocateInfo::handleTypes when memory was created.
@@ -297,7 +297,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
             }
 
             auto image_state = Get<vvl::Image>(mem_ded_alloc_info->image);
-            if (!image_state) return skip;
+            ASSERT_AND_RETURN_SKIP(image_state);
             const auto *ici = &image_state->create_info;
             const Location &dedicated_image_loc = allocate_info_loc.dot(Struct::VkMemoryDedicatedAllocateInfo, Field::image);
 
@@ -557,7 +557,7 @@ bool CoreChecks::ValidateCreateImageANDROID(const VkImageCreateInfo &create_info
 bool CoreChecks::ValidateCreateImageViewANDROID(const VkImageViewCreateInfo &create_info, const Location &create_info_loc) const {
     bool skip = false;
     auto image_state = Get<vvl::Image>(create_info.image);
-    if (!image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(image_state);
 
     if (image_state->HasAHBFormat()) {
         if (VK_FORMAT_UNDEFINED != create_info.format) {

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -449,7 +449,7 @@ bool CoreChecks::PreCallValidateCmdFillBuffer(VkCommandBuffer commandBuffer, VkB
     bool skip = false;
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto buffer_state = Get<vvl::Buffer>(dstBuffer);
-    if (!cb_state_ptr || !buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(cb_state_ptr && buffer_state);
 
     const LogObjectList objlist(commandBuffer, dstBuffer);
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;

--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -145,7 +145,7 @@ class BufferAddressValidation {
 template <size_t ChecksCount>
 bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer* const> buffer_list) const noexcept {
     for (const auto& buffer : buffer_list) {
-        assert(buffer);
+        ASSERT_AND_CONTINUE(buffer);
 
         bool valid_buffer_found = true;
         for (const auto& vuidAndValidation : vuidsAndValidationFunctions) {
@@ -163,7 +163,7 @@ bool BufferAddressValidation<ChecksCount>::HasValidBuffer(vvl::span<vvl::Buffer*
 template <size_t ChecksCount>
 bool BufferAddressValidation<ChecksCount>::HasInvalidBuffer(vvl::span<vvl::Buffer* const> buffer_list) const noexcept {
     for (const auto& buffer : buffer_list) {
-        assert(buffer);
+        ASSERT_AND_CONTINUE(buffer);
 
         for (const auto& vuidAndValidation : vuidsAndValidationFunctions) {
             if (!vuidAndValidation.validation_func(buffer, nullptr)) {
@@ -198,7 +198,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const CoreChecks& c
 
     // For each buffer, and for each violated VUID, build an error message
     for (const auto& buffer : buffer_list) {
-        assert(buffer);
+        ASSERT_AND_CONTINUE(buffer);
 
         for (size_t i = 0; i < ChecksCount; ++i) {
             [[maybe_unused]] const auto& [vuid, validation_func, error_msg_header_suffix_func] = vuidsAndValidationFunctions[i];

--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -1388,9 +1388,8 @@ bool CoreChecks::ValidateCmdCopyImage(VkCommandBuffer commandBuffer, VkImage src
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (!cb_state_ptr || !src_image_state || !dst_image_state) {
-        return skip;
-    }
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
+
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
     const VkFormat src_format = src_image_state->create_info.format;
     const VkFormat dst_format = dst_image_state->create_info.format;
@@ -1783,30 +1782,30 @@ void CoreChecks::PreCallRecordCmdCopyImage(VkCommandBuffer commandBuffer, VkImag
                                            const VkImageCopy *pRegions, const RecordObject &record_obj) {
     StateTracker::PreCallRecordCmdCopyImage(commandBuffer, srcImage, srcImageLayout, dstImage, dstImageLayout, regionCount,
                                             pRegions, record_obj);
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (cb_state_ptr && src_image_state && dst_image_state) {
-        // Make sure that all image slices are updated to correct layout
-        for (uint32_t i = 0; i < regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*src_image_state, pRegions[i].srcSubresource, srcImageLayout);
-            cb_state_ptr->SetImageInitialLayout(*dst_image_state, pRegions[i].dstSubresource, dstImageLayout);
-        }
+    ASSERT_AND_RETURN(src_image_state && dst_image_state);
+
+    // Make sure that all image slices are updated to correct layout
+    for (uint32_t i = 0; i < regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*src_image_state, pRegions[i].srcSubresource, srcImageLayout);
+        cb_state->SetImageInitialLayout(*dst_image_state, pRegions[i].dstSubresource, dstImageLayout);
     }
 }
 
 void CoreChecks::RecordCmdCopyImage2(VkCommandBuffer commandBuffer, const VkCopyImageInfo2 *pCopyImageInfo) {
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(pCopyImageInfo->srcImage);
     auto dst_image_state = Get<vvl::Image>(pCopyImageInfo->dstImage);
-    if (cb_state_ptr && src_image_state && dst_image_state) {
-        // Make sure that all image slices are updated to correct layout
-        for (uint32_t i = 0; i < pCopyImageInfo->regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*src_image_state, pCopyImageInfo->pRegions[i].srcSubresource,
-                                                pCopyImageInfo->srcImageLayout);
-            cb_state_ptr->SetImageInitialLayout(*dst_image_state, pCopyImageInfo->pRegions[i].dstSubresource,
-                                                pCopyImageInfo->dstImageLayout);
-        }
+    ASSERT_AND_RETURN(src_image_state && dst_image_state);
+
+    // Make sure that all image slices are updated to correct layout
+    for (uint32_t i = 0; i < pCopyImageInfo->regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*src_image_state, pCopyImageInfo->pRegions[i].srcSubresource,
+                                        pCopyImageInfo->srcImageLayout);
+        cb_state->SetImageInitialLayout(*dst_image_state, pCopyImageInfo->pRegions[i].dstSubresource,
+                                        pCopyImageInfo->dstImageLayout);
     }
 }
 
@@ -1829,10 +1828,10 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
 
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
-    if (!src_buffer_state || !dst_buffer_state) return;
+    ASSERT_AND_RETURN(src_buffer_state && dst_buffer_state);
 
     if (src_buffer_state->sparse || dst_buffer_state->sparse) {
-        auto cb_state_ptr = Get<vvl::CommandBuffer>(commandBuffer);
+        auto cb_state = Get<vvl::CommandBuffer>(commandBuffer);
 
         std::vector<sparse_container::range<VkDeviceSize>> src_ranges;
         std::vector<sparse_container::range<VkDeviceSize>> dst_ranges;
@@ -1869,7 +1868,7 @@ void CoreChecks::RecordCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer src
             return skip;
         };
 
-        cb_state_ptr->queue_submit_functions.emplace_back(queue_submit_validation);
+        cb_state->queue_submit_functions.emplace_back(queue_submit_validation);
     }
 }
 
@@ -2061,9 +2060,8 @@ bool CoreChecks::ValidateCmdCopyImageToBuffer(VkCommandBuffer commandBuffer, VkI
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_buffer_state = Get<vvl::Buffer>(dstBuffer);
-    if (!cb_state_ptr || !src_image_state || !dst_buffer_state) {
-        return skip;
-    }
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_buffer_state);
+
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
 
     const bool is_2 = loc.function == Func::vkCmdCopyImageToBuffer2 || loc.function == Func::vkCmdCopyImageToBuffer2KHR;
@@ -2183,13 +2181,13 @@ void CoreChecks::PreCallRecordCmdCopyImageToBuffer(VkCommandBuffer commandBuffer
     StateTracker::PreCallRecordCmdCopyImageToBuffer(commandBuffer, srcImage, srcImageLayout, dstBuffer, regionCount, pRegions,
                                                     record_obj);
 
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
-    if (cb_state_ptr && src_image_state) {
-        // Make sure that all image slices record referenced layout
-        for (uint32_t i = 0; i < regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*src_image_state, pRegions[i].imageSubresource, srcImageLayout);
-        }
+    ASSERT_AND_RETURN(src_image_state);
+
+    // Make sure that all image slices record referenced layout
+    for (uint32_t i = 0; i < regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*src_image_state, pRegions[i].imageSubresource, srcImageLayout);
     }
 }
 
@@ -2204,14 +2202,14 @@ void CoreChecks::PreCallRecordCmdCopyImageToBuffer2(VkCommandBuffer commandBuffe
                                                     const RecordObject &record_obj) {
     StateTracker::PreCallRecordCmdCopyImageToBuffer2(commandBuffer, pCopyImageToBufferInfo, record_obj);
 
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(pCopyImageToBufferInfo->srcImage);
-    if (cb_state_ptr && src_image_state) {
-        // Make sure that all image slices record referenced layout
-        for (uint32_t i = 0; i < pCopyImageToBufferInfo->regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*src_image_state, pCopyImageToBufferInfo->pRegions[i].imageSubresource,
-                                                pCopyImageToBufferInfo->srcImageLayout);
-        }
+    ASSERT_AND_RETURN(src_image_state);
+
+    // Make sure that all image slices record referenced layout
+    for (uint32_t i = 0; i < pCopyImageToBufferInfo->regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*src_image_state, pCopyImageToBufferInfo->pRegions[i].imageSubresource,
+                                        pCopyImageToBufferInfo->srcImageLayout);
     }
 }
 
@@ -2223,9 +2221,8 @@ bool CoreChecks::ValidateCmdCopyBufferToImage(VkCommandBuffer commandBuffer, VkB
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_buffer_state = Get<vvl::Buffer>(srcBuffer);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (!cb_state_ptr || !src_buffer_state || !dst_image_state) {
-        return skip;
-    }
+    ASSERT_AND_RETURN_SKIP(src_buffer_state && dst_image_state);
+
     const vvl::CommandBuffer &cb_state = *cb_state_ptr;
 
     const bool is_2 = loc.function == Func::vkCmdCopyBufferToImage2 || loc.function == Func::vkCmdCopyBufferToImage2KHR;
@@ -2343,13 +2340,13 @@ void CoreChecks::PreCallRecordCmdCopyBufferToImage(VkCommandBuffer commandBuffer
     StateTracker::PreCallRecordCmdCopyBufferToImage(commandBuffer, srcBuffer, dstImage, dstImageLayout, regionCount, pRegions,
                                                     record_obj);
 
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (cb_state_ptr && dst_image_state) {
-        // Make sure that all image slices are record referenced layout
-        for (uint32_t i = 0; i < regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*dst_image_state, pRegions[i].imageSubresource, dstImageLayout);
-        }
+    ASSERT_AND_RETURN(dst_image_state);
+
+    // Make sure that all image slices are record referenced layout
+    for (uint32_t i = 0; i < regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*dst_image_state, pRegions[i].imageSubresource, dstImageLayout);
     }
 }
 
@@ -2364,14 +2361,14 @@ void CoreChecks::PreCallRecordCmdCopyBufferToImage2(VkCommandBuffer commandBuffe
                                                     const RecordObject &record_obj) {
     StateTracker::PreCallRecordCmdCopyBufferToImage2(commandBuffer, pCopyBufferToImageInfo, record_obj);
 
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto dst_image_state = Get<vvl::Image>(pCopyBufferToImageInfo->dstImage);
-    if (cb_state_ptr && dst_image_state) {
-        // Make sure that all image slices are record referenced layout
-        for (uint32_t i = 0; i < pCopyBufferToImageInfo->regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*dst_image_state, pCopyBufferToImageInfo->pRegions[i].imageSubresource,
-                                                pCopyBufferToImageInfo->dstImageLayout);
-        }
+    ASSERT_AND_RETURN(dst_image_state);
+
+    // Make sure that all image slices are record referenced layout
+    for (uint32_t i = 0; i < pCopyBufferToImageInfo->regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*dst_image_state, pCopyBufferToImageInfo->pRegions[i].imageSubresource,
+                                        pCopyBufferToImageInfo->dstImageLayout);
     }
 }
 
@@ -2442,7 +2439,7 @@ bool CoreChecks::ValidateMemoryImageCopyCommon(InfoPointer info_ptr, const Locat
     bool skip = false;
     VkImage image = GetImage(*info_ptr);
     auto image_state = Get<vvl::Image>(image);
-    if (!image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(image_state);
     auto image_layout = GetImageLayout(*info_ptr);
     auto regionCount = info_ptr->regionCount;
     const bool from_image = loc.function == Func::vkCopyImageToMemoryEXT;
@@ -2744,7 +2741,8 @@ bool CoreChecks::PreCallValidateCopyImageToImageEXT(VkDevice device, const VkCop
     const Location loc = error_obj.location.dot(Field::pCopyImageToImageInfo);
     auto src_image_state = Get<vvl::Image>(info_ptr->srcImage);
     auto dst_image_state = Get<vvl::Image>(info_ptr->dstImage);
-    if (!src_image_state || !dst_image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
+
     // Formats are required to match, but check each image anyway
     auto src_plane_count = vkuFormatPlaneCount(src_image_state->create_info.format);
     auto dst_plane_count = vkuFormatPlaneCount(dst_image_state->create_info.format);
@@ -2828,9 +2826,7 @@ bool CoreChecks::ValidateCmdBlitImage(VkCommandBuffer commandBuffer, VkImage src
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (!cb_state_ptr || !src_image_state || !src_image_state) {
-        return skip;
-    }
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
     const bool is_2 = loc.function == Func::vkCmdBlitImage2 || loc.function == Func::vkCmdBlitImage2KHR;
     const Location src_image_loc = loc.dot(Field::srcImage);
@@ -3208,15 +3204,15 @@ template <typename RegionType>
 void CoreChecks::RecordCmdBlitImage(VkCommandBuffer commandBuffer, VkImage srcImage, VkImageLayout srcImageLayout, VkImage dstImage,
                                     VkImageLayout dstImageLayout, uint32_t regionCount, const RegionType *pRegions,
                                     VkFilter filter) {
-    auto cb_state_ptr = GetWrite<vvl::CommandBuffer>(commandBuffer);
+    auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (cb_state_ptr && src_image_state && dst_image_state) {
-        // Make sure that all image slices are updated to correct layout
-        for (uint32_t i = 0; i < regionCount; ++i) {
-            cb_state_ptr->SetImageInitialLayout(*src_image_state, pRegions[i].srcSubresource, srcImageLayout);
-            cb_state_ptr->SetImageInitialLayout(*dst_image_state, pRegions[i].dstSubresource, dstImageLayout);
-        }
+    ASSERT_AND_RETURN(src_image_state && dst_image_state);
+
+    // Make sure that all image slices are updated to correct layout
+    for (uint32_t i = 0; i < regionCount; ++i) {
+        cb_state->SetImageInitialLayout(*src_image_state, pRegions[i].srcSubresource, srcImageLayout);
+        cb_state->SetImageInitialLayout(*dst_image_state, pRegions[i].dstSubresource, dstImageLayout);
     }
 }
 
@@ -3249,9 +3245,7 @@ bool CoreChecks::ValidateCmdResolveImage(VkCommandBuffer commandBuffer, VkImage 
     auto cb_state_ptr = GetRead<vvl::CommandBuffer>(commandBuffer);
     auto src_image_state = Get<vvl::Image>(srcImage);
     auto dst_image_state = Get<vvl::Image>(dstImage);
-    if (!cb_state_ptr || !src_image_state || !dst_image_state) {
-        return skip;
-    }
+    ASSERT_AND_RETURN_SKIP(src_image_state && dst_image_state);
 
     const bool is_2 = loc.function == Func::vkCmdResolveImage2 || loc.function == Func::vkCmdResolveImage2KHR;
     const char *vuid;

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -781,7 +781,7 @@ bool CoreChecks::PreCallValidateResetCommandPool(VkDevice device, VkCommandPool 
                                                  const ErrorObject &error_obj) const {
     bool skip = false;
     auto cp_state = Get<vvl::CommandPool>(commandPool);
-    if (!cp_state) return skip;
+    ASSERT_AND_RETURN_SKIP(cp_state);
     // Verify that command buffers in pool are complete (not in-flight)
     for (auto &entry : cp_state->commandBuffers) {
         auto cb_state = entry.second;

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -299,7 +299,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer, V
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
 
@@ -348,7 +348,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBu
     skip |= ValidateGraphicsIndexedCmd(cb_state, error_obj.location);
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
 
@@ -520,7 +520,7 @@ bool CoreChecks::PreCallValidateCmdDispatchIndirect(VkCommandBuffer commandBuffe
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     if (offset & 3) {
         skip |= LogError("VUID-vkCmdDispatchIndirect-offset-02710", cb_state.GetObjectList(VK_SHADER_STAGE_COMPUTE_BIT),
@@ -563,7 +563,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
                          "call this command.");
     }
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateCmdDrawStrideWithStruct(cb_state, "VUID-vkCmdDrawIndirectCount-stride-03110", stride,
                                             Struct::VkDrawIndirectCommand, sizeof(VkDrawIndirectCommand), error_obj.location);
     if (maxDrawCount > 1) {
@@ -575,7 +575,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuff
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    if (!count_buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(count_buffer_state);
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
     return skip;
@@ -617,7 +617,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
                                             Struct::VkDrawIndexedIndirectCommand, sizeof(VkDrawIndexedIndirectCommand),
                                             error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     if (maxDrawCount > 1) {
         skip |= ValidateCmdDrawStrideWithBuffer(cb_state, "VUID-vkCmdDrawIndexedIndirectCount-maxDrawCount-03143", stride,
                                                 Struct::VkDrawIndexedIndirectCommand, sizeof(VkDrawIndexedIndirectCommand),
@@ -628,7 +628,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer comm
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    if (!count_buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(count_buffer_state);
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
     return skip;
@@ -689,6 +689,7 @@ bool CoreChecks::PreCallValidateCmdDrawIndirectByteCountEXT(VkCommandBuffer comm
     skip |= ValidateCmdDrawInstance(cb_state, instanceCount, firstInstance, error_obj.location);
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto counter_buffer_state = Get<vvl::Buffer>(counterBuffer);
+    ASSERT_AND_RETURN_SKIP(counter_buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *counter_buffer_state, error_obj.location);
     skip |= ValidateVTGShaderStages(cb_state, error_obj.location);
     return skip;
@@ -1284,7 +1285,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectNV(VkCommandBuffer comma
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
     if (drawCount > 1) {
@@ -1347,7 +1348,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountNV(VkCommandBuffer 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    if (!buffer_state || !count_buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state && count_buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateIndirectCountCmd(cb_state, *count_buffer_state, countBufferOffset, error_obj.location);
     skip |= ValidateCmdDrawStrideWithStruct(cb_state, "VUID-vkCmdDrawMeshTasksIndirectCountNV-stride-02182", stride,
@@ -1435,7 +1436,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectEXT(VkCommandBuffer comm
 
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
 
     if (drawCount > 1) {
@@ -1486,7 +1487,7 @@ bool CoreChecks::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkCommandBuffer
     skip |= ValidateActionState(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, error_obj.location);
     auto buffer_state = Get<vvl::Buffer>(buffer);
     auto count_buffer_state = Get<vvl::Buffer>(countBuffer);
-    if (!buffer_state || !count_buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state && count_buffer_state);
     skip |= ValidateIndirectCmd(cb_state, *buffer_state, error_obj.location);
     skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *count_buffer_state, error_obj.location.dot(Field::countBuffer),
                                           vuid.indirect_count_contiguous_memory_02714);
@@ -1640,7 +1641,7 @@ bool CoreChecks::ValidateActionStateDescriptors(const LastBound &last_bound_stat
                     } else {  // Valid set is bound and layout compatible, validate that it's updated
                         // Pull the set node
                         const auto *descriptor_set = set_info.bound_descriptor_set.get();
-                        assert(descriptor_set);
+                        ASSERT_AND_CONTINUE(descriptor_set);
                         // Validate the draw-time state for this descriptor set
                         // We can skip validating the descriptor set if "nothing" has changed since the last validation.
                         // Same set, no image layout changes, and same "pipeline state" (binding_req_map). If there are
@@ -1714,7 +1715,7 @@ bool CoreChecks::ValidateActionStateDescriptors(const LastBound &last_bound_stat
                     } else {  // Valid set is bound and layout compatible, validate that it's updated
                         // Pull the set node
                         const auto *descriptor_set = set_info.bound_descriptor_set.get();
-                        assert(descriptor_set);
+                        ASSERT_AND_CONTINUE(descriptor_set);
                         // Validate the draw-time state for this descriptor set
                         // We can skip validating the descriptor set if "nothing" has changed since the last validation.
                         // Same set, no image layout changes, and same "pipeline state" (binding_req_map). If there are

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -68,7 +68,7 @@ bool CoreChecks::PreCallValidateImportSemaphoreFdKHR(VkDevice device, const VkIm
                                                      const ErrorObject &error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pImportSemaphoreFdInfo->semaphore);
-    if (!sem_state) return skip;
+    ASSERT_AND_RETURN_SKIP(sem_state);
 
     const Location info_loc = error_obj.location.dot(Field::pImportSemaphoreFdInfo);
     skip |= ValidateObjectNotInUse(sem_state.get(), info_loc.dot(Field::semaphore), "VUID-vkImportSemaphoreFdKHR-semaphore-01142");
@@ -110,7 +110,7 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
                                                   const ErrorObject &error_obj) const {
     bool skip = false;
     auto sem_state = Get<vvl::Semaphore>(pGetFdInfo->semaphore);
-    if (!sem_state) return skip;
+    ASSERT_AND_RETURN_SKIP(sem_state);
 
     const Location info_loc = error_obj.location.dot(Field::pGetFdInfo);
     if ((pGetFdInfo->handleType & sem_state->exportHandleTypes) == 0) {
@@ -144,7 +144,8 @@ bool CoreChecks::PreCallValidateGetSemaphoreFdKHR(VkDevice device, const VkSemap
 bool CoreChecks::ValidateImportFence(VkFence fence, const char *vuid, const Location &loc) const {
     auto fence_node = Get<vvl::Fence>(fence);
     bool skip = false;
-    if (fence_node && fence_node->Scope() == vvl::Fence::kInternal && fence_node->State() == vvl::Fence::kInflight) {
+    ASSERT_AND_RETURN_SKIP(fence_node);
+    if (fence_node->Scope() == vvl::Fence::kInternal && fence_node->State() == vvl::Fence::kInflight) {
         skip |= LogError(vuid, fence, loc.dot(Field::fence), "(%s) is currently in use.", FormatHandle(fence).c_str());
     }
     return skip;

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -206,7 +206,7 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
 
         auto *overlay_map = GetLayoutRangeMap(overlayLayoutMap, *image_state);
         const auto *global_map = image_state->layout_range_map.get();
-        assert(global_map);
+        ASSERT_AND_CONTINUE(global_map);
         auto global_map_guard = global_map->ReadLock();
 
         // Note: don't know if it would matter
@@ -218,7 +218,6 @@ bool CoreChecks::ValidateCmdBufImageLayouts(const Location &loc, const vvl::Comm
                                                                                             pos->first.begin);
         while (pos != end) {
             VkImageLayout initial_layout = pos->second.initial_layout;
-            assert(initial_layout != image_layout_map::kInvalidLayout);
             if (initial_layout == image_layout_map::kInvalidLayout) {
                 continue;
             }
@@ -827,7 +826,7 @@ bool CoreChecks::UpdateCommandBufferImageLayoutMap(const vvl::CommandBuffer &cb_
                                                    vvl::CommandBuffer::ImageLayoutMap &layout_updates) const {
     bool skip = false;
     auto image_state = Get<vvl::Image>(img_barrier.image);
-    if (!image_state) return skip;
+    ASSERT_AND_RETURN_SKIP(image_state);
 
     std::shared_ptr<ImageSubresourceLayoutMap> write_subresource_map;
     auto iter = layout_updates.find(image_state->VkHandle());
@@ -910,7 +909,7 @@ void CoreChecks::RecordTransitionImageLayout(vvl::CommandBuffer &cb_state, const
         }
     }
     auto image_state = Get<vvl::Image>(mem_barrier.image);
-    if (!image_state) return;
+    ASSERT_AND_RETURN(image_state);
 
     auto normalized_isr = image_state->NormalizeSubresourceRange(mem_barrier.subresourceRange);
 

--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -194,7 +194,8 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDevice devi
                                            "VUID-vkGetPipelineExecutableStatisticsKHR-pipelineExecutableInfo-03272");
 
     auto pipeline_state = Get<vvl::Pipeline>(pExecutableInfo->pipeline);
-    if (pipeline_state && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR)) {
+    ASSERT_AND_RETURN_SKIP(pipeline_state);
+    if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR)) {
         skip |= LogError("VUID-vkGetPipelineExecutableStatisticsKHR-pipeline-03274", pExecutableInfo->pipeline, error_obj.location,
                          "called on a pipeline created without the "
                          "VK_PIPELINE_CREATE_CAPTURE_STATISTICS_BIT_KHR flag set.");
@@ -211,7 +212,8 @@ bool CoreChecks::PreCallValidateGetPipelineExecutableInternalRepresentationsKHR(
                                            "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipelineExecutableInfo-03276");
 
     auto pipeline_state = Get<vvl::Pipeline>(pExecutableInfo->pipeline);
-    if (pipeline_state && !(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR)) {
+    ASSERT_AND_RETURN_SKIP(pipeline_state);
+    if (!(pipeline_state->create_flags & VK_PIPELINE_CREATE_CAPTURE_INTERNAL_REPRESENTATIONS_BIT_KHR)) {
         skip |= LogError("VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pipeline-03278", pExecutableInfo->pipeline,
                          error_obj.location,
                          "called on a pipeline created without the "
@@ -233,14 +235,13 @@ bool CoreChecks::PreCallValidateDestroyPipeline(VkDevice device, VkPipeline pipe
 bool CoreChecks::PreCallValidateCmdBindPipeline(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
                                                 VkPipeline pipeline, const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
 
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
     skip |= ValidatePipelineBindPoint(*cb_state, pipelineBindPoint, error_obj.location);
 
     auto pipeline_ptr = Get<vvl::Pipeline>(pipeline);
-    if (!pipeline_ptr) return skip;
+    ASSERT_AND_RETURN_SKIP(pipeline_ptr);
     const vvl::Pipeline &pipeline_state = *pipeline_ptr;
 
     if (pipelineBindPoint != pipeline_state.pipeline_type) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -219,7 +219,7 @@ bool CoreChecks::ValidateGraphicsPipelinePortability(const vvl::Pipeline &pipeli
         // Validate color attachments
         const uint32_t subpass = pipeline.Subpass();
         auto render_pass = Get<vvl::RenderPass>(pipeline.GraphicsCreateInfo().renderPass);
-        if (!render_pass) return skip;
+        ASSERT_AND_RETURN_SKIP(render_pass);
         const bool ignore_color_blend_state =
             raster_state_ci->rasterizerDiscardEnable ||
             (pipeline.rendering_create_info ? (pipeline.rendering_create_info->colorAttachmentCount == 0)
@@ -3322,7 +3322,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpass(const LastBound &last_bou
     const vvl::CommandBuffer &cb_state = last_bound_state.cb_state;
 
     const auto rp_state = pipeline.RenderPassState();
-    if (!rp_state) return skip;
+    ASSERT_AND_RETURN_SKIP(rp_state);
     if (rp_state->VkHandle() != VK_NULL_HANDLE) {
         const LogObjectList objlist(cb_state.Handle(), pipeline.Handle(), rp_state->Handle());
         skip |= LogError(vuid.dynamic_rendering_06198, objlist, vuid.loc(),
@@ -3433,7 +3433,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
         if (enabled_features.dynamicRenderingUnusedAttachments) {
             if (rendering_info.pColorAttachments[i].imageView != VK_NULL_HANDLE) {
                 auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-                if (!view_state) continue;
+                ASSERT_AND_CONTINUE(view_state);
                 if ((pipeline_rendering_ci.colorAttachmentCount > i) && (view_state->create_info.format != VK_FORMAT_UNDEFINED) &&
                     (pipeline_rendering_ci.pColorAttachmentFormats[i] != VK_FORMAT_UNDEFINED) &&
                     (view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i])) {
@@ -3461,7 +3461,7 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassUnusedAttachments(const La
                 }
             } else {
                 auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-                if (!view_state) continue;
+                ASSERT_AND_CONTINUE(view_state);
                 if ((pipeline_rendering_ci.colorAttachmentCount > i) &&
                     view_state->create_info.format != pipeline_rendering_ci.pColorAttachmentFormats[i]) {
                     const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
@@ -3730,9 +3730,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
                 continue;
             }
             auto color_view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-            if (!color_view_state) continue;
+            ASSERT_AND_CONTINUE(color_view_state);
             auto color_image_samples = Get<vvl::Image>(color_view_state->create_info.image)->create_info.samples;
-            if (!color_image_samples) continue;
+            ASSERT_AND_CONTINUE(color_image_samples);
 
             if (p_attachment_sample_count_info &&
                 (color_image_samples != p_attachment_sample_count_info->pColorAttachmentSamples[i])) {
@@ -3748,9 +3748,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
 
         if (rendering_info.pDepthAttachment != nullptr) {
             auto depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-            if (!depth_view_state) return skip;
+            ASSERT_AND_RETURN_SKIP(depth_view_state);
             auto depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->create_info.samples;
-            if (!depth_image_samples) return skip;
+            ASSERT_AND_RETURN_SKIP(depth_image_samples);
 
             if (p_attachment_sample_count_info) {
                 if (depth_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
@@ -3767,9 +3767,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
 
         if (rendering_info.pStencilAttachment != nullptr) {
             auto stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-            if (!stencil_view_state) return skip;
+            ASSERT_AND_RETURN_SKIP(stencil_view_state);
             auto stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->create_info.samples;
-            if (!stencil_image_samples) return skip;
+            ASSERT_AND_RETURN_SKIP(stencil_image_samples);
 
             if (p_attachment_sample_count_info) {
                 if (stencil_image_samples != p_attachment_sample_count_info->depthStencilAttachmentSamples) {
@@ -3790,9 +3790,9 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
                 continue;
             }
             auto view_state = Get<vvl::ImageView>(rendering_info.pColorAttachments[i].imageView);
-            if (!view_state) continue;
+            ASSERT_AND_CONTINUE(view_state);
             auto image_state = Get<vvl::Image>(view_state->create_info.image);
-            if (!image_state) continue;
+            ASSERT_AND_CONTINUE(image_state);
 
             auto samples = image_state->create_info.samples;
             if (samples != rasterization_samples) {
@@ -3807,9 +3807,11 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
 
         if ((rendering_info.pDepthAttachment != nullptr) && (rendering_info.pDepthAttachment->imageView != VK_NULL_HANDLE)) {
             const auto &depth_view_state = Get<vvl::ImageView>(rendering_info.pDepthAttachment->imageView);
-            if (!depth_view_state) return skip;
+            ASSERT_AND_RETURN_SKIP(depth_view_state);
             const auto &depth_image_samples = Get<vvl::Image>(depth_view_state->create_info.image)->create_info.samples;
-            if (depth_image_samples && (depth_image_samples != rasterization_samples)) {
+            ASSERT_AND_RETURN_SKIP(depth_image_samples);
+
+            if (depth_image_samples != rasterization_samples) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_rendering_07286, objlist, vuid.loc(),
                                  "Depth attachment sample count (%s) must match corresponding "
@@ -3821,9 +3823,11 @@ bool CoreChecks::ValidateDrawPipelineDynamicRenderpassSampleCount(const LastBoun
 
         if ((rendering_info.pStencilAttachment != nullptr) && (rendering_info.pStencilAttachment->imageView != VK_NULL_HANDLE)) {
             const auto &stencil_view_state = Get<vvl::ImageView>(rendering_info.pStencilAttachment->imageView);
-            if (!stencil_view_state) return skip;
+            ASSERT_AND_RETURN_SKIP(stencil_view_state);
             const auto &stencil_image_samples = Get<vvl::Image>(stencil_view_state->create_info.image)->create_info.samples;
-            if (stencil_image_samples && (stencil_image_samples != rasterization_samples)) {
+            ASSERT_AND_RETURN_SKIP(stencil_image_samples);
+
+            if (stencil_image_samples != rasterization_samples) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_rendering_07287, objlist, vuid.loc(),
                                  "Stencil attachment sample count (%s) must match corresponding "

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -284,7 +284,8 @@ bool CoreChecks::ValidateRenderPassStripeSubmitInfo(VkQueue queue, const vvl::Co
     for (uint32_t count = 0; count < rp_submit_info->stripeSemaphoreInfoCount; ++count) {
         auto semaphore = rp_submit_info->pStripeSemaphoreInfos[count].semaphore;
         auto semaphore_state = Get<vvl::Semaphore>(semaphore);
-        if (semaphore_state && semaphore_state->type != VK_SEMAPHORE_TYPE_BINARY) {
+        ASSERT_AND_CONTINUE(semaphore_state);
+        if (semaphore_state->type != VK_SEMAPHORE_TYPE_BINARY) {
             objlist.add(semaphore);
             skip |= LogError("VUID-VkRenderPassStripeSubmitInfoARM-semaphore-09447", objlist,
                              loc.pNext(Struct::VkRenderPassStripeSubmitInfoARM, Field::pStripeSemaphoreInfos, count),
@@ -485,7 +486,7 @@ bool CoreChecks::ValidateQueueFamilyIndices(const Location &loc, const vvl::Comm
     using sync_vuid_maps::SubmitError;
     bool skip = false;
     auto pool = cb_state.command_pool;
-    if (!pool) return skip;
+    ASSERT_AND_RETURN_SKIP(pool);
 
     if (pool->queueFamilyIndex != queue_state.queueFamilyIndex) {
         const LogObjectList objlist(cb_state.Handle(), queue_state.Handle());
@@ -663,7 +664,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const VkSparseBufferMemoryBindInfo &buffer_bind = bind_info.pBufferBinds[buffer_idx];
                 if (buffer_bind.pBinds) {
                     auto buffer_state = Get<vvl::Buffer>(buffer_bind.buffer);
-                    if (!buffer_state) continue;
+                    ASSERT_AND_CONTINUE(buffer_state);
                     for (uint32_t buffer_bind_idx = 0; buffer_bind_idx < buffer_bind.bindCount; ++buffer_bind_idx) {
                         const VkSparseMemoryBind &memory_bind = buffer_bind.pBinds[buffer_bind_idx];
                         const Location buffer_loc = bind_info_loc.dot(Field::pBufferBinds, buffer_idx);
@@ -681,7 +682,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const VkSparseImageOpaqueMemoryBindInfo &image_opaque_bind = bind_info.pImageOpaqueBinds[image_opaque_idx];
                 if (image_opaque_bind.pBinds) {
                     auto image_state = Get<vvl::Image>(image_opaque_bind.image);
-                    if (!image_state) continue;
+                    ASSERT_AND_CONTINUE(image_state);
                     for (uint32_t image_opaque_bind_idx = 0; image_opaque_bind_idx < image_opaque_bind.bindCount;
                          ++image_opaque_bind_idx) {
                         const VkSparseMemoryBind &memory_bind = image_opaque_bind.pBinds[image_opaque_bind_idx];
@@ -702,7 +703,7 @@ bool CoreChecks::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindInfo
                 const Location bind_loc = bind_info_loc.dot(Field::pImageBinds, image_idx);
                 const VkSparseImageMemoryBindInfo &image_bind = bind_info.pImageBinds[image_idx];
                 auto image_state = Get<vvl::Image>(image_bind.image);
-                if (!image_state) continue;
+                ASSERT_AND_CONTINUE(image_state);
 
                 if (!image_state->sparse_residency) {
                     skip |=

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -57,7 +57,7 @@ bool CoreChecks::PreCallValidateCreateAccelerationStructureKHR(VkDevice device,
     bool skip = false;
     if (!pCreateInfo) return skip;
     auto buffer_state = Get<vvl::Buffer>(pCreateInfo->buffer);
-    if (!buffer_state) return skip;
+    ASSERT_AND_RETURN_SKIP(buffer_state);
 
     if (!(buffer_state->usage & VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR)) {
         skip |= LogError("VUID-VkAccelerationStructureCreateInfoKHR-buffer-03614", buffer_state->Handle(),
@@ -86,7 +86,7 @@ bool CoreChecks::PreCallValidateBindAccelerationStructureMemoryNV(VkDevice devic
         const Location bind_info_loc = error_obj.location.dot(Field::pBindInfos, i);
         const VkBindAccelerationStructureMemoryInfoNV &info = pBindInfos[i];
         auto as_state = Get<vvl::AccelerationStructureNV>(info.accelerationStructure);
-        if (!as_state) continue;
+        ASSERT_AND_CONTINUE(as_state);
 
         if (as_state->HasFullRangeBound()) {
             skip |= LogError("VUID-VkBindAccelerationStructureMemoryInfoNV-accelerationStructure-03620", info.accelerationStructure,
@@ -847,7 +847,6 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresKHR(
     using sparse_container::range;
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     if (!pInfos || !ppBuildRangeInfos) {
@@ -1102,7 +1101,6 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructuresIndirectKHR(VkComm
                                                                           const uint32_t *const *ppMaxPrimitiveCounts,
                                                                           const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
     if (!cb_state->unprotected) {
@@ -1164,7 +1162,6 @@ bool CoreChecks::PreCallValidateCmdBuildAccelerationStructureNV(VkCommandBuffer 
                                                                 VkBuffer scratch, VkDeviceSize scratchOffset,
                                                                 const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     bool skip = false;
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1328,7 +1325,6 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureNV(VkCommandBuffer c
                                                                VkCopyAccelerationStructureModeNV mode,
                                                                const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     bool skip = false;
 
     skip |= ValidateCmd(*cb_state, error_obj.location);
@@ -1423,7 +1419,7 @@ bool CoreChecks::PreCallValidateWriteAccelerationStructuresPropertiesKHR(VkDevic
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         const Location as_loc = error_obj.location.dot(Field::pAccelerationStructures, i);
         auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
-        if (!as_state) continue;
+        ASSERT_AND_CONTINUE(as_state);
         const auto &as_info = as_state->build_info_khr;
 
         skip |= ValidateAccelStructBufferMemoryIsHostVisible(*as_state, as_loc,
@@ -1455,7 +1451,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
-    if (!query_pool_state) return skip;
+    ASSERT_AND_RETURN_SKIP(query_pool_state);
     const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType != queryType) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryPool-02493", commandBuffer,
@@ -1466,7 +1462,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesKHR(
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         const Location as_loc = error_obj.location.dot(Field::pAccelerationStructures, i);
         auto as_state = Get<vvl::AccelerationStructureKHR>(pAccelerationStructures[i]);
-        if (!as_state) continue;
+        ASSERT_AND_CONTINUE(as_state);
 
         skip |= ValidateMemoryIsBoundToBuffer(commandBuffer, *as_state->buffer_state, as_loc.dot(Field::buffer),
                                               "VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-buffer-03736");
@@ -1495,7 +1491,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
     skip |= ValidateCmd(*cb_state, error_obj.location);
     auto query_pool_state = Get<vvl::QueryPool>(queryPool);
-    if (!query_pool_state) return skip;
+    ASSERT_AND_RETURN_SKIP(query_pool_state);
     const auto &query_pool_ci = query_pool_state->create_info;
     if (query_pool_ci.queryType != queryType) {
         skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesNV-queryPool-03755", commandBuffer,
@@ -1506,7 +1502,7 @@ bool CoreChecks::PreCallValidateCmdWriteAccelerationStructuresPropertiesNV(
     for (uint32_t i = 0; i < accelerationStructureCount; ++i) {
         if (queryType == VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV) {
             auto as_state = Get<vvl::AccelerationStructureNV>(pAccelerationStructures[i]);
-            if (!as_state) continue;
+            ASSERT_AND_CONTINUE(as_state);
 
             if (!(as_state->build_info.flags & VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR)) {
                 skip |= LogError("VUID-vkCmdWriteAccelerationStructuresPropertiesNV-pAccelerationStructures-06215", commandBuffer,
@@ -1566,7 +1562,6 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureKHR(VkCommandBuffer 
                                                                 const ErrorObject &error_obj) const {
     bool skip = false;
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
     const Location info_loc = error_obj.location.dot(Field::pInfo);
@@ -1658,7 +1653,6 @@ bool CoreChecks::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(VkComman
                                                                         const VkCopyAccelerationStructureToMemoryInfoKHR *pInfo,
                                                                         const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
@@ -1718,7 +1712,6 @@ bool CoreChecks::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(VkComman
                                                                         const VkCopyMemoryToAccelerationStructureInfoKHR *pInfo,
                                                                         const ErrorObject &error_obj) const {
     auto cb_state = GetRead<vvl::CommandBuffer>(commandBuffer);
-    assert(cb_state);
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
@@ -1784,9 +1777,8 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupHandlesKHR(VkDevice devi
                                                                    const ErrorObject &error_obj) const {
     bool skip = false;
     auto pipeline_ptr = Get<vvl::Pipeline>(pipeline);
-    if (!pipeline_ptr) {
-        return skip;
-    } else if (pipeline_ptr->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
+    ASSERT_AND_RETURN_SKIP(pipeline_ptr);
+    if (pipeline_ptr->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         skip |=
             LogError("VUID-vkGetRayTracingShaderGroupHandlesKHR-pipeline-04619", pipeline, error_obj.location.dot(Field::pipeline),
                      "is a %s pipeline.", string_VkPipelineBindPoint(pipeline_ptr->pipeline_type));
@@ -1842,9 +1834,8 @@ bool CoreChecks::PreCallValidateGetRayTracingCaptureReplayShaderGroupHandlesKHR(
                          dataSize, phys_dev_ext_props.ray_tracing_props_khr.shaderGroupHandleCaptureReplaySize, groupCount);
     }
     auto pipeline_state = Get<vvl::Pipeline>(pipeline);
-    if (!pipeline_state) {
-        return skip;
-    } else if (pipeline_state->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
+    ASSERT_AND_RETURN_SKIP(pipeline_state);
+    if (pipeline_state->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         skip |= LogError("VUID-vkGetRayTracingCaptureReplayShaderGroupHandlesKHR-pipeline-04620", pipeline,
                          error_obj.location.dot(Field::pipeline), "is a %s pipeline.",
                          string_VkPipelineBindPoint(pipeline_state->pipeline_type));
@@ -1897,7 +1888,7 @@ bool CoreChecks::PreCallValidateGetRayTracingShaderGroupStackSizeKHR(VkDevice de
                                                                      const ErrorObject &error_obj) const {
     bool skip = false;
     auto pipeline_state = Get<vvl::Pipeline>(pipeline);
-    if (!pipeline_state) return skip;
+    ASSERT_AND_RETURN_SKIP(pipeline_state);
 
     if (pipeline_state->pipeline_type != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
         skip |= LogError("VUID-vkGetRayTracingShaderGroupStackSizeKHR-pipeline-04622", pipeline,

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -865,7 +865,6 @@ bool CoreChecks::ValidateGraphicsPipelineShaderState(const vvl::Pipeline &pipeli
             producer.spirv_state ? producer.spirv_state : producer.module_state->spirv;
         const std::shared_ptr<const spirv::Module> &consumer_spirv =
             consumer.spirv_state ? consumer.spirv_state : consumer.module_state->spirv;
-        assert(producer.module_state);
         if (&producer == fragment_stage) {
             break;
         }

--- a/layers/core_checks/cc_video.cpp
+++ b/layers/core_checks/cc_video.cpp
@@ -3983,8 +3983,7 @@ bool CoreChecks::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer commandBuffer,
     if (vs_state->create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR) {
         const auto inline_query_info = vku::FindStructInPNextChain<VkVideoInlineQueryInfoKHR>(pDecodeInfo->pNext);
         if (inline_query_info != nullptr) {
-            auto query_pool_state = Get<vvl::QueryPool>(inline_query_info->queryPool);
-            if (query_pool_state) {
+            if (auto query_pool_state = Get<vvl::QueryPool>(inline_query_info->queryPool)) {
                 skip |= ValidateVideoInlineQueryInfo(*query_pool_state, *inline_query_info,
                                                      decode_info_loc.pNext(Struct::VkVideoInlineQueryInfoKHR));
 
@@ -4393,8 +4392,7 @@ bool CoreChecks::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer commandBuffer,
     if (vs_state->create_info.flags & VK_VIDEO_SESSION_CREATE_INLINE_QUERIES_BIT_KHR) {
         const auto inline_query_info = vku::FindStructInPNextChain<VkVideoInlineQueryInfoKHR>(pEncodeInfo->pNext);
         if (inline_query_info != nullptr) {
-            auto query_pool_state = Get<vvl::QueryPool>(inline_query_info->queryPool);
-            if (query_pool_state) {
+            if (auto query_pool_state = Get<vvl::QueryPool>(inline_query_info->queryPool)) {
                 skip |= ValidateVideoInlineQueryInfo(*query_pool_state, *inline_query_info,
                                                      encode_info_loc.pNext(Struct::VkVideoInlineQueryInfoKHR));
 

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -151,7 +151,7 @@ class CoreChecks : public ValidationStateTracker {
     void EnqueueSubmitTimeValidateImageBarrierAttachment(const Location& loc, vvl::CommandBuffer& cb_state,
                                                          const ImageBarrier& barrier);
     bool ValidateImageBarrierAttachment(const Location& barrier_loc, vvl::CommandBuffer const& cb_state,
-                                        const vvl::Framebuffer* framebuffer, uint32_t active_subpass,
+                                        const vvl::Framebuffer& fb_state, uint32_t active_subpass,
                                         const vku::safe_VkSubpassDescription2& sub_desc, const VkRenderPass rp_handle,
                                         const ImageBarrier& img_barrier,
                                         const vvl::CommandBuffer* primary_cb_state = nullptr) const;

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -122,7 +122,7 @@ void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDis
             disable_data[sync_validation_queue_submit] = true;
             break;
         default:
-            assert(true);
+            assert(false);
     }
 }
 
@@ -181,7 +181,7 @@ void SetValidationEnable(CHECK_ENABLED &enable_data, const ValidationCheckEnable
             enable_data[vendor_specific_nvidia] = true;
             break;
         default:
-            assert(true);
+            assert(false);
     }
 }
 

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1068,7 +1068,7 @@ void CommandBuffer::ExecuteCommands(vvl::span<const VkCommandBuffer> secondary_c
     RecordCmd(Func::vkCmdExecuteCommands);
     for (const VkCommandBuffer sub_command_buffer : secondary_command_buffers) {
         auto sub_cb_state = dev_data.GetWrite<CommandBuffer>(sub_command_buffer);
-        assert(sub_cb_state);
+        ASSERT_AND_RETURN(sub_cb_state);
         if (!(sub_cb_state->beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT)) {
             if (beginInfo.flags & VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT) {
                 // TODO: Because this is a state change, clearing the VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT needs to be moved
@@ -1276,7 +1276,7 @@ void CommandBuffer::UpdateLastBoundDescriptorSets(VkPipelineBindPoint pipeline_b
                                                   uint32_t set_count, const VkDescriptorSet *pDescriptorSets,
                                                   std::shared_ptr<vvl::DescriptorSet> &push_descriptor_set,
                                                   uint32_t dynamic_offset_count, const uint32_t *p_dynamic_offsets) {
-    assert((pDescriptorSets == nullptr) ^ (push_descriptor_set == nullptr));
+    ASSERT_AND_RETURN((pDescriptorSets == nullptr) ^ (push_descriptor_set == nullptr));
 
     uint32_t required_size = first_set + set_count;
     const uint32_t last_binding_index = required_size - 1;
@@ -1444,7 +1444,7 @@ void CommandBuffer::SetImageInitialLayout(const vvl::Image &image_state, const V
 
 void CommandBuffer::SetImageInitialLayout(VkImage image, const VkImageSubresourceRange &range, VkImageLayout layout) {
     auto image_state = dev_data.Get<vvl::Image>(image);
-    if (!image_state) return;
+    ASSERT_AND_RETURN(image_state);
     SetImageInitialLayout(*image_state, range, layout);
 }
 

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -80,7 +80,7 @@ void vvl::DescriptorPool::Free(uint32_t count, const VkDescriptorSet *descriptor
     for (uint32_t i = 0; i < count; ++i) {
         if (descriptor_sets[i] != VK_NULL_HANDLE) {
             auto iter = sets_.find(descriptor_sets[i]);
-            assert(iter != sets_.end());
+            ASSERT_AND_CONTINUE(iter != sets_.end());
             auto *set_state = iter->second;
             const auto &layout = set_state->Layout();
             uint32_t type_index = 0, descriptor_count = 0;
@@ -345,7 +345,6 @@ const vvl::IndexRange &vvl::DescriptorSetLayoutDef::GetGlobalIndexRangeFromBindi
 // Move to next valid binding having a non-zero binding count
 uint32_t vvl::DescriptorSetLayoutDef::GetNextValidBinding(const uint32_t binding) const {
     auto it = non_empty_bindings_.upper_bound(binding);
-    assert(it != non_empty_bindings_.cend());
     if (it != non_empty_bindings_.cend()) return *it;
     return GetMaxBinding() + 1;
 }
@@ -425,7 +424,8 @@ vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorP
     auto free_binding = bindings_store_.data();
     for (uint32_t i = 0; i < binding_count; ++i) {
         auto create_info = layout_->GetDescriptorSetLayoutBindingPtrFromIndex(i);
-        assert(create_info);
+        ASSERT_AND_CONTINUE(create_info);
+
         uint32_t descriptor_count = create_info->descriptorCount;
         auto flags = layout_->GetDescriptorBindingFlagsFromIndex(i);
         if (flags & VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT) {
@@ -499,7 +499,7 @@ vvl::DescriptorSet::DescriptorSet(const VkDescriptorSet handle, vvl::DescriptorP
                 break;
             }
             default:
-                assert(0);  // Bad descriptor type specified
+                assert(false);  // Bad descriptor type specified
                 break;
         }
     }
@@ -544,7 +544,7 @@ void vvl::DescriptorSet::PerformWriteUpdate(const VkWriteDescriptorSet &update) 
     // Perform update on a per-binding basis as consecutive updates roll over to next binding
     auto descriptors_remaining = update.descriptorCount;
     auto iter = FindDescriptor(update.dstBinding, update.dstArrayElement);
-    assert(!iter.AtEnd());
+    ASSERT_AND_RETURN(!iter.AtEnd());
     auto &orig_binding = iter.CurrentBinding();
 
     // Verify next consecutive binding matches type, stage flags & immutable sampler use and if AtEnd
@@ -612,7 +612,8 @@ void vvl::DescriptorSet::UpdateDrawState(ValidationStateTracker *device_data, vv
     // resources
     for (const auto &binding_req_pair : binding_req_map) {
         auto *binding = GetBinding(binding_req_pair.first);
-        assert(binding);
+        ASSERT_AND_CONTINUE(binding);
+
         // core validation doesn't handle descriptor indexing, that is only done by GPU-AV
         if (SkipBinding(*binding, binding_req_pair.second.variable->is_dynamic_accessed)) {
             continue;

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -108,7 +108,7 @@ DeviceMemory::DeviceMemory(VkDeviceMemory handle, const VkMemoryAllocateInfo *pA
 
 void vvl::BindableLinearMemoryTracker::BindMemory(StateObject *parent, std::shared_ptr<vvl::DeviceMemory> &mem_state,
                                              VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
-    if (!mem_state) return;
+    ASSERT_AND_RETURN(mem_state);
 
     mem_state->AddParent(parent);
     binding_ = {mem_state, memory_offset, 0u};
@@ -235,7 +235,7 @@ bool vvl::BindableMultiplanarMemoryTracker::HasFullRangeBound() const {
 // resource_offset is the plane index
 void vvl::BindableMultiplanarMemoryTracker::BindMemory(StateObject *parent, std::shared_ptr<vvl::DeviceMemory> &mem_state,
                                                   VkDeviceSize memory_offset, VkDeviceSize resource_offset, VkDeviceSize size) {
-    if (!mem_state) return;
+    ASSERT_AND_RETURN(mem_state);
 
     assert(resource_offset < planes_.size());
     mem_state->AddParent(parent);

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -139,7 +139,7 @@ uint32_t Instruction::GetBitWidth() const {
         default:
             // Most likely the caller is not checking for this being a matrix/array/struct/etc
             // This class only knows a single instruction's information
-            assert(0);
+            assert(false);
             break;
     }
     return bit_width;

--- a/layers/thread_tracker/thread_safety_validation.cpp
+++ b/layers/thread_tracker/thread_safety_validation.cpp
@@ -99,7 +99,7 @@ void ThreadSafety::PostCallRecordAllocateDescriptorSets(VkDevice device, const V
             if (iter != dsl_read_only_map.end()) {
                 ds_read_only_map.insert_or_assign(pDescriptorSets[index0], iter->second);
             } else {
-                assert(0 && "descriptor set layout not found");
+                assert(false && "descriptor set layout not found");
             }
         }
     }

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -55,6 +55,33 @@
 #endif
 #endif
 
+// There are many times we want to assert, but also it is highly important to not crash for release builds.
+// This Macro also makes it more obvious if we are returning early because of a known situation or if we are just guarding against
+// something wrong actually happening.
+#define ASSERT_AND_RETURN(cond) \
+    do {                        \
+        if (!(cond)) {          \
+            assert(false);      \
+            return;             \
+        }                       \
+    } while (0)
+
+#define ASSERT_AND_RETURN_SKIP(cond) \
+    do {                             \
+        if (!(cond)) {               \
+            assert(false);           \
+            return skip;             \
+        }                            \
+    } while (0)
+
+#define ASSERT_AND_CONTINUE(cond) \
+    do {                          \
+        if (!(cond)) {            \
+            assert(false);        \
+            continue;             \
+        }                         \
+    } while (0)
+
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};
     return d3;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8052

follow-up of  https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8024

There are a LOT of early return and assert and no idea which are "valid to hit" and which we should never hit (but clearly in the issue we do sometimes). This will make it more clear when we should be asserting or not... but if in a release build and the assert doesn't trigger, we still need to fail gracefully