### PR TITLE
layers: Add Device Queue Type check

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -229,6 +229,7 @@ vvl_sources = [
   "layers/state_tracker/descriptor_sets.h",
   "layers/state_tracker/device_memory_state.cpp",
   "layers/state_tracker/device_memory_state.h",
+  "layers/state_tracker/device_state.cpp",
   "layers/state_tracker/device_state.h",
   "layers/state_tracker/fence_state.cpp",
   "layers/state_tracker/fence_state.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -265,6 +265,7 @@ target_sources(vvl PRIVATE
     state_tracker/descriptor_sets.h
     state_tracker/device_memory_state.cpp
     state_tracker/device_memory_state.h
+    state_tracker/device_state.cpp
     state_tracker/device_state.h
     state_tracker/fence_state.cpp
     state_tracker/fence_state.h

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -131,9 +131,9 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
                                              const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer,
                                              const ErrorObject &error_obj) const {
     bool skip = false;
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-    auto chained_devaddr_struct = vku::FindStructInPNextChain<VkBufferDeviceAddressCreateInfoEXT>(pCreateInfo->pNext);
-    if (chained_devaddr_struct) {
+    if (auto chained_devaddr_struct = vku::FindStructInPNextChain<VkBufferDeviceAddressCreateInfoEXT>(pCreateInfo->pNext)) {
         if (!(pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) &&
             chained_devaddr_struct->deviceAddress != 0) {
             skip |= LogError("VUID-VkBufferCreateInfo-deviceAddress-02604", device,
@@ -143,8 +143,7 @@ bool CoreChecks::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCrea
         }
     }
 
-    auto chained_opaqueaddr_struct = vku::FindStructInPNextChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext);
-    if (chained_opaqueaddr_struct) {
+    if (auto chained_opaqueaddr_struct = vku::FindStructInPNextChain<VkBufferOpaqueCaptureAddressCreateInfo>(pCreateInfo->pNext)) {
         if (!(pCreateInfo->flags & VK_BUFFER_CREATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) &&
             chained_opaqueaddr_struct->opaqueCaptureAddress != 0) {
             skip |= LogError("VUID-VkBufferCreateInfo-opaqueCaptureAddress-03337", device,
@@ -312,6 +311,7 @@ bool CoreChecks::PreCallValidateCreateBufferView(VkDevice device, const VkBuffer
                                                  const VkAllocationCallbacks *pAllocator, VkBufferView *pView,
                                                  const ErrorObject &error_obj) const {
     bool skip = false;
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     auto buffer_state_ptr = Get<vvl::Buffer>(pCreateInfo->buffer);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     // If this isn't a sparse buffer, it needs to have memory backing it at CreateBufferView time

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -2587,6 +2587,7 @@ bool CoreChecks::PreCallValidateCreateEvent(VkDevice device, const VkEventCreate
                                             const VkAllocationCallbacks* pAllocator, VkEvent* pEvent,
                                             const ErrorObject& error_obj) const {
     bool skip = false;
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     if (IsExtEnabled(device_extensions.vk_khr_portability_subset)) {
         if (VK_FALSE == enabled_features.events) {
             skip |= LogError("VUID-vkCreateEvent-events-04468", device, error_obj.location,

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -4527,6 +4527,7 @@ bool CoreChecks::PreCallValidateCreateSampler(VkDevice device, const VkSamplerCr
                                               const ErrorObject &error_obj) const {
     bool skip = false;
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     auto num_samplers = Count<vvl::Sampler>();
     if (num_samplers >= phys_dev_props.limits.maxSamplerAllocationCount) {
         skip |= LogError("VUID-vkCreateSampler-maxSamplerAllocationCount-04110", device, error_obj.location,

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -851,3 +851,73 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
     }
     return skip;
 }
+
+// These were all added from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6672
+bool CoreChecks::ValidateDeviceQueueSupport(const Location &loc) const {
+    bool skip = false;
+    const char *vuid = kVUIDUndefined;
+    VkQueueFlags flags = 0;
+
+    switch (loc.function) {
+        case Func::vkCreateRayTracingPipelinesKHR:
+            vuid = "VUID-vkCreateRayTracingPipelinesKHR-device-09677";
+            flags = VK_QUEUE_COMPUTE_BIT;
+            break;
+        case Func::vkCreateRayTracingPipelinesNV:
+            vuid = "VUID-vkCreateRayTracingPipelinesNV-device-09677";
+            flags = VK_QUEUE_COMPUTE_BIT;
+            break;
+        case Func::vkCreateComputePipelines:
+            vuid = "VUID-vkCreateComputePipelines-device-09661";
+            flags = VK_QUEUE_COMPUTE_BIT;
+            break;
+        case Func::vkCreateGraphicsPipelines:
+            vuid = "VUID-vkCreateGraphicsPipelines-device-09662";
+            flags = VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateQueryPool:
+            vuid = "VUID-vkCreateQueryPool-device-09663";
+            flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateBuffer:
+            vuid = "VUID-vkCreateBuffer-device-09664";
+            flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_SPARSE_BINDING_BIT |
+                    VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateBufferView:
+            vuid = "VUID-vkCreateBufferView-device-09665";
+            flags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateImage:
+            vuid = "VUID-vkCreateImage-device-09666";
+            flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_OPTICAL_FLOW_BIT_NV |
+                    VK_QUEUE_SPARSE_BINDING_BIT | VK_QUEUE_TRANSFER_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateImageView:
+            vuid = "VUID-vkCreateImageView-device-09667";
+            flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateSampler:
+            vuid = "VUID-vkCreateSampler-device-09668";
+            flags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateEvent:
+            vuid = "VUID-vkCreateEvent-device-09672";
+            flags = VK_QUEUE_VIDEO_ENCODE_BIT_KHR | VK_QUEUE_VIDEO_DECODE_BIT_KHR | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        case Func::vkCreateShadersEXT:
+            vuid = "VUID-vkCreateShadersEXT-device-09669";
+            flags = VK_QUEUE_COMPUTE_BIT | VK_QUEUE_GRAPHICS_BIT;
+            break;
+        default:
+            assert(false);  // missing case
+            return skip;
+    }
+
+    if ((physical_device_state->supported_queues & flags) == 0) {
+        skip |= LogError(vuid, device, loc, "device only supports (%s) but require one of (%s).",
+                         string_VkQueueFlags(physical_device_state->supported_queues).c_str(), string_VkQueueFlags(flags).c_str());
+    }
+
+    return skip;
+}

--- a/layers/core_checks/cc_image.cpp
+++ b/layers/core_checks/cc_image.cpp
@@ -171,6 +171,7 @@ bool CoreChecks::PreCallValidateCreateImage(VkDevice device, const VkImageCreate
                                             const VkAllocationCallbacks *pAllocator, VkImage *pImage,
                                             const ErrorObject &error_obj) const {
     bool skip = false;
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     if (IsExtEnabled(device_extensions.vk_android_external_memory_android_hardware_buffer)) {
         skip |= ValidateCreateImageANDROID(*pCreateInfo, create_info_loc);
@@ -1808,6 +1809,7 @@ bool CoreChecks::PreCallValidateCreateImageView(VkDevice device, const VkImageVi
     auto image_state_ptr = Get<vvl::Image>(pCreateInfo->image);
     if (!image_state_ptr) return skip;
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     const auto &image_state = *image_state_ptr;
 

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -35,6 +35,8 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
                                                        chassis::CreateComputePipelines &chassis_state) const {
     bool skip = StateTracker::PreCallValidateCreateComputePipelines(device, pipelineCache, count, pCreateInfos, pAllocator,
                                                                     pPipelines, error_obj, pipeline_states, chassis_state);
+
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {
         const vvl::Pipeline *pipeline = pipeline_states[i].get();
         if (!pipeline) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -42,6 +42,7 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
     bool skip = StateTracker::PreCallValidateCreateGraphicsPipelines(device, pipelineCache, count, pCreateInfos, pAllocator,
                                                                      pPipelines, error_obj, pipeline_states, chassis_state);
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {
         const Location create_info_loc = error_obj.location.dot(Field::pCreateInfos, i);
         skip |= ValidateGraphicsPipeline(*pipeline_states[i].get(), create_info_loc);

--- a/layers/core_checks/cc_pipeline_ray_tracing.cpp
+++ b/layers/core_checks/cc_pipeline_ray_tracing.cpp
@@ -176,6 +176,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkP
     bool skip = StateTracker::PreCallValidateCreateRayTracingPipelinesNV(device, pipelineCache, count, pCreateInfos, pAllocator,
                                                                          pPipelines, error_obj, pipeline_states, chassis_state);
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     for (uint32_t i = 0; i < count; i++) {
         const vvl::Pipeline *pipeline = pipeline_states[i].get();
         if (!pipeline) {
@@ -218,6 +219,7 @@ bool CoreChecks::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, Vk
                                                                           pCreateInfos, pAllocator, pPipelines, error_obj,
                                                                           pipeline_states, chassis_state);
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     skip |= ValidateDeferredOperation(device, deferredOperation, error_obj.location.dot(Field::deferredOperation),
                                       "VUID-vkCreateRayTracingPipelinesKHR-deferredOperation-03678");
 

--- a/layers/core_checks/cc_query.cpp
+++ b/layers/core_checks/cc_query.cpp
@@ -264,6 +264,7 @@ bool CoreChecks::PreCallValidateCreateQueryPool(VkDevice device, const VkQueryPo
                                                 const ErrorObject &error_obj) const {
     if (disabled[query_validation]) return false;
     bool skip = false;
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     switch (pCreateInfo->queryType) {
         case VK_QUERY_TYPE_PIPELINE_STATISTICS: {
@@ -397,7 +398,6 @@ bool CoreChecks::HasRequiredQueueFlags(const vvl::CommandBuffer &cb_state, const
         }
     }
     return true;
-    ;
 }
 
 std::string CoreChecks::DescribeRequiredQueueFlag(const vvl::CommandBuffer &cb_state,

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -263,6 +263,7 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
                                                  VkShaderEXT* pShaders, const ErrorObject& error_obj) const {
     bool skip = false;
 
+    skip |= ValidateDeviceQueueSupport(error_obj.location);
     if (enabled_features.shaderObject == VK_FALSE) {
         skip |=
             LogError("VUID-vkCreateShadersEXT-None-08400", device, error_obj.location, "the shaderObject feature was not enabled.");

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -317,6 +317,7 @@ class CoreChecks : public ValidationStateTracker {
                                       const char* vuid) const;
 
     bool ValidateObjectNotInUse(const vvl::StateObject* obj_node, const Location& loc, const char* error_code) const;
+    bool ValidateDeviceQueueSupport(const Location& loc) const;
     bool HasRequiredQueueFlags(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,
                                VkQueueFlags required_flags) const;
     std::string DescribeRequiredQueueFlag(const vvl::CommandBuffer& cb_state, const vvl::PhysicalDevice& physical_device_state,

--- a/layers/state_tracker/device_state.cpp
+++ b/layers/state_tracker/device_state.cpp
@@ -1,0 +1,44 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "state_tracker/device_state.h"
+
+namespace vvl {
+
+const std::vector<VkQueueFamilyProperties> PhysicalDevice::GetQueueFamilyProps(VkPhysicalDevice phys_dev) {
+    std::vector<VkQueueFamilyProperties> result;
+    uint32_t count;
+    DispatchGetPhysicalDeviceQueueFamilyProperties(phys_dev, &count, nullptr);
+    result.resize(count);
+    DispatchGetPhysicalDeviceQueueFamilyProperties(phys_dev, &count, result.data());
+    return result;
+}
+
+VkQueueFlags PhysicalDevice::GetSupportedQueues() {
+    VkQueueFlags flag = 0;
+    for (const auto& prop : queue_family_properties) {
+        flag |= prop.queueFlags;
+    }
+    return flag;
+}
+
+PhysicalDevice::PhysicalDevice(VkPhysicalDevice handle)
+    : StateObject(handle, kVulkanObjectTypePhysicalDevice),
+      queue_family_properties(GetQueueFamilyProps(handle)),
+      supported_queues(GetSupportedQueues()) {}
+
+}  // namespace vvl

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -40,6 +40,7 @@ class PhysicalDevice : public StateObject {
   public:
     uint32_t queue_family_known_count = 1;  // spec implies one QF must always be supported
     const std::vector<VkQueueFamilyProperties> queue_family_properties;
+    const VkQueueFlags supported_queues;
     // TODO These are currently used by CoreChecks, but should probably be refactored
     bool vkGetPhysicalDeviceDisplayPlanePropertiesKHR_called = false;
     uint32_t display_plane_property_count = 0;
@@ -50,20 +51,13 @@ class PhysicalDevice : public StateObject {
     // Surfaceless Query extension needs 'global' surface_state data
     SurfacelessQueryState surfaceless_query_state{};
 
-    PhysicalDevice(VkPhysicalDevice handle)
-        : StateObject(handle, kVulkanObjectTypePhysicalDevice), queue_family_properties(GetQueueFamilyProps(handle)) {}
+    PhysicalDevice(VkPhysicalDevice handle);
 
     VkPhysicalDevice VkHandle() const { return handle_.Cast<VkPhysicalDevice>(); }
 
   private:
-    const std::vector<VkQueueFamilyProperties> GetQueueFamilyProps(VkPhysicalDevice phys_dev) {
-        std::vector<VkQueueFamilyProperties> result;
-        uint32_t count;
-        DispatchGetPhysicalDeviceQueueFamilyProperties(phys_dev, &count, nullptr);
-        result.resize(count);
-        DispatchGetPhysicalDeviceQueueFamilyProperties(phys_dev, &count, result.data());
-        return result;
-    }
+    const std::vector<VkQueueFamilyProperties> GetQueueFamilyProps(VkPhysicalDevice phys_dev);
+    VkQueueFlags GetSupportedQueues();
 };
 
 class DisplayMode : public StateObject {


### PR DESCRIPTION
These VUs were added in the 1.3.286 header and just check that creating certain handles is only possible if your device supports a required queue type

Moved it off to its own function as this is a very niche thing and likely not to get hit for most people (but will be helpful for the few who deal with these types of devices)