### PR TITLE
sync: Use vector to return last batches

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -1048,6 +1048,14 @@ bool Contains(const Container &container, const Key &key) {
 }
 
 //
+// if (vvl::Contains(objects_vector, candidate)) { candidate->jump(); }
+//
+template <typename T>
+bool Contains(const std::vector<T> &v, const T &value) {
+    return std::find(v.cbegin(), v.cend(), value) != v.cend();
+}
+
+//
 // if (auto* thing = vvl::Find(map, key)) { thing->jump(); }
 //
 template <typename Container, typename Key = typename Container::key_type, typename Value = typename Container::mapped_type>


### PR DESCRIPTION
Started this as cleanup to remove specialized templates that generalize some helpers. Inline code directly where it's needed - results in simpler code and it's less code.
Adds alias names for smart pointers. 
Replaces map with a vector to store per-queue last batch list, which usually is few elements. Run Doom/cs2 performance traces.
