### PR TITLE
gpu: Fix OpTypeArray logic in TypeLength

### DIFF
--- a/layers/gpu/spirv/type_manager.cpp
+++ b/layers/gpu/spirv/type_manager.cpp
@@ -354,8 +354,11 @@ uint32_t TypeManager::TypeLength(const Type& type) {
             return 8u;
         case spv::OpTypeArray: {
             const Type* element_type = FindTypeById(type.inst_.Operand(0));
-            const uint32_t count = element_type->inst_.Operand(0);
-            return count * TypeLength(*element_type);
+            const Constant* count = FindConstantById(type.inst_.Operand(1));
+            // TODO - Need to handle spec constant here, for now return zero to have things not blowup
+            assert(count);
+            const uint32_t length = count ? count->inst_.Operand(0) : 0;
+            return length * TypeLength(*element_type);
         }
         case spv::OpTypeStruct: {
             // Get the offset of the last member and then figure out it's size

--- a/layers/gpu/spirv/type_manager.cpp
+++ b/layers/gpu/spirv/type_manager.cpp
@@ -357,7 +357,7 @@ uint32_t TypeManager::TypeLength(const Type& type) {
             const Constant* count = FindConstantById(type.inst_.Operand(1));
             // TODO - Need to handle spec constant here, for now return zero to have things not blowup
             assert(count);
-            const uint32_t length = count ? count->inst_.Operand(0) : 0;
+            const uint32_t array_length = count ? count->inst_.Operand(0) : 0;
             return length * TypeLength(*element_type);
         }
         case spv::OpTypeStruct: {

--- a/layers/gpu/spirv/type_manager.cpp
+++ b/layers/gpu/spirv/type_manager.cpp
@@ -358,7 +358,7 @@ uint32_t TypeManager::TypeLength(const Type& type) {
             // TODO - Need to handle spec constant here, for now return zero to have things not blowup
             assert(count);
             const uint32_t array_length = count ? count->inst_.Operand(0) : 0;
-            return length * TypeLength(*element_type);
+            return array_length * TypeLength(*element_type);
         }
         case spv::OpTypeStruct: {
             // Get the offset of the last member and then figure out it's size


### PR DESCRIPTION
as spotted out in https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8073#issuecomment-2143491763

The `OpTypeArray` logic is wrong