### PR TITLE
github: Suspend running Window Tests

### DIFF
--- a/.github/workflows/vvl.yml
+++ b/.github/workflows/vvl.yml
@@ -185,8 +185,6 @@ jobs:
           key: windows-dependencies-${{ matrix.arch }}-${{ hashfiles('scripts/known_good.json') }}
       - name: Build
         run: python3 scripts/tests.py --build --config debug --cmake='-DUPDATE_DEPS_SKIP_EXISTING_INSTALL=ON'
-      - name: Test Max Profile
-        run: python scripts/tests.py --test
 
   windowsUpload:
     needs: windows


### PR DESCRIPTION
(will create an issue pointing to this if we merge this)

Github Windows machines have been updated

```
Failing
  Image: windows-2022
  Version: 20240603.1.0

passing
  Image: windows-2022
  Version: 20240514.3.0
```

We locally tried using `17.10` to compile and still not able to reproduce this

For now removing the running of test from github CI and we are running the internally