### PR TITLE
docs: Update list of syncval limitations

### DIFF
--- a/docs/synchronization_usage.md
+++ b/docs/synchronization_usage.md
@@ -1,5 +1,5 @@
 <!-- markdownlint-disable MD041 -->
-<!-- Copyright 2015-2023 LunarG, Inc. -->
+<!-- Copyright 2015-2024 LunarG, Inc. -->
 [![Khronos Vulkan][1]][2]
 
 [1]: https://vulkan.lunarg.com/img/Vulkan_100px_Dec16.png "https://www.khronos.org/vulkan/"
@@ -111,6 +111,7 @@ The pipelined and multi-threaded nature of Vulkan makes it particularly importan
 - Indirectly accessed (indirect/indexed) buffers validated at *binding* granularity. (Every valid location assumed to be accessed.)
 - Host synchronization not supported, except Fences (above).
 - Timeline Semaphore not supported
+- Queue family ownership transfer not supported
 
 ## Typical Synchronization Validation Usage
 


### PR DESCRIPTION
Document that ownership transfer is not supported by syncval. Users rely on the list of supported/unsupported features (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8112)

Ownership transfer is planned as the third stage of timeline semahores support (after stage 1 - gpu timeline support, stage 2 - host timeline support). Ownership transfer is not related to timeline semaphores but it is often used in a multi-queue apps that use timeline semaphores, so it's good to add support to be able to fully validate correctness of timeline semaphore synchronization.