### PR TITLE
Add Dual Source Blending check

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1570,7 +1570,7 @@ bool CoreChecks::ValidateDrawDynamicStateShaderObject(const LastBound& last_boun
             const LogObjectList frag_objlist(cb_state.Handle(), fragment_shader_stage->Handle());
             skip |= LogError(vuid.alpha_component_word_08920, frag_objlist, loc,
                              "alphaToCoverageEnable is set, but fragment shader doesn't declare a variable that covers "
-                             "Location 0, Component 0.");
+                             "Location 0, Component 3 (alpha channel).");
         }
     }
 

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -3175,14 +3175,11 @@ bool CoreChecks::ValidateDrawPipeline(const LastBound &last_bound_state, const v
     if (pipeline.IsDynamic(CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT) &&
         cb_state.dynamic_state_value.alpha_to_coverage_enable) {
         if (pipeline.fragment_shader_state && pipeline.fragment_shader_state->fragment_entry_point) {
-            // TODO - DualSource blend has two outputs at location zero, so Index == 0 is the one that's required.
-            // Currently lack support to test each index.
-            if (!pipeline.fragment_shader_state->fragment_entry_point->has_alpha_to_coverage_variable &&
-                !pipeline.DualSourceBlending()) {
+            if (!pipeline.fragment_shader_state->fragment_entry_point->has_alpha_to_coverage_variable) {
                 const LogObjectList objlist(cb_state.Handle(), pipeline.Handle());
                 skip |= LogError(vuid.dynamic_alpha_to_coverage_component_08919, objlist, vuid.loc(),
                                  "vkCmdSetAlphaToCoverageEnableEXT set alphaToCoverageEnable to true but the bound pipeline "
-                                 "fragment shader doesn't declare a variable that covers Location 0, Component 3.");
+                                 "fragment shader doesn't declare a variable that covers Location 0, Component 3 (alpha channel).");
             }
         }
     }

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -1489,18 +1489,15 @@ bool CoreChecks::ValidateGraphicsPipelineColorBlendAttachmentState(const vvl::Pi
                                                                    const Location &color_loc) const {
     bool skip = false;
     const auto &attachment_states = pipeline.AttachmentStates();
-    if (attachment_states.empty()) {
-        return skip;
-    }
-    if (!enabled_features.independentBlend) {
-        if (attachment_states.size() > 1) {
-            for (size_t i = 1; i < attachment_states.size(); i++) {
-                if (!ComparePipelineColorBlendAttachmentState(attachment_states[0], attachment_states[i])) {
-                    skip |= LogError("VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605", device,
-                                     color_loc.dot(Field::pAttachments, (uint32_t)i),
-                                     "is different than pAttachments[0] and independentBlend feature was not enabled.");
-                    break;
-                }
+    if (attachment_states.empty()) return skip;
+
+    if (!enabled_features.independentBlend && attachment_states.size() > 1) {
+        for (size_t i = 1; i < attachment_states.size(); i++) {
+            if (!ComparePipelineColorBlendAttachmentState(attachment_states[0], attachment_states[i])) {
+                skip |= LogError("VUID-VkPipelineColorBlendStateCreateInfo-pAttachments-00605", device,
+                                 color_loc.dot(Field::pAttachments, (uint32_t)i),
+                                 "is different than pAttachments[0] and independentBlend feature was not enabled.");
+                break;
             }
         }
     }

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -166,13 +166,11 @@ bool CoreChecks::ValidateInterfaceFragmentOutput(const vvl::Pipeline &pipeline, 
     bool skip = false;
     const auto *ms_state = pipeline.MultisampleState();
     if (!pipeline.IsDynamic(CB_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT) && ms_state && ms_state->alphaToCoverageEnable) {
-        // TODO - DualSource blend has two outputs at location zero, so Index == 0 is the one that's required.
-        // Currently lack support to test each index.
-        if (!entrypoint.has_alpha_to_coverage_variable && !pipeline.DualSourceBlending()) {
+        if (!entrypoint.has_alpha_to_coverage_variable) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891", module_state.handle(),
                              create_info_loc.dot(Field::pMultisampleState).dot(Field::alphaToCoverageEnable),
                              "is VK_TRUE, but the fragment shader doesn't declare a variable that covers "
-                             "Location 0, Component 3.");
+                             "Location 0, Component 3 (alpha channel).");
         }
     }
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -108,6 +108,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateTraceRaysDynamicStateSetStatus(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawPrimitivesGeneratedQuery(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawProtectedMemory(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateDrawDualSourceBlend(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateStageMaskHost(const LogObjectList& objlist, const Location& stage_mask_loc,
                                VkPipelineStageFlags2KHR stageMask) const;
     bool ValidateMapMemory(const vvl::DeviceMemory& mem_info, VkDeviceSize offset, VkDeviceSize size, const Location& offset_loc,

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -73,6 +73,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDraw-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDraw-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDraw-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDraw-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDraw-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDraw-None-07880";
         dynamic_discard_rectangle_mode_07881     = "VUID-vkCmdDraw-None-07881";
@@ -389,6 +390,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawMultiEXT-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawMultiEXT-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawMultiEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMultiEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMultiEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMultiEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     = "VUID-vkCmdDrawMultiEXT-None-07881";
@@ -706,6 +708,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndexed-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndexed-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndexed-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndexed-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndexed-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndexed-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndexed-None-07881";
@@ -1023,6 +1026,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawMultiIndexedEXT-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawMultiIndexedEXT-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawMultiIndexedEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMultiIndexedEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMultiIndexedEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMultiIndexedEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMultiIndexedEXT-None-07881";
@@ -1340,6 +1344,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndirect-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndirect-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndirect-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndirect-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndirect-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndirect-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndirect-None-07881";
@@ -1656,6 +1661,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndexedIndirect-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndexedIndirect-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndexedIndirect-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndexedIndirect-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndexedIndirect-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndexedIndirect-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndexedIndirect-None-07881";
@@ -2071,6 +2077,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndirectCount-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndirectCount-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndirectCount-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndirectCount-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndirectCount-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndirectCount-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndirectCount-None-07881";
@@ -2390,6 +2397,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndexedIndirectCount-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndexedIndirectCount-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndexedIndirectCount-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndexedIndirectCount-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndexedIndirectCount-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndexedIndirectCount-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndexedIndirectCount-None-07881";
@@ -2888,6 +2896,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksNV-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksNV-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksNV-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksNV-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksNV-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksNV-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksNV-None-07881";
@@ -3190,6 +3199,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksIndirectNV-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksIndirectNV-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksIndirectNV-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksIndirectNV-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksIndirectNV-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksIndirectNV-None-07881";
@@ -3495,6 +3505,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksIndirectCountNV-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-07881";
@@ -3794,6 +3805,7 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksEXT-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksEXT-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksEXT-None-07881";
@@ -4096,6 +4108,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksIndirectEXT-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksIndirectEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksIndirectEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksIndirectEXT-None-07881";
@@ -4401,6 +4414,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         depth_bias_enable_04877                  = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-04877";
         logic_op_04878                           = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-logicOp-04878";
         blend_enable_04727                       = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-07881";
@@ -4713,6 +4727,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         vertex_input_04914                       = "VUID-vkCmdDrawIndirectByteCountEXT-None-04914";
         vertex_input_08734                       = "VUID-vkCmdDrawIndirectByteCountEXT-Input-08734";
         blend_enable_04727                       = "VUID-vkCmdDrawIndirectByteCountEXT-blendEnable-04727";
+        blend_dual_source_09239                  = "VUID-vkCmdDrawIndirectByteCountEXT-maxFragmentDualSrcAttachments-09239";
         dynamic_discard_rectangle_07751          = "VUID-vkCmdDrawIndirectByteCountEXT-None-07751";
         dynamic_discard_rectangle_enable_07880   = "VUID-vkCmdDrawIndirectByteCountEXT-None-07880";
         dynamic_discard_rectangle_mode_07881     =  "VUID-vkCmdDrawIndirectByteCountEXT-None-07881";

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -89,6 +89,7 @@ struct DrawDispatchVuid {
     const char* vertex_input_04914 = kVUIDUndefined;
     const char* vertex_input_08734 = kVUIDUndefined;
     const char* blend_enable_04727 = kVUIDUndefined;
+    const char* blend_dual_source_09239 = kVUIDUndefined;
     const char* dynamic_discard_rectangle_07751 = kVUIDUndefined;
     const char* dynamic_discard_rectangle_enable_07880 = kVUIDUndefined;
     const char* dynamic_discard_rectangle_mode_07881 = kVUIDUndefined;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1871,13 +1871,13 @@ std::string CommandBuffer::GetDebugRegionName(const std::vector<LabelCommand> &l
 
 std::string CommandBuffer::DescribeInvalidatedState(CBDynamicState dynamic_state) const {
     std::stringstream ss;
-    if (dynamic_state_status.history[dynamic_state]) {
+    if (dynamic_state_status.history[dynamic_state] && !dynamic_state_status.cb[dynamic_state]) {
         ss << " (There was a call to vkCmdBindPipeline";
         if (auto pipeline = dev_data.Get<vvl::Pipeline>(invalidated_state_pipe[dynamic_state])) {
             ss << " with " << dev_data.FormatHandle(*pipeline);
         }
-        ss << " that didn't have the dynamic state and invalidated the prior " << DescribeDynamicStateCommand(dynamic_state)
-           << " call)";
+        ss << " that didn't have " << DynamicStateToString(dynamic_state) << " and invalidated the prior "
+           << DescribeDynamicStateCommand(dynamic_state) << " call)";
     }
     return ss.str();
 }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1715,22 +1715,6 @@ bool CommandBuffer::HasExternalFormatResolveAttachment() const {
     }
     return false;
 }
-bool CommandBuffer::HasDynamicDualSourceBlend(uint32_t attachmentCount) const {
-    if (dynamic_state_value.color_blend_enabled.any()) {
-        if (IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT)) {
-            for (uint32_t i = 0; i < dynamic_state_value.color_blend_equations.size() && i < attachmentCount; ++i) {
-                const auto &color_blend_equation = dynamic_state_value.color_blend_equations[i];
-                if (IsSecondaryColorInputBlendFactor(color_blend_equation.srcColorBlendFactor) ||
-                    IsSecondaryColorInputBlendFactor(color_blend_equation.dstColorBlendFactor) ||
-                    IsSecondaryColorInputBlendFactor(color_blend_equation.srcAlphaBlendFactor) ||
-                    IsSecondaryColorInputBlendFactor(color_blend_equation.dstAlphaBlendFactor)) {
-                    return true;
-                }
-            }
-        }
-    }
-    return false;
-}
 
 void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state) {
     auto &lastBoundState = lastBound[ConvertToPipelineBindPoint(shader_stage)];

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -676,7 +676,6 @@ class CommandBuffer : public RefcountedStateObject {
     bool HasValidDynamicDepthAttachment() const;
     bool HasValidDynamicStencilAttachment() const;
     bool HasExternalFormatResolveAttachment() const;
-    bool HasDynamicDualSourceBlend(uint32_t attachmentCount) const;
 
     inline void BindPipeline(LvlBindPoint bind_point, vvl::Pipeline *pipe_state) {
         lastBound[bind_point].pipeline_state = pipe_state;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -296,13 +296,6 @@ class Pipeline : public StateObject {
         return false;
     }
 
-    bool DualSourceBlending() const {
-        if (fragment_output_state) {
-            return fragment_output_state->dual_source_blending == VK_TRUE;
-        }
-        return false;
-    }
-
     const vku::safe_VkPipelineViewportStateCreateInfo *ViewportState() const {
         // TODO A render pass object is required for all of these sub-states. Which one should be used for an "executable pipeline"?
         if (pre_raster_state) {

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -257,22 +257,3 @@ bool FragmentOutputState::IsBlendConstantsEnabled(const AttachmentStateVector &a
     }
     return result;
 }
-
-// static
-bool FragmentOutputState::GetDualSourceBlending(const vku::safe_VkPipelineColorBlendStateCreateInfo *color_blend_state) {
-    if (!color_blend_state) {
-        return false;
-    }
-    for (uint32_t i = 0; i < color_blend_state->attachmentCount; ++i) {
-        const auto &attachment = color_blend_state->pAttachments[i];
-        if (attachment.blendEnable) {
-            if (IsSecondaryColorInputBlendFactor(attachment.srcColorBlendFactor) ||
-                IsSecondaryColorInputBlendFactor(attachment.dstColorBlendFactor) ||
-                IsSecondaryColorInputBlendFactor(attachment.srcAlphaBlendFactor) ||
-                IsSecondaryColorInputBlendFactor(attachment.dstAlphaBlendFactor)) {
-                return true;
-            }
-        }
-    }
-    return false;
-}

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -176,7 +176,6 @@ struct FragmentOutputState : public PipelineSubState {
             color_blend_state = ToSafeColorBlendState(cbci);
             // In case of being dynamic state
             if (cbci.pAttachments) {
-                dual_source_blending = GetDualSourceBlending(color_blend_state.get());
                 if (cbci.attachmentCount) {
                     attachment_states.reserve(cbci.attachmentCount);
                     std::copy(cbci.pAttachments, cbci.pAttachments + cbci.attachmentCount, std::back_inserter(attachment_states));
@@ -195,7 +194,6 @@ struct FragmentOutputState : public PipelineSubState {
     }
 
     static bool IsBlendConstantsEnabled(const AttachmentStateVector &attachment_states);
-    static bool GetDualSourceBlending(const vku::safe_VkPipelineColorBlendStateCreateInfo *color_blend_state);
 
     std::shared_ptr<const vvl::RenderPass> rp_state;
     uint32_t subpass = 0;
@@ -207,5 +205,4 @@ struct FragmentOutputState : public PipelineSubState {
 
     bool blend_constants_enabled = false;  // Blend constants enabled for any attachments
     bool sample_location_enabled = false;
-    bool dual_source_blending = false;
 };

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -43,6 +43,9 @@ void DecorationBase::Add(uint32_t decoration, uint32_t value) {
         case spv::DecorationComponent:
             component = value;
             break;
+        case spv::DecorationIndex:
+            index = value;
+            break;
         case spv::DecorationNonWritable:
             flags |= nonwritable_bit;
             break;
@@ -811,7 +814,8 @@ EntryPoint::EntryPoint(const Module& module_state, const Instruction& entrypoint
                         max_output_slot = &slot;
                         max_output_slot_variable = &variable;
                     }
-                    if (slot.Location() == 0 && slot.Component() == 3) {
+                    // Dual source blending can use a non-index of zero here
+                    if (slot.Location() == 0 && slot.Component() == 3 && variable.decorations.index == 0) {
                         has_alpha_to_coverage_variable = true;
                     }
                 }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -60,8 +60,9 @@ struct DecorationBase {
 
     // When being used as an User-defined Variable (input, output, rtx)
     uint32_t location = kInvalidValue;
-    // Component is optional and spec says it is 0 if not defined
+    // Component and Index are optional and spec says it is 0 if not defined
     uint32_t component = 0;
+    uint32_t index = 0;
 
     uint32_t offset = 0;
 

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -1316,6 +1316,32 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputLocation0) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
 
+TEST_F(PositiveShaderInterface, AlphaToCoverageOutputIndex1) {
+    TEST_DESCRIPTION("DualSource blend has two outputs at location zero, so Index 0 is the one that's required");
+    AddRequiredFeature(vkt::Feature::dualSrcBlend);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget(0u);
+
+    const char *fs_src = R"glsl(
+        #version 460
+        layout(location = 0, index = 1) out vec4 c0;
+        void main() {
+		    c0 = vec4(0.0f);
+        }
+    )glsl";
+    VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
+    ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    ms_state_ci.alphaToCoverageEnable = VK_TRUE;
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.ms_ci_ = ms_state_ci;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
+}
+
 TEST_F(NegativeShaderInterface, AlphaToCoverageOutputNoAlpha) {
     TEST_DESCRIPTION(
         "Test that an error is produced when alpha to coverage is enabled but output at location 0 doesn't have alpha component.");

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -735,6 +735,32 @@ TEST_F(PositiveShaderInterface, FragmentOutputNotConsumedButAlphaToCoverageEnabl
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
 
+TEST_F(PositiveShaderInterface, AlphaToCoverageOutputIndex0) {
+    TEST_DESCRIPTION("DualSource blend has two outputs at location zero, so Index 0 is the one that's required");
+    AddRequiredFeature(vkt::Feature::dualSrcBlend);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget(0u);
+
+    const char *fs_src = R"glsl(
+        #version 460
+        layout(location = 0, index = 0) out vec4 c0;
+        void main() {
+		    c0 = vec4(0.0f);
+        }
+    )glsl";
+    VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);
+
+    VkPipelineMultisampleStateCreateInfo ms_state_ci = vku::InitStructHelper();
+    ms_state_ci.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    ms_state_ci.alphaToCoverageEnable = VK_TRUE;
+
+    const auto set_info = [&](CreatePipelineHelper &helper) {
+        helper.shader_stages_ = {helper.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
+        helper.ms_ci_ = ms_state_ci;
+    };
+    CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
+}
+
 // Spec doesn't clarify if this is valid or not
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/3445
 TEST_F(PositiveShaderInterface, DISABLED_InputOutputMatch2) {


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5208

This adds `VUID-vkCmdDraw-maxFragmentDualSrcAttachments-09239`

Now that the dynamic state situation is better, was finally able to add this check in