### PR TITLE
github: Remove redundant CI matrix

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -73,6 +73,11 @@ jobs:
           - config: release
             robin_hood: "OFF"
             sanitize: address
+        exclude:
+          # Have found over time this finds nothing extra, while taking the longest and using the most CI minutes.
+          - config: debug
+            robin_hood: "ON"
+            sanitize: thread
     steps:
       - uses: actions/checkout@v4
       - uses: lukka/get-cmake@latest


### PR DESCRIPTION
Help reduce CI minute pressure by removing our longest run that has caught nothing for us