### PR TITLE
sync: Refactor batch tag_range initialization

### DIFF
--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -250,20 +250,16 @@ class QueueBatchContext : public CommandExecutionContext {
     QueueId GetQueueId() const override;
     ExecutionType Type() const override { return kSubmitted; }
 
-    void SetupBatchTags(const ResourceUsageRange &tag_range);
-    void SetupBatchTags();
+    ResourceUsageTag SetupBatchTags(uint32_t tag_count);
     void SetCurrentLabelStack(std::vector<std::string>* current_label_stack);
     void ResetEventsContext() { events_context_.Clear(); }
     ResourceUsageTag GetTagLimit() const override { return batch_.bias; }
-    // begin is the tag bias  / .size() is the number of total records that should eventually be in access_log_
-    ResourceUsageRange GetTagRange() const { return tag_range_; }
     void InsertRecordedAccessLogEntries(const CommandBufferAccessContext &cb_context) override;
 
-    void SetTagBias(ResourceUsageTag);
     // For Submit
     void SetupAccessContext(const std::shared_ptr<const QueueBatchContext> &prev, const VkSubmitInfo2 &submit_info,
                             SignaledSemaphoresUpdate &signaled_semaphores_update);
-    void SetupCommandBufferInfo(const VkSubmitInfo2 &submit_info);
+    uint32_t SetupCommandBufferInfo(const VkSubmitInfo2 &submit_info);
     bool DoQueueSubmitValidate(const SyncValidator &sync_state, QueueSubmitCmdState &cmd_state, const VkSubmitInfo2 &submit_info);
     void ResolveSubmittedCommandBuffer(const AccessContext &recorded_context, ResourceUsageTag offset);
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -535,8 +535,8 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
 
     bool PreCallValidateQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
                                         const ErrorObject &error_obj) const override;
-    ResourceUsageRange SetupPresentInfo(const VkPresentInfoKHR &present_info, QueueBatchContext::Ptr &batch,
-                                        PresentedImages &presented_images) const;
+    uint32_t SetupPresentInfo(const VkPresentInfoKHR &present_info, QueueBatchContext::Ptr &batch,
+                              PresentedImages &presented_images) const;
     void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR *pPresentInfo,
                                        const RecordObject &record_obj) override;
     void PostCallRecordAcquireNextImageKHR(VkDevice device, VkSwapchainKHR swapchain, uint64_t timeout, VkSemaphore semaphore,


### PR DESCRIPTION
This change ensures that `QueueBatchContext::tag_range_` has a single meaning independent of the context - global range of tags.

Previously, depending on the context, the tag_range was either a local range (just a tag count, begin field was always zero) or a global range (after all initialization was done). This was confusing at times because you need to check the context of the code.

As a bonus reduced LOC and few functions are removed from the interface.