### PR TITLE
layers: Use DeviceFeature helper instead of pNext checks

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -437,9 +437,9 @@ bool CoreChecks::PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDevic
     return skip;
 }
 
-void CoreChecks::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void CoreChecks::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
     // The state tracker sets up the device state (also if extension and/or features are enabled)
-    StateTracker::CreateDevice(pCreateInfo, loc);
+    StateTracker::PostCreateDevice(pCreateInfo, loc);
 
     // Add the callback hooks for the functions that are either broadly or deeply used and that the ValidationStateTracker refactor
     // would be messier without.

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -1258,7 +1258,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                      const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
                                      const ErrorObject& error_obj) const override;
-    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
+    void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
     bool PreCallValidateCmdUpdateBuffer(VkCommandBuffer commandBuffer, VkBuffer dstBuffer, VkDeviceSize dstOffset,
                                         VkDeviceSize dataSize, const void* pData, const ErrorObject& error_obj) const override;
     bool PreCallValidateGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -60,9 +60,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
   public:
     Validator() {
         container_type = LayerObjectTypeGpuAssisted;
-        desired_features_.vertexPipelineStoresAndAtomics = true;
-        desired_features_.fragmentStoresAndAtomics = true;
-        desired_features_.shaderInt64 = true;
         force_buffer_device_address_ = true;
     }
 
@@ -110,7 +107,10 @@ class Validator : public gpu::GpuShaderInstrumentor {
     std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
                                             const VkQueueFamilyProperties& queueFamilyProperties) final;
 
-    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
+    void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
+                                   vku::safe_VkDeviceCreateInfo* modified_create_info) final;
+    void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
     // gpuav_record.cpp
     // --------------

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -81,13 +81,12 @@ namespace debug_printf {
 class Validator : public gpu::GpuShaderInstrumentor {
   public:
     using BaseClass = gpu::GpuShaderInstrumentor;
-    Validator() {
-        container_type = LayerObjectTypeDebugPrintf;
-        desired_features_.vertexPipelineStoresAndAtomics = true;
-        desired_features_.fragmentStoresAndAtomics = true;
-    }
+    Validator() { container_type = LayerObjectTypeDebugPrintf; }
 
-    void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
+    void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
+                                   const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
+                                   vku::safe_VkDeviceCreateInfo* modified_create_info) final;
+    void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
     bool InstrumentShader(const vvl::span<const uint32_t>& input, uint32_t unique_shader_id, const Location& loc,
                           std::vector<uint32_t>& out_instrumented_spirv) override;
     void PreCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -61,7 +61,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                    const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, const RecordObject &record_obj,
                                    vku::safe_VkDeviceCreateInfo *modified_create_info) override;
-    void CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
+    void PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                     const RecordObject &record_obj) override;
 
@@ -170,8 +170,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     bool force_buffer_device_address_;
     PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
-    VkPhysicalDeviceFeatures supported_features_{};
-    VkPhysicalDeviceFeatures desired_features_{};
     uint32_t adjusted_max_desc_sets_ = 0;
     std::atomic<uint32_t> unique_shader_module_id_ = 1;  // zero represents no shader module found
     uint32_t output_buffer_byte_size_ = 0;

--- a/layers/object_tracker/object_lifetime_validation.h
+++ b/layers/object_tracker/object_lifetime_validation.h
@@ -62,18 +62,13 @@ class ObjectLifetimes : public ValidationObject {
     object_map_type swapchain_image_map;
     object_list_map_type linked_graphics_pipeline_map;
 
-    void *device_createinfo_pnext;
     bool null_descriptor_enabled;
 
     // Constructor for object lifetime tracking
-    ObjectLifetimes() : num_objects{}, num_total_objects(0), device_createinfo_pnext(nullptr), null_descriptor_enabled(false) {
+    ObjectLifetimes() : num_objects{}, num_total_objects(0), null_descriptor_enabled(false) {
         container_type = LayerObjectTypeObjectTracker;
     }
-    ~ObjectLifetimes() {
-        if (device_createinfo_pnext) {
-            vku::FreePnextChain(device_createinfo_pnext);
-        }
-    }
+    ~ObjectLifetimes() {}
 
     template <typename T1>
     void InsertObject(object_map_type &map, T1 object, VulkanObjectType object_type, const Location &loc,

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -732,9 +732,7 @@ void ObjectLifetimes::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice
     auto device_data = GetLayerDataPtr(GetDispatchKey(*pDevice), layer_data_map);
     auto object_tracking = device_data->GetValidationObject<ObjectLifetimes>();
 
-    object_tracking->device_createinfo_pnext = vku::SafePnextCopy(pCreateInfo->pNext);
-    const auto *robustness2_features =
-        vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(object_tracking->device_createinfo_pnext);
+    const auto *robustness2_features = vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(pCreateInfo->pNext);
     object_tracking->null_descriptor_enabled = robustness2_features && robustness2_features->nullDescriptor;
 }
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -27,7 +27,6 @@
 #include "utils/vk_layer_utils.h"
 
 #include "generated/chassis.h"
-#include "generated/state_tracker_helper.h"
 #include "state_tracker/state_tracker.h"
 #include "sync/sync_utils.h"
 #include "state_tracker/shader_stage_state.h"

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -692,7 +692,7 @@ void ValidationStateTracker::PostCallRecordCreateDevice(VkPhysicalDevice gpu, co
     // Save local link to this device's physical device state
     device_state->physical_device_state = Get<vvl::PhysicalDevice>(gpu).get();
     // finish setup in the object representing the device
-    device_state->CreateDevice(pCreateInfo, record_obj.location);
+    device_state->PostCreateDevice(pCreateInfo, record_obj.location);
 }
 
 std::shared_ptr<vvl::Queue> ValidationStateTracker::CreateQueue(VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
@@ -700,7 +700,7 @@ std::shared_ptr<vvl::Queue> ValidationStateTracker::CreateQueue(VkQueue handle, 
     return std::make_shared<vvl::Queue>(*this, handle, index, flags, queueFamilyProperties);
 }
 
-void ValidationStateTracker::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
     GetEnabledDeviceFeatures(pCreateInfo, &enabled_features, api_version);
 
     const auto *device_group_ci = vku::FindStructInPNextChain<VkDeviceGroupDeviceCreateInfo>(pCreateInfo->pNext);

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -605,7 +605,7 @@ class ValidationStateTracker : public ValidationObject {
     void PostCallRecordCreateDevice(VkPhysicalDevice gpu, const VkDeviceCreateInfo* pCreateInfo,
                                     const VkAllocationCallbacks* pAllocator, VkDevice* pDevice,
                                     const RecordObject& record_obj) override;
-    virtual void CreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc);
+    virtual void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc);
 
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks* pAllocator,
                                     const RecordObject& record_obj) override;

--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -70,8 +70,7 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
                          string_VkBufferCreateFlags(pCreateInfo->flags).c_str());
     }
 
-    const auto *maintenance4_features = vku::FindStructInPNextChain<VkPhysicalDeviceMaintenance4FeaturesKHR>(device_createinfo_pnext);
-    if (maintenance4_features && maintenance4_features->maintenance4) {
+    if (enabled_features.maintenance4) {
         if (pCreateInfo->size > phys_dev_ext_props.maintenance4_props.maxBufferSize) {
             skip |= LogError("VUID-VkBufferCreateInfo-size-06409", device, create_info_loc.dot(Field::size),
                              "(%" PRIu64

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -32,8 +32,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindIndexBuffer(VkCommandBuff
                          "is VK_INDEX_TYPE_NONE_KHR.");
     }
 
-    const auto *index_type_uint8_features = vku::FindStructInPNextChain<VkPhysicalDeviceIndexTypeUint8FeaturesEXT>(device_createinfo_pnext);
-    if (indexType == VK_INDEX_TYPE_UINT8_KHR && (!index_type_uint8_features || !index_type_uint8_features->indexTypeUint8)) {
+    if (indexType == VK_INDEX_TYPE_UINT8_KHR && (!enabled_features.indexTypeUint8)) {
         skip |= LogError("VUID-vkCmdBindIndexBuffer-indexType-08787", commandBuffer, error_obj.location.dot(Field::indexType),
                          "is VK_INDEX_TYPE_UINT8_KHR but indexTypeUint8 feature was not enabled.");
     }
@@ -50,8 +49,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindIndexBuffer2KHR(VkCommand
         skip |= LogError("VUID-vkCmdBindIndexBuffer2KHR-indexType-08786", commandBuffer, error_obj.location.dot(Field::indexType),
                          "is VK_INDEX_TYPE_NONE_KHR.");
     } else if (indexType == VK_INDEX_TYPE_UINT8_KHR) {
-        const auto *index_type_uint8_features = vku::FindStructInPNextChain<VkPhysicalDeviceIndexTypeUint8FeaturesEXT>(device_createinfo_pnext);
-        if (!index_type_uint8_features || !index_type_uint8_features->indexTypeUint8) {
+        if (!enabled_features.indexTypeUint8) {
             skip |=
                 LogError("VUID-vkCmdBindIndexBuffer2KHR-indexType-08787", commandBuffer, error_obj.location.dot(Field::indexType),
                          "is VK_INDEX_TYPE_UINT8_KHR but indexTypeUint8 feature was not enabled.");
@@ -86,8 +84,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers(VkCommandBu
         }
         if (pBuffers[i] == VK_NULL_HANDLE) {
             const Location buffer_loc = error_obj.location.dot(Field::pBuffers, i);
-            const auto *robustness2_features = vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-            if (!(robustness2_features && robustness2_features->nullDescriptor)) {
+            if (!enabled_features.nullDescriptor) {
                 skip |= LogError("VUID-vkCmdBindVertexBuffers-pBuffers-04001", commandBuffer, buffer_loc, "is VK_NULL_HANDLE.");
             } else {
                 if (pOffsets[i] != 0) {
@@ -250,8 +247,7 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandB
         }
         if (pBuffers[i] == VK_NULL_HANDLE) {
             const Location buffer_loc = error_obj.location.dot(Field::pBuffers, i);
-            const auto *robustness2_features = vku::FindStructInPNextChain<VkPhysicalDeviceRobustness2FeaturesEXT>(device_createinfo_pnext);
-            if (!(robustness2_features && robustness2_features->nullDescriptor)) {
+            if (!enabled_features.nullDescriptor) {
                 skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04111", commandBuffer, buffer_loc, "is VK_NULL_HANDLE.");
             } else if (pOffsets && pOffsets[i] != 0) {
                 skip |= LogError("VUID-vkCmdBindVertexBuffers2-pBuffers-04112", commandBuffer, buffer_loc,
@@ -723,9 +719,7 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
 
         const auto *conditional_rendering = vku::FindStructInPNextChain<VkCommandBufferInheritanceConditionalRenderingInfoEXT>(info->pNext);
         if (conditional_rendering) {
-            const auto *cr_features = vku::FindStructInPNextChain<VkPhysicalDeviceConditionalRenderingFeaturesEXT>(device_createinfo_pnext);
-            const auto inherited_conditional_rendering = cr_features && cr_features->inheritedConditionalRendering;
-            if (!inherited_conditional_rendering && conditional_rendering->conditionalRenderingEnable == VK_TRUE) {
+            if (!enabled_features.inheritedConditionalRendering && conditional_rendering->conditionalRenderingEnable == VK_TRUE) {
                 skip |= LogError(
                     "VUID-VkCommandBufferInheritanceConditionalRenderingInfoEXT-conditionalRenderingEnable-01977", commandBuffer,
                     error_obj.location,

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -121,8 +121,6 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
     const VkVertexInputBindingDescription2EXT *pVertexBindingDescriptions, uint32_t vertexAttributeDescriptionCount,
     const VkVertexInputAttributeDescription2EXT *pVertexAttributeDescriptions, const ErrorObject &error_obj) const {
     bool skip = false;
-    const auto *vertex_attribute_divisor_features =
-        vku::FindStructInPNextChain<VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT>(device_createinfo_pnext);
 
     if (vertexBindingDescriptionCount > device_limits.maxVertexInputBindings) {
         skip |= LogError("VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791", commandBuffer,
@@ -196,8 +194,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
                              pVertexBindingDescriptions[binding].stride, device_limits.maxVertexInputBindingStride);
         }
 
-        if (pVertexBindingDescriptions[binding].divisor == 0 &&
-            (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateZeroDivisor)) {
+        if (pVertexBindingDescriptions[binding].divisor == 0 && (!enabled_features.vertexAttributeInstanceRateZeroDivisor)) {
             skip |=
                 LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04798", commandBuffer, binding_loc.dot(Field::divisor),
                          "is zero but "
@@ -205,7 +202,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetVertexInputEXT(
         }
 
         if (pVertexBindingDescriptions[binding].divisor > 1) {
-            if (!vertex_attribute_divisor_features || !vertex_attribute_divisor_features->vertexAttributeInstanceRateDivisor) {
+            if (!enabled_features.vertexAttributeInstanceRateDivisor) {
                 skip |= LogError("VUID-VkVertexInputBindingDescription2EXT-divisor-04799", commandBuffer,
                                  binding_loc.dot(Field::divisor),
                                  "is %" PRIu32

--- a/layers/stateless/sl_device_memory.cpp
+++ b/layers/stateless/sl_device_memory.cpp
@@ -41,25 +41,12 @@ bool StatelessValidation::manual_PreCallValidateAllocateMemory(VkDevice device, 
 
     if (flags) {
         const Location flags_loc = allocate_info_loc.pNext(Struct::VkMemoryAllocateFlagsInfo, Field::flags);
-        VkBool32 capture_replay = false;
-        VkBool32 buffer_device_address = false;
-        const auto *vulkan_12_features = vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(device_createinfo_pnext);
-        if (vulkan_12_features) {
-            capture_replay = vulkan_12_features->bufferDeviceAddressCaptureReplay;
-            buffer_device_address = vulkan_12_features->bufferDeviceAddress;
-        } else {
-            const auto *bda_features = vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(device_createinfo_pnext);
-            if (bda_features) {
-                capture_replay = bda_features->bufferDeviceAddressCaptureReplay;
-                buffer_device_address = bda_features->bufferDeviceAddress;
-            }
-        }
-        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) && !capture_replay) {
+        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT) && !enabled_features.bufferDeviceAddressCaptureReplay) {
             skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03330", device, flags_loc,
                              "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_CAPTURE_REPLAY_BIT set, but"
                              "bufferDeviceAddressCaptureReplay feature is not enabled.");
         }
-        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) && !buffer_device_address) {
+        if ((flags & VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT) && !enabled_features.bufferDeviceAddress) {
             skip |= LogError("VUID-VkMemoryAllocateInfo-flags-03331", device, flags_loc,
                              "has VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT set, but bufferDeviceAddress feature is not enabled.");
         }

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -238,10 +238,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                              "alias VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV), but samples is %s.",
                              string_VkSampleCountFlagBits(pCreateInfo->samples));
         }
-        const auto *shading_rate_image_features =
-            vku::FindStructInPNextChain<VkPhysicalDeviceShadingRateImageFeaturesNV>(device_createinfo_pnext);
-        if (shading_rate_image_features && shading_rate_image_features->shadingRateImage &&
-            pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
+        if (enabled_features.shadingRateImage && pCreateInfo->tiling != VK_IMAGE_TILING_OPTIMAL) {
             // KHR flag can be non-optimal
             skip |= LogError("VUID-VkImageCreateInfo-shadingRateImage-07727", device, create_info_loc.dot(Field::usage),
                              "includes VK_IMAGE_USAGE_SHADING_RATE_IMAGE_BIT_NV, tiling must be "

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -438,6 +438,8 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
 
     stateless_validation->phys_dev_ext_props = this->phys_dev_ext_props;
 
+    GetEnabledDeviceFeatures(pCreateInfo, &stateless_validation->enabled_features, api_version);
+
     // Save app-enabled features in this device's validation object
     // The enabled features can come from either pEnabledFeatures, or from the pNext chain
     const auto *features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
@@ -450,8 +452,6 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
     } else {
         tmp_features2_state.features = {};
     }
-    // Use pCreateInfo->pNext to get full chain
-    stateless_validation->device_createinfo_pnext = vku::SafePnextCopy(pCreateInfo->pNext);
     stateless_validation->physical_device_features2 = tmp_features2_state;
 }
 

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -181,9 +181,7 @@ bool StatelessValidation::ValidateCreateGraphicsPipelinesFlags(const VkPipelineC
     }
 
     if ((flags & VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV) != 0) {
-        const auto *device_generated_commands_features =
-            vku::FindStructInPNextChain<VkPhysicalDeviceDeviceGeneratedCommandsFeaturesNV>(device_createinfo_pnext);
-        if (!device_generated_commands_features || !device_generated_commands_features->deviceGeneratedCommands) {
+        if (!enabled_features.deviceGeneratedCommands) {
             skip |=
                 LogError("VUID-VkGraphicsPipelineCreateInfo-flags-02877", device, flags_loc,
                          "(%s) contains VK_PIPELINE_CREATE_INDIRECT_BINDABLE_BIT_NV, but deviceGeneratedCommands was not enabled.",
@@ -192,9 +190,7 @@ bool StatelessValidation::ValidateCreateGraphicsPipelinesFlags(const VkPipelineC
     }
 
     if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) != 0) {
-        const auto *gpl_features =
-            vku::FindStructInPNextChain<VkPhysicalDeviceGraphicsPipelineLibraryFeaturesEXT>(device_createinfo_pnext);
-        if (!gpl_features || !gpl_features->graphicsPipelineLibrary) {
+        if (!enabled_features.graphicsPipelineLibrary) {
             skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-graphicsPipelineLibrary-06606", device, flags_loc,
                              "(%s) contains VK_PIPELINE_CREATE_LIBRARY_BIT_KHR, but graphicsPipelineLibrary was not enabled.",
                              string_VkPipelineCreateFlags2KHR(flags).c_str());
@@ -877,11 +873,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                 }
 
                 if (depth_clip_control_struct) {
-                    const auto *depth_clip_control_features =
-                        vku::FindStructInPNextChain<VkPhysicalDeviceDepthClipControlFeaturesEXT>(device_createinfo_pnext);
-                    const bool enabled_depth_clip_control =
-                        depth_clip_control_features && depth_clip_control_features->depthClipControl;
-                    if (depth_clip_control_struct->negativeOneToOne && !enabled_depth_clip_control) {
+                    if (depth_clip_control_struct->negativeOneToOne && !enabled_features.depthClipControl) {
                         skip |= LogError(
                             "VUID-VkPipelineViewportDepthClipControlCreateInfoEXT-negativeOneToOne-06470", device,
                             viewport_loc.pNext(Struct::VkPhysicalDeviceDepthClipControlFeaturesEXT, Field::negativeOneToOne),
@@ -1051,10 +1043,8 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                         }
                     }
 
-                    const auto *line_features =
-                        vku::FindStructInPNextChain<VkPhysicalDeviceLineRasterizationFeaturesKHR>(device_createinfo_pnext);
                     if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR &&
-                        (!line_features || !line_features->rectangularLines)) {
+                        (!enabled_features.rectangularLines)) {
                         skip |= LogError(
                             "VUID-VkPipelineRasterizationLineStateCreateInfoKHR-lineRasterizationMode-02768", device,
                             rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
@@ -1062,7 +1052,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                             "is VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR but the rectangularLines feature was not enabled.");
                     }
                     if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR &&
-                        (!line_features || !line_features->bresenhamLines)) {
+                        (!enabled_features.bresenhamLines)) {
                         skip |=
                             LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-lineRasterizationMode-02769", device,
                                      rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
@@ -1070,7 +1060,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                      "is VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR but the bresenhamLines feature was not enabled.");
                     }
                     if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_KHR &&
-                        (!line_features || !line_features->smoothLines)) {
+                        (!enabled_features.smoothLines)) {
                         skip |= LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-lineRasterizationMode-02770", device,
                                          rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
                                                                  Field::lineRasterizationMode),
@@ -1079,7 +1069,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                     }
                     if (line_state->stippledLineEnable && !dynamic_line_stipple_enable) {
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_KHR &&
-                            (!line_features || !line_features->stippledRectangularLines)) {
+                            (!enabled_features.stippledRectangularLines)) {
                             skip |= LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-stippledLineEnable-02771", device,
                                              rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
                                                                      Field::lineRasterizationMode),
@@ -1087,7 +1077,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                              "but the stippledRectangularLines feature was not enabled.");
                         }
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_BRESENHAM_KHR &&
-                            (!line_features || !line_features->stippledBresenhamLines)) {
+                            (!enabled_features.stippledBresenhamLines)) {
                             skip |= LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-stippledLineEnable-02772", device,
                                              rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
                                                                      Field::lineRasterizationMode),
@@ -1095,7 +1085,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                              "the stippledBresenhamLines feature was not enabled.");
                         }
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_RECTANGULAR_SMOOTH_KHR &&
-                            (!line_features || !line_features->stippledSmoothLines)) {
+                            (!enabled_features.stippledSmoothLines)) {
                             skip |= LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-stippledLineEnable-02773", device,
                                              rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
                                                                      Field::lineRasterizationMode),
@@ -1103,7 +1093,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                              "VK_TRUE, but the stippledSmoothLines feature was not enabled.");
                         }
                         if (line_state->lineRasterizationMode == VK_LINE_RASTERIZATION_MODE_DEFAULT_KHR &&
-                            (!line_features || !line_features->stippledRectangularLines || !device_limits.strictLines)) {
+                            (!enabled_features.stippledRectangularLines || !device_limits.strictLines)) {
                             skip |= LogError("VUID-VkPipelineRasterizationLineStateCreateInfoKHR-stippledLineEnable-02774", device,
                                              rasterization_loc.pNext(Struct::VkPhysicalDeviceLineRasterizationFeaturesKHR,
                                                                      Field::lineRasterizationMode),
@@ -1138,9 +1128,7 @@ bool StatelessValidation::ValidateCreateComputePipelinesFlags(const VkPipelineCr
                                                               const Location &flags_loc) const {
     bool skip = false;
     if ((flags & VK_PIPELINE_CREATE_LIBRARY_BIT_KHR) != 0) {
-        const auto *shader_enqueue_features =
-            vku::FindStructInPNextChain<VkPhysicalDeviceShaderEnqueueFeaturesAMDX>(device_createinfo_pnext);
-        if (!shader_enqueue_features || shader_enqueue_features->shaderEnqueue) {
+        if (!enabled_features.shaderEnqueue) {
             skip |= LogError("VUID-VkComputePipelineCreateInfo-shaderEnqueue-09177", device, flags_loc,
                              "%s must not include VK_PIPELINE_CREATE_LIBRARY_BIT_KHR.",
                              string_VkPipelineCreateFlags2KHR(flags).c_str());
@@ -1283,9 +1271,7 @@ bool StatelessValidation::manual_PreCallValidateGetPipelinePropertiesEXT(VkDevic
                                                                          const ErrorObject &error_obj) const {
     bool skip = false;
 
-    const auto *pipeline_props_features =
-        vku::FindStructInPNextChain<VkPhysicalDevicePipelinePropertiesFeaturesEXT>(device_createinfo_pnext);
-    if (!pipeline_props_features || !pipeline_props_features->pipelinePropertiesIdentifier) {
+    if (!enabled_features.pipelinePropertiesIdentifier) {
         skip |= LogError("VUID-vkGetPipelinePropertiesEXT-None-06766", device, error_obj.location,
                          "the pipelinePropertiesIdentifier feature was not enabled.");
     }

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -568,9 +568,9 @@ void SyncValidator::PreCallRecordCmdPipelineBarrier2(VkCommandBuffer commandBuff
                                                            *pDependencyInfo);
 }
 
-void SyncValidator::CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
+void SyncValidator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
     // The state tracker sets up the device state
-    StateTracker::CreateDevice(pCreateInfo, loc);
+    StateTracker::PostCreateDevice(pCreateInfo, loc);
 
     ForEachShared<vvl::Queue>([this](const std::shared_ptr<vvl::Queue> &queue_state) {
         auto queue_flags = physical_device_state->queue_family_properties[queue_state->queueFamilyIndex].queueFlags;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -105,7 +105,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     void RecordCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo *pSubpassEndInfo, Func command);
     bool SupressedBoundDescriptorWAW(const HazardResult &hazard) const;
 
-    void CreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
+    void PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
 
     bool ValidateBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,
                                  const VkSubpassBeginInfo *pSubpassBeginInfo, const ErrorObject &error_obj) const;

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -593,6 +593,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         item->device_extensions = device_extensions;
     }
 
+    // Make copy to modify as some ValidationObjects will want to add extensions/features on
     vku::safe_VkDeviceCreateInfo modified_create_info(pCreateInfo);
 
     bool skip = false;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1269,6 +1269,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     item->device_extensions = device_extensions;
                 }
 
+                // Make copy to modify as some ValidationObjects will want to add extensions/features on
                 vku::safe_VkDeviceCreateInfo modified_create_info(pCreateInfo);
 
                 bool skip = false;

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -15,7 +15,7 @@
             "sub_dir": "Vulkan-Utility-Libraries",
             "build_dir": "Vulkan-Utility-Libraries/build",
             "install_dir": "Vulkan-Utility-Libraries/build/install",
-            "commit": "v1.3.287",
+            "commit": "07759f04791dc3fbb390174f0d24d4a792e0d357",
             "deps": [
                 {
                     "var_name": "VULKAN_HEADERS_INSTALL_DIR",


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8110 (with help of https://github.com/KhronosGroup/Vulkan-Utility-Libraries/pull/218)

We have this nice `DeviceFeature` that we fill so we can go `enabled_features.someFeature`

This removes all the stateless checks that were scanning the `pNext` and just uses this instead... which in turn doesn't create a 200+ callstack on deletion of the `VkDevice`

----

Another issue was the use of `safe_VkDeviceCreateInfo` which was used to allow GPU-AV / DebugPrintF to add features, this has been updated