### PR TITLE
layers: Remove sType string in stateless

### DIFF
--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -674,8 +674,7 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
     const VkCommandBufferInheritanceInfo *info = pBeginInfo->pInheritanceInfo;
     const Location begin_info_loc = error_obj.location.dot(Field::pBeginInfo);
     const Location inheritance_loc = begin_info_loc.dot(Field::pInheritanceInfo);
-    skip |= ValidateStructType(inheritance_loc, "VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO", info,
-                               VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, k_not_required, k_no_vuid,
+    skip |= ValidateStructType(inheritance_loc, info, VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO, k_not_required, k_no_vuid,
                                "VUID-VkCommandBufferInheritanceInfo-sType-sType");
 
     if (info) {

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -348,15 +348,14 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
             }
 
             skip |= ValidateStructTypeArray(
-                create_info_loc.dot(Field::stageCount), create_info_loc.dot(Field::pStages),
-                "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO", create_info.stageCount, create_info.pStages,
-                VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true, "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
-                "VUID-VkGraphicsPipelineCreateInfo-pStages-06600", "VUID-VkGraphicsPipelineCreateInfo-pStages-06600");
+                create_info_loc.dot(Field::stageCount), create_info_loc.dot(Field::pStages), create_info.stageCount,
+                create_info.pStages, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true,
+                "VUID-VkPipelineShaderStageCreateInfo-sType-sType", "VUID-VkGraphicsPipelineCreateInfo-pStages-06600",
+                "VUID-VkGraphicsPipelineCreateInfo-pStages-06600");
             // Can be null with enough dynamic states
-            skip |= ValidateStructType(create_info_loc.dot(Field::pRasterizationState),
-                                       "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO",
-                                       create_info.pRasterizationState, VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO,
-                                       false, "VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-09040",
+            skip |= ValidateStructType(create_info_loc.dot(Field::pRasterizationState), create_info.pRasterizationState,
+                                       VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO, false,
+                                       "VUID-VkGraphicsPipelineCreateInfo-pRasterizationState-09040",
                                        "VUID-VkPipelineRasterizationStateCreateInfo-sType-sType");
         }
 

--- a/layers/stateless/sl_ray_tracing.cpp
+++ b/layers/stateless/sl_ray_tracing.cpp
@@ -980,22 +980,18 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(cons
         if (geom.geometryType == VK_GEOMETRY_TYPE_TRIANGLES_KHR) {
             constexpr std::array allowed_structs = {VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_TRIANGLES_OPACITY_MICROMAP_EXT};
 
-            skip |=
-                ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::triangles),
-                                   "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR",
-                                   &(geom.geometry.triangles), VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR,
-                                   false, kVUIDUndefined, "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-sType-sType");
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::triangles), &(geom.geometry.triangles),
+                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR, false, kVUIDUndefined,
+                                       "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-sType-sType");
             skip |= ValidateStructPnext(geometry_loc.dot(Field::geometry).dot(Field::triangles), geom.geometry.triangles.pNext,
                                         allowed_structs.size(), allowed_structs.data(), GeneratedVulkanHeaderVersion,
                                         "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-pNext-pNext", kVUIDUndefined);
             skip |= ValidateRangedEnum(geometry_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::vertexFormat),
                                        vvl::Enum::VkFormat, geom.geometry.triangles.vertexFormat,
                                        "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-parameter");
-            skip |=
-                ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::triangles),
-                                   "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR", &geom.geometry.triangles,
-                                   VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR, true,
-                                   "VUID-VkAccelerationStructureGeometryKHR-triangles-parameter", kVUIDUndefined);
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::triangles), &geom.geometry.triangles,
+                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_TRIANGLES_DATA_KHR, true,
+                                       "VUID-VkAccelerationStructureGeometryKHR-triangles-parameter", kVUIDUndefined);
             skip |= ValidateRangedEnum(geometry_loc.dot(Field::geometry).dot(Field::triangles).dot(Field::indexType),
                                        vvl::Enum::VkIndexType, geom.geometry.triangles.indexType,
                                        "VUID-VkAccelerationStructureGeometryTrianglesDataKHR-indexType-parameter");
@@ -1014,16 +1010,12 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(cons
             }
         }
         if (geom.geometryType == VK_GEOMETRY_TYPE_INSTANCES_KHR) {
-            skip |=
-                ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::instances),
-                                   "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR", &geom.geometry.instances,
-                                   VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR, true,
-                                   "VUID-VkAccelerationStructureGeometryKHR-instances-parameter", kVUIDUndefined);
-            skip |=
-                ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::instances),
-                                   "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR",
-                                   &(geom.geometry.instances), VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR,
-                                   false, kVUIDUndefined, "VUID-VkAccelerationStructureGeometryInstancesDataKHR-sType-sType");
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::instances), &geom.geometry.instances,
+                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR, true,
+                                       "VUID-VkAccelerationStructureGeometryKHR-instances-parameter", kVUIDUndefined);
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::instances), &(geom.geometry.instances),
+                                       VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_INSTANCES_DATA_KHR, false, kVUIDUndefined,
+                                       "VUID-VkAccelerationStructureGeometryInstancesDataKHR-sType-sType");
             skip |= ValidateStructPnext(geometry_loc.dot(Field::geometry).dot(Field::instances), geom.geometry.instances.pNext, 0,
                                         nullptr, GeneratedVulkanHeaderVersion,
                                         "VUID-VkAccelerationStructureGeometryInstancesDataKHR-pNext-pNext", kVUIDUndefined);
@@ -1032,12 +1024,10 @@ bool StatelessValidation::ValidateAccelerationStructureBuildGeometryInfoKHR(cons
                                    geom.geometry.instances.arrayOfPointers);
         }
         if (geom.geometryType == VK_GEOMETRY_TYPE_AABBS_KHR) {
-            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::aabbs),
-                                       "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR", &geom.geometry.aabbs,
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::aabbs), &geom.geometry.aabbs,
                                        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR, true,
                                        "VUID-VkAccelerationStructureGeometryKHR-aabbs-parameter", kVUIDUndefined);
-            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::aabbs),
-                                       "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR", &(geom.geometry.aabbs),
+            skip |= ValidateStructType(geometry_loc.dot(Field::geometry).dot(Field::aabbs), &(geom.geometry.aabbs),
                                        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_AABBS_DATA_KHR, false, kVUIDUndefined,
                                        "VUID-VkAccelerationStructureGeometryAabbsDataKHR-sType-sType");
             skip |= ValidateStructPnext(geometry_loc.dot(Field::geometry).dot(Field::aabbs), geom.geometry.aabbs.pNext, 0, nullptr,

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -343,10 +343,9 @@ bool StatelessValidation::PreCallValidateGetDeviceGroupSurfacePresentModes2EXT(V
                          error_obj.location.dot(Field::pModes), "is NULL.");
     }
 
-    skip |= ValidateStructType(error_obj.location.dot(Field::pSurfaceInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR",
-                               pSurfaceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, true,
-                               "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-parameter",
-                               "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-sType");
+    skip |= ValidateStructType(
+        error_obj.location.dot(Field::pSurfaceInfo), pSurfaceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, true,
+        "VUID-vkGetDeviceGroupSurfacePresentModes2EXT-pSurfaceInfo-parameter", "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-sType");
     if (pSurfaceInfo != NULL) {
         constexpr std::array allowed_structs = {VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_INFO_EXT,
                                                 VK_STRUCTURE_TYPE_SURFACE_FULL_SCREEN_EXCLUSIVE_WIN32_INFO_EXT};

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -154,15 +154,14 @@ class StatelessValidation : public ValidationObject {
      * VkStructureType value.
      *
      * @param loc Name of API call being validated.
-     * @param sTypeName Name of expected VkStructureType value.
      * @param value Pointer to the struct to validate.
      * @param sType VkStructureType for structure validation.
      * @param required The parameter may not be NULL when true.
      * @return Boolean value indicating that the call should be skipped.
      */
     template <typename T>
-    bool ValidateStructType(const Location &loc, const char *sTypeName, const T *value, VkStructureType sType, bool required,
-                            const char *struct_vuid, const char *stype_vuid) const {
+    bool ValidateStructType(const Location &loc, const T *value, VkStructureType sType, bool required, const char *struct_vuid,
+                            const char *stype_vuid) const {
         bool skip = false;
 
         if (value == nullptr) {
@@ -170,7 +169,7 @@ class StatelessValidation : public ValidationObject {
                 skip |= LogError(struct_vuid, device, loc, "is NULL.");
             }
         } else if (value->sType != sType) {
-            skip |= LogError(stype_vuid, device, loc.dot(Field::sType), "must be %s.", sTypeName);
+            skip |= LogError(stype_vuid, device, loc.dot(Field::sType), "must be %s.", string_VkStructureType(sType));
         }
 
         return skip;
@@ -185,7 +184,6 @@ class StatelessValidation : public ValidationObject {
      *
      * @param count_loc Name of count parameter.
      * @param array_loc Name of array parameter.
-     * @param sTypeName Name of expected VkStructureType value.
      * @param count Number of elements in the array.
      * @param array Array to validate.
      * @param sType VkStructureType for structure validation.
@@ -194,9 +192,9 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     template <typename T>
-    bool ValidateStructTypeArray(const Location &count_loc, const Location &array_loc, const char *sTypeName, uint32_t count,
-                                 const T *array, VkStructureType sType, bool countRequired, bool arrayRequired,
-                                 const char *stype_vuid, const char *param_vuid, const char *count_required_vuid) const {
+    bool ValidateStructTypeArray(const Location &count_loc, const Location &array_loc, uint32_t count, const T *array,
+                                 VkStructureType sType, bool countRequired, bool arrayRequired, const char *stype_vuid,
+                                 const char *param_vuid, const char *count_required_vuid) const {
         bool skip = false;
 
         if ((array == nullptr) || (count == 0)) {
@@ -206,7 +204,8 @@ class StatelessValidation : public ValidationObject {
             // Verify that all structs in the array have the correct type
             for (uint32_t i = 0; i < count; ++i) {
                 if (array[i].sType != sType) {
-                    skip |= LogError(stype_vuid, device, array_loc.dot(i).dot(Field::sType), "must be %s", sTypeName);
+                    skip |= LogError(stype_vuid, device, array_loc.dot(i).dot(Field::sType), "must be %s",
+                                     string_VkStructureType(sType));
                 }
             }
         }
@@ -223,7 +222,6 @@ class StatelessValidation : public ValidationObject {
      *
      * @param count_loc Name of count parameter.
      * @param array_loc Name of array parameter.
-     * @param sTypeName Name of expected VkStructureType value.
      * @param count Number of elements in the array.
      * @param array Array to validate.
      * @param sType VkStructureType for structure validation.
@@ -232,9 +230,9 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     template <typename T>
-    bool ValidateStructPointerTypeArray(const Location &count_loc, const Location &array_loc, const char *sTypeName, uint32_t count,
-                                        const T *array, VkStructureType sType, bool countRequired, bool arrayRequired,
-                                        const char *stype_vuid, const char *param_vuid, const char *count_required_vuid) const {
+    bool ValidateStructPointerTypeArray(const Location &count_loc, const Location &array_loc, uint32_t count, const T *array,
+                                        VkStructureType sType, bool countRequired, bool arrayRequired, const char *stype_vuid,
+                                        const char *param_vuid, const char *count_required_vuid) const {
         bool skip = false;
 
         if ((array == nullptr) || (count == 0)) {
@@ -244,7 +242,8 @@ class StatelessValidation : public ValidationObject {
             // Verify that all structs in the array have the correct type
             for (uint32_t i = 0; i < count; ++i) {
                 if (array[i]->sType != sType) {
-                    skip |= LogError(stype_vuid, device, array_loc.dot(i).dot(Field::sType), "must be %s", sTypeName);
+                    skip |= LogError(stype_vuid, device, array_loc.dot(i).dot(Field::sType), "must be %s",
+                                     string_VkStructureType(sType));
                 }
             }
         }
@@ -262,7 +261,6 @@ class StatelessValidation : public ValidationObject {
      *
      * @param count_loc Name of count parameter.
      * @param array_loc Name of array parameter.
-     * @param sTypeName Name of expected VkStructureType value.
      * @param count Pointer to the number of elements in the array.
      * @param array Array to validate.
      * @param sType VkStructureType for structure validation.
@@ -272,10 +270,10 @@ class StatelessValidation : public ValidationObject {
      * @return Boolean value indicating that the call should be skipped.
      */
     template <typename T>
-    bool ValidateStructTypeArray(const Location &count_loc, const Location &array_loc, const char *sTypeName, uint32_t *count,
-                                 const T *array, VkStructureType sType, bool countPtrRequired, bool countValueRequired,
-                                 bool arrayRequired, const char *stype_vuid, const char *param_vuid,
-                                 const char *count_ptr_required_vuid, const char *count_required_vuid) const {
+    bool ValidateStructTypeArray(const Location &count_loc, const Location &array_loc, uint32_t *count, const T *array,
+                                 VkStructureType sType, bool countPtrRequired, bool countValueRequired, bool arrayRequired,
+                                 const char *stype_vuid, const char *param_vuid, const char *count_ptr_required_vuid,
+                                 const char *count_required_vuid) const {
         bool skip = false;
 
         if (count == nullptr) {
@@ -283,9 +281,8 @@ class StatelessValidation : public ValidationObject {
                 skip |= LogError(count_ptr_required_vuid, device, count_loc, "is NULL.");
             }
         } else {
-            skip |= ValidateStructTypeArray(count_loc, array_loc, sTypeName, (*count), array, sType,
-                                            countValueRequired && (array != nullptr), arrayRequired, stype_vuid, param_vuid,
-                                            count_required_vuid);
+            skip |= ValidateStructTypeArray(count_loc, array_loc, (*count), array, sType, countValueRequired && (array != nullptr),
+                                            arrayRequired, stype_vuid, param_vuid, count_required_vuid);
         }
 
         return skip;

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -5610,11 +5610,11 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                                      "extended struct requires the extensions VK_KHR_depth_stencil_resolve");
                 }
                 VkSubpassDescriptionDepthStencilResolve* structure = (VkSubpassDescriptionDepthStencilResolve*)header;
-                skip |= ValidateStructType(pNext_loc.dot(Field::pDepthStencilResolveAttachment),
-                                           "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2", structure->pDepthStencilResolveAttachment,
-                                           VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
-                                           "VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-parameter",
-                                           "VUID-VkAttachmentReference2-sType-sType");
+                skip |=
+                    ValidateStructType(pNext_loc.dot(Field::pDepthStencilResolveAttachment),
+                                       structure->pDepthStencilResolveAttachment, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
+                                       "VUID-VkSubpassDescriptionDepthStencilResolve-pDepthStencilResolveAttachment-parameter",
+                                       "VUID-VkAttachmentReference2-sType-sType");
 
                 if (structure->pDepthStencilResolveAttachment != nullptr) {
                     [[maybe_unused]] const Location pDepthStencilResolveAttachment_loc =
@@ -5692,8 +5692,8 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 VkFramebufferAttachmentsCreateInfo* structure = (VkFramebufferAttachmentsCreateInfo*)header;
                 skip |= ValidateStructTypeArray(
                     pNext_loc.dot(Field::attachmentImageInfoCount), pNext_loc.dot(Field::pAttachmentImageInfos),
-                    "VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENT_IMAGE_INFO", structure->attachmentImageInfoCount,
-                    structure->pAttachmentImageInfos, VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENT_IMAGE_INFO, false, true,
+                    structure->attachmentImageInfoCount, structure->pAttachmentImageInfos,
+                    VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENT_IMAGE_INFO, false, true,
                     "VUID-VkFramebufferAttachmentImageInfo-sType-sType",
                     "VUID-VkFramebufferAttachmentsCreateInfo-pAttachmentImageInfos-parameter", kVUIDUndefined);
 
@@ -6168,8 +6168,8 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoProfileListInfoKHR);
                 VkVideoProfileListInfoKHR* structure = (VkVideoProfileListInfoKHR*)header;
                 skip |= ValidateStructTypeArray(
-                    pNext_loc.dot(Field::profileCount), pNext_loc.dot(Field::pProfiles), "VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR",
-                    structure->profileCount, structure->pProfiles, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, false, true,
+                    pNext_loc.dot(Field::profileCount), pNext_loc.dot(Field::pProfiles), structure->profileCount,
+                    structure->pProfiles, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, false, true,
                     "VUID-VkVideoProfileInfoKHR-sType-sType", "VUID-VkVideoProfileListInfoKHR-pProfiles-parameter", kVUIDUndefined);
 
                 if (structure->pProfiles != nullptr) {
@@ -6242,11 +6242,10 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoEncodeH264SessionParametersCreateInfoKHR);
                 VkVideoEncodeH264SessionParametersCreateInfoKHR* structure =
                     (VkVideoEncodeH264SessionParametersCreateInfoKHR*)header;
-                skip |= ValidateStructType(
-                    pNext_loc.dot(Field::pParametersAddInfo), "VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR",
-                    structure->pParametersAddInfo, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR, false,
-                    "VUID-VkVideoEncodeH264SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
-                    "VUID-VkVideoEncodeH264SessionParametersAddInfoKHR-sType-sType");
+                skip |= ValidateStructType(pNext_loc.dot(Field::pParametersAddInfo), structure->pParametersAddInfo,
+                                           VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR, false,
+                                           "VUID-VkVideoEncodeH264SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
+                                           "VUID-VkVideoEncodeH264SessionParametersAddInfoKHR-sType-sType");
 
                 if (structure->pParametersAddInfo != nullptr) {
                     [[maybe_unused]] const Location pParametersAddInfo_loc = pNext_loc.dot(Field::pParametersAddInfo);
@@ -6275,7 +6274,6 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoEncodeH264PictureInfoKHR);
                 VkVideoEncodeH264PictureInfoKHR* structure = (VkVideoEncodeH264PictureInfoKHR*)header;
                 skip |= ValidateStructTypeArray(pNext_loc.dot(Field::naluSliceEntryCount), pNext_loc.dot(Field::pNaluSliceEntries),
-                                                "VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR",
                                                 structure->naluSliceEntryCount, structure->pNaluSliceEntries,
                                                 VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_NALU_SLICE_INFO_KHR, true, true,
                                                 "VUID-VkVideoEncodeH264NaluSliceInfoKHR-sType-sType",
@@ -6375,11 +6373,10 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoEncodeH265SessionParametersCreateInfoKHR);
                 VkVideoEncodeH265SessionParametersCreateInfoKHR* structure =
                     (VkVideoEncodeH265SessionParametersCreateInfoKHR*)header;
-                skip |= ValidateStructType(
-                    pNext_loc.dot(Field::pParametersAddInfo), "VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR",
-                    structure->pParametersAddInfo, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR, false,
-                    "VUID-VkVideoEncodeH265SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
-                    "VUID-VkVideoEncodeH265SessionParametersAddInfoKHR-sType-sType");
+                skip |= ValidateStructType(pNext_loc.dot(Field::pParametersAddInfo), structure->pParametersAddInfo,
+                                           VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR, false,
+                                           "VUID-VkVideoEncodeH265SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
+                                           "VUID-VkVideoEncodeH265SessionParametersAddInfoKHR-sType-sType");
 
                 if (structure->pParametersAddInfo != nullptr) {
                     [[maybe_unused]] const Location pParametersAddInfo_loc = pNext_loc.dot(Field::pParametersAddInfo);
@@ -6409,13 +6406,13 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
             if (is_const_param) {
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoEncodeH265PictureInfoKHR);
                 VkVideoEncodeH265PictureInfoKHR* structure = (VkVideoEncodeH265PictureInfoKHR*)header;
-                skip |= ValidateStructTypeArray(
-                    pNext_loc.dot(Field::naluSliceSegmentEntryCount), pNext_loc.dot(Field::pNaluSliceSegmentEntries),
-                    "VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR", structure->naluSliceSegmentEntryCount,
-                    structure->pNaluSliceSegmentEntries, VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR, true,
-                    true, "VUID-VkVideoEncodeH265NaluSliceSegmentInfoKHR-sType-sType",
-                    "VUID-VkVideoEncodeH265PictureInfoKHR-pNaluSliceSegmentEntries-parameter",
-                    "VUID-VkVideoEncodeH265PictureInfoKHR-naluSliceSegmentEntryCount-arraylength");
+                skip |= ValidateStructTypeArray(pNext_loc.dot(Field::naluSliceSegmentEntryCount),
+                                                pNext_loc.dot(Field::pNaluSliceSegmentEntries),
+                                                structure->naluSliceSegmentEntryCount, structure->pNaluSliceSegmentEntries,
+                                                VK_STRUCTURE_TYPE_VIDEO_ENCODE_H265_NALU_SLICE_SEGMENT_INFO_KHR, true, true,
+                                                "VUID-VkVideoEncodeH265NaluSliceSegmentInfoKHR-sType-sType",
+                                                "VUID-VkVideoEncodeH265PictureInfoKHR-pNaluSliceSegmentEntries-parameter",
+                                                "VUID-VkVideoEncodeH265PictureInfoKHR-naluSliceSegmentEntryCount-arraylength");
 
                 if (structure->pNaluSliceSegmentEntries != nullptr) {
                     for (uint32_t naluSliceSegmentEntryIndex = 0;
@@ -6521,11 +6518,10 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoDecodeH264SessionParametersCreateInfoKHR);
                 VkVideoDecodeH264SessionParametersCreateInfoKHR* structure =
                     (VkVideoDecodeH264SessionParametersCreateInfoKHR*)header;
-                skip |= ValidateStructType(
-                    pNext_loc.dot(Field::pParametersAddInfo), "VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR",
-                    structure->pParametersAddInfo, VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR, false,
-                    "VUID-VkVideoDecodeH264SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
-                    "VUID-VkVideoDecodeH264SessionParametersAddInfoKHR-sType-sType");
+                skip |= ValidateStructType(pNext_loc.dot(Field::pParametersAddInfo), structure->pParametersAddInfo,
+                                           VK_STRUCTURE_TYPE_VIDEO_DECODE_H264_SESSION_PARAMETERS_ADD_INFO_KHR, false,
+                                           "VUID-VkVideoDecodeH264SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
+                                           "VUID-VkVideoDecodeH264SessionParametersAddInfoKHR-sType-sType");
 
                 if (structure->pParametersAddInfo != nullptr) {
                     [[maybe_unused]] const Location pParametersAddInfo_loc = pNext_loc.dot(Field::pParametersAddInfo);
@@ -6793,11 +6789,10 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkVideoDecodeH265SessionParametersCreateInfoKHR);
                 VkVideoDecodeH265SessionParametersCreateInfoKHR* structure =
                     (VkVideoDecodeH265SessionParametersCreateInfoKHR*)header;
-                skip |= ValidateStructType(
-                    pNext_loc.dot(Field::pParametersAddInfo), "VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR",
-                    structure->pParametersAddInfo, VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR, false,
-                    "VUID-VkVideoDecodeH265SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
-                    "VUID-VkVideoDecodeH265SessionParametersAddInfoKHR-sType-sType");
+                skip |= ValidateStructType(pNext_loc.dot(Field::pParametersAddInfo), structure->pParametersAddInfo,
+                                           VK_STRUCTURE_TYPE_VIDEO_DECODE_H265_SESSION_PARAMETERS_ADD_INFO_KHR, false,
+                                           "VUID-VkVideoDecodeH265SessionParametersCreateInfoKHR-pParametersAddInfo-parameter",
+                                           "VUID-VkVideoDecodeH265SessionParametersAddInfoKHR-sType-sType");
 
                 if (structure->pParametersAddInfo != nullptr) {
                     [[maybe_unused]] const Location pParametersAddInfo_loc = pNext_loc.dot(Field::pParametersAddInfo);
@@ -6874,11 +6869,11 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                                      "extended struct requires the extensions VK_KHR_fragment_shading_rate");
                 }
                 VkFragmentShadingRateAttachmentInfoKHR* structure = (VkFragmentShadingRateAttachmentInfoKHR*)header;
-                skip |= ValidateStructType(pNext_loc.dot(Field::pFragmentShadingRateAttachment),
-                                           "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2", structure->pFragmentShadingRateAttachment,
-                                           VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
-                                           "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-parameter",
-                                           "VUID-VkAttachmentReference2-sType-sType");
+                skip |=
+                    ValidateStructType(pNext_loc.dot(Field::pFragmentShadingRateAttachment),
+                                       structure->pFragmentShadingRateAttachment, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
+                                       "VUID-VkFragmentShadingRateAttachmentInfoKHR-pFragmentShadingRateAttachment-parameter",
+                                       "VUID-VkAttachmentReference2-sType-sType");
 
                 if (structure->pFragmentShadingRateAttachment != nullptr) {
                     [[maybe_unused]] const Location pFragmentShadingRateAttachment_loc =
@@ -6979,11 +6974,11 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                                   AllVkVideoEncodeRateControlModeFlagBitsKHR, structure->rateControlMode, kOptionalSingleBit,
                                   "VUID-VkVideoEncodeRateControlInfoKHR-rateControlMode-parameter");
 
-                skip |= ValidateStructTypeArray(pNext_loc.dot(Field::layerCount), pNext_loc.dot(Field::pLayers),
-                                                "VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR", structure->layerCount,
-                                                structure->pLayers, VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR,
-                                                false, true, "VUID-VkVideoEncodeRateControlLayerInfoKHR-sType-sType",
-                                                "VUID-VkVideoEncodeRateControlInfoKHR-pLayers-parameter", kVUIDUndefined);
+                skip |=
+                    ValidateStructTypeArray(pNext_loc.dot(Field::layerCount), pNext_loc.dot(Field::pLayers), structure->layerCount,
+                                            structure->pLayers, VK_STRUCTURE_TYPE_VIDEO_ENCODE_RATE_CONTROL_LAYER_INFO_KHR, false,
+                                            true, "VUID-VkVideoEncodeRateControlLayerInfoKHR-sType-sType",
+                                            "VUID-VkVideoEncodeRateControlInfoKHR-pLayers-parameter", kVUIDUndefined);
 
                 if (structure->pLayers != nullptr) {
                     for (uint32_t layerIndex = 0; layerIndex < structure->layerCount; ++layerIndex) {
@@ -7653,7 +7648,6 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                             pNext_loc.dot(Field::pAttachmentInitialSampleLocations, attachmentInitialSampleLocationsIndex);
                         skip |=
                             ValidateStructType(pAttachmentInitialSampleLocations_loc.dot(Field::sampleLocationsInfo),
-                                               "VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT",
                                                &(structure->pAttachmentInitialSampleLocations[attachmentInitialSampleLocationsIndex]
                                                      .sampleLocationsInfo),
                                                VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, false, kVUIDUndefined,
@@ -7695,7 +7689,6 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                             pNext_loc.dot(Field::pPostSubpassSampleLocations, postSubpassSampleLocationsIndex);
                         skip |= ValidateStructType(
                             pPostSubpassSampleLocations_loc.dot(Field::sampleLocationsInfo),
-                            "VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT",
                             &(structure->pPostSubpassSampleLocations[postSubpassSampleLocationsIndex].sampleLocationsInfo),
                             VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, false, kVUIDUndefined,
                             "VUID-VkSampleLocationsInfoEXT-sType-sType");
@@ -7736,9 +7729,9 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 VkPipelineSampleLocationsStateCreateInfoEXT* structure = (VkPipelineSampleLocationsStateCreateInfoEXT*)header;
                 skip |= ValidateBool32(pNext_loc.dot(Field::sampleLocationsEnable), structure->sampleLocationsEnable);
 
-                skip |= ValidateStructType(pNext_loc.dot(Field::sampleLocationsInfo), "VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT",
-                                           &(structure->sampleLocationsInfo), VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, false,
-                                           kVUIDUndefined, "VUID-VkSampleLocationsInfoEXT-sType-sType");
+                skip |= ValidateStructType(pNext_loc.dot(Field::sampleLocationsInfo), &(structure->sampleLocationsInfo),
+                                           VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, false, kVUIDUndefined,
+                                           "VUID-VkSampleLocationsInfoEXT-sType-sType");
 
                 skip |= ValidateArray(pNext_loc.dot(Field::sampleLocationsCount), pNext_loc.dot(Field::pSampleLocations),
                                       structure->sampleLocationsInfo.sampleLocationsCount,
@@ -8315,8 +8308,7 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 }
                 VkGraphicsPipelineShaderGroupsCreateInfoNV* structure = (VkGraphicsPipelineShaderGroupsCreateInfoNV*)header;
                 skip |=
-                    ValidateStructTypeArray(pNext_loc.dot(Field::groupCount), pNext_loc.dot(Field::pGroups),
-                                            "VK_STRUCTURE_TYPE_GRAPHICS_SHADER_GROUP_CREATE_INFO_NV", structure->groupCount,
+                    ValidateStructTypeArray(pNext_loc.dot(Field::groupCount), pNext_loc.dot(Field::pGroups), structure->groupCount,
                                             structure->pGroups, VK_STRUCTURE_TYPE_GRAPHICS_SHADER_GROUP_CREATE_INFO_NV, false, true,
                                             "VUID-VkGraphicsShaderGroupCreateInfoNV-sType-sType",
                                             "VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pGroups-parameter", kVUIDUndefined);
@@ -8324,13 +8316,13 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 if (structure->pGroups != nullptr) {
                     for (uint32_t groupIndex = 0; groupIndex < structure->groupCount; ++groupIndex) {
                         [[maybe_unused]] const Location pGroups_loc = pNext_loc.dot(Field::pGroups, groupIndex);
-                        skip |= ValidateStructTypeArray(
-                            pGroups_loc.dot(Field::stageCount), pGroups_loc.dot(Field::pStages),
-                            "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO", structure->pGroups[groupIndex].stageCount,
-                            structure->pGroups[groupIndex].pStages, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true,
-                            "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
-                            "VUID-VkGraphicsShaderGroupCreateInfoNV-pStages-parameter",
-                            "VUID-VkGraphicsShaderGroupCreateInfoNV-stageCount-arraylength");
+                        skip |= ValidateStructTypeArray(pGroups_loc.dot(Field::stageCount), pGroups_loc.dot(Field::pStages),
+                                                        structure->pGroups[groupIndex].stageCount,
+                                                        structure->pGroups[groupIndex].pStages,
+                                                        VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true,
+                                                        "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
+                                                        "VUID-VkGraphicsShaderGroupCreateInfoNV-pStages-parameter",
+                                                        "VUID-VkGraphicsShaderGroupCreateInfoNV-stageCount-arraylength");
 
                         if (structure->pGroups[groupIndex].pStages != nullptr) {
                             for (uint32_t stageIndex = 0; stageIndex < structure->pGroups[groupIndex].stageCount; ++stageIndex) {
@@ -9017,12 +9009,11 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                                      "extended struct requires the extensions VK_ARM_render_pass_striped");
                 }
                 VkRenderPassStripeBeginInfoARM* structure = (VkRenderPassStripeBeginInfoARM*)header;
-                skip |= ValidateStructTypeArray(pNext_loc.dot(Field::stripeInfoCount), pNext_loc.dot(Field::pStripeInfos),
-                                                "VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_INFO_ARM", structure->stripeInfoCount,
-                                                structure->pStripeInfos, VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_INFO_ARM, true, true,
-                                                "VUID-VkRenderPassStripeInfoARM-sType-sType",
-                                                "VUID-VkRenderPassStripeBeginInfoARM-pStripeInfos-parameter",
-                                                "VUID-VkRenderPassStripeBeginInfoARM-stripeInfoCount-arraylength");
+                skip |= ValidateStructTypeArray(
+                    pNext_loc.dot(Field::stripeInfoCount), pNext_loc.dot(Field::pStripeInfos), structure->stripeInfoCount,
+                    structure->pStripeInfos, VK_STRUCTURE_TYPE_RENDER_PASS_STRIPE_INFO_ARM, true, true,
+                    "VUID-VkRenderPassStripeInfoARM-sType-sType", "VUID-VkRenderPassStripeBeginInfoARM-pStripeInfos-parameter",
+                    "VUID-VkRenderPassStripeBeginInfoARM-stripeInfoCount-arraylength");
 
                 if (structure->pStripeInfos != nullptr) {
                     for (uint32_t stripeInfoIndex = 0; stripeInfoIndex < structure->stripeInfoCount; ++stripeInfoIndex) {
@@ -9042,8 +9033,7 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 }
                 VkRenderPassStripeSubmitInfoARM* structure = (VkRenderPassStripeSubmitInfoARM*)header;
                 skip |= ValidateStructTypeArray(pNext_loc.dot(Field::stripeSemaphoreInfoCount),
-                                                pNext_loc.dot(Field::pStripeSemaphoreInfos),
-                                                "VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO", structure->stripeSemaphoreInfoCount,
+                                                pNext_loc.dot(Field::pStripeSemaphoreInfos), structure->stripeSemaphoreInfoCount,
                                                 structure->pStripeSemaphoreInfos, VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, true,
                                                 true, "VUID-VkSemaphoreSubmitInfo-sType-sType",
                                                 "VUID-VkRenderPassStripeSubmitInfoARM-pStripeSemaphoreInfos-parameter",
@@ -9170,12 +9160,11 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
                 skip |= ValidateRangedEnum(pNext_loc.dot(Field::mode), vvl::Enum::VkDirectDriverLoadingModeLUNARG, structure->mode,
                                            "VUID-VkDirectDriverLoadingListLUNARG-mode-parameter");
 
-                skip |= ValidateStructTypeArray(pNext_loc.dot(Field::driverCount), pNext_loc.dot(Field::pDrivers),
-                                                "VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_INFO_LUNARG", structure->driverCount,
-                                                structure->pDrivers, VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_INFO_LUNARG, true,
-                                                true, "VUID-VkDirectDriverLoadingInfoLUNARG-sType-sType",
-                                                "VUID-VkDirectDriverLoadingListLUNARG-pDrivers-parameter",
-                                                "VUID-VkDirectDriverLoadingListLUNARG-driverCount-arraylength");
+                skip |= ValidateStructTypeArray(
+                    pNext_loc.dot(Field::driverCount), pNext_loc.dot(Field::pDrivers), structure->driverCount, structure->pDrivers,
+                    VK_STRUCTURE_TYPE_DIRECT_DRIVER_LOADING_INFO_LUNARG, true, true,
+                    "VUID-VkDirectDriverLoadingInfoLUNARG-sType-sType", "VUID-VkDirectDriverLoadingListLUNARG-pDrivers-parameter",
+                    "VUID-VkDirectDriverLoadingListLUNARG-driverCount-arraylength");
 
                 if (structure->pDrivers != nullptr) {
                     for (uint32_t driverIndex = 0; driverIndex < structure->driverCount; ++driverIndex) {
@@ -9423,9 +9412,8 @@ bool StatelessValidation::PreCallValidateCreateInstance(const VkInstanceCreateIn
                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, true, "VUID-vkCreateInstance-pCreateInfo-parameter",
-                               "VUID-VkInstanceCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO, true,
+                               "VUID-vkCreateInstance-pCreateInfo-parameter", "VUID-VkInstanceCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkInstanceCreateInfo = {VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
@@ -9445,8 +9433,8 @@ bool StatelessValidation::PreCallValidateCreateInstance(const VkInstanceCreateIn
                               AllVkInstanceCreateFlagBits, pCreateInfo->flags, kOptionalFlags,
                               "VUID-VkInstanceCreateInfo-flags-parameter");
 
-        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::pApplicationInfo), "VK_STRUCTURE_TYPE_APPLICATION_INFO",
-                                   pCreateInfo->pApplicationInfo, VK_STRUCTURE_TYPE_APPLICATION_INFO, false,
+        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::pApplicationInfo), pCreateInfo->pApplicationInfo,
+                                   VK_STRUCTURE_TYPE_APPLICATION_INFO, false,
                                    "VUID-VkInstanceCreateInfo-pApplicationInfo-parameter", "VUID-VkApplicationInfo-sType-sType");
 
         if (pCreateInfo->pApplicationInfo != nullptr) {
@@ -9648,9 +9636,8 @@ bool StatelessValidation::PreCallValidateCreateDevice(VkPhysicalDevice physicalD
                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, true, "VUID-vkCreateDevice-pCreateInfo-parameter",
-                               "VUID-VkDeviceCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO, true,
+                               "VUID-vkCreateDevice-pCreateInfo-parameter", "VUID-VkDeviceCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkDeviceCreateInfo = {
@@ -9862,9 +9849,9 @@ bool StatelessValidation::PreCallValidateCreateDevice(VkPhysicalDevice physicalD
 
         skip |= ValidateStructTypeArray(
             pCreateInfo_loc.dot(Field::queueCreateInfoCount), pCreateInfo_loc.dot(Field::pQueueCreateInfos),
-            "VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO", pCreateInfo->queueCreateInfoCount, pCreateInfo->pQueueCreateInfos,
-            VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, true, true, "VUID-VkDeviceQueueCreateInfo-sType-sType",
-            "VUID-VkDeviceCreateInfo-pQueueCreateInfos-parameter", "VUID-VkDeviceCreateInfo-queueCreateInfoCount-arraylength");
+            pCreateInfo->queueCreateInfoCount, pCreateInfo->pQueueCreateInfos, VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, true,
+            true, "VUID-VkDeviceQueueCreateInfo-sType-sType", "VUID-VkDeviceCreateInfo-pQueueCreateInfos-parameter",
+            "VUID-VkDeviceCreateInfo-queueCreateInfoCount-arraylength");
 
         if (pCreateInfo->pQueueCreateInfos != nullptr) {
             for (uint32_t queueCreateInfoIndex = 0; queueCreateInfoIndex < pCreateInfo->queueCreateInfoCount;
@@ -10130,9 +10117,9 @@ bool StatelessValidation::PreCallValidateQueueSubmit(VkQueue queue, uint32_t sub
                                                      VkFence fence, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(loc.dot(Field::submitCount), loc.dot(Field::pSubmits), "VK_STRUCTURE_TYPE_SUBMIT_INFO",
-                                    submitCount, pSubmits, VK_STRUCTURE_TYPE_SUBMIT_INFO, false, true,
-                                    "VUID-VkSubmitInfo-sType-sType", "VUID-vkQueueSubmit-pSubmits-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::submitCount), loc.dot(Field::pSubmits), submitCount, pSubmits,
+                                    VK_STRUCTURE_TYPE_SUBMIT_INFO, false, true, "VUID-VkSubmitInfo-sType-sType",
+                                    "VUID-vkQueueSubmit-pSubmits-parameter", kVUIDUndefined);
     if (pSubmits != nullptr) {
         for (uint32_t submitIndex = 0; submitIndex < submitCount; ++submitIndex) {
             [[maybe_unused]] const Location pSubmits_loc = loc.dot(Field::pSubmits, submitIndex);
@@ -10191,9 +10178,8 @@ bool StatelessValidation::PreCallValidateAllocateMemory(VkDevice device, const V
                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pAllocateInfo), "VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO", pAllocateInfo,
-                               VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, true, "VUID-vkAllocateMemory-pAllocateInfo-parameter",
-                               "VUID-VkMemoryAllocateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pAllocateInfo), pAllocateInfo, VK_STRUCTURE_TYPE_MEMORY_ALLOCATE_INFO, true,
+                               "VUID-vkAllocateMemory-pAllocateInfo-parameter", "VUID-VkMemoryAllocateInfo-sType-sType");
     if (pAllocateInfo != nullptr) {
         [[maybe_unused]] const Location pAllocateInfo_loc = loc.dot(Field::pAllocateInfo);
         constexpr std::array allowed_structs_VkMemoryAllocateInfo = {VK_STRUCTURE_TYPE_DEDICATED_ALLOCATION_MEMORY_ALLOCATE_INFO_NV,
@@ -10307,8 +10293,8 @@ bool StatelessValidation::PreCallValidateFlushMappedMemoryRanges(VkDevice device
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::memoryRangeCount), loc.dot(Field::pMemoryRanges), "VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE", memoryRangeCount,
-        pMemoryRanges, VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, true, true, "VUID-VkMappedMemoryRange-sType-sType",
+        loc.dot(Field::memoryRangeCount), loc.dot(Field::pMemoryRanges), memoryRangeCount, pMemoryRanges,
+        VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, true, true, "VUID-VkMappedMemoryRange-sType-sType",
         "VUID-vkFlushMappedMemoryRanges-pMemoryRanges-parameter", "VUID-vkFlushMappedMemoryRanges-memoryRangeCount-arraylength");
     if (pMemoryRanges != nullptr) {
         for (uint32_t memoryRangeIndex = 0; memoryRangeIndex < memoryRangeCount; ++memoryRangeIndex) {
@@ -10328,11 +10314,11 @@ bool StatelessValidation::PreCallValidateInvalidateMappedMemoryRanges(VkDevice d
                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(loc.dot(Field::memoryRangeCount), loc.dot(Field::pMemoryRanges),
-                                    "VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE", memoryRangeCount, pMemoryRanges,
-                                    VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, true, true, "VUID-VkMappedMemoryRange-sType-sType",
-                                    "VUID-vkInvalidateMappedMemoryRanges-pMemoryRanges-parameter",
-                                    "VUID-vkInvalidateMappedMemoryRanges-memoryRangeCount-arraylength");
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::memoryRangeCount), loc.dot(Field::pMemoryRanges), memoryRangeCount, pMemoryRanges,
+                                VK_STRUCTURE_TYPE_MAPPED_MEMORY_RANGE, true, true, "VUID-VkMappedMemoryRange-sType-sType",
+                                "VUID-vkInvalidateMappedMemoryRanges-pMemoryRanges-parameter",
+                                "VUID-vkInvalidateMappedMemoryRanges-memoryRangeCount-arraylength");
     if (pMemoryRanges != nullptr) {
         for (uint32_t memoryRangeIndex = 0; memoryRangeIndex < memoryRangeCount; ++memoryRangeIndex) {
             [[maybe_unused]] const Location pMemoryRanges_loc = loc.dot(Field::pMemoryRanges, memoryRangeIndex);
@@ -10460,10 +10446,9 @@ bool StatelessValidation::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t
                                                          VkFence fence, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |=
-        ValidateStructTypeArray(loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfo), "VK_STRUCTURE_TYPE_BIND_SPARSE_INFO",
-                                bindInfoCount, pBindInfo, VK_STRUCTURE_TYPE_BIND_SPARSE_INFO, false, true,
-                                "VUID-VkBindSparseInfo-sType-sType", "VUID-vkQueueBindSparse-pBindInfo-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfo), bindInfoCount, pBindInfo,
+                                    VK_STRUCTURE_TYPE_BIND_SPARSE_INFO, false, true, "VUID-VkBindSparseInfo-sType-sType",
+                                    "VUID-vkQueueBindSparse-pBindInfo-parameter", kVUIDUndefined);
     if (pBindInfo != nullptr) {
         for (uint32_t bindInfoIndex = 0; bindInfoIndex < bindInfoCount; ++bindInfoIndex) {
             [[maybe_unused]] const Location pBindInfo_loc = loc.dot(Field::pBindInfo, bindInfoIndex);
@@ -10595,9 +10580,8 @@ bool StatelessValidation::PreCallValidateCreateFence(VkDevice device, const VkFe
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_FENCE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, true, "VUID-vkCreateFence-pCreateInfo-parameter",
-                               "VUID-VkFenceCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, true,
+                               "VUID-vkCreateFence-pCreateInfo-parameter", "VUID-VkFenceCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkFenceCreateInfo = {VK_STRUCTURE_TYPE_EXPORT_FENCE_CREATE_INFO,
@@ -10703,9 +10687,8 @@ bool StatelessValidation::PreCallValidateCreateSemaphore(VkDevice device, const 
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, true, "VUID-vkCreateSemaphore-pCreateInfo-parameter",
-                               "VUID-VkSemaphoreCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO, true,
+                               "VUID-vkCreateSemaphore-pCreateInfo-parameter", "VUID-VkSemaphoreCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkSemaphoreCreateInfo = {
@@ -10789,9 +10772,8 @@ bool StatelessValidation::PreCallValidateCreateEvent(VkDevice device, const VkEv
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_EVENT_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_EVENT_CREATE_INFO, true, "VUID-vkCreateEvent-pCreateInfo-parameter",
-                               "VUID-VkEventCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_EVENT_CREATE_INFO, true,
+                               "VUID-vkCreateEvent-pCreateInfo-parameter", "VUID-VkEventCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkEventCreateInfo = {VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECT_CREATE_INFO_EXT,
@@ -10893,9 +10875,8 @@ bool StatelessValidation::PreCallValidateCreateQueryPool(VkDevice device, const 
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, true, "VUID-vkCreateQueryPool-pCreateInfo-parameter",
-                               "VUID-VkQueryPoolCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_QUERY_POOL_CREATE_INFO, true,
+                               "VUID-vkCreateQueryPool-pCreateInfo-parameter", "VUID-VkQueryPoolCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkQueryPoolCreateInfo = {
@@ -11006,9 +10987,8 @@ bool StatelessValidation::PreCallValidateCreateBuffer(VkDevice device, const VkB
                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, true, "VUID-vkCreateBuffer-pCreateInfo-parameter",
-                               "VUID-VkBufferCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, true,
+                               "VUID-vkCreateBuffer-pCreateInfo-parameter", "VUID-VkBufferCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkBufferCreateInfo = {VK_STRUCTURE_TYPE_BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA,
@@ -11099,9 +11079,8 @@ bool StatelessValidation::PreCallValidateCreateBufferView(VkDevice device, const
                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO, true, "VUID-vkCreateBufferView-pCreateInfo-parameter",
-                               "VUID-VkBufferViewCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_BUFFER_VIEW_CREATE_INFO, true,
+                               "VUID-vkCreateBufferView-pCreateInfo-parameter", "VUID-VkBufferViewCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkBufferViewCreateInfo = {VK_STRUCTURE_TYPE_BUFFER_USAGE_FLAGS_2_CREATE_INFO_KHR,
@@ -11188,9 +11167,8 @@ bool StatelessValidation::PreCallValidateCreateImage(VkDevice device, const VkIm
                                                      const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true, "VUID-vkCreateImage-pCreateInfo-parameter",
-                               "VUID-VkImageCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
+                               "VUID-vkCreateImage-pCreateInfo-parameter", "VUID-VkImageCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkImageCreateInfo = {
@@ -11333,9 +11311,8 @@ bool StatelessValidation::PreCallValidateCreateImageView(VkDevice device, const 
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, true, "VUID-vkCreateImageView-pCreateInfo-parameter",
-                               "VUID-VkImageViewCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_IMAGE_VIEW_CREATE_INFO, true,
+                               "VUID-vkCreateImageView-pCreateInfo-parameter", "VUID-VkImageViewCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkImageViewCreateInfo = {
@@ -11450,9 +11427,8 @@ bool StatelessValidation::PreCallValidateCreateShaderModule(VkDevice device, con
                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, true, "VUID-vkCreateShaderModule-pCreateInfo-parameter",
-                               "VUID-VkShaderModuleCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, true,
+                               "VUID-vkCreateShaderModule-pCreateInfo-parameter", "VUID-VkShaderModuleCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |= ValidateReservedFlags(pCreateInfo_loc.dot(Field::flags), pCreateInfo->flags,
@@ -11530,8 +11506,7 @@ bool StatelessValidation::PreCallValidateCreatePipelineCache(VkDevice device, co
                                                              VkPipelineCache* pPipelineCache, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO, true,
                                "VUID-vkCreatePipelineCache-pCreateInfo-parameter", "VUID-VkPipelineCacheCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -11640,10 +11615,9 @@ bool StatelessValidation::PreCallValidateCreateGraphicsPipelines(VkDevice device
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO",
-        createInfoCount, pCreateInfos, VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, true, true,
-        "VUID-VkGraphicsPipelineCreateInfo-sType-sType", "VUID-vkCreateGraphicsPipelines-pCreateInfos-parameter",
-        "VUID-vkCreateGraphicsPipelines-createInfoCount-arraylength");
+        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
+        VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO, true, true, "VUID-VkGraphicsPipelineCreateInfo-sType-sType",
+        "VUID-vkCreateGraphicsPipelines-pCreateInfos-parameter", "VUID-vkCreateGraphicsPipelines-createInfoCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t createInfoIndex = 0; createInfoIndex < createInfoCount; ++createInfoIndex) {
             [[maybe_unused]] const Location pCreateInfos_loc = loc.dot(Field::pCreateInfos, createInfoIndex);
@@ -11672,10 +11646,10 @@ bool StatelessValidation::PreCallValidateCreateGraphicsPipelines(VkDevice device
                                         "VUID-VkGraphicsPipelineCreateInfo-pNext-pNext",
                                         "VUID-VkGraphicsPipelineCreateInfo-sType-unique", VK_NULL_HANDLE, true);
 
-            skip |= ValidateStructType(
-                pCreateInfos_loc.dot(Field::pDynamicState), "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
-                pCreateInfos[createInfoIndex].pDynamicState, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, false,
-                "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-parameter", "VUID-VkPipelineDynamicStateCreateInfo-sType-sType");
+            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::pDynamicState), pCreateInfos[createInfoIndex].pDynamicState,
+                                       VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, false,
+                                       "VUID-VkGraphicsPipelineCreateInfo-pDynamicState-parameter",
+                                       "VUID-VkPipelineDynamicStateCreateInfo-sType-sType");
 
             if (pCreateInfos[createInfoIndex].pDynamicState != nullptr) {
                 [[maybe_unused]] const Location pDynamicState_loc = pCreateInfos_loc.dot(Field::pDynamicState);
@@ -11737,10 +11711,9 @@ bool StatelessValidation::PreCallValidateCreateComputePipelines(VkDevice device,
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO",
-        createInfoCount, pCreateInfos, VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, true, true,
-        "VUID-VkComputePipelineCreateInfo-sType-sType", "VUID-vkCreateComputePipelines-pCreateInfos-parameter",
-        "VUID-vkCreateComputePipelines-createInfoCount-arraylength");
+        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
+        VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, true, true, "VUID-VkComputePipelineCreateInfo-sType-sType",
+        "VUID-vkCreateComputePipelines-pCreateInfos-parameter", "VUID-vkCreateComputePipelines-createInfoCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t createInfoIndex = 0; createInfoIndex < createInfoCount; ++createInfoIndex) {
             [[maybe_unused]] const Location pCreateInfos_loc = loc.dot(Field::pCreateInfos, createInfoIndex);
@@ -11758,9 +11731,9 @@ bool StatelessValidation::PreCallValidateCreateComputePipelines(VkDevice device,
                                         "VUID-VkComputePipelineCreateInfo-pNext-pNext",
                                         "VUID-VkComputePipelineCreateInfo-sType-unique", VK_NULL_HANDLE, true);
 
-            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::stage), "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                                       &(pCreateInfos[createInfoIndex].stage), VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO,
-                                       false, kVUIDUndefined, "VUID-VkPipelineShaderStageCreateInfo-sType-sType");
+            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::stage), &(pCreateInfos[createInfoIndex].stage),
+                                       VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, false, kVUIDUndefined,
+                                       "VUID-VkPipelineShaderStageCreateInfo-sType-sType");
 
             constexpr std::array allowed_structs_VkPipelineShaderStageCreateInfo = {
                 VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
@@ -11888,8 +11861,7 @@ bool StatelessValidation::PreCallValidateCreatePipelineLayout(VkDevice device, c
                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO, true,
                                "VUID-vkCreatePipelineLayout-pCreateInfo-parameter", "VUID-VkPipelineLayoutCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -11985,9 +11957,8 @@ bool StatelessValidation::PreCallValidateCreateSampler(VkDevice device, const Vk
                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, true, "VUID-vkCreateSampler-pCreateInfo-parameter",
-                               "VUID-VkSamplerCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO, true,
+                               "VUID-vkCreateSampler-pCreateInfo-parameter", "VUID-VkSamplerCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkSamplerCreateInfo = {
@@ -12101,8 +12072,7 @@ bool StatelessValidation::PreCallValidateCreateDescriptorSetLayout(VkDevice devi
                                                                    const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, true,
                                "VUID-vkCreateDescriptorSetLayout-pCreateInfo-parameter",
                                "VUID-VkDescriptorSetLayoutCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -12203,8 +12173,7 @@ bool StatelessValidation::PreCallValidateCreateDescriptorPool(VkDevice device, c
                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, true,
                                "VUID-vkCreateDescriptorPool-pCreateInfo-parameter", "VUID-VkDescriptorPoolCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -12312,8 +12281,7 @@ bool StatelessValidation::PreCallValidateAllocateDescriptorSets(VkDevice device,
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |=
-        ValidateStructType(loc.dot(Field::pAllocateInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO", pAllocateInfo,
-                           VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, true,
+        ValidateStructType(loc.dot(Field::pAllocateInfo), pAllocateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO, true,
                            "VUID-vkAllocateDescriptorSets-pAllocateInfo-parameter", "VUID-VkDescriptorSetAllocateInfo-sType-sType");
     if (pAllocateInfo != nullptr) {
         [[maybe_unused]] const Location pAllocateInfo_loc = loc.dot(Field::pAllocateInfo);
@@ -12360,9 +12328,9 @@ bool StatelessValidation::PreCallValidateUpdateDescriptorSets(VkDevice device, u
                                                               const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorWriteCount), loc.dot(Field::pDescriptorWrites),
-                                    "VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET", descriptorWriteCount, pDescriptorWrites,
-                                    VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, false, true, "VUID-VkWriteDescriptorSet-sType-sType",
+    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorWriteCount), loc.dot(Field::pDescriptorWrites), descriptorWriteCount,
+                                    pDescriptorWrites, VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, false, true,
+                                    "VUID-VkWriteDescriptorSet-sType-sType",
                                     "VUID-vkUpdateDescriptorSets-pDescriptorWrites-parameter", kVUIDUndefined);
     if (pDescriptorWrites != nullptr) {
         for (uint32_t descriptorWriteIndex = 0; descriptorWriteIndex < descriptorWriteCount; ++descriptorWriteIndex) {
@@ -12387,9 +12355,9 @@ bool StatelessValidation::PreCallValidateUpdateDescriptorSets(VkDevice device, u
                                   "VUID-VkWriteDescriptorSet-descriptorCount-arraylength", kVUIDUndefined);
         }
     }
-    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorCopyCount), loc.dot(Field::pDescriptorCopies),
-                                    "VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET", descriptorCopyCount, pDescriptorCopies,
-                                    VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET, false, true, "VUID-VkCopyDescriptorSet-sType-sType",
+    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorCopyCount), loc.dot(Field::pDescriptorCopies), descriptorCopyCount,
+                                    pDescriptorCopies, VK_STRUCTURE_TYPE_COPY_DESCRIPTOR_SET, false, true,
+                                    "VUID-VkCopyDescriptorSet-sType-sType",
                                     "VUID-vkUpdateDescriptorSets-pDescriptorCopies-parameter", kVUIDUndefined);
     if (pDescriptorCopies != nullptr) {
         for (uint32_t descriptorCopyIndex = 0; descriptorCopyIndex < descriptorCopyCount; ++descriptorCopyIndex) {
@@ -12414,9 +12382,8 @@ bool StatelessValidation::PreCallValidateCreateFramebuffer(VkDevice device, cons
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, true, "VUID-vkCreateFramebuffer-pCreateInfo-parameter",
-                               "VUID-VkFramebufferCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO, true,
+                               "VUID-vkCreateFramebuffer-pCreateInfo-parameter", "VUID-VkFramebufferCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkFramebufferCreateInfo = {VK_STRUCTURE_TYPE_FRAMEBUFFER_ATTACHMENTS_CREATE_INFO};
@@ -12500,9 +12467,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass(VkDevice device, const
                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, true, "VUID-vkCreateRenderPass-pCreateInfo-parameter",
-                               "VUID-VkRenderPassCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO, true,
+                               "VUID-vkCreateRenderPass-pCreateInfo-parameter", "VUID-VkRenderPassCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkRenderPassCreateInfo = {
@@ -12752,9 +12718,8 @@ bool StatelessValidation::PreCallValidateCreateCommandPool(VkDevice device, cons
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, true, "VUID-vkCreateCommandPool-pCreateInfo-parameter",
-                               "VUID-VkCommandPoolCreateInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_COMMAND_POOL_CREATE_INFO, true,
+                               "VUID-vkCreateCommandPool-pCreateInfo-parameter", "VUID-VkCommandPoolCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -12842,8 +12807,7 @@ bool StatelessValidation::PreCallValidateAllocateCommandBuffers(VkDevice device,
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |=
-        ValidateStructType(loc.dot(Field::pAllocateInfo), "VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO", pAllocateInfo,
-                           VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, true,
+        ValidateStructType(loc.dot(Field::pAllocateInfo), pAllocateInfo, VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO, true,
                            "VUID-vkAllocateCommandBuffers-pAllocateInfo-parameter", "VUID-VkCommandBufferAllocateInfo-sType-sType");
     if (pAllocateInfo != nullptr) {
         [[maybe_unused]] const Location pAllocateInfo_loc = loc.dot(Field::pAllocateInfo);
@@ -12882,9 +12846,8 @@ bool StatelessValidation::PreCallValidateBeginCommandBuffer(VkCommandBuffer comm
                                                             const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pBeginInfo), "VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO", pBeginInfo,
-                               VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, true, "VUID-vkBeginCommandBuffer-pBeginInfo-parameter",
-                               "VUID-VkCommandBufferBeginInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pBeginInfo), pBeginInfo, VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, true,
+                               "VUID-vkBeginCommandBuffer-pBeginInfo-parameter", "VUID-VkCommandBufferBeginInfo-sType-sType");
     if (pBeginInfo != nullptr) {
         [[maybe_unused]] const Location pBeginInfo_loc = loc.dot(Field::pBeginInfo);
         constexpr std::array allowed_structs_VkCommandBufferBeginInfo = {VK_STRUCTURE_TYPE_DEVICE_GROUP_COMMAND_BUFFER_BEGIN_INFO};
@@ -13443,10 +13406,10 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents(
                           srcStageMask, kOptionalFlags, "VUID-vkCmdWaitEvents-srcStageMask-parameter");
     skip |= ValidateFlags(loc.dot(Field::dstStageMask), vvl::FlagBitmask::VkPipelineStageFlagBits, AllVkPipelineStageFlagBits,
                           dstStageMask, kOptionalFlags, "VUID-vkCmdWaitEvents-dstStageMask-parameter");
-    skip |= ValidateStructTypeArray(loc.dot(Field::memoryBarrierCount), loc.dot(Field::pMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_MEMORY_BARRIER", memoryBarrierCount, pMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_MEMORY_BARRIER, false, true, "VUID-VkMemoryBarrier-sType-sType",
-                                    "VUID-vkCmdWaitEvents-pMemoryBarriers-parameter", kVUIDUndefined);
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::memoryBarrierCount), loc.dot(Field::pMemoryBarriers), memoryBarrierCount,
+                                pMemoryBarriers, VK_STRUCTURE_TYPE_MEMORY_BARRIER, false, true, "VUID-VkMemoryBarrier-sType-sType",
+                                "VUID-vkCmdWaitEvents-pMemoryBarriers-parameter", kVUIDUndefined);
     if (pMemoryBarriers != nullptr) {
         for (uint32_t memoryBarrierIndex = 0; memoryBarrierIndex < memoryBarrierCount; ++memoryBarrierIndex) {
             [[maybe_unused]] const Location pMemoryBarriers_loc = loc.dot(Field::pMemoryBarriers, memoryBarrierIndex);
@@ -13464,8 +13427,8 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents(
         }
     }
     skip |= ValidateStructTypeArray(loc.dot(Field::bufferMemoryBarrierCount), loc.dot(Field::pBufferMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER", bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, false, true, "VUID-VkBufferMemoryBarrier-sType-sType",
+                                    bufferMemoryBarrierCount, pBufferMemoryBarriers, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, false,
+                                    true, "VUID-VkBufferMemoryBarrier-sType-sType",
                                     "VUID-vkCmdWaitEvents-pBufferMemoryBarriers-parameter", kVUIDUndefined);
     if (pBufferMemoryBarriers != nullptr) {
         for (uint32_t bufferMemoryBarrierIndex = 0; bufferMemoryBarrierIndex < bufferMemoryBarrierCount;
@@ -13484,8 +13447,8 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents(
         }
     }
     skip |= ValidateStructTypeArray(loc.dot(Field::imageMemoryBarrierCount), loc.dot(Field::pImageMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER", imageMemoryBarrierCount, pImageMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, false, true, "VUID-VkImageMemoryBarrier-sType-sType",
+                                    imageMemoryBarrierCount, pImageMemoryBarriers, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, false,
+                                    true, "VUID-VkImageMemoryBarrier-sType-sType",
                                     "VUID-vkCmdWaitEvents-pImageMemoryBarriers-parameter", kVUIDUndefined);
     if (pImageMemoryBarriers != nullptr) {
         for (uint32_t imageMemoryBarrierIndex = 0; imageMemoryBarrierIndex < imageMemoryBarrierCount; ++imageMemoryBarrierIndex) {
@@ -13532,10 +13495,10 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier(
                           dstStageMask, kOptionalFlags, "VUID-vkCmdPipelineBarrier-dstStageMask-parameter");
     skip |= ValidateFlags(loc.dot(Field::dependencyFlags), vvl::FlagBitmask::VkDependencyFlagBits, AllVkDependencyFlagBits,
                           dependencyFlags, kOptionalFlags, "VUID-vkCmdPipelineBarrier-dependencyFlags-parameter");
-    skip |= ValidateStructTypeArray(loc.dot(Field::memoryBarrierCount), loc.dot(Field::pMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_MEMORY_BARRIER", memoryBarrierCount, pMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_MEMORY_BARRIER, false, true, "VUID-VkMemoryBarrier-sType-sType",
-                                    "VUID-vkCmdPipelineBarrier-pMemoryBarriers-parameter", kVUIDUndefined);
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::memoryBarrierCount), loc.dot(Field::pMemoryBarriers), memoryBarrierCount,
+                                pMemoryBarriers, VK_STRUCTURE_TYPE_MEMORY_BARRIER, false, true, "VUID-VkMemoryBarrier-sType-sType",
+                                "VUID-vkCmdPipelineBarrier-pMemoryBarriers-parameter", kVUIDUndefined);
     if (pMemoryBarriers != nullptr) {
         for (uint32_t memoryBarrierIndex = 0; memoryBarrierIndex < memoryBarrierCount; ++memoryBarrierIndex) {
             [[maybe_unused]] const Location pMemoryBarriers_loc = loc.dot(Field::pMemoryBarriers, memoryBarrierIndex);
@@ -13553,8 +13516,8 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier(
         }
     }
     skip |= ValidateStructTypeArray(loc.dot(Field::bufferMemoryBarrierCount), loc.dot(Field::pBufferMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER", bufferMemoryBarrierCount, pBufferMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, false, true, "VUID-VkBufferMemoryBarrier-sType-sType",
+                                    bufferMemoryBarrierCount, pBufferMemoryBarriers, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER, false,
+                                    true, "VUID-VkBufferMemoryBarrier-sType-sType",
                                     "VUID-vkCmdPipelineBarrier-pBufferMemoryBarriers-parameter", kVUIDUndefined);
     if (pBufferMemoryBarriers != nullptr) {
         for (uint32_t bufferMemoryBarrierIndex = 0; bufferMemoryBarrierIndex < bufferMemoryBarrierCount;
@@ -13573,8 +13536,8 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier(
         }
     }
     skip |= ValidateStructTypeArray(loc.dot(Field::imageMemoryBarrierCount), loc.dot(Field::pImageMemoryBarriers),
-                                    "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER", imageMemoryBarrierCount, pImageMemoryBarriers,
-                                    VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, false, true, "VUID-VkImageMemoryBarrier-sType-sType",
+                                    imageMemoryBarrierCount, pImageMemoryBarriers, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER, false,
+                                    true, "VUID-VkImageMemoryBarrier-sType-sType",
                                     "VUID-vkCmdPipelineBarrier-pImageMemoryBarriers-parameter", kVUIDUndefined);
     if (pImageMemoryBarriers != nullptr) {
         for (uint32_t imageMemoryBarrierIndex = 0; imageMemoryBarrierIndex < imageMemoryBarrierCount; ++imageMemoryBarrierIndex) {
@@ -13680,8 +13643,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass(VkCommandBuffer comm
                                                             VkSubpassContents contents, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pRenderPassBegin), "VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO", pRenderPassBegin,
-                               VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pRenderPassBegin), pRenderPassBegin, VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, true,
                                "VUID-vkCmdBeginRenderPass-pRenderPassBegin-parameter", "VUID-VkRenderPassBeginInfo-sType-sType");
     if (pRenderPassBegin != nullptr) {
         [[maybe_unused]] const Location pRenderPassBegin_loc = loc.dot(Field::pRenderPassBegin);
@@ -13743,10 +13705,10 @@ bool StatelessValidation::PreCallValidateBindBufferMemory2(VkDevice device, uint
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), "VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO", bindInfoCount,
-        pBindInfos, VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO, true, true, "VUID-VkBindBufferMemoryInfo-sType-sType",
-        "VUID-vkBindBufferMemory2-pBindInfos-parameter", "VUID-vkBindBufferMemory2-bindInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), bindInfoCount, pBindInfos,
+                                    VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO, true, true,
+                                    "VUID-VkBindBufferMemoryInfo-sType-sType", "VUID-vkBindBufferMemory2-pBindInfos-parameter",
+                                    "VUID-vkBindBufferMemory2-bindInfoCount-arraylength");
     if (pBindInfos != nullptr) {
         for (uint32_t bindInfoIndex = 0; bindInfoIndex < bindInfoCount; ++bindInfoIndex) {
             [[maybe_unused]] const Location pBindInfos_loc = loc.dot(Field::pBindInfos, bindInfoIndex);
@@ -13771,10 +13733,10 @@ bool StatelessValidation::PreCallValidateBindImageMemory2(VkDevice device, uint3
                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), "VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO", bindInfoCount,
-        pBindInfos, VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO, true, true, "VUID-VkBindImageMemoryInfo-sType-sType",
-        "VUID-vkBindImageMemory2-pBindInfos-parameter", "VUID-vkBindImageMemory2-bindInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), bindInfoCount, pBindInfos,
+                                    VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO, true, true, "VUID-VkBindImageMemoryInfo-sType-sType",
+                                    "VUID-vkBindImageMemory2-pBindInfos-parameter",
+                                    "VUID-vkBindImageMemory2-bindInfoCount-arraylength");
     if (pBindInfos != nullptr) {
         for (uint32_t bindInfoIndex = 0; bindInfoIndex < bindInfoCount; ++bindInfoIndex) {
             [[maybe_unused]] const Location pBindInfos_loc = loc.dot(Field::pBindInfos, bindInfoIndex);
@@ -13830,9 +13792,9 @@ bool StatelessValidation::PreCallValidateEnumeratePhysicalDeviceGroups(
         CheckPromotedApiAgainstVulkanVersion(instance, loc, VK_API_VERSION_1_1))
         return true;
     skip |= ValidateStructTypeArray(loc.dot(Field::pPhysicalDeviceGroupCount), loc.dot(Field::pPhysicalDeviceGroupProperties),
-                                    "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES", pPhysicalDeviceGroupCount,
-                                    pPhysicalDeviceGroupProperties, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, true, false,
-                                    false, "VUID-VkPhysicalDeviceGroupProperties-sType-sType",
+                                    pPhysicalDeviceGroupCount, pPhysicalDeviceGroupProperties,
+                                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES, true, false, false,
+                                    "VUID-VkPhysicalDeviceGroupProperties-sType-sType",
                                     "VUID-vkEnumeratePhysicalDeviceGroups-pPhysicalDeviceGroupProperties-parameter",
                                     "VUID-vkEnumeratePhysicalDeviceGroups-pPhysicalDeviceGroupCount-parameter", kVUIDUndefined);
     if (pPhysicalDeviceGroupProperties != nullptr) {
@@ -13855,8 +13817,7 @@ bool StatelessValidation::PreCallValidateGetImageMemoryRequirements2(VkDevice de
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |=
-        ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2", pInfo,
-                           VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2, true,
+        ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_IMAGE_MEMORY_REQUIREMENTS_INFO_2, true,
                            "VUID-vkGetImageMemoryRequirements2-pInfo-parameter", "VUID-VkImageMemoryRequirementsInfo2-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -13870,9 +13831,8 @@ bool StatelessValidation::PreCallValidateGetImageMemoryRequirements2(VkDevice de
 
         skip |= ValidateRequiredHandle(pInfo_loc.dot(Field::image), pInfo->image);
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetImageMemoryRequirements2-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetImageMemoryRequirements2-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -13891,8 +13851,7 @@ bool StatelessValidation::PreCallValidateGetBufferMemoryRequirements2(VkDevice d
                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2", pInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_BUFFER_MEMORY_REQUIREMENTS_INFO_2, true,
                                "VUID-vkGetBufferMemoryRequirements2-pInfo-parameter",
                                "VUID-VkBufferMemoryRequirementsInfo2-sType-sType");
     if (pInfo != nullptr) {
@@ -13902,9 +13861,8 @@ bool StatelessValidation::PreCallValidateGetBufferMemoryRequirements2(VkDevice d
 
         skip |= ValidateRequiredHandle(pInfo_loc.dot(Field::buffer), pInfo->buffer);
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetBufferMemoryRequirements2-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetBufferMemoryRequirements2-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -13923,8 +13881,7 @@ bool StatelessValidation::PreCallValidateGetImageSparseMemoryRequirements2(
     VkSparseImageMemoryRequirements2* pSparseMemoryRequirements, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2", pInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_IMAGE_SPARSE_MEMORY_REQUIREMENTS_INFO_2, true,
                                "VUID-vkGetImageSparseMemoryRequirements2-pInfo-parameter",
                                "VUID-VkImageSparseMemoryRequirementsInfo2-sType-sType");
     if (pInfo != nullptr) {
@@ -13934,13 +13891,12 @@ bool StatelessValidation::PreCallValidateGetImageSparseMemoryRequirements2(
 
         skip |= ValidateRequiredHandle(pInfo_loc.dot(Field::image), pInfo->image);
     }
-    skip |=
-        ValidateStructTypeArray(loc.dot(Field::pSparseMemoryRequirementCount), loc.dot(Field::pSparseMemoryRequirements),
-                                "VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2", pSparseMemoryRequirementCount,
-                                pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false, false,
-                                "VUID-VkSparseImageMemoryRequirements2-sType-sType",
-                                "VUID-vkGetImageSparseMemoryRequirements2-pSparseMemoryRequirements-parameter",
-                                "VUID-vkGetImageSparseMemoryRequirements2-pSparseMemoryRequirementCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(
+        loc.dot(Field::pSparseMemoryRequirementCount), loc.dot(Field::pSparseMemoryRequirements), pSparseMemoryRequirementCount,
+        pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false, false,
+        "VUID-VkSparseImageMemoryRequirements2-sType-sType",
+        "VUID-vkGetImageSparseMemoryRequirements2-pSparseMemoryRequirements-parameter",
+        "VUID-vkGetImageSparseMemoryRequirements2-pSparseMemoryRequirementCount-parameter", kVUIDUndefined);
     if (pSparseMemoryRequirements != nullptr) {
         for (uint32_t pSparseMemoryRequirementIndex = 0; pSparseMemoryRequirementIndex < *pSparseMemoryRequirementCount;
              ++pSparseMemoryRequirementIndex) {
@@ -13964,8 +13920,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceFeatures2(VkPhysicalDe
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
     skip |=
-        ValidateStructType(loc.dot(Field::pFeatures), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2", pFeatures,
-                           VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, true,
+        ValidateStructType(loc.dot(Field::pFeatures), pFeatures, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2, true,
                            "VUID-vkGetPhysicalDeviceFeatures2-pFeatures-parameter", "VUID-VkPhysicalDeviceFeatures2-sType-sType");
     return skip;
 }
@@ -13978,8 +13933,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceProperties2(VkPhysical
     if (loc.function == vvl::Func::vkGetPhysicalDeviceProperties2 &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2", pProperties,
-                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2, true,
                                "VUID-vkGetPhysicalDeviceProperties2-pProperties-parameter",
                                "VUID-VkPhysicalDeviceProperties2-sType-sType");
     if (pProperties != nullptr) {
@@ -14095,8 +14049,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceFormatProperties2(VkPh
         return true;
     skip |= ValidateRangedEnum(loc.dot(Field::format), vvl::Enum::VkFormat, format,
                                "VUID-vkGetPhysicalDeviceFormatProperties2-format-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pFormatProperties), "VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2", pFormatProperties,
-                               VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pFormatProperties), pFormatProperties, VK_STRUCTURE_TYPE_FORMAT_PROPERTIES_2, true,
                                "VUID-vkGetPhysicalDeviceFormatProperties2-pFormatProperties-parameter",
                                "VUID-VkFormatProperties2-sType-sType");
     if (pFormatProperties != nullptr) {
@@ -14121,8 +14074,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceImageFormatProperties2
     if (loc.function == vvl::Func::vkGetPhysicalDeviceImageFormatProperties2 &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pImageFormatInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2",
-                               pImageFormatInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pImageFormatInfo), pImageFormatInfo,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_IMAGE_FORMAT_INFO_2, true,
                                "VUID-vkGetPhysicalDeviceImageFormatProperties2-pImageFormatInfo-parameter",
                                "VUID-VkPhysicalDeviceImageFormatInfo2-sType-sType");
     if (pImageFormatInfo != nullptr) {
@@ -14161,8 +14114,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceImageFormatProperties2
             ValidateFlags(pImageFormatInfo_loc.dot(Field::flags), vvl::FlagBitmask::VkImageCreateFlagBits, AllVkImageCreateFlagBits,
                           pImageFormatInfo->flags, kOptionalFlags, "VUID-VkPhysicalDeviceImageFormatInfo2-flags-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pImageFormatProperties), "VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2",
-                               pImageFormatProperties, VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pImageFormatProperties), pImageFormatProperties,
+                               VK_STRUCTURE_TYPE_IMAGE_FORMAT_PROPERTIES_2, true,
                                "VUID-vkGetPhysicalDeviceImageFormatProperties2-pImageFormatProperties-parameter",
                                "VUID-VkImageFormatProperties2-sType-sType");
     if (pImageFormatProperties != nullptr) {
@@ -14196,12 +14149,12 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceQueueFamilyProperties2
     if (loc.function == vvl::Func::vkGetPhysicalDeviceQueueFamilyProperties2 &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pQueueFamilyPropertyCount), loc.dot(Field::pQueueFamilyProperties),
-        "VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2", pQueueFamilyPropertyCount, pQueueFamilyProperties,
-        VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, true, false, false, "VUID-VkQueueFamilyProperties2-sType-sType",
-        "VUID-vkGetPhysicalDeviceQueueFamilyProperties2-pQueueFamilyProperties-parameter",
-        "VUID-vkGetPhysicalDeviceQueueFamilyProperties2-pQueueFamilyPropertyCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pQueueFamilyPropertyCount), loc.dot(Field::pQueueFamilyProperties),
+                                    pQueueFamilyPropertyCount, pQueueFamilyProperties, VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2,
+                                    true, false, false, "VUID-VkQueueFamilyProperties2-sType-sType",
+                                    "VUID-vkGetPhysicalDeviceQueueFamilyProperties2-pQueueFamilyProperties-parameter",
+                                    "VUID-vkGetPhysicalDeviceQueueFamilyProperties2-pQueueFamilyPropertyCount-parameter",
+                                    kVUIDUndefined);
     if (pQueueFamilyProperties != nullptr) {
         for (uint32_t pQueueFamilyPropertyIndex = 0; pQueueFamilyPropertyIndex < *pQueueFamilyPropertyCount;
              ++pQueueFamilyPropertyIndex) {
@@ -14231,8 +14184,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceMemoryProperties2(VkPh
     if (loc.function == vvl::Func::vkGetPhysicalDeviceMemoryProperties2 &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pMemoryProperties), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2",
-                               pMemoryProperties, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, true,
+    skip |= ValidateStructType(loc.dot(Field::pMemoryProperties), pMemoryProperties,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MEMORY_PROPERTIES_2, true,
                                "VUID-vkGetPhysicalDeviceMemoryProperties2-pMemoryProperties-parameter",
                                "VUID-VkPhysicalDeviceMemoryProperties2-sType-sType");
     if (pMemoryProperties != nullptr) {
@@ -14257,10 +14210,10 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSparseImageFormatPrope
     if (loc.function == vvl::Func::vkGetPhysicalDeviceSparseImageFormatProperties2 &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pFormatInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2",
-                               pFormatInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2, true,
-                               "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-pFormatInfo-parameter",
-                               "VUID-VkPhysicalDeviceSparseImageFormatInfo2-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pFormatInfo), pFormatInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SPARSE_IMAGE_FORMAT_INFO_2,
+                           true, "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-pFormatInfo-parameter",
+                           "VUID-VkPhysicalDeviceSparseImageFormatInfo2-sType-sType");
     if (pFormatInfo != nullptr) {
         [[maybe_unused]] const Location pFormatInfo_loc = loc.dot(Field::pFormatInfo);
         skip |=
@@ -14286,9 +14239,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSparseImageFormatPrope
                                    "VUID-VkPhysicalDeviceSparseImageFormatInfo2-tiling-parameter");
     }
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2",
-        pPropertyCount, pProperties, VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, true, false, false,
-        "VUID-VkSparseImageFormatProperties2-sType-sType",
+        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+        VK_STRUCTURE_TYPE_SPARSE_IMAGE_FORMAT_PROPERTIES_2, true, false, false, "VUID-VkSparseImageFormatProperties2-sType-sType",
         "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-pProperties-parameter",
         "VUID-vkGetPhysicalDeviceSparseImageFormatProperties2-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
@@ -14315,9 +14267,8 @@ bool StatelessValidation::PreCallValidateGetDeviceQueue2(VkDevice device, const 
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pQueueInfo), "VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2", pQueueInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2, true, "VUID-vkGetDeviceQueue2-pQueueInfo-parameter",
-                               "VUID-VkDeviceQueueInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pQueueInfo), pQueueInfo, VK_STRUCTURE_TYPE_DEVICE_QUEUE_INFO_2, true,
+                               "VUID-vkGetDeviceQueue2-pQueueInfo-parameter", "VUID-VkDeviceQueueInfo2-sType-sType");
     if (pQueueInfo != nullptr) {
         [[maybe_unused]] const Location pQueueInfo_loc = loc.dot(Field::pQueueInfo);
         skip |= ValidateStructPnext(pQueueInfo_loc, pQueueInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -14338,9 +14289,8 @@ bool StatelessValidation::PreCallValidateCreateSamplerYcbcrConversion(VkDevice d
                                                                       const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO, true,
-                               "VUID-vkCreateSamplerYcbcrConversion-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SAMPLER_YCBCR_CONVERSION_CREATE_INFO,
+                               true, "VUID-vkCreateSamplerYcbcrConversion-pCreateInfo-parameter",
                                "VUID-VkSamplerYcbcrConversionCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -14457,9 +14407,8 @@ bool StatelessValidation::PreCallValidateCreateDescriptorUpdateTemplate(VkDevice
                                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO, true,
-                               "VUID-vkCreateDescriptorUpdateTemplate-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_UPDATE_TEMPLATE_CREATE_INFO,
+                               true, "VUID-vkCreateDescriptorUpdateTemplate-pCreateInfo-parameter",
                                "VUID-VkDescriptorUpdateTemplateCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -14571,8 +14520,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalBufferProperti
     if (loc.function == vvl::Func::vkGetPhysicalDeviceExternalBufferProperties &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pExternalBufferInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO",
-                               pExternalBufferInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalBufferInfo), pExternalBufferInfo,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO, true,
                                "VUID-vkGetPhysicalDeviceExternalBufferProperties-pExternalBufferInfo-parameter",
                                "VUID-VkPhysicalDeviceExternalBufferInfo-sType-sType");
     if (pExternalBufferInfo != nullptr) {
@@ -14595,8 +14544,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalBufferProperti
                               "VUID-VkPhysicalDeviceExternalBufferInfo-handleType-parameter",
                               "VUID-VkPhysicalDeviceExternalBufferInfo-handleType-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pExternalBufferProperties), "VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES",
-                               pExternalBufferProperties, VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalBufferProperties), pExternalBufferProperties,
+                               VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES, true,
                                "VUID-vkGetPhysicalDeviceExternalBufferProperties-pExternalBufferProperties-parameter",
                                "VUID-VkExternalBufferProperties-sType-sType");
     if (pExternalBufferProperties != nullptr) {
@@ -14619,8 +14568,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalFencePropertie
     if (loc.function == vvl::Func::vkGetPhysicalDeviceExternalFenceProperties &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pExternalFenceInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO",
-                               pExternalFenceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalFenceInfo), pExternalFenceInfo,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_FENCE_INFO, true,
                                "VUID-vkGetPhysicalDeviceExternalFenceProperties-pExternalFenceInfo-parameter",
                                "VUID-VkPhysicalDeviceExternalFenceInfo-sType-sType");
     if (pExternalFenceInfo != nullptr) {
@@ -14633,8 +14582,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalFencePropertie
                               "VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter",
                               "VUID-VkPhysicalDeviceExternalFenceInfo-handleType-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pExternalFenceProperties), "VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES",
-                               pExternalFenceProperties, VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalFenceProperties), pExternalFenceProperties,
+                               VK_STRUCTURE_TYPE_EXTERNAL_FENCE_PROPERTIES, true,
                                "VUID-vkGetPhysicalDeviceExternalFenceProperties-pExternalFenceProperties-parameter",
                                "VUID-VkExternalFenceProperties-sType-sType");
     if (pExternalFenceProperties != nullptr) {
@@ -14654,8 +14603,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalSemaphorePrope
     if (loc.function == vvl::Func::vkGetPhysicalDeviceExternalSemaphoreProperties &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_1))
         return true;
-    skip |= ValidateStructType(loc.dot(Field::pExternalSemaphoreInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO",
-                               pExternalSemaphoreInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalSemaphoreInfo), pExternalSemaphoreInfo,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_SEMAPHORE_INFO, true,
                                "VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-pExternalSemaphoreInfo-parameter",
                                "VUID-VkPhysicalDeviceExternalSemaphoreInfo-sType-sType");
     if (pExternalSemaphoreInfo != nullptr) {
@@ -14674,8 +14623,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceExternalSemaphorePrope
                               "VUID-VkPhysicalDeviceExternalSemaphoreInfo-handleType-parameter",
                               "VUID-VkPhysicalDeviceExternalSemaphoreInfo-handleType-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pExternalSemaphoreProperties), "VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES",
-                               pExternalSemaphoreProperties, VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, true,
+    skip |= ValidateStructType(loc.dot(Field::pExternalSemaphoreProperties), pExternalSemaphoreProperties,
+                               VK_STRUCTURE_TYPE_EXTERNAL_SEMAPHORE_PROPERTIES, true,
                                "VUID-vkGetPhysicalDeviceExternalSemaphoreProperties-pExternalSemaphoreProperties-parameter",
                                "VUID-VkExternalSemaphoreProperties-sType-sType");
     if (pExternalSemaphoreProperties != nullptr) {
@@ -14693,8 +14642,7 @@ bool StatelessValidation::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice 
                                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, true,
                                "VUID-vkGetDescriptorSetLayoutSupport-pCreateInfo-parameter",
                                "VUID-VkDescriptorSetLayoutCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -14725,8 +14673,7 @@ bool StatelessValidation::PreCallValidateGetDescriptorSetLayoutSupport(VkDevice 
             }
         }
     }
-    skip |= ValidateStructType(loc.dot(Field::pSupport), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT", pSupport,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, true,
+    skip |= ValidateStructType(loc.dot(Field::pSupport), pSupport, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_SUPPORT, true,
                                "VUID-vkGetDescriptorSetLayoutSupport-pSupport-parameter",
                                "VUID-VkDescriptorSetLayoutSupport-sType-sType");
     if (pSupport != nullptr) {
@@ -14770,9 +14717,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2", pCreateInfo,
-                               VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2, true, "VUID-vkCreateRenderPass2-pCreateInfo-parameter",
-                               "VUID-VkRenderPassCreateInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2, true,
+                               "VUID-vkCreateRenderPass2-pCreateInfo-parameter", "VUID-VkRenderPassCreateInfo2-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkRenderPassCreateInfo2 = {
@@ -14788,11 +14734,10 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
                               AllVkRenderPassCreateFlagBits, pCreateInfo->flags, kOptionalFlags,
                               "VUID-VkRenderPassCreateInfo2-flags-parameter");
 
-        skip |= ValidateStructTypeArray(pCreateInfo_loc.dot(Field::attachmentCount), pCreateInfo_loc.dot(Field::pAttachments),
-                                        "VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2", pCreateInfo->attachmentCount,
-                                        pCreateInfo->pAttachments, VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2, false, true,
-                                        "VUID-VkAttachmentDescription2-sType-sType",
-                                        "VUID-VkRenderPassCreateInfo2-pAttachments-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(
+            pCreateInfo_loc.dot(Field::attachmentCount), pCreateInfo_loc.dot(Field::pAttachments), pCreateInfo->attachmentCount,
+            pCreateInfo->pAttachments, VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2, false, true,
+            "VUID-VkAttachmentDescription2-sType-sType", "VUID-VkRenderPassCreateInfo2-pAttachments-parameter", kVUIDUndefined);
 
         if (pCreateInfo->pAttachments != nullptr) {
             for (uint32_t attachmentIndex = 0; attachmentIndex < pCreateInfo->attachmentCount; ++attachmentIndex) {
@@ -14846,9 +14791,8 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
         }
 
         skip |= ValidateStructTypeArray(
-            pCreateInfo_loc.dot(Field::subpassCount), pCreateInfo_loc.dot(Field::pSubpasses),
-            "VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2", pCreateInfo->subpassCount, pCreateInfo->pSubpasses,
-            VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2, true, true, "VUID-VkSubpassDescription2-sType-sType",
+            pCreateInfo_loc.dot(Field::subpassCount), pCreateInfo_loc.dot(Field::pSubpasses), pCreateInfo->subpassCount,
+            pCreateInfo->pSubpasses, VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2, true, true, "VUID-VkSubpassDescription2-sType-sType",
             "VUID-VkRenderPassCreateInfo2-pSubpasses-parameter", "VUID-VkRenderPassCreateInfo2-subpassCount-arraylength");
 
         if (pCreateInfo->pSubpasses != nullptr) {
@@ -14876,7 +14820,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
 
                 skip |= ValidateStructTypeArray(
                     pSubpasses_loc.dot(Field::inputAttachmentCount), pSubpasses_loc.dot(Field::pInputAttachments),
-                    "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2", pCreateInfo->pSubpasses[subpassIndex].inputAttachmentCount,
+                    pCreateInfo->pSubpasses[subpassIndex].inputAttachmentCount,
                     pCreateInfo->pSubpasses[subpassIndex].pInputAttachments, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false, true,
                     "VUID-VkAttachmentReference2-sType-sType", "VUID-VkSubpassDescription2-pInputAttachments-parameter",
                     kVUIDUndefined);
@@ -14906,7 +14850,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
 
                 skip |= ValidateStructTypeArray(
                     pSubpasses_loc.dot(Field::colorAttachmentCount), pSubpasses_loc.dot(Field::pColorAttachments),
-                    "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2", pCreateInfo->pSubpasses[subpassIndex].colorAttachmentCount,
+                    pCreateInfo->pSubpasses[subpassIndex].colorAttachmentCount,
                     pCreateInfo->pSubpasses[subpassIndex].pColorAttachments, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false, true,
                     "VUID-VkAttachmentReference2-sType-sType", "VUID-VkSubpassDescription2-pColorAttachments-parameter",
                     kVUIDUndefined);
@@ -14936,7 +14880,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
 
                 skip |= ValidateStructTypeArray(
                     pSubpasses_loc.dot(Field::colorAttachmentCount), pSubpasses_loc.dot(Field::pResolveAttachments),
-                    "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2", pCreateInfo->pSubpasses[subpassIndex].colorAttachmentCount,
+                    pCreateInfo->pSubpasses[subpassIndex].colorAttachmentCount,
                     pCreateInfo->pSubpasses[subpassIndex].pResolveAttachments, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
                     false, "VUID-VkAttachmentReference2-sType-sType", "VUID-VkSubpassDescription2-pResolveAttachments-parameter",
                     kVUIDUndefined);
@@ -14965,7 +14909,7 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
                 }
 
                 skip |= ValidateStructType(
-                    pSubpasses_loc.dot(Field::pDepthStencilAttachment), "VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2",
+                    pSubpasses_loc.dot(Field::pDepthStencilAttachment),
                     pCreateInfo->pSubpasses[subpassIndex].pDepthStencilAttachment, VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2, false,
                     "VUID-VkSubpassDescription2-pDepthStencilAttachment-parameter", "VUID-VkAttachmentReference2-sType-sType");
 
@@ -14994,11 +14938,10 @@ bool StatelessValidation::PreCallValidateCreateRenderPass2(VkDevice device, cons
             }
         }
 
-        skip |= ValidateStructTypeArray(pCreateInfo_loc.dot(Field::dependencyCount), pCreateInfo_loc.dot(Field::pDependencies),
-                                        "VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2", pCreateInfo->dependencyCount,
-                                        pCreateInfo->pDependencies, VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2, false, true,
-                                        "VUID-VkSubpassDependency2-sType-sType",
-                                        "VUID-VkRenderPassCreateInfo2-pDependencies-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(
+            pCreateInfo_loc.dot(Field::dependencyCount), pCreateInfo_loc.dot(Field::pDependencies), pCreateInfo->dependencyCount,
+            pCreateInfo->pDependencies, VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2, false, true,
+            "VUID-VkSubpassDependency2-sType-sType", "VUID-VkRenderPassCreateInfo2-pDependencies-parameter", kVUIDUndefined);
 
         if (pCreateInfo->pDependencies != nullptr) {
             for (uint32_t dependencyIndex = 0; dependencyIndex < pCreateInfo->dependencyCount; ++dependencyIndex) {
@@ -15081,8 +15024,7 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer com
                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pRenderPassBegin), "VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO", pRenderPassBegin,
-                               VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pRenderPassBegin), pRenderPassBegin, VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO, true,
                                "VUID-vkCmdBeginRenderPass2-pRenderPassBegin-parameter", "VUID-VkRenderPassBeginInfo-sType-sType");
     if (pRenderPassBegin != nullptr) {
         [[maybe_unused]] const Location pRenderPassBegin_loc = loc.dot(Field::pRenderPassBegin);
@@ -15107,9 +15049,8 @@ bool StatelessValidation::PreCallValidateCmdBeginRenderPass2(VkCommandBuffer com
 
         // No xml-driven validation
     }
-    skip |= ValidateStructType(loc.dot(Field::pSubpassBeginInfo), "VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO", pSubpassBeginInfo,
-                               VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO, true, "VUID-vkCmdBeginRenderPass2-pSubpassBeginInfo-parameter",
-                               "VUID-VkSubpassBeginInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSubpassBeginInfo), pSubpassBeginInfo, VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO, true,
+                               "VUID-vkCmdBeginRenderPass2-pSubpassBeginInfo-parameter", "VUID-VkSubpassBeginInfo-sType-sType");
     if (pSubpassBeginInfo != nullptr) {
         [[maybe_unused]] const Location pSubpassBeginInfo_loc = loc.dot(Field::pSubpassBeginInfo);
         skip |= ValidateStructPnext(pSubpassBeginInfo_loc, pSubpassBeginInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15127,9 +15068,8 @@ bool StatelessValidation::PreCallValidateCmdNextSubpass2(VkCommandBuffer command
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pSubpassBeginInfo), "VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO", pSubpassBeginInfo,
-                               VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO, true, "VUID-vkCmdNextSubpass2-pSubpassBeginInfo-parameter",
-                               "VUID-VkSubpassBeginInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSubpassBeginInfo), pSubpassBeginInfo, VK_STRUCTURE_TYPE_SUBPASS_BEGIN_INFO, true,
+                               "VUID-vkCmdNextSubpass2-pSubpassBeginInfo-parameter", "VUID-VkSubpassBeginInfo-sType-sType");
     if (pSubpassBeginInfo != nullptr) {
         [[maybe_unused]] const Location pSubpassBeginInfo_loc = loc.dot(Field::pSubpassBeginInfo);
         skip |= ValidateStructPnext(pSubpassBeginInfo_loc, pSubpassBeginInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15138,9 +15078,8 @@ bool StatelessValidation::PreCallValidateCmdNextSubpass2(VkCommandBuffer command
         skip |= ValidateRangedEnum(pSubpassBeginInfo_loc.dot(Field::contents), vvl::Enum::VkSubpassContents,
                                    pSubpassBeginInfo->contents, "VUID-VkSubpassBeginInfo-contents-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pSubpassEndInfo), "VK_STRUCTURE_TYPE_SUBPASS_END_INFO", pSubpassEndInfo,
-                               VK_STRUCTURE_TYPE_SUBPASS_END_INFO, true, "VUID-vkCmdNextSubpass2-pSubpassEndInfo-parameter",
-                               "VUID-VkSubpassEndInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSubpassEndInfo), pSubpassEndInfo, VK_STRUCTURE_TYPE_SUBPASS_END_INFO, true,
+                               "VUID-vkCmdNextSubpass2-pSubpassEndInfo-parameter", "VUID-VkSubpassEndInfo-sType-sType");
     if (pSubpassEndInfo != nullptr) {
         [[maybe_unused]] const Location pSubpassEndInfo_loc = loc.dot(Field::pSubpassEndInfo);
         constexpr std::array allowed_structs_VkSubpassEndInfo = {
@@ -15158,9 +15097,8 @@ bool StatelessValidation::PreCallValidateCmdEndRenderPass2(VkCommandBuffer comma
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pSubpassEndInfo), "VK_STRUCTURE_TYPE_SUBPASS_END_INFO", pSubpassEndInfo,
-                               VK_STRUCTURE_TYPE_SUBPASS_END_INFO, true, "VUID-vkCmdEndRenderPass2-pSubpassEndInfo-parameter",
-                               "VUID-VkSubpassEndInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSubpassEndInfo), pSubpassEndInfo, VK_STRUCTURE_TYPE_SUBPASS_END_INFO, true,
+                               "VUID-vkCmdEndRenderPass2-pSubpassEndInfo-parameter", "VUID-VkSubpassEndInfo-sType-sType");
     if (pSubpassEndInfo != nullptr) {
         [[maybe_unused]] const Location pSubpassEndInfo_loc = loc.dot(Field::pSubpassEndInfo);
         constexpr std::array allowed_structs_VkSubpassEndInfo = {
@@ -15195,9 +15133,8 @@ bool StatelessValidation::PreCallValidateWaitSemaphores(VkDevice device, const V
                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pWaitInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO", pWaitInfo,
-                               VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO, true, "VUID-vkWaitSemaphores-pWaitInfo-parameter",
-                               "VUID-VkSemaphoreWaitInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pWaitInfo), pWaitInfo, VK_STRUCTURE_TYPE_SEMAPHORE_WAIT_INFO, true,
+                               "VUID-vkWaitSemaphores-pWaitInfo-parameter", "VUID-VkSemaphoreWaitInfo-sType-sType");
     if (pWaitInfo != nullptr) {
         [[maybe_unused]] const Location pWaitInfo_loc = loc.dot(Field::pWaitInfo);
         skip |= ValidateStructPnext(pWaitInfo_loc, pWaitInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15222,9 +15159,8 @@ bool StatelessValidation::PreCallValidateSignalSemaphore(VkDevice device, const 
                                                          const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pSignalInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO", pSignalInfo,
-                               VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO, true, "VUID-vkSignalSemaphore-pSignalInfo-parameter",
-                               "VUID-VkSemaphoreSignalInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSignalInfo), pSignalInfo, VK_STRUCTURE_TYPE_SEMAPHORE_SIGNAL_INFO, true,
+                               "VUID-vkSignalSemaphore-pSignalInfo-parameter", "VUID-VkSemaphoreSignalInfo-sType-sType");
     if (pSignalInfo != nullptr) {
         [[maybe_unused]] const Location pSignalInfo_loc = loc.dot(Field::pSignalInfo);
         skip |= ValidateStructPnext(pSignalInfo_loc, pSignalInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15239,9 +15175,8 @@ bool StatelessValidation::PreCallValidateGetBufferDeviceAddress(VkDevice device,
                                                                 const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO", pInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, true, "VUID-vkGetBufferDeviceAddress-pInfo-parameter",
-                               "VUID-VkBufferDeviceAddressInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, true,
+                               "VUID-vkGetBufferDeviceAddress-pInfo-parameter", "VUID-VkBufferDeviceAddressInfo-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15256,9 +15191,9 @@ bool StatelessValidation::PreCallValidateGetBufferOpaqueCaptureAddress(VkDevice 
                                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(
-        loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO", pInfo, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO,
-        true, "VUID-vkGetBufferOpaqueCaptureAddress-pInfo-parameter", "VUID-VkBufferDeviceAddressInfo-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_INFO, true,
+                           "VUID-vkGetBufferOpaqueCaptureAddress-pInfo-parameter", "VUID-VkBufferDeviceAddressInfo-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15274,8 +15209,7 @@ bool StatelessValidation::PreCallValidateGetDeviceMemoryOpaqueCaptureAddress(VkD
                                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO", pInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_DEVICE_MEMORY_OPAQUE_CAPTURE_ADDRESS_INFO, true,
                                "VUID-vkGetDeviceMemoryOpaqueCaptureAddress-pInfo-parameter",
                                "VUID-VkDeviceMemoryOpaqueCaptureAddressInfo-sType-sType");
     if (pInfo != nullptr) {
@@ -15297,11 +15231,11 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceToolProperties(VkPhysi
     if (loc.function == vvl::Func::vkGetPhysicalDeviceToolProperties &&
         CheckPromotedApiAgainstVulkanVersion(physicalDevice, loc, VK_API_VERSION_1_3))
         return true;
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pToolCount), loc.dot(Field::pToolProperties), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES",
-        pToolCount, pToolProperties, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, true, false, false,
-        "VUID-VkPhysicalDeviceToolProperties-sType-sType", "VUID-vkGetPhysicalDeviceToolProperties-pToolProperties-parameter",
-        "VUID-vkGetPhysicalDeviceToolProperties-pToolCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pToolCount), loc.dot(Field::pToolProperties), pToolCount, pToolProperties,
+                                    VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_TOOL_PROPERTIES, true, false, false,
+                                    "VUID-VkPhysicalDeviceToolProperties-sType-sType",
+                                    "VUID-vkGetPhysicalDeviceToolProperties-pToolProperties-parameter",
+                                    "VUID-vkGetPhysicalDeviceToolProperties-pToolCount-parameter", kVUIDUndefined);
     if (pToolProperties != nullptr) {
         for (uint32_t pToolIndex = 0; pToolIndex < *pToolCount; ++pToolIndex) {
             [[maybe_unused]] const Location pToolProperties_loc = loc.dot(Field::pToolProperties, pToolIndex);
@@ -15320,8 +15254,7 @@ bool StatelessValidation::PreCallValidateCreatePrivateDataSlot(VkDevice device, 
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO", pCreateInfo,
-                           VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_PRIVATE_DATA_SLOT_CREATE_INFO, true,
                            "VUID-vkCreatePrivateDataSlot-pCreateInfo-parameter", "VUID-VkPrivateDataSlotCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -15422,9 +15355,8 @@ bool StatelessValidation::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuf
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateRequiredHandle(loc.dot(Field::event), event);
-    skip |= ValidateStructType(loc.dot(Field::pDependencyInfo), "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", pDependencyInfo,
-                               VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, "VUID-vkCmdSetEvent2-pDependencyInfo-parameter",
-                               "VUID-VkDependencyInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pDependencyInfo), pDependencyInfo, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true,
+                               "VUID-vkCmdSetEvent2-pDependencyInfo-parameter", "VUID-VkDependencyInfo-sType-sType");
     if (pDependencyInfo != nullptr) {
         [[maybe_unused]] const Location pDependencyInfo_loc = loc.dot(Field::pDependencyInfo);
         skip |= ValidateStructPnext(pDependencyInfo_loc, pDependencyInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15434,11 +15366,10 @@ bool StatelessValidation::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuf
                               AllVkDependencyFlagBits, pDependencyInfo->dependencyFlags, kOptionalFlags,
                               "VUID-VkDependencyInfo-dependencyFlags-parameter");
 
-        skip |= ValidateStructTypeArray(pDependencyInfo_loc.dot(Field::memoryBarrierCount),
-                                        pDependencyInfo_loc.dot(Field::pMemoryBarriers), "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2",
-                                        pDependencyInfo->memoryBarrierCount, pDependencyInfo->pMemoryBarriers,
-                                        VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true, "VUID-VkMemoryBarrier2-sType-sType",
-                                        "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(
+            pDependencyInfo_loc.dot(Field::memoryBarrierCount), pDependencyInfo_loc.dot(Field::pMemoryBarriers),
+            pDependencyInfo->memoryBarrierCount, pDependencyInfo->pMemoryBarriers, VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true,
+            "VUID-VkMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pMemoryBarriers != nullptr) {
             for (uint32_t memoryBarrierIndex = 0; memoryBarrierIndex < pDependencyInfo->memoryBarrierCount; ++memoryBarrierIndex) {
@@ -15470,9 +15401,9 @@ bool StatelessValidation::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuf
 
         skip |= ValidateStructTypeArray(
             pDependencyInfo_loc.dot(Field::bufferMemoryBarrierCount), pDependencyInfo_loc.dot(Field::pBufferMemoryBarriers),
-            "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2", pDependencyInfo->bufferMemoryBarrierCount,
-            pDependencyInfo->pBufferMemoryBarriers, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true,
-            "VUID-VkBufferMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
+            pDependencyInfo->bufferMemoryBarrierCount, pDependencyInfo->pBufferMemoryBarriers,
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true, "VUID-VkBufferMemoryBarrier2-sType-sType",
+            "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pBufferMemoryBarriers != nullptr) {
             for (uint32_t bufferMemoryBarrierIndex = 0; bufferMemoryBarrierIndex < pDependencyInfo->bufferMemoryBarrierCount;
@@ -15515,9 +15446,9 @@ bool StatelessValidation::PreCallValidateCmdSetEvent2(VkCommandBuffer commandBuf
 
         skip |= ValidateStructTypeArray(
             pDependencyInfo_loc.dot(Field::imageMemoryBarrierCount), pDependencyInfo_loc.dot(Field::pImageMemoryBarriers),
-            "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2", pDependencyInfo->imageMemoryBarrierCount,
-            pDependencyInfo->pImageMemoryBarriers, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true,
-            "VUID-VkImageMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
+            pDependencyInfo->imageMemoryBarrierCount, pDependencyInfo->pImageMemoryBarriers,
+            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true, "VUID-VkImageMemoryBarrier2-sType-sType",
+            "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pImageMemoryBarriers != nullptr) {
             for (uint32_t imageMemoryBarrierIndex = 0; imageMemoryBarrierIndex < pDependencyInfo->imageMemoryBarrierCount;
@@ -15592,10 +15523,10 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandB
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateHandleArray(loc.dot(Field::eventCount), loc.dot(Field::pEvents), eventCount, pEvents, true, true,
                                 "VUID-vkCmdWaitEvents2-eventCount-arraylength");
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::eventCount), loc.dot(Field::pDependencyInfos), "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", eventCount,
-        pDependencyInfos, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, true, "VUID-VkDependencyInfo-sType-sType",
-        "VUID-vkCmdWaitEvents2-pDependencyInfos-parameter", "VUID-vkCmdWaitEvents2-eventCount-arraylength");
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::eventCount), loc.dot(Field::pDependencyInfos), eventCount, pDependencyInfos,
+                                VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, true, "VUID-VkDependencyInfo-sType-sType",
+                                "VUID-vkCmdWaitEvents2-pDependencyInfos-parameter", "VUID-vkCmdWaitEvents2-eventCount-arraylength");
     if (pDependencyInfos != nullptr) {
         for (uint32_t eventIndex = 0; eventIndex < eventCount; ++eventIndex) {
             [[maybe_unused]] const Location pDependencyInfos_loc = loc.dot(Field::pDependencyInfos, eventIndex);
@@ -15609,9 +15540,9 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandB
 
             skip |= ValidateStructTypeArray(
                 pDependencyInfos_loc.dot(Field::memoryBarrierCount), pDependencyInfos_loc.dot(Field::pMemoryBarriers),
-                "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2", pDependencyInfos[eventIndex].memoryBarrierCount,
-                pDependencyInfos[eventIndex].pMemoryBarriers, VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true,
-                "VUID-VkMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
+                pDependencyInfos[eventIndex].memoryBarrierCount, pDependencyInfos[eventIndex].pMemoryBarriers,
+                VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true, "VUID-VkMemoryBarrier2-sType-sType",
+                "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
 
             if (pDependencyInfos[eventIndex].pMemoryBarriers != nullptr) {
                 for (uint32_t memoryBarrierIndex = 0; memoryBarrierIndex < pDependencyInfos[eventIndex].memoryBarrierCount;
@@ -15646,9 +15577,9 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandB
 
             skip |= ValidateStructTypeArray(
                 pDependencyInfos_loc.dot(Field::bufferMemoryBarrierCount), pDependencyInfos_loc.dot(Field::pBufferMemoryBarriers),
-                "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2", pDependencyInfos[eventIndex].bufferMemoryBarrierCount,
-                pDependencyInfos[eventIndex].pBufferMemoryBarriers, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true,
-                "VUID-VkBufferMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
+                pDependencyInfos[eventIndex].bufferMemoryBarrierCount, pDependencyInfos[eventIndex].pBufferMemoryBarriers,
+                VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true, "VUID-VkBufferMemoryBarrier2-sType-sType",
+                "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
 
             if (pDependencyInfos[eventIndex].pBufferMemoryBarriers != nullptr) {
                 for (uint32_t bufferMemoryBarrierIndex = 0;
@@ -15695,9 +15626,9 @@ bool StatelessValidation::PreCallValidateCmdWaitEvents2(VkCommandBuffer commandB
 
             skip |= ValidateStructTypeArray(
                 pDependencyInfos_loc.dot(Field::imageMemoryBarrierCount), pDependencyInfos_loc.dot(Field::pImageMemoryBarriers),
-                "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2", pDependencyInfos[eventIndex].imageMemoryBarrierCount,
-                pDependencyInfos[eventIndex].pImageMemoryBarriers, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true,
-                "VUID-VkImageMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
+                pDependencyInfos[eventIndex].imageMemoryBarrierCount, pDependencyInfos[eventIndex].pImageMemoryBarriers,
+                VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true, "VUID-VkImageMemoryBarrier2-sType-sType",
+                "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
 
             if (pDependencyInfos[eventIndex].pImageMemoryBarriers != nullptr) {
                 for (uint32_t imageMemoryBarrierIndex = 0;
@@ -15762,9 +15693,8 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer com
                                                              const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pDependencyInfo), "VK_STRUCTURE_TYPE_DEPENDENCY_INFO", pDependencyInfo,
-                               VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true, "VUID-vkCmdPipelineBarrier2-pDependencyInfo-parameter",
-                               "VUID-VkDependencyInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pDependencyInfo), pDependencyInfo, VK_STRUCTURE_TYPE_DEPENDENCY_INFO, true,
+                               "VUID-vkCmdPipelineBarrier2-pDependencyInfo-parameter", "VUID-VkDependencyInfo-sType-sType");
     if (pDependencyInfo != nullptr) {
         [[maybe_unused]] const Location pDependencyInfo_loc = loc.dot(Field::pDependencyInfo);
         skip |= ValidateStructPnext(pDependencyInfo_loc, pDependencyInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -15774,11 +15704,10 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer com
                               AllVkDependencyFlagBits, pDependencyInfo->dependencyFlags, kOptionalFlags,
                               "VUID-VkDependencyInfo-dependencyFlags-parameter");
 
-        skip |= ValidateStructTypeArray(pDependencyInfo_loc.dot(Field::memoryBarrierCount),
-                                        pDependencyInfo_loc.dot(Field::pMemoryBarriers), "VK_STRUCTURE_TYPE_MEMORY_BARRIER_2",
-                                        pDependencyInfo->memoryBarrierCount, pDependencyInfo->pMemoryBarriers,
-                                        VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true, "VUID-VkMemoryBarrier2-sType-sType",
-                                        "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(
+            pDependencyInfo_loc.dot(Field::memoryBarrierCount), pDependencyInfo_loc.dot(Field::pMemoryBarriers),
+            pDependencyInfo->memoryBarrierCount, pDependencyInfo->pMemoryBarriers, VK_STRUCTURE_TYPE_MEMORY_BARRIER_2, false, true,
+            "VUID-VkMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pMemoryBarriers != nullptr) {
             for (uint32_t memoryBarrierIndex = 0; memoryBarrierIndex < pDependencyInfo->memoryBarrierCount; ++memoryBarrierIndex) {
@@ -15810,9 +15739,9 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer com
 
         skip |= ValidateStructTypeArray(
             pDependencyInfo_loc.dot(Field::bufferMemoryBarrierCount), pDependencyInfo_loc.dot(Field::pBufferMemoryBarriers),
-            "VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2", pDependencyInfo->bufferMemoryBarrierCount,
-            pDependencyInfo->pBufferMemoryBarriers, VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true,
-            "VUID-VkBufferMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
+            pDependencyInfo->bufferMemoryBarrierCount, pDependencyInfo->pBufferMemoryBarriers,
+            VK_STRUCTURE_TYPE_BUFFER_MEMORY_BARRIER_2, false, true, "VUID-VkBufferMemoryBarrier2-sType-sType",
+            "VUID-VkDependencyInfo-pBufferMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pBufferMemoryBarriers != nullptr) {
             for (uint32_t bufferMemoryBarrierIndex = 0; bufferMemoryBarrierIndex < pDependencyInfo->bufferMemoryBarrierCount;
@@ -15855,9 +15784,9 @@ bool StatelessValidation::PreCallValidateCmdPipelineBarrier2(VkCommandBuffer com
 
         skip |= ValidateStructTypeArray(
             pDependencyInfo_loc.dot(Field::imageMemoryBarrierCount), pDependencyInfo_loc.dot(Field::pImageMemoryBarriers),
-            "VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2", pDependencyInfo->imageMemoryBarrierCount,
-            pDependencyInfo->pImageMemoryBarriers, VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true,
-            "VUID-VkImageMemoryBarrier2-sType-sType", "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
+            pDependencyInfo->imageMemoryBarrierCount, pDependencyInfo->pImageMemoryBarriers,
+            VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER_2, false, true, "VUID-VkImageMemoryBarrier2-sType-sType",
+            "VUID-VkDependencyInfo-pImageMemoryBarriers-parameter", kVUIDUndefined);
 
         if (pDependencyInfo->pImageMemoryBarriers != nullptr) {
             for (uint32_t imageMemoryBarrierIndex = 0; imageMemoryBarrierIndex < pDependencyInfo->imageMemoryBarrierCount;
@@ -15930,9 +15859,9 @@ bool StatelessValidation::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t su
                                                       VkFence fence, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(loc.dot(Field::submitCount), loc.dot(Field::pSubmits), "VK_STRUCTURE_TYPE_SUBMIT_INFO_2",
-                                    submitCount, pSubmits, VK_STRUCTURE_TYPE_SUBMIT_INFO_2, false, true,
-                                    "VUID-VkSubmitInfo2-sType-sType", "VUID-vkQueueSubmit2-pSubmits-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::submitCount), loc.dot(Field::pSubmits), submitCount, pSubmits,
+                                    VK_STRUCTURE_TYPE_SUBMIT_INFO_2, false, true, "VUID-VkSubmitInfo2-sType-sType",
+                                    "VUID-vkQueueSubmit2-pSubmits-parameter", kVUIDUndefined);
     if (pSubmits != nullptr) {
         for (uint32_t submitIndex = 0; submitIndex < submitCount; ++submitIndex) {
             [[maybe_unused]] const Location pSubmits_loc = loc.dot(Field::pSubmits, submitIndex);
@@ -15950,9 +15879,9 @@ bool StatelessValidation::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t su
 
             skip |= ValidateStructTypeArray(
                 pSubmits_loc.dot(Field::waitSemaphoreInfoCount), pSubmits_loc.dot(Field::pWaitSemaphoreInfos),
-                "VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO", pSubmits[submitIndex].waitSemaphoreInfoCount,
-                pSubmits[submitIndex].pWaitSemaphoreInfos, VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, false, true,
-                "VUID-VkSemaphoreSubmitInfo-sType-sType", "VUID-VkSubmitInfo2-pWaitSemaphoreInfos-parameter", kVUIDUndefined);
+                pSubmits[submitIndex].waitSemaphoreInfoCount, pSubmits[submitIndex].pWaitSemaphoreInfos,
+                VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, false, true, "VUID-VkSemaphoreSubmitInfo-sType-sType",
+                "VUID-VkSubmitInfo2-pWaitSemaphoreInfos-parameter", kVUIDUndefined);
 
             if (pSubmits[submitIndex].pWaitSemaphoreInfos != nullptr) {
                 for (uint32_t waitSemaphoreInfoIndex = 0; waitSemaphoreInfoIndex < pSubmits[submitIndex].waitSemaphoreInfoCount;
@@ -15976,9 +15905,9 @@ bool StatelessValidation::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t su
 
             skip |= ValidateStructTypeArray(
                 pSubmits_loc.dot(Field::commandBufferInfoCount), pSubmits_loc.dot(Field::pCommandBufferInfos),
-                "VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO", pSubmits[submitIndex].commandBufferInfoCount,
-                pSubmits[submitIndex].pCommandBufferInfos, VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, false, true,
-                "VUID-VkCommandBufferSubmitInfo-sType-sType", "VUID-VkSubmitInfo2-pCommandBufferInfos-parameter", kVUIDUndefined);
+                pSubmits[submitIndex].commandBufferInfoCount, pSubmits[submitIndex].pCommandBufferInfos,
+                VK_STRUCTURE_TYPE_COMMAND_BUFFER_SUBMIT_INFO, false, true, "VUID-VkCommandBufferSubmitInfo-sType-sType",
+                "VUID-VkSubmitInfo2-pCommandBufferInfos-parameter", kVUIDUndefined);
 
             if (pSubmits[submitIndex].pCommandBufferInfos != nullptr) {
                 for (uint32_t commandBufferInfoIndex = 0; commandBufferInfoIndex < pSubmits[submitIndex].commandBufferInfoCount;
@@ -16001,9 +15930,9 @@ bool StatelessValidation::PreCallValidateQueueSubmit2(VkQueue queue, uint32_t su
 
             skip |= ValidateStructTypeArray(
                 pSubmits_loc.dot(Field::signalSemaphoreInfoCount), pSubmits_loc.dot(Field::pSignalSemaphoreInfos),
-                "VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO", pSubmits[submitIndex].signalSemaphoreInfoCount,
-                pSubmits[submitIndex].pSignalSemaphoreInfos, VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, false, true,
-                "VUID-VkSemaphoreSubmitInfo-sType-sType", "VUID-VkSubmitInfo2-pSignalSemaphoreInfos-parameter", kVUIDUndefined);
+                pSubmits[submitIndex].signalSemaphoreInfoCount, pSubmits[submitIndex].pSignalSemaphoreInfos,
+                VK_STRUCTURE_TYPE_SEMAPHORE_SUBMIT_INFO, false, true, "VUID-VkSemaphoreSubmitInfo-sType-sType",
+                "VUID-VkSubmitInfo2-pSignalSemaphoreInfos-parameter", kVUIDUndefined);
 
             if (pSubmits[submitIndex].pSignalSemaphoreInfos != nullptr) {
                 for (uint32_t signalSemaphoreInfoIndex = 0;
@@ -16033,9 +15962,8 @@ bool StatelessValidation::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandB
                                                         const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCopyBufferInfo), "VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2", pCopyBufferInfo,
-                               VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2, true, "VUID-vkCmdCopyBuffer2-pCopyBufferInfo-parameter",
-                               "VUID-VkCopyBufferInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCopyBufferInfo), pCopyBufferInfo, VK_STRUCTURE_TYPE_COPY_BUFFER_INFO_2, true,
+                               "VUID-vkCmdCopyBuffer2-pCopyBufferInfo-parameter", "VUID-VkCopyBufferInfo2-sType-sType");
     if (pCopyBufferInfo != nullptr) {
         [[maybe_unused]] const Location pCopyBufferInfo_loc = loc.dot(Field::pCopyBufferInfo);
         skip |= ValidateStructPnext(pCopyBufferInfo_loc, pCopyBufferInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -16045,11 +15973,10 @@ bool StatelessValidation::PreCallValidateCmdCopyBuffer2(VkCommandBuffer commandB
 
         skip |= ValidateRequiredHandle(pCopyBufferInfo_loc.dot(Field::dstBuffer), pCopyBufferInfo->dstBuffer);
 
-        skip |=
-            ValidateStructTypeArray(pCopyBufferInfo_loc.dot(Field::regionCount), pCopyBufferInfo_loc.dot(Field::pRegions),
-                                    "VK_STRUCTURE_TYPE_BUFFER_COPY_2", pCopyBufferInfo->regionCount, pCopyBufferInfo->pRegions,
-                                    VK_STRUCTURE_TYPE_BUFFER_COPY_2, true, true, "VUID-VkBufferCopy2-sType-sType",
-                                    "VUID-VkCopyBufferInfo2-pRegions-parameter", "VUID-VkCopyBufferInfo2-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pCopyBufferInfo_loc.dot(Field::regionCount), pCopyBufferInfo_loc.dot(Field::pRegions),
+                                        pCopyBufferInfo->regionCount, pCopyBufferInfo->pRegions, VK_STRUCTURE_TYPE_BUFFER_COPY_2,
+                                        true, true, "VUID-VkBufferCopy2-sType-sType", "VUID-VkCopyBufferInfo2-pRegions-parameter",
+                                        "VUID-VkCopyBufferInfo2-regionCount-arraylength");
 
         if (pCopyBufferInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyBufferInfo->regionCount; ++regionIndex) {
@@ -16068,9 +15995,8 @@ bool StatelessValidation::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBu
                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCopyImageInfo), "VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2", pCopyImageInfo,
-                               VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2, true, "VUID-vkCmdCopyImage2-pCopyImageInfo-parameter",
-                               "VUID-VkCopyImageInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCopyImageInfo), pCopyImageInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_INFO_2, true,
+                               "VUID-vkCmdCopyImage2-pCopyImageInfo-parameter", "VUID-VkCopyImageInfo2-sType-sType");
     if (pCopyImageInfo != nullptr) {
         [[maybe_unused]] const Location pCopyImageInfo_loc = loc.dot(Field::pCopyImageInfo);
         skip |= ValidateStructPnext(pCopyImageInfo_loc, pCopyImageInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -16086,11 +16012,10 @@ bool StatelessValidation::PreCallValidateCmdCopyImage2(VkCommandBuffer commandBu
         skip |= ValidateRangedEnum(pCopyImageInfo_loc.dot(Field::dstImageLayout), vvl::Enum::VkImageLayout,
                                    pCopyImageInfo->dstImageLayout, "VUID-VkCopyImageInfo2-dstImageLayout-parameter");
 
-        skip |=
-            ValidateStructTypeArray(pCopyImageInfo_loc.dot(Field::regionCount), pCopyImageInfo_loc.dot(Field::pRegions),
-                                    "VK_STRUCTURE_TYPE_IMAGE_COPY_2", pCopyImageInfo->regionCount, pCopyImageInfo->pRegions,
-                                    VK_STRUCTURE_TYPE_IMAGE_COPY_2, true, true, "VUID-VkImageCopy2-sType-sType",
-                                    "VUID-VkCopyImageInfo2-pRegions-parameter", "VUID-VkCopyImageInfo2-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pCopyImageInfo_loc.dot(Field::regionCount), pCopyImageInfo_loc.dot(Field::pRegions),
+                                        pCopyImageInfo->regionCount, pCopyImageInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_COPY_2, true,
+                                        true, "VUID-VkImageCopy2-sType-sType", "VUID-VkCopyImageInfo2-pRegions-parameter",
+                                        "VUID-VkCopyImageInfo2-regionCount-arraylength");
 
         if (pCopyImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyImageInfo->regionCount; ++regionIndex) {
@@ -16125,10 +16050,9 @@ bool StatelessValidation::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer c
                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCopyBufferToImageInfo), "VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2",
-                               pCopyBufferToImageInfo, VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2, true,
-                               "VUID-vkCmdCopyBufferToImage2-pCopyBufferToImageInfo-parameter",
-                               "VUID-VkCopyBufferToImageInfo2-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCopyBufferToImageInfo), pCopyBufferToImageInfo, VK_STRUCTURE_TYPE_COPY_BUFFER_TO_IMAGE_INFO_2, true,
+        "VUID-vkCmdCopyBufferToImage2-pCopyBufferToImageInfo-parameter", "VUID-VkCopyBufferToImageInfo2-sType-sType");
     if (pCopyBufferToImageInfo != nullptr) {
         [[maybe_unused]] const Location pCopyBufferToImageInfo_loc = loc.dot(Field::pCopyBufferToImageInfo);
         skip |=
@@ -16143,11 +16067,11 @@ bool StatelessValidation::PreCallValidateCmdCopyBufferToImage2(VkCommandBuffer c
             ValidateRangedEnum(pCopyBufferToImageInfo_loc.dot(Field::dstImageLayout), vvl::Enum::VkImageLayout,
                                pCopyBufferToImageInfo->dstImageLayout, "VUID-VkCopyBufferToImageInfo2-dstImageLayout-parameter");
 
-        skip |= ValidateStructTypeArray(
-            pCopyBufferToImageInfo_loc.dot(Field::regionCount), pCopyBufferToImageInfo_loc.dot(Field::pRegions),
-            "VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2", pCopyBufferToImageInfo->regionCount, pCopyBufferToImageInfo->pRegions,
-            VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2, true, true, "VUID-VkBufferImageCopy2-sType-sType",
-            "VUID-VkCopyBufferToImageInfo2-pRegions-parameter", "VUID-VkCopyBufferToImageInfo2-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pCopyBufferToImageInfo_loc.dot(Field::regionCount),
+                                        pCopyBufferToImageInfo_loc.dot(Field::pRegions), pCopyBufferToImageInfo->regionCount,
+                                        pCopyBufferToImageInfo->pRegions, VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2, true, true,
+                                        "VUID-VkBufferImageCopy2-sType-sType", "VUID-VkCopyBufferToImageInfo2-pRegions-parameter",
+                                        "VUID-VkCopyBufferToImageInfo2-regionCount-arraylength");
 
         if (pCopyBufferToImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyBufferToImageInfo->regionCount; ++regionIndex) {
@@ -16179,10 +16103,9 @@ bool StatelessValidation::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer c
                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pCopyImageToBufferInfo), "VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2",
-                               pCopyImageToBufferInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2, true,
-                               "VUID-vkCmdCopyImageToBuffer2-pCopyImageToBufferInfo-parameter",
-                               "VUID-VkCopyImageToBufferInfo2-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCopyImageToBufferInfo), pCopyImageToBufferInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_BUFFER_INFO_2, true,
+        "VUID-vkCmdCopyImageToBuffer2-pCopyImageToBufferInfo-parameter", "VUID-VkCopyImageToBufferInfo2-sType-sType");
     if (pCopyImageToBufferInfo != nullptr) {
         [[maybe_unused]] const Location pCopyImageToBufferInfo_loc = loc.dot(Field::pCopyImageToBufferInfo);
         skip |=
@@ -16197,11 +16120,11 @@ bool StatelessValidation::PreCallValidateCmdCopyImageToBuffer2(VkCommandBuffer c
 
         skip |= ValidateRequiredHandle(pCopyImageToBufferInfo_loc.dot(Field::dstBuffer), pCopyImageToBufferInfo->dstBuffer);
 
-        skip |= ValidateStructTypeArray(
-            pCopyImageToBufferInfo_loc.dot(Field::regionCount), pCopyImageToBufferInfo_loc.dot(Field::pRegions),
-            "VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2", pCopyImageToBufferInfo->regionCount, pCopyImageToBufferInfo->pRegions,
-            VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2, true, true, "VUID-VkBufferImageCopy2-sType-sType",
-            "VUID-VkCopyImageToBufferInfo2-pRegions-parameter", "VUID-VkCopyImageToBufferInfo2-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pCopyImageToBufferInfo_loc.dot(Field::regionCount),
+                                        pCopyImageToBufferInfo_loc.dot(Field::pRegions), pCopyImageToBufferInfo->regionCount,
+                                        pCopyImageToBufferInfo->pRegions, VK_STRUCTURE_TYPE_BUFFER_IMAGE_COPY_2, true, true,
+                                        "VUID-VkBufferImageCopy2-sType-sType", "VUID-VkCopyImageToBufferInfo2-pRegions-parameter",
+                                        "VUID-VkCopyImageToBufferInfo2-regionCount-arraylength");
 
         if (pCopyImageToBufferInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyImageToBufferInfo->regionCount; ++regionIndex) {
@@ -16232,9 +16155,8 @@ bool StatelessValidation::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBu
                                                        const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pBlitImageInfo), "VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2", pBlitImageInfo,
-                               VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2, true, "VUID-vkCmdBlitImage2-pBlitImageInfo-parameter",
-                               "VUID-VkBlitImageInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pBlitImageInfo), pBlitImageInfo, VK_STRUCTURE_TYPE_BLIT_IMAGE_INFO_2, true,
+                               "VUID-vkCmdBlitImage2-pBlitImageInfo-parameter", "VUID-VkBlitImageInfo2-sType-sType");
     if (pBlitImageInfo != nullptr) {
         [[maybe_unused]] const Location pBlitImageInfo_loc = loc.dot(Field::pBlitImageInfo);
         constexpr std::array allowed_structs_VkBlitImageInfo2 = {VK_STRUCTURE_TYPE_BLIT_IMAGE_CUBIC_WEIGHTS_INFO_QCOM};
@@ -16254,11 +16176,10 @@ bool StatelessValidation::PreCallValidateCmdBlitImage2(VkCommandBuffer commandBu
         skip |= ValidateRangedEnum(pBlitImageInfo_loc.dot(Field::dstImageLayout), vvl::Enum::VkImageLayout,
                                    pBlitImageInfo->dstImageLayout, "VUID-VkBlitImageInfo2-dstImageLayout-parameter");
 
-        skip |=
-            ValidateStructTypeArray(pBlitImageInfo_loc.dot(Field::regionCount), pBlitImageInfo_loc.dot(Field::pRegions),
-                                    "VK_STRUCTURE_TYPE_IMAGE_BLIT_2", pBlitImageInfo->regionCount, pBlitImageInfo->pRegions,
-                                    VK_STRUCTURE_TYPE_IMAGE_BLIT_2, true, true, "VUID-VkImageBlit2-sType-sType",
-                                    "VUID-VkBlitImageInfo2-pRegions-parameter", "VUID-VkBlitImageInfo2-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pBlitImageInfo_loc.dot(Field::regionCount), pBlitImageInfo_loc.dot(Field::pRegions),
+                                        pBlitImageInfo->regionCount, pBlitImageInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_BLIT_2, true,
+                                        true, "VUID-VkImageBlit2-sType-sType", "VUID-VkBlitImageInfo2-pRegions-parameter",
+                                        "VUID-VkBlitImageInfo2-regionCount-arraylength");
 
         if (pBlitImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pBlitImageInfo->regionCount; ++regionIndex) {
@@ -16293,9 +16214,8 @@ bool StatelessValidation::PreCallValidateCmdResolveImage2(VkCommandBuffer comman
                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pResolveImageInfo), "VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2", pResolveImageInfo,
-                               VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2, true, "VUID-vkCmdResolveImage2-pResolveImageInfo-parameter",
-                               "VUID-VkResolveImageInfo2-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pResolveImageInfo), pResolveImageInfo, VK_STRUCTURE_TYPE_RESOLVE_IMAGE_INFO_2, true,
+                               "VUID-vkCmdResolveImage2-pResolveImageInfo-parameter", "VUID-VkResolveImageInfo2-sType-sType");
     if (pResolveImageInfo != nullptr) {
         [[maybe_unused]] const Location pResolveImageInfo_loc = loc.dot(Field::pResolveImageInfo);
         skip |= ValidateStructPnext(pResolveImageInfo_loc, pResolveImageInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -16311,11 +16231,11 @@ bool StatelessValidation::PreCallValidateCmdResolveImage2(VkCommandBuffer comman
         skip |= ValidateRangedEnum(pResolveImageInfo_loc.dot(Field::dstImageLayout), vvl::Enum::VkImageLayout,
                                    pResolveImageInfo->dstImageLayout, "VUID-VkResolveImageInfo2-dstImageLayout-parameter");
 
-        skip |= ValidateStructTypeArray(pResolveImageInfo_loc.dot(Field::regionCount), pResolveImageInfo_loc.dot(Field::pRegions),
-                                        "VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2", pResolveImageInfo->regionCount,
-                                        pResolveImageInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2, true, true,
-                                        "VUID-VkImageResolve2-sType-sType", "VUID-VkResolveImageInfo2-pRegions-parameter",
-                                        "VUID-VkResolveImageInfo2-regionCount-arraylength");
+        skip |=
+            ValidateStructTypeArray(pResolveImageInfo_loc.dot(Field::regionCount), pResolveImageInfo_loc.dot(Field::pRegions),
+                                    pResolveImageInfo->regionCount, pResolveImageInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_RESOLVE_2,
+                                    true, true, "VUID-VkImageResolve2-sType-sType", "VUID-VkResolveImageInfo2-pRegions-parameter",
+                                    "VUID-VkResolveImageInfo2-regionCount-arraylength");
 
         if (pResolveImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pResolveImageInfo->regionCount; ++regionIndex) {
@@ -16349,9 +16269,8 @@ bool StatelessValidation::PreCallValidateCmdBeginRendering(VkCommandBuffer comma
                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pRenderingInfo), "VK_STRUCTURE_TYPE_RENDERING_INFO", pRenderingInfo,
-                               VK_STRUCTURE_TYPE_RENDERING_INFO, true, "VUID-vkCmdBeginRendering-pRenderingInfo-parameter",
-                               "VUID-VkRenderingInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pRenderingInfo), pRenderingInfo, VK_STRUCTURE_TYPE_RENDERING_INFO, true,
+                               "VUID-vkCmdBeginRendering-pRenderingInfo-parameter", "VUID-VkRenderingInfo-sType-sType");
     if (pRenderingInfo != nullptr) {
         [[maybe_unused]] const Location pRenderingInfo_loc = loc.dot(Field::pRenderingInfo);
         constexpr std::array allowed_structs_VkRenderingInfo = {
@@ -16374,11 +16293,11 @@ bool StatelessValidation::PreCallValidateCmdBeginRendering(VkCommandBuffer comma
 
         // No xml-driven validation
 
-        skip |= ValidateStructTypeArray(
-            pRenderingInfo_loc.dot(Field::colorAttachmentCount), pRenderingInfo_loc.dot(Field::pColorAttachments),
-            "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO", pRenderingInfo->colorAttachmentCount, pRenderingInfo->pColorAttachments,
-            VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false, true, "VUID-VkRenderingAttachmentInfo-sType-sType",
-            "VUID-VkRenderingInfo-pColorAttachments-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(pRenderingInfo_loc.dot(Field::colorAttachmentCount),
+                                        pRenderingInfo_loc.dot(Field::pColorAttachments), pRenderingInfo->colorAttachmentCount,
+                                        pRenderingInfo->pColorAttachments, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false, true,
+                                        "VUID-VkRenderingAttachmentInfo-sType-sType",
+                                        "VUID-VkRenderingInfo-pColorAttachments-parameter", kVUIDUndefined);
 
         if (pRenderingInfo->pColorAttachments != nullptr) {
             for (uint32_t colorAttachmentIndex = 0; colorAttachmentIndex < pRenderingInfo->colorAttachmentCount;
@@ -16413,8 +16332,8 @@ bool StatelessValidation::PreCallValidateCmdBeginRendering(VkCommandBuffer comma
             }
         }
 
-        skip |= ValidateStructType(pRenderingInfo_loc.dot(Field::pDepthAttachment), "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO",
-                                   pRenderingInfo->pDepthAttachment, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
+        skip |= ValidateStructType(pRenderingInfo_loc.dot(Field::pDepthAttachment), pRenderingInfo->pDepthAttachment,
+                                   VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
                                    "VUID-VkRenderingInfo-pDepthAttachment-parameter", "VUID-VkRenderingAttachmentInfo-sType-sType");
 
         if (pRenderingInfo->pDepthAttachment != nullptr) {
@@ -16446,8 +16365,8 @@ bool StatelessValidation::PreCallValidateCmdBeginRendering(VkCommandBuffer comma
         }
 
         skip |=
-            ValidateStructType(pRenderingInfo_loc.dot(Field::pStencilAttachment), "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO",
-                               pRenderingInfo->pStencilAttachment, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
+            ValidateStructType(pRenderingInfo_loc.dot(Field::pStencilAttachment), pRenderingInfo->pStencilAttachment,
+                               VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
                                "VUID-VkRenderingInfo-pStencilAttachment-parameter", "VUID-VkRenderingAttachmentInfo-sType-sType");
 
         if (pRenderingInfo->pStencilAttachment != nullptr) {
@@ -16657,8 +16576,7 @@ bool StatelessValidation::PreCallValidateGetDeviceBufferMemoryRequirements(VkDev
                                                                            const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS", pInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_DEVICE_BUFFER_MEMORY_REQUIREMENTS, true,
                                "VUID-vkGetDeviceBufferMemoryRequirements-pInfo-parameter",
                                "VUID-VkDeviceBufferMemoryRequirements-sType-sType");
     if (pInfo != nullptr) {
@@ -16666,9 +16584,8 @@ bool StatelessValidation::PreCallValidateGetDeviceBufferMemoryRequirements(VkDev
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                     "VUID-VkDeviceBufferMemoryRequirements-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO", pInfo->pCreateInfo,
-                                   VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, true,
-                                   "VUID-VkDeviceBufferMemoryRequirements-pCreateInfo-parameter",
+        skip |= ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), pInfo->pCreateInfo, VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO,
+                                   true, "VUID-VkDeviceBufferMemoryRequirements-pCreateInfo-parameter",
                                    "VUID-VkBufferCreateInfo-sType-sType");
 
         if (pInfo->pCreateInfo != nullptr) {
@@ -16696,9 +16613,8 @@ bool StatelessValidation::PreCallValidateGetDeviceBufferMemoryRequirements(VkDev
                                        pInfo->pCreateInfo->sharingMode, "VUID-VkBufferCreateInfo-sharingMode-parameter");
         }
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetDeviceBufferMemoryRequirements-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetDeviceBufferMemoryRequirements-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -16718,8 +16634,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirements(VkDevi
                                                                           const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS", pInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS, true,
                                "VUID-vkGetDeviceImageMemoryRequirements-pInfo-parameter",
                                "VUID-VkDeviceImageMemoryRequirements-sType-sType");
     if (pInfo != nullptr) {
@@ -16728,8 +16643,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirements(VkDevi
                                     "VUID-VkDeviceImageMemoryRequirements-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
         skip |=
-            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO", pInfo->pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
+            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), pInfo->pCreateInfo, VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
                                "VUID-VkDeviceImageMemoryRequirements-pCreateInfo-parameter", "VUID-VkImageCreateInfo-sType-sType");
 
         if (pInfo->pCreateInfo != nullptr) {
@@ -16793,9 +16707,8 @@ bool StatelessValidation::PreCallValidateGetDeviceImageMemoryRequirements(VkDevi
         skip |= ValidateFlags(pInfo_loc.dot(Field::planeAspect), vvl::FlagBitmask::VkImageAspectFlagBits, AllVkImageAspectFlagBits,
                               pInfo->planeAspect, kOptionalSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetDeviceImageMemoryRequirements-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetDeviceImageMemoryRequirements-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -16815,8 +16728,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirements(
     VkSparseImageMemoryRequirements2* pSparseMemoryRequirements, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS", pInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_DEVICE_IMAGE_MEMORY_REQUIREMENTS, true,
                                "VUID-vkGetDeviceImageSparseMemoryRequirements-pInfo-parameter",
                                "VUID-VkDeviceImageMemoryRequirements-sType-sType");
     if (pInfo != nullptr) {
@@ -16825,8 +16737,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirements(
                                     "VUID-VkDeviceImageMemoryRequirements-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
         skip |=
-            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO", pInfo->pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
+            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), pInfo->pCreateInfo, VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
                                "VUID-VkDeviceImageMemoryRequirements-pCreateInfo-parameter", "VUID-VkImageCreateInfo-sType-sType");
 
         if (pInfo->pCreateInfo != nullptr) {
@@ -16890,13 +16801,12 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSparseMemoryRequirements(
         skip |= ValidateFlags(pInfo_loc.dot(Field::planeAspect), vvl::FlagBitmask::VkImageAspectFlagBits, AllVkImageAspectFlagBits,
                               pInfo->planeAspect, kOptionalSingleBit, "VUID-VkDeviceImageMemoryRequirements-planeAspect-parameter");
     }
-    skip |= ValidateStructTypeArray(loc.dot(Field::pSparseMemoryRequirementCount), loc.dot(Field::pSparseMemoryRequirements),
-                                    "VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2", pSparseMemoryRequirementCount,
-                                    pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false,
-                                    false, "VUID-VkSparseImageMemoryRequirements2-sType-sType",
-                                    "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirements-parameter",
-                                    "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirementCount-parameter",
-                                    kVUIDUndefined);
+    skip |= ValidateStructTypeArray(
+        loc.dot(Field::pSparseMemoryRequirementCount), loc.dot(Field::pSparseMemoryRequirements), pSparseMemoryRequirementCount,
+        pSparseMemoryRequirements, VK_STRUCTURE_TYPE_SPARSE_IMAGE_MEMORY_REQUIREMENTS_2, true, false, false,
+        "VUID-VkSparseImageMemoryRequirements2-sType-sType",
+        "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirements-parameter",
+        "VUID-vkGetDeviceImageSparseMemoryRequirements-pSparseMemoryRequirementCount-parameter", kVUIDUndefined);
     if (pSparseMemoryRequirements != nullptr) {
         for (uint32_t pSparseMemoryRequirementIndex = 0; pSparseMemoryRequirementIndex < *pSparseMemoryRequirementCount;
              ++pSparseMemoryRequirementIndex) {
@@ -17024,9 +16934,8 @@ bool StatelessValidation::PreCallValidateCreateSwapchainKHR(VkDevice device, con
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_swapchain)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_swapchain});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR, true, "VUID-vkCreateSwapchainKHR-pCreateInfo-parameter",
-                               "VUID-VkSwapchainCreateInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR, true,
+                               "VUID-vkCreateSwapchainKHR-pCreateInfo-parameter", "VUID-VkSwapchainCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         constexpr std::array allowed_structs_VkSwapchainCreateInfoKHR = {
@@ -17180,9 +17089,8 @@ bool StatelessValidation::PreCallValidateQueuePresentKHR(VkQueue queue, const Vk
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_swapchain)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_swapchain});
-    skip |= ValidateStructType(loc.dot(Field::pPresentInfo), "VK_STRUCTURE_TYPE_PRESENT_INFO_KHR", pPresentInfo,
-                               VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, true, "VUID-vkQueuePresentKHR-pPresentInfo-parameter",
-                               "VUID-VkPresentInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pPresentInfo), pPresentInfo, VK_STRUCTURE_TYPE_PRESENT_INFO_KHR, true,
+                               "VUID-vkQueuePresentKHR-pPresentInfo-parameter", "VUID-VkPresentInfoKHR-sType-sType");
     if (pPresentInfo != nullptr) {
         [[maybe_unused]] const Location pPresentInfo_loc = loc.dot(Field::pPresentInfo);
         constexpr std::array allowed_structs_VkPresentInfoKHR = {VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_INFO_KHR,
@@ -17226,8 +17134,7 @@ bool StatelessValidation::PreCallValidateGetDeviceGroupPresentCapabilitiesKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!(IsExtEnabled(device_extensions.vk_khr_swapchain) || IsExtEnabled(device_extensions.vk_khr_device_group)))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_swapchain, vvl::Extension::_VK_KHR_device_group});
-    skip |= ValidateStructType(loc.dot(Field::pDeviceGroupPresentCapabilities),
-                               "VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR", pDeviceGroupPresentCapabilities,
+    skip |= ValidateStructType(loc.dot(Field::pDeviceGroupPresentCapabilities), pDeviceGroupPresentCapabilities,
                                VK_STRUCTURE_TYPE_DEVICE_GROUP_PRESENT_CAPABILITIES_KHR, true,
                                "VUID-vkGetDeviceGroupPresentCapabilitiesKHR-pDeviceGroupPresentCapabilities-parameter",
                                "VUID-VkDeviceGroupPresentCapabilitiesKHR-sType-sType");
@@ -17271,8 +17178,7 @@ bool StatelessValidation::PreCallValidateAcquireNextImage2KHR(VkDevice device, c
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!(IsExtEnabled(device_extensions.vk_khr_swapchain) || IsExtEnabled(device_extensions.vk_khr_device_group)))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_swapchain, vvl::Extension::_VK_KHR_device_group});
-    skip |= ValidateStructType(loc.dot(Field::pAcquireInfo), "VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR", pAcquireInfo,
-                               VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pAcquireInfo), pAcquireInfo, VK_STRUCTURE_TYPE_ACQUIRE_NEXT_IMAGE_INFO_KHR, true,
                                "VUID-vkAcquireNextImage2KHR-pAcquireInfo-parameter", "VUID-VkAcquireNextImageInfoKHR-sType-sType");
     if (pAcquireInfo != nullptr) {
         [[maybe_unused]] const Location pAcquireInfo_loc = loc.dot(Field::pAcquireInfo);
@@ -17364,8 +17270,7 @@ bool StatelessValidation::PreCallValidateCreateDisplayModeKHR(VkPhysicalDevice p
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_display)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_display});
     skip |= ValidateRequiredHandle(loc.dot(Field::display), display);
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DISPLAY_MODE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateDisplayModeKHR-pCreateInfo-parameter", "VUID-VkDisplayModeCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -17432,8 +17337,7 @@ bool StatelessValidation::PreCallValidateCreateDisplayPlaneSurfaceKHR(VkInstance
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_display)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_display});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DISPLAY_SURFACE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateDisplayPlaneSurfaceKHR-pCreateInfo-parameter",
                                "VUID-VkDisplaySurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -17497,8 +17401,8 @@ bool StatelessValidation::PreCallValidateCreateSharedSwapchainsKHR(VkDevice devi
     if (!IsExtEnabled(device_extensions.vk_khr_display_swapchain))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_display_swapchain});
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::swapchainCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR", swapchainCount,
-        pCreateInfos, VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR, true, true, "VUID-VkSwapchainCreateInfoKHR-sType-sType",
+        loc.dot(Field::swapchainCount), loc.dot(Field::pCreateInfos), swapchainCount, pCreateInfos,
+        VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR, true, true, "VUID-VkSwapchainCreateInfoKHR-sType-sType",
         "VUID-vkCreateSharedSwapchainsKHR-pCreateInfos-parameter", "VUID-vkCreateSharedSwapchainsKHR-swapchainCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t swapchainIndex = 0; swapchainIndex < swapchainCount; ++swapchainIndex) {
@@ -17605,8 +17509,7 @@ bool StatelessValidation::PreCallValidateCreateXlibSurfaceKHR(VkInstance instanc
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_xlib_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_xlib_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_XLIB_SURFACE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateXlibSurfaceKHR-pCreateInfo-parameter", "VUID-VkXlibSurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -17667,8 +17570,7 @@ bool StatelessValidation::PreCallValidateCreateXcbSurfaceKHR(VkInstance instance
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_xcb_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_xcb_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_XCB_SURFACE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateXcbSurfaceKHR-pCreateInfo-parameter", "VUID-VkXcbSurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -17732,8 +17634,7 @@ bool StatelessValidation::PreCallValidateCreateWaylandSurfaceKHR(VkInstance inst
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_wayland_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_wayland_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_WAYLAND_SURFACE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateWaylandSurfaceKHR-pCreateInfo-parameter",
                                "VUID-VkWaylandSurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -17797,8 +17698,7 @@ bool StatelessValidation::PreCallValidateCreateAndroidSurfaceKHR(VkInstance inst
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_android_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_android_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_ANDROID_SURFACE_CREATE_INFO_KHR, true,
                                "VUID-vkCreateAndroidSurfaceKHR-pCreateInfo-parameter",
                                "VUID-VkAndroidSurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -17849,8 +17749,7 @@ bool StatelessValidation::PreCallValidateCreateWin32SurfaceKHR(VkInstance instan
     if (!IsExtEnabled(instance_extensions.vk_khr_win32_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_win32_surface});
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR", pCreateInfo,
-                           VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_WIN32_SURFACE_CREATE_INFO_KHR, true,
                            "VUID-vkCreateWin32SurfaceKHR-pCreateInfo-parameter", "VUID-VkWin32SurfaceCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -17908,8 +17807,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoCapabilitiesKHR(V
                                                                                const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pVideoProfile), "VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR", pVideoProfile,
-                               VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pVideoProfile), pVideoProfile, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
                                "VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pVideoProfile-parameter",
                                "VUID-VkVideoProfileInfoKHR-sType-sType");
     if (pVideoProfile != nullptr) {
@@ -17944,8 +17842,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoCapabilitiesKHR(V
                               AllVkVideoComponentBitDepthFlagBitsKHR, pVideoProfile->chromaBitDepth, kOptionalFlags,
                               "VUID-VkVideoProfileInfoKHR-chromaBitDepth-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pCapabilities), "VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR", pCapabilities,
-                               VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pCapabilities), pCapabilities, VK_STRUCTURE_TYPE_VIDEO_CAPABILITIES_KHR, true,
                                "VUID-vkGetPhysicalDeviceVideoCapabilitiesKHR-pCapabilities-parameter",
                                "VUID-VkVideoCapabilitiesKHR-sType-sType");
     if (pCapabilities != nullptr) {
@@ -17969,8 +17866,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoFormatPropertiesK
     uint32_t* pVideoFormatPropertyCount, VkVideoFormatPropertiesKHR* pVideoFormatProperties, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pVideoFormatInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR",
-                               pVideoFormatInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pVideoFormatInfo), pVideoFormatInfo,
+                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_FORMAT_INFO_KHR, true,
                                "VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pVideoFormatInfo-parameter",
                                "VUID-VkPhysicalDeviceVideoFormatInfoKHR-sType-sType");
     if (pVideoFormatInfo != nullptr) {
@@ -17989,9 +17886,9 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoFormatPropertiesK
                               "VUID-VkPhysicalDeviceVideoFormatInfoKHR-imageUsage-requiredbitmask");
     }
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pVideoFormatPropertyCount), loc.dot(Field::pVideoFormatProperties),
-        "VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR", pVideoFormatPropertyCount, pVideoFormatProperties,
-        VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, true, false, false, "VUID-VkVideoFormatPropertiesKHR-sType-sType",
+        loc.dot(Field::pVideoFormatPropertyCount), loc.dot(Field::pVideoFormatProperties), pVideoFormatPropertyCount,
+        pVideoFormatProperties, VK_STRUCTURE_TYPE_VIDEO_FORMAT_PROPERTIES_KHR, true, false, false,
+        "VUID-VkVideoFormatPropertiesKHR-sType-sType",
         "VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pVideoFormatProperties-parameter",
         "VUID-vkGetPhysicalDeviceVideoFormatPropertiesKHR-pVideoFormatPropertyCount-parameter", kVUIDUndefined);
     if (pVideoFormatProperties != nullptr) {
@@ -18016,8 +17913,7 @@ bool StatelessValidation::PreCallValidateCreateVideoSessionKHR(VkDevice device, 
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR", pCreateInfo,
-                           VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_VIDEO_SESSION_CREATE_INFO_KHR, true,
                            "VUID-vkCreateVideoSessionKHR-pCreateInfo-parameter", "VUID-VkVideoSessionCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -18034,10 +17930,9 @@ bool StatelessValidation::PreCallValidateCreateVideoSessionKHR(VkDevice device, 
                               AllVkVideoSessionCreateFlagBitsKHR, pCreateInfo->flags, kOptionalFlags,
                               "VUID-VkVideoSessionCreateInfoKHR-flags-parameter");
 
-        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::pVideoProfile), "VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR",
-                                   pCreateInfo->pVideoProfile, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
-                                   "VUID-VkVideoSessionCreateInfoKHR-pVideoProfile-parameter",
-                                   "VUID-VkVideoProfileInfoKHR-sType-sType");
+        skip |= ValidateStructType(
+            pCreateInfo_loc.dot(Field::pVideoProfile), pCreateInfo->pVideoProfile, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
+            "VUID-VkVideoSessionCreateInfoKHR-pVideoProfile-parameter", "VUID-VkVideoProfileInfoKHR-sType-sType");
 
         if (pCreateInfo->pVideoProfile != nullptr) {
             [[maybe_unused]] const Location pVideoProfile_loc = pCreateInfo_loc.dot(Field::pVideoProfile);
@@ -18164,13 +18059,12 @@ bool StatelessValidation::PreCallValidateGetVideoSessionMemoryRequirementsKHR(
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
     skip |= ValidateRequiredHandle(loc.dot(Field::videoSession), videoSession);
-    skip |=
-        ValidateStructTypeArray(loc.dot(Field::pMemoryRequirementsCount), loc.dot(Field::pMemoryRequirements),
-                                "VK_STRUCTURE_TYPE_VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR", pMemoryRequirementsCount,
-                                pMemoryRequirements, VK_STRUCTURE_TYPE_VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR, true, false, false,
-                                "VUID-VkVideoSessionMemoryRequirementsKHR-sType-sType",
-                                "VUID-vkGetVideoSessionMemoryRequirementsKHR-pMemoryRequirements-parameter",
-                                "VUID-vkGetVideoSessionMemoryRequirementsKHR-pMemoryRequirementsCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(
+        loc.dot(Field::pMemoryRequirementsCount), loc.dot(Field::pMemoryRequirements), pMemoryRequirementsCount,
+        pMemoryRequirements, VK_STRUCTURE_TYPE_VIDEO_SESSION_MEMORY_REQUIREMENTS_KHR, true, false, false,
+        "VUID-VkVideoSessionMemoryRequirementsKHR-sType-sType",
+        "VUID-vkGetVideoSessionMemoryRequirementsKHR-pMemoryRequirements-parameter",
+        "VUID-vkGetVideoSessionMemoryRequirementsKHR-pMemoryRequirementsCount-parameter", kVUIDUndefined);
     if (pMemoryRequirements != nullptr) {
         for (uint32_t pMemoryRequirementsIndex = 0; pMemoryRequirementsIndex < *pMemoryRequirementsCount;
              ++pMemoryRequirementsIndex) {
@@ -18192,12 +18086,11 @@ bool StatelessValidation::PreCallValidateBindVideoSessionMemoryKHR(VkDevice devi
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
     skip |= ValidateRequiredHandle(loc.dot(Field::videoSession), videoSession);
-    skip |= ValidateStructTypeArray(loc.dot(Field::bindSessionMemoryInfoCount), loc.dot(Field::pBindSessionMemoryInfos),
-                                    "VK_STRUCTURE_TYPE_BIND_VIDEO_SESSION_MEMORY_INFO_KHR", bindSessionMemoryInfoCount,
-                                    pBindSessionMemoryInfos, VK_STRUCTURE_TYPE_BIND_VIDEO_SESSION_MEMORY_INFO_KHR, true, true,
-                                    "VUID-VkBindVideoSessionMemoryInfoKHR-sType-sType",
-                                    "VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-parameter",
-                                    "VUID-vkBindVideoSessionMemoryKHR-bindSessionMemoryInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(
+        loc.dot(Field::bindSessionMemoryInfoCount), loc.dot(Field::pBindSessionMemoryInfos), bindSessionMemoryInfoCount,
+        pBindSessionMemoryInfos, VK_STRUCTURE_TYPE_BIND_VIDEO_SESSION_MEMORY_INFO_KHR, true, true,
+        "VUID-VkBindVideoSessionMemoryInfoKHR-sType-sType", "VUID-vkBindVideoSessionMemoryKHR-pBindSessionMemoryInfos-parameter",
+        "VUID-vkBindVideoSessionMemoryKHR-bindSessionMemoryInfoCount-arraylength");
     if (pBindSessionMemoryInfos != nullptr) {
         for (uint32_t bindSessionMemoryInfoIndex = 0; bindSessionMemoryInfoIndex < bindSessionMemoryInfoCount;
              ++bindSessionMemoryInfoIndex) {
@@ -18223,9 +18116,8 @@ bool StatelessValidation::PreCallValidateCreateVideoSessionParametersKHR(VkDevic
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR",
-                               pCreateInfo, VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR, true,
-                               "VUID-vkCreateVideoSessionParametersKHR-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_CREATE_INFO_KHR,
+                               true, "VUID-vkCreateVideoSessionParametersKHR-pCreateInfo-parameter",
                                "VUID-VkVideoSessionParametersCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -18287,9 +18179,8 @@ bool StatelessValidation::PreCallValidateUpdateVideoSessionParametersKHR(VkDevic
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
     skip |= ValidateRequiredHandle(loc.dot(Field::videoSessionParameters), videoSessionParameters);
-    skip |= ValidateStructType(loc.dot(Field::pUpdateInfo), "VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_UPDATE_INFO_KHR",
-                               pUpdateInfo, VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_UPDATE_INFO_KHR, true,
-                               "VUID-vkUpdateVideoSessionParametersKHR-pUpdateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pUpdateInfo), pUpdateInfo, VK_STRUCTURE_TYPE_VIDEO_SESSION_PARAMETERS_UPDATE_INFO_KHR,
+                               true, "VUID-vkUpdateVideoSessionParametersKHR-pUpdateInfo-parameter",
                                "VUID-VkVideoSessionParametersUpdateInfoKHR-sType-sType");
     if (pUpdateInfo != nullptr) {
         [[maybe_unused]] const Location pUpdateInfo_loc = loc.dot(Field::pUpdateInfo);
@@ -18351,8 +18242,7 @@ bool StatelessValidation::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
-    skip |= ValidateStructType(loc.dot(Field::pBeginInfo), "VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR", pBeginInfo,
-                               VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pBeginInfo), pBeginInfo, VK_STRUCTURE_TYPE_VIDEO_BEGIN_CODING_INFO_KHR, true,
                                "VUID-vkCmdBeginVideoCodingKHR-pBeginInfo-parameter", "VUID-VkVideoBeginCodingInfoKHR-sType-sType");
     if (pBeginInfo != nullptr) {
         [[maybe_unused]] const Location pBeginInfo_loc = loc.dot(Field::pBeginInfo);
@@ -18373,8 +18263,8 @@ bool StatelessValidation::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer 
         skip |= ValidateRequiredHandle(pBeginInfo_loc.dot(Field::videoSession), pBeginInfo->videoSession);
 
         skip |= ValidateStructTypeArray(pBeginInfo_loc.dot(Field::referenceSlotCount), pBeginInfo_loc.dot(Field::pReferenceSlots),
-                                        "VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR", pBeginInfo->referenceSlotCount,
-                                        pBeginInfo->pReferenceSlots, VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
+                                        pBeginInfo->referenceSlotCount, pBeginInfo->pReferenceSlots,
+                                        VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
                                         "VUID-VkVideoReferenceSlotInfoKHR-sType-sType",
                                         "VUID-VkVideoBeginCodingInfoKHR-pReferenceSlots-parameter", kVUIDUndefined);
 
@@ -18394,7 +18284,6 @@ bool StatelessValidation::PreCallValidateCmdBeginVideoCodingKHR(VkCommandBuffer 
                                             "VUID-VkVideoReferenceSlotInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
                 skip |= ValidateStructType(pReferenceSlots_loc.dot(Field::pPictureResource),
-                                           "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
                                            pBeginInfo->pReferenceSlots[referenceSlotIndex].pPictureResource,
                                            VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
                                            "VUID-VkVideoReferenceSlotInfoKHR-pPictureResource-parameter",
@@ -18428,8 +18317,7 @@ bool StatelessValidation::PreCallValidateCmdEndVideoCodingKHR(VkCommandBuffer co
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
-    skip |= ValidateStructType(loc.dot(Field::pEndCodingInfo), "VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR", pEndCodingInfo,
-                               VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pEndCodingInfo), pEndCodingInfo, VK_STRUCTURE_TYPE_VIDEO_END_CODING_INFO_KHR, true,
                                "VUID-vkCmdEndVideoCodingKHR-pEndCodingInfo-parameter", "VUID-VkVideoEndCodingInfoKHR-sType-sType");
     if (pEndCodingInfo != nullptr) {
         [[maybe_unused]] const Location pEndCodingInfo_loc = loc.dot(Field::pEndCodingInfo);
@@ -18449,10 +18337,9 @@ bool StatelessValidation::PreCallValidateCmdControlVideoCodingKHR(VkCommandBuffe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_queue});
-    skip |= ValidateStructType(loc.dot(Field::pCodingControlInfo), "VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR",
-                               pCodingControlInfo, VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR, true,
-                               "VUID-vkCmdControlVideoCodingKHR-pCodingControlInfo-parameter",
-                               "VUID-VkVideoCodingControlInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCodingControlInfo), pCodingControlInfo, VK_STRUCTURE_TYPE_VIDEO_CODING_CONTROL_INFO_KHR, true,
+        "VUID-vkCmdControlVideoCodingKHR-pCodingControlInfo-parameter", "VUID-VkVideoCodingControlInfoKHR-sType-sType");
     if (pCodingControlInfo != nullptr) {
         [[maybe_unused]] const Location pCodingControlInfo_loc = loc.dot(Field::pCodingControlInfo);
         constexpr std::array allowed_structs_VkVideoCodingControlInfoKHR = {
@@ -18478,9 +18365,8 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_decode_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_decode_queue});
-    skip |= ValidateStructType(loc.dot(Field::pDecodeInfo), "VK_STRUCTURE_TYPE_VIDEO_DECODE_INFO_KHR", pDecodeInfo,
-                               VK_STRUCTURE_TYPE_VIDEO_DECODE_INFO_KHR, true, "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-parameter",
-                               "VUID-VkVideoDecodeInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pDecodeInfo), pDecodeInfo, VK_STRUCTURE_TYPE_VIDEO_DECODE_INFO_KHR, true,
+                               "VUID-vkCmdDecodeVideoKHR-pDecodeInfo-parameter", "VUID-VkVideoDecodeInfoKHR-sType-sType");
     if (pDecodeInfo != nullptr) {
         [[maybe_unused]] const Location pDecodeInfo_loc = loc.dot(Field::pDecodeInfo);
         constexpr std::array allowed_structs_VkVideoDecodeInfoKHR = {
@@ -18497,10 +18383,9 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
 
         skip |= ValidateRequiredHandle(pDecodeInfo_loc.dot(Field::srcBuffer), pDecodeInfo->srcBuffer);
 
-        skip |=
-            ValidateStructType(pDecodeInfo_loc.dot(Field::dstPictureResource), "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
-                               &(pDecodeInfo->dstPictureResource), VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
-                               kVUIDUndefined, "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
+        skip |= ValidateStructType(pDecodeInfo_loc.dot(Field::dstPictureResource), &(pDecodeInfo->dstPictureResource),
+                                   VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false, kVUIDUndefined,
+                                   "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
 
         skip |=
             ValidateStructPnext(pDecodeInfo_loc, pDecodeInfo->dstPictureResource.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -18513,10 +18398,10 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
         skip |=
             ValidateRequiredHandle(pDecodeInfo_loc.dot(Field::imageViewBinding), pDecodeInfo->dstPictureResource.imageViewBinding);
 
-        skip |= ValidateStructType(
-            pDecodeInfo_loc.dot(Field::pSetupReferenceSlot), "VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR",
-            pDecodeInfo->pSetupReferenceSlot, VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false,
-            "VUID-VkVideoDecodeInfoKHR-pSetupReferenceSlot-parameter", "VUID-VkVideoReferenceSlotInfoKHR-sType-sType");
+        skip |= ValidateStructType(pDecodeInfo_loc.dot(Field::pSetupReferenceSlot), pDecodeInfo->pSetupReferenceSlot,
+                                   VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false,
+                                   "VUID-VkVideoDecodeInfoKHR-pSetupReferenceSlot-parameter",
+                                   "VUID-VkVideoReferenceSlotInfoKHR-sType-sType");
 
         if (pDecodeInfo->pSetupReferenceSlot != nullptr) {
             [[maybe_unused]] const Location pSetupReferenceSlot_loc = pDecodeInfo_loc.dot(Field::pSetupReferenceSlot);
@@ -18532,8 +18417,8 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
                                         "VUID-VkVideoReferenceSlotInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
             skip |= ValidateStructType(
-                pSetupReferenceSlot_loc.dot(Field::pPictureResource), "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
-                pDecodeInfo->pSetupReferenceSlot->pPictureResource, VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
+                pSetupReferenceSlot_loc.dot(Field::pPictureResource), pDecodeInfo->pSetupReferenceSlot->pPictureResource,
+                VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
                 "VUID-VkVideoReferenceSlotInfoKHR-pPictureResource-parameter", "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
 
             if (pDecodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
@@ -18552,8 +18437,8 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
         }
 
         skip |= ValidateStructTypeArray(pDecodeInfo_loc.dot(Field::referenceSlotCount), pDecodeInfo_loc.dot(Field::pReferenceSlots),
-                                        "VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR", pDecodeInfo->referenceSlotCount,
-                                        pDecodeInfo->pReferenceSlots, VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
+                                        pDecodeInfo->referenceSlotCount, pDecodeInfo->pReferenceSlots,
+                                        VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
                                         "VUID-VkVideoReferenceSlotInfoKHR-sType-sType",
                                         "VUID-VkVideoDecodeInfoKHR-pReferenceSlots-parameter", kVUIDUndefined);
 
@@ -18573,7 +18458,6 @@ bool StatelessValidation::PreCallValidateCmdDecodeVideoKHR(VkCommandBuffer comma
                                             "VUID-VkVideoReferenceSlotInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
                 skip |= ValidateStructType(pReferenceSlots_loc.dot(Field::pPictureResource),
-                                           "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
                                            pDecodeInfo->pReferenceSlots[referenceSlotIndex].pPictureResource,
                                            VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
                                            "VUID-VkVideoReferenceSlotInfoKHR-pPictureResource-parameter",
@@ -18776,10 +18660,9 @@ bool StatelessValidation::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_memory_win32))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_memory_win32});
-    skip |= ValidateStructType(loc.dot(Field::pGetWin32HandleInfo), "VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR",
-                               pGetWin32HandleInfo, VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, true,
-                               "VUID-vkGetMemoryWin32HandleKHR-pGetWin32HandleInfo-parameter",
-                               "VUID-VkMemoryGetWin32HandleInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pGetWin32HandleInfo), pGetWin32HandleInfo, VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, true,
+        "VUID-vkGetMemoryWin32HandleKHR-pGetWin32HandleInfo-parameter", "VUID-VkMemoryGetWin32HandleInfoKHR-sType-sType");
     if (pGetWin32HandleInfo != nullptr) {
         [[maybe_unused]] const Location pGetWin32HandleInfo_loc = loc.dot(Field::pGetWin32HandleInfo);
         skip |= ValidateStructPnext(pGetWin32HandleInfo_loc, pGetWin32HandleInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -18808,8 +18691,8 @@ bool StatelessValidation::PreCallValidateGetMemoryWin32HandlePropertiesKHR(
                           AllVkExternalMemoryHandleTypeFlagBits, handleType, kRequiredSingleBit,
                           "VUID-vkGetMemoryWin32HandlePropertiesKHR-handleType-parameter",
                           "VUID-vkGetMemoryWin32HandlePropertiesKHR-handleType-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pMemoryWin32HandleProperties), "VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR",
-                               pMemoryWin32HandleProperties, VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pMemoryWin32HandleProperties), pMemoryWin32HandleProperties,
+                               VK_STRUCTURE_TYPE_MEMORY_WIN32_HANDLE_PROPERTIES_KHR, true,
                                "VUID-vkGetMemoryWin32HandlePropertiesKHR-pMemoryWin32HandleProperties-parameter",
                                "VUID-VkMemoryWin32HandlePropertiesKHR-sType-sType");
     if (pMemoryWin32HandleProperties != nullptr) {
@@ -18831,9 +18714,8 @@ bool StatelessValidation::PreCallValidateGetMemoryFdKHR(VkDevice device, const V
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_memory_fd))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_memory_fd});
-    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), "VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR", pGetFdInfo,
-                               VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, true, "VUID-vkGetMemoryFdKHR-pGetFdInfo-parameter",
-                               "VUID-VkMemoryGetFdInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), pGetFdInfo, VK_STRUCTURE_TYPE_MEMORY_GET_FD_INFO_KHR, true,
+                               "VUID-vkGetMemoryFdKHR-pGetFdInfo-parameter", "VUID-VkMemoryGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr) {
         [[maybe_unused]] const Location pGetFdInfo_loc = loc.dot(Field::pGetFdInfo);
         skip |= ValidateStructPnext(pGetFdInfo_loc, pGetFdInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -18861,9 +18743,8 @@ bool StatelessValidation::PreCallValidateGetMemoryFdPropertiesKHR(VkDevice devic
                           AllVkExternalMemoryHandleTypeFlagBits, handleType, kRequiredSingleBit,
                           "VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter",
                           "VUID-vkGetMemoryFdPropertiesKHR-handleType-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pMemoryFdProperties), "VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR",
-                               pMemoryFdProperties, VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR, true,
-                               "VUID-vkGetMemoryFdPropertiesKHR-pMemoryFdProperties-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryFdProperties), pMemoryFdProperties, VK_STRUCTURE_TYPE_MEMORY_FD_PROPERTIES_KHR,
+                               true, "VUID-vkGetMemoryFdPropertiesKHR-pMemoryFdProperties-parameter",
                                "VUID-VkMemoryFdPropertiesKHR-sType-sType");
     if (pMemoryFdProperties != nullptr) {
         [[maybe_unused]] const Location pMemoryFdProperties_loc = loc.dot(Field::pMemoryFdProperties);
@@ -18894,8 +18775,7 @@ bool StatelessValidation::PreCallValidateImportSemaphoreWin32HandleKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_win32))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_semaphore_win32});
-    skip |= ValidateStructType(loc.dot(Field::pImportSemaphoreWin32HandleInfo),
-                               "VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR", pImportSemaphoreWin32HandleInfo,
+    skip |= ValidateStructType(loc.dot(Field::pImportSemaphoreWin32HandleInfo), pImportSemaphoreWin32HandleInfo,
                                VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_WIN32_HANDLE_INFO_KHR, true,
                                "VUID-vkImportSemaphoreWin32HandleKHR-pImportSemaphoreWin32HandleInfo-parameter",
                                "VUID-VkImportSemaphoreWin32HandleInfoKHR-sType-sType");
@@ -18923,10 +18803,9 @@ bool StatelessValidation::PreCallValidateGetSemaphoreWin32HandleKHR(VkDevice dev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_win32))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_semaphore_win32});
-    skip |= ValidateStructType(loc.dot(Field::pGetWin32HandleInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR",
-                               pGetWin32HandleInfo, VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR, true,
-                               "VUID-vkGetSemaphoreWin32HandleKHR-pGetWin32HandleInfo-parameter",
-                               "VUID-VkSemaphoreGetWin32HandleInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pGetWin32HandleInfo), pGetWin32HandleInfo, VK_STRUCTURE_TYPE_SEMAPHORE_GET_WIN32_HANDLE_INFO_KHR, true,
+        "VUID-vkGetSemaphoreWin32HandleKHR-pGetWin32HandleInfo-parameter", "VUID-VkSemaphoreGetWin32HandleInfoKHR-sType-sType");
     if (pGetWin32HandleInfo != nullptr) {
         [[maybe_unused]] const Location pGetWin32HandleInfo_loc = loc.dot(Field::pGetWin32HandleInfo);
         skip |= ValidateStructPnext(pGetWin32HandleInfo_loc, pGetWin32HandleInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -18953,10 +18832,9 @@ bool StatelessValidation::PreCallValidateImportSemaphoreFdKHR(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_semaphore_fd});
-    skip |= ValidateStructType(loc.dot(Field::pImportSemaphoreFdInfo), "VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR",
-                               pImportSemaphoreFdInfo, VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR, true,
-                               "VUID-vkImportSemaphoreFdKHR-pImportSemaphoreFdInfo-parameter",
-                               "VUID-VkImportSemaphoreFdInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pImportSemaphoreFdInfo), pImportSemaphoreFdInfo, VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_FD_INFO_KHR, true,
+        "VUID-vkImportSemaphoreFdKHR-pImportSemaphoreFdInfo-parameter", "VUID-VkImportSemaphoreFdInfoKHR-sType-sType");
     if (pImportSemaphoreFdInfo != nullptr) {
         [[maybe_unused]] const Location pImportSemaphoreFdInfo_loc = loc.dot(Field::pImportSemaphoreFdInfo);
         skip |=
@@ -18984,9 +18862,8 @@ bool StatelessValidation::PreCallValidateGetSemaphoreFdKHR(VkDevice device, cons
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_semaphore_fd))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_semaphore_fd});
-    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR", pGetFdInfo,
-                               VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR, true, "VUID-vkGetSemaphoreFdKHR-pGetFdInfo-parameter",
-                               "VUID-VkSemaphoreGetFdInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), pGetFdInfo, VK_STRUCTURE_TYPE_SEMAPHORE_GET_FD_INFO_KHR, true,
+                               "VUID-vkGetSemaphoreFdKHR-pGetFdInfo-parameter", "VUID-VkSemaphoreGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr) {
         [[maybe_unused]] const Location pGetFdInfo_loc = loc.dot(Field::pGetFdInfo);
         skip |= ValidateStructPnext(pGetFdInfo_loc, pGetFdInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19016,9 +18893,9 @@ bool StatelessValidation::PreCallValidateCmdPushDescriptorSetKHR(VkCommandBuffer
     skip |= ValidateRangedEnum(loc.dot(Field::pipelineBindPoint), vvl::Enum::VkPipelineBindPoint, pipelineBindPoint,
                                "VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-parameter");
     skip |= ValidateRequiredHandle(loc.dot(Field::layout), layout);
-    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorWriteCount), loc.dot(Field::pDescriptorWrites),
-                                    "VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET", descriptorWriteCount, pDescriptorWrites,
-                                    VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, true, true, "VUID-VkWriteDescriptorSet-sType-sType",
+    skip |= ValidateStructTypeArray(loc.dot(Field::descriptorWriteCount), loc.dot(Field::pDescriptorWrites), descriptorWriteCount,
+                                    pDescriptorWrites, VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, true, true,
+                                    "VUID-VkWriteDescriptorSet-sType-sType",
                                     "VUID-vkCmdPushDescriptorSetKHR-pDescriptorWrites-parameter",
                                     "VUID-vkCmdPushDescriptorSetKHR-descriptorWriteCount-arraylength");
     if (pDescriptorWrites != nullptr) {
@@ -19177,8 +19054,8 @@ bool StatelessValidation::PreCallValidateImportFenceWin32HandleKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_fence_win32))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_fence_win32});
-    skip |= ValidateStructType(loc.dot(Field::pImportFenceWin32HandleInfo), "VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR",
-                               pImportFenceWin32HandleInfo, VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pImportFenceWin32HandleInfo), pImportFenceWin32HandleInfo,
+                               VK_STRUCTURE_TYPE_IMPORT_FENCE_WIN32_HANDLE_INFO_KHR, true,
                                "VUID-vkImportFenceWin32HandleKHR-pImportFenceWin32HandleInfo-parameter",
                                "VUID-VkImportFenceWin32HandleInfoKHR-sType-sType");
     if (pImportFenceWin32HandleInfo != nullptr) {
@@ -19204,10 +19081,9 @@ bool StatelessValidation::PreCallValidateGetFenceWin32HandleKHR(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_fence_win32))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_fence_win32});
-    skip |= ValidateStructType(loc.dot(Field::pGetWin32HandleInfo), "VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR",
-                               pGetWin32HandleInfo, VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR, true,
-                               "VUID-vkGetFenceWin32HandleKHR-pGetWin32HandleInfo-parameter",
-                               "VUID-VkFenceGetWin32HandleInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pGetWin32HandleInfo), pGetWin32HandleInfo, VK_STRUCTURE_TYPE_FENCE_GET_WIN32_HANDLE_INFO_KHR, true,
+        "VUID-vkGetFenceWin32HandleKHR-pGetWin32HandleInfo-parameter", "VUID-VkFenceGetWin32HandleInfoKHR-sType-sType");
     if (pGetWin32HandleInfo != nullptr) {
         [[maybe_unused]] const Location pGetWin32HandleInfo_loc = loc.dot(Field::pGetWin32HandleInfo);
         skip |= ValidateStructPnext(pGetWin32HandleInfo_loc, pGetWin32HandleInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19232,9 +19108,9 @@ bool StatelessValidation::PreCallValidateImportFenceFdKHR(VkDevice device, const
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_fence_fd))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_fence_fd});
-    skip |= ValidateStructType(loc.dot(Field::pImportFenceFdInfo), "VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR", pImportFenceFdInfo,
-                               VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR, true,
-                               "VUID-vkImportFenceFdKHR-pImportFenceFdInfo-parameter", "VUID-VkImportFenceFdInfoKHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pImportFenceFdInfo), pImportFenceFdInfo, VK_STRUCTURE_TYPE_IMPORT_FENCE_FD_INFO_KHR, true,
+                           "VUID-vkImportFenceFdKHR-pImportFenceFdInfo-parameter", "VUID-VkImportFenceFdInfoKHR-sType-sType");
     if (pImportFenceFdInfo != nullptr) {
         [[maybe_unused]] const Location pImportFenceFdInfo_loc = loc.dot(Field::pImportFenceFdInfo);
         skip |= ValidateStructPnext(pImportFenceFdInfo_loc, pImportFenceFdInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19261,9 +19137,8 @@ bool StatelessValidation::PreCallValidateGetFenceFdKHR(VkDevice device, const Vk
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_external_fence_fd))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_external_fence_fd});
-    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), "VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR", pGetFdInfo,
-                               VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR, true, "VUID-vkGetFenceFdKHR-pGetFdInfo-parameter",
-                               "VUID-VkFenceGetFdInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pGetFdInfo), pGetFdInfo, VK_STRUCTURE_TYPE_FENCE_GET_FD_INFO_KHR, true,
+                               "VUID-vkGetFenceFdKHR-pGetFdInfo-parameter", "VUID-VkFenceGetFdInfoKHR-sType-sType");
     if (pGetFdInfo != nullptr) {
         [[maybe_unused]] const Location pGetFdInfo_loc = loc.dot(Field::pGetFdInfo);
         skip |= ValidateStructPnext(pGetFdInfo_loc, pGetFdInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19286,8 +19161,8 @@ bool StatelessValidation::PreCallValidateEnumeratePhysicalDeviceQueueFamilyPerfo
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pCounterCount), loc.dot(Field::pCounters), "VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR", pCounterCount,
-        pCounters, VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR, true, false, false, "VUID-VkPerformanceCounterKHR-sType-sType",
+        loc.dot(Field::pCounterCount), loc.dot(Field::pCounters), pCounterCount, pCounters,
+        VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_KHR, true, false, false, "VUID-VkPerformanceCounterKHR-sType-sType",
         "VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-pCounters-parameter",
         "VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-pCounterCount-parameter", kVUIDUndefined);
     if (pCounters != nullptr) {
@@ -19298,8 +19173,7 @@ bool StatelessValidation::PreCallValidateEnumeratePhysicalDeviceQueueFamilyPerfo
         }
     }
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pCounterCount), loc.dot(Field::pCounterDescriptions),
-        "VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR", pCounterCount, pCounterDescriptions,
+        loc.dot(Field::pCounterCount), loc.dot(Field::pCounterDescriptions), pCounterCount, pCounterDescriptions,
         VK_STRUCTURE_TYPE_PERFORMANCE_COUNTER_DESCRIPTION_KHR, true, false, false,
         "VUID-VkPerformanceCounterDescriptionKHR-sType-sType",
         "VUID-vkEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR-pCounterDescriptions-parameter",
@@ -19320,11 +19194,10 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceQueueFamilyPerformance
     const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |=
-        ValidateStructType(loc.dot(Field::pPerformanceQueryCreateInfo), "VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR",
-                           pPerformanceQueryCreateInfo, VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR, true,
-                           "VUID-vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR-pPerformanceQueryCreateInfo-parameter",
-                           "VUID-VkQueryPoolPerformanceCreateInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pPerformanceQueryCreateInfo), pPerformanceQueryCreateInfo,
+                               VK_STRUCTURE_TYPE_QUERY_POOL_PERFORMANCE_CREATE_INFO_KHR, true,
+                               "VUID-vkGetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR-pPerformanceQueryCreateInfo-parameter",
+                               "VUID-VkQueryPoolPerformanceCreateInfoKHR-sType-sType");
     if (pPerformanceQueryCreateInfo != nullptr) {
         [[maybe_unused]] const Location pPerformanceQueryCreateInfo_loc = loc.dot(Field::pPerformanceQueryCreateInfo);
         skip |= ValidateStructPnext(pPerformanceQueryCreateInfo_loc, pPerformanceQueryCreateInfo->pNext, 0, nullptr,
@@ -19347,8 +19220,7 @@ bool StatelessValidation::PreCallValidateAcquireProfilingLockKHR(VkDevice device
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_ACQUIRE_PROFILING_LOCK_INFO_KHR, true,
                                "VUID-vkAcquireProfilingLockKHR-pInfo-parameter", "VUID-VkAcquireProfilingLockInfoKHR-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -19377,9 +19249,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KH
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_surface_capabilities2});
-    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR", pSurfaceInfo,
-                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, true,
-                               "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), pSurfaceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR,
+                               true, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceInfo-parameter",
                                "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-sType");
     if (pSurfaceInfo != nullptr) {
         [[maybe_unused]] const Location pSurfaceInfo_loc = loc.dot(Field::pSurfaceInfo);
@@ -19392,10 +19263,10 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2KH
                                     "VUID-VkPhysicalDeviceSurfaceInfo2KHR-pNext-pNext",
                                     "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-unique", physicalDevice, true);
     }
-    skip |= ValidateStructType(loc.dot(Field::pSurfaceCapabilities), "VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR",
-                               pSurfaceCapabilities, VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR, true,
-                               "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceCapabilities-parameter",
-                               "VUID-VkSurfaceCapabilities2KHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pSurfaceCapabilities), pSurfaceCapabilities, VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_KHR,
+                           true, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceCapabilities-parameter",
+                           "VUID-VkSurfaceCapabilities2KHR-sType-sType");
     if (pSurfaceCapabilities != nullptr) {
         [[maybe_unused]] const Location pSurfaceCapabilities_loc = loc.dot(Field::pSurfaceCapabilities);
         constexpr std::array allowed_structs_VkSurfaceCapabilities2KHR = {
@@ -19428,9 +19299,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkP
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_get_surface_capabilities2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_surface_capabilities2});
-    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR", pSurfaceInfo,
-                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, true,
-                               "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), pSurfaceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR,
+                               true, "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-parameter",
                                "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-sType");
     if (pSurfaceInfo != nullptr) {
         [[maybe_unused]] const Location pSurfaceInfo_loc = loc.dot(Field::pSurfaceInfo);
@@ -19443,11 +19313,11 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfaceFormats2KHR(VkP
                                     "VUID-VkPhysicalDeviceSurfaceInfo2KHR-pNext-pNext",
                                     "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-unique", physicalDevice, true);
     }
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pSurfaceFormatCount), loc.dot(Field::pSurfaceFormats), "VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR",
-        pSurfaceFormatCount, pSurfaceFormats, VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, true, false, false,
-        "VUID-VkSurfaceFormat2KHR-sType-sType", "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceFormats-parameter",
-        "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceFormatCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pSurfaceFormatCount), loc.dot(Field::pSurfaceFormats), pSurfaceFormatCount,
+                                    pSurfaceFormats, VK_STRUCTURE_TYPE_SURFACE_FORMAT_2_KHR, true, false, false,
+                                    "VUID-VkSurfaceFormat2KHR-sType-sType",
+                                    "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceFormats-parameter",
+                                    "VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceFormatCount-parameter", kVUIDUndefined);
     if (pSurfaceFormats != nullptr) {
         for (uint32_t pSurfaceFormatIndex = 0; pSurfaceFormatIndex < *pSurfaceFormatCount; ++pSurfaceFormatIndex) {
             [[maybe_unused]] const Location pSurfaceFormats_loc = loc.dot(Field::pSurfaceFormats, pSurfaceFormatIndex);
@@ -19473,11 +19343,11 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceDisplayProperties2KHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_get_display_properties2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_display_properties2});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR", pPropertyCount,
-        pProperties, VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, true, false, false, "VUID-VkDisplayProperties2KHR-sType-sType",
-        "VUID-vkGetPhysicalDeviceDisplayProperties2KHR-pProperties-parameter",
-        "VUID-vkGetPhysicalDeviceDisplayProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+                                    VK_STRUCTURE_TYPE_DISPLAY_PROPERTIES_2_KHR, true, false, false,
+                                    "VUID-VkDisplayProperties2KHR-sType-sType",
+                                    "VUID-vkGetPhysicalDeviceDisplayProperties2KHR-pProperties-parameter",
+                                    "VUID-vkGetPhysicalDeviceDisplayProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
         for (uint32_t pPropertyIndex = 0; pPropertyIndex < *pPropertyCount; ++pPropertyIndex) {
             [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties, pPropertyIndex);
@@ -19497,11 +19367,11 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceDisplayPlaneProperties
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_get_display_properties2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_display_properties2});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR",
-        pPropertyCount, pProperties, VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, true, false, false,
-        "VUID-VkDisplayPlaneProperties2KHR-sType-sType", "VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-pProperties-parameter",
-        "VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+                                    VK_STRUCTURE_TYPE_DISPLAY_PLANE_PROPERTIES_2_KHR, true, false, false,
+                                    "VUID-VkDisplayPlaneProperties2KHR-sType-sType",
+                                    "VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-pProperties-parameter",
+                                    "VUID-vkGetPhysicalDeviceDisplayPlaneProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
         for (uint32_t pPropertyIndex = 0; pPropertyIndex < *pPropertyCount; ++pPropertyIndex) {
             [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties, pPropertyIndex);
@@ -19522,11 +19392,11 @@ bool StatelessValidation::PreCallValidateGetDisplayModeProperties2KHR(VkPhysical
     if (!IsExtEnabled(instance_extensions.vk_khr_get_display_properties2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_display_properties2});
     skip |= ValidateRequiredHandle(loc.dot(Field::display), display);
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR",
-        pPropertyCount, pProperties, VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, true, false, false,
-        "VUID-VkDisplayModeProperties2KHR-sType-sType", "VUID-vkGetDisplayModeProperties2KHR-pProperties-parameter",
-        "VUID-vkGetDisplayModeProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+                                    VK_STRUCTURE_TYPE_DISPLAY_MODE_PROPERTIES_2_KHR, true, false, false,
+                                    "VUID-VkDisplayModeProperties2KHR-sType-sType",
+                                    "VUID-vkGetDisplayModeProperties2KHR-pProperties-parameter",
+                                    "VUID-vkGetDisplayModeProperties2KHR-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
         for (uint32_t pPropertyIndex = 0; pPropertyIndex < *pPropertyCount; ++pPropertyIndex) {
             [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties, pPropertyIndex);
@@ -19546,9 +19416,8 @@ bool StatelessValidation::PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysi
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_khr_get_display_properties2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_get_display_properties2});
-    skip |= ValidateStructType(loc.dot(Field::pDisplayPlaneInfo), "VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR", pDisplayPlaneInfo,
-                               VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR, true,
-                               "VUID-vkGetDisplayPlaneCapabilities2KHR-pDisplayPlaneInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pDisplayPlaneInfo), pDisplayPlaneInfo, VK_STRUCTURE_TYPE_DISPLAY_PLANE_INFO_2_KHR,
+                               true, "VUID-vkGetDisplayPlaneCapabilities2KHR-pDisplayPlaneInfo-parameter",
                                "VUID-VkDisplayPlaneInfo2KHR-sType-sType");
     if (pDisplayPlaneInfo != nullptr) {
         [[maybe_unused]] const Location pDisplayPlaneInfo_loc = loc.dot(Field::pDisplayPlaneInfo);
@@ -19557,9 +19426,8 @@ bool StatelessValidation::PreCallValidateGetDisplayPlaneCapabilities2KHR(VkPhysi
 
         skip |= ValidateRequiredHandle(pDisplayPlaneInfo_loc.dot(Field::mode), pDisplayPlaneInfo->mode);
     }
-    skip |= ValidateStructType(loc.dot(Field::pCapabilities), "VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR", pCapabilities,
-                               VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR, true,
-                               "VUID-vkGetDisplayPlaneCapabilities2KHR-pCapabilities-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCapabilities), pCapabilities, VK_STRUCTURE_TYPE_DISPLAY_PLANE_CAPABILITIES_2_KHR,
+                               true, "VUID-vkGetDisplayPlaneCapabilities2KHR-pCapabilities-parameter",
                                "VUID-VkDisplayPlaneCapabilities2KHR-sType-sType");
     if (pCapabilities != nullptr) {
         [[maybe_unused]] const Location pCapabilities_loc = loc.dot(Field::pCapabilities);
@@ -19724,13 +19592,12 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceFragmentShadingRatesKH
     VkPhysicalDeviceFragmentShadingRateKHR* pFragmentShadingRates, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(loc.dot(Field::pFragmentShadingRateCount), loc.dot(Field::pFragmentShadingRates),
-                                    "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR", pFragmentShadingRateCount,
-                                    pFragmentShadingRates, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR, true, false,
-                                    false, "VUID-VkPhysicalDeviceFragmentShadingRateKHR-sType-sType",
-                                    "VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-pFragmentShadingRates-parameter",
-                                    "VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-pFragmentShadingRateCount-parameter",
-                                    kVUIDUndefined);
+    skip |= ValidateStructTypeArray(
+        loc.dot(Field::pFragmentShadingRateCount), loc.dot(Field::pFragmentShadingRates), pFragmentShadingRateCount,
+        pFragmentShadingRates, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADING_RATE_KHR, true, false, false,
+        "VUID-VkPhysicalDeviceFragmentShadingRateKHR-sType-sType",
+        "VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-pFragmentShadingRates-parameter",
+        "VUID-vkGetPhysicalDeviceFragmentShadingRatesKHR-pFragmentShadingRateCount-parameter", kVUIDUndefined);
     if (pFragmentShadingRates != nullptr) {
         for (uint32_t pFragmentShadingRateIndex = 0; pFragmentShadingRateIndex < *pFragmentShadingRateCount;
              ++pFragmentShadingRateIndex) {
@@ -19770,10 +19637,10 @@ bool StatelessValidation::PreCallValidateCmdSetRenderingAttachmentLocationsKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering_local_read))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_dynamic_rendering_local_read});
-    skip |= ValidateStructType(loc.dot(Field::pLocationInfo), "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR",
-                               pLocationInfo, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR, true,
-                               "VUID-vkCmdSetRenderingAttachmentLocationsKHR-pLocationInfo-parameter",
-                               "VUID-VkRenderingAttachmentLocationInfoKHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pLocationInfo), pLocationInfo, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_LOCATION_INFO_KHR,
+                           true, "VUID-vkCmdSetRenderingAttachmentLocationsKHR-pLocationInfo-parameter",
+                           "VUID-VkRenderingAttachmentLocationInfoKHR-sType-sType");
     if (pLocationInfo != nullptr) {
         [[maybe_unused]] const Location pLocationInfo_loc = loc.dot(Field::pLocationInfo);
         skip |= ValidateStructPnext(pLocationInfo_loc, pLocationInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19789,11 +19656,10 @@ bool StatelessValidation::PreCallValidateCmdSetRenderingInputAttachmentIndicesKH
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_dynamic_rendering_local_read))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_dynamic_rendering_local_read});
-    skip |=
-        ValidateStructType(loc.dot(Field::pInputAttachmentIndexInfo), "VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR",
-                           pInputAttachmentIndexInfo, VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, true,
-                           "VUID-vkCmdSetRenderingInputAttachmentIndicesKHR-pInputAttachmentIndexInfo-parameter",
-                           "VUID-VkRenderingInputAttachmentIndexInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pInputAttachmentIndexInfo), pInputAttachmentIndexInfo,
+                               VK_STRUCTURE_TYPE_RENDERING_INPUT_ATTACHMENT_INDEX_INFO_KHR, true,
+                               "VUID-vkCmdSetRenderingInputAttachmentIndicesKHR-pInputAttachmentIndexInfo-parameter",
+                               "VUID-VkRenderingInputAttachmentIndexInfoKHR-sType-sType");
     if (pInputAttachmentIndexInfo != nullptr) {
         [[maybe_unused]] const Location pInputAttachmentIndexInfo_loc = loc.dot(Field::pInputAttachmentIndexInfo);
         skip |= ValidateStructPnext(pInputAttachmentIndexInfo_loc, pInputAttachmentIndexInfo->pNext, 0, nullptr,
@@ -19953,9 +19819,9 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_pipeline_executable_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_pipeline_executable_properties});
-    skip |= ValidateStructType(
-        loc.dot(Field::pPipelineInfo), "VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR", pPipelineInfo, VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR,
-        true, "VUID-vkGetPipelineExecutablePropertiesKHR-pPipelineInfo-parameter", "VUID-VkPipelineInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pPipelineInfo), pPipelineInfo, VK_STRUCTURE_TYPE_PIPELINE_INFO_KHR, true,
+                               "VUID-vkGetPipelineExecutablePropertiesKHR-pPipelineInfo-parameter",
+                               "VUID-VkPipelineInfoKHR-sType-sType");
     if (pPipelineInfo != nullptr) {
         [[maybe_unused]] const Location pPipelineInfo_loc = loc.dot(Field::pPipelineInfo);
         skip |= ValidateStructPnext(pPipelineInfo_loc, pPipelineInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -19963,11 +19829,11 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutablePropertiesKHR(VkDe
 
         skip |= ValidateRequiredHandle(pPipelineInfo_loc.dot(Field::pipeline), pPipelineInfo->pipeline);
     }
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pExecutableCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR",
-        pExecutableCount, pProperties, VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, true, false, false,
-        "VUID-VkPipelineExecutablePropertiesKHR-sType-sType", "VUID-vkGetPipelineExecutablePropertiesKHR-pProperties-parameter",
-        "VUID-vkGetPipelineExecutablePropertiesKHR-pExecutableCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pExecutableCount), loc.dot(Field::pProperties), pExecutableCount, pProperties,
+                                    VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_PROPERTIES_KHR, true, false, false,
+                                    "VUID-VkPipelineExecutablePropertiesKHR-sType-sType",
+                                    "VUID-vkGetPipelineExecutablePropertiesKHR-pProperties-parameter",
+                                    "VUID-vkGetPipelineExecutablePropertiesKHR-pExecutableCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
         for (uint32_t pExecutableIndex = 0; pExecutableIndex < *pExecutableCount; ++pExecutableIndex) {
             [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties, pExecutableIndex);
@@ -19988,9 +19854,8 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_pipeline_executable_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_pipeline_executable_properties});
-    skip |= ValidateStructType(loc.dot(Field::pExecutableInfo), "VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR", pExecutableInfo,
-                               VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR, true,
-                               "VUID-vkGetPipelineExecutableStatisticsKHR-pExecutableInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pExecutableInfo), pExecutableInfo, VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR,
+                               true, "VUID-vkGetPipelineExecutableStatisticsKHR-pExecutableInfo-parameter",
                                "VUID-VkPipelineExecutableInfoKHR-sType-sType");
     if (pExecutableInfo != nullptr) {
         [[maybe_unused]] const Location pExecutableInfo_loc = loc.dot(Field::pExecutableInfo);
@@ -19999,11 +19864,11 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutableStatisticsKHR(VkDe
 
         skip |= ValidateRequiredHandle(pExecutableInfo_loc.dot(Field::pipeline), pExecutableInfo->pipeline);
     }
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pStatisticCount), loc.dot(Field::pStatistics), "VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR",
-        pStatisticCount, pStatistics, VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, true, false, false,
-        "VUID-VkPipelineExecutableStatisticKHR-sType-sType", "VUID-vkGetPipelineExecutableStatisticsKHR-pStatistics-parameter",
-        "VUID-vkGetPipelineExecutableStatisticsKHR-pStatisticCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pStatisticCount), loc.dot(Field::pStatistics), pStatisticCount, pStatistics,
+                                    VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_STATISTIC_KHR, true, false, false,
+                                    "VUID-VkPipelineExecutableStatisticKHR-sType-sType",
+                                    "VUID-vkGetPipelineExecutableStatisticsKHR-pStatistics-parameter",
+                                    "VUID-vkGetPipelineExecutableStatisticsKHR-pStatisticCount-parameter", kVUIDUndefined);
     if (pStatistics != nullptr) {
         for (uint32_t pStatisticIndex = 0; pStatisticIndex < *pStatisticCount; ++pStatisticIndex) {
             [[maybe_unused]] const Location pStatistics_loc = loc.dot(Field::pStatistics, pStatisticIndex);
@@ -20022,9 +19887,8 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutableInternalRepresenta
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_pipeline_executable_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_pipeline_executable_properties});
-    skip |= ValidateStructType(loc.dot(Field::pExecutableInfo), "VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR", pExecutableInfo,
-                               VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR, true,
-                               "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pExecutableInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pExecutableInfo), pExecutableInfo, VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INFO_KHR,
+                               true, "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pExecutableInfo-parameter",
                                "VUID-VkPipelineExecutableInfoKHR-sType-sType");
     if (pExecutableInfo != nullptr) {
         [[maybe_unused]] const Location pExecutableInfo_loc = loc.dot(Field::pExecutableInfo);
@@ -20034,9 +19898,8 @@ bool StatelessValidation::PreCallValidateGetPipelineExecutableInternalRepresenta
         skip |= ValidateRequiredHandle(pExecutableInfo_loc.dot(Field::pipeline), pExecutableInfo->pipeline);
     }
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pInternalRepresentationCount), loc.dot(Field::pInternalRepresentations),
-        "VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR", pInternalRepresentationCount, pInternalRepresentations,
-        VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, true, false, false,
+        loc.dot(Field::pInternalRepresentationCount), loc.dot(Field::pInternalRepresentations), pInternalRepresentationCount,
+        pInternalRepresentations, VK_STRUCTURE_TYPE_PIPELINE_EXECUTABLE_INTERNAL_REPRESENTATION_KHR, true, false, false,
         "VUID-VkPipelineExecutableInternalRepresentationKHR-sType-sType",
         "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pInternalRepresentations-parameter",
         "VUID-vkGetPipelineExecutableInternalRepresentationsKHR-pInternalRepresentationCount-parameter", kVUIDUndefined);
@@ -20060,9 +19923,8 @@ bool StatelessValidation::PreCallValidateMapMemory2KHR(VkDevice device, const Vk
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_map_memory2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_map_memory2});
-    skip |= ValidateStructType(loc.dot(Field::pMemoryMapInfo), "VK_STRUCTURE_TYPE_MEMORY_MAP_INFO_KHR", pMemoryMapInfo,
-                               VK_STRUCTURE_TYPE_MEMORY_MAP_INFO_KHR, true, "VUID-vkMapMemory2KHR-pMemoryMapInfo-parameter",
-                               "VUID-VkMemoryMapInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pMemoryMapInfo), pMemoryMapInfo, VK_STRUCTURE_TYPE_MEMORY_MAP_INFO_KHR, true,
+                               "VUID-vkMapMemory2KHR-pMemoryMapInfo-parameter", "VUID-VkMemoryMapInfoKHR-sType-sType");
     if (pMemoryMapInfo != nullptr) {
         [[maybe_unused]] const Location pMemoryMapInfo_loc = loc.dot(Field::pMemoryMapInfo);
         constexpr std::array allowed_structs_VkMemoryMapInfoKHR = {VK_STRUCTURE_TYPE_MEMORY_MAP_PLACED_INFO_EXT};
@@ -20087,9 +19949,8 @@ bool StatelessValidation::PreCallValidateUnmapMemory2KHR(VkDevice device, const 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_map_memory2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_map_memory2});
-    skip |= ValidateStructType(loc.dot(Field::pMemoryUnmapInfo), "VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR", pMemoryUnmapInfo,
-                               VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR, true, "VUID-vkUnmapMemory2KHR-pMemoryUnmapInfo-parameter",
-                               "VUID-VkMemoryUnmapInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pMemoryUnmapInfo), pMemoryUnmapInfo, VK_STRUCTURE_TYPE_MEMORY_UNMAP_INFO_KHR, true,
+                               "VUID-vkUnmapMemory2KHR-pMemoryUnmapInfo-parameter", "VUID-VkMemoryUnmapInfoKHR-sType-sType");
     if (pMemoryUnmapInfo != nullptr) {
         [[maybe_unused]] const Location pMemoryUnmapInfo_loc = loc.dot(Field::pMemoryUnmapInfo);
         skip |= ValidateStructPnext(pMemoryUnmapInfo_loc, pMemoryUnmapInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -20109,8 +19970,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoEncodeQualityLeve
     VkVideoEncodeQualityLevelPropertiesKHR* pQualityLevelProperties, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pQualityLevelInfo),
-                               "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR", pQualityLevelInfo,
+    skip |= ValidateStructType(loc.dot(Field::pQualityLevelInfo), pQualityLevelInfo,
                                VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VIDEO_ENCODE_QUALITY_LEVEL_INFO_KHR, true,
                                "VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelInfo-parameter",
                                "VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-sType-sType");
@@ -20120,8 +19980,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoEncodeQualityLeve
                                     "VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pNext-pNext", kVUIDUndefined,
                                     physicalDevice, true);
 
-        skip |= ValidateStructType(pQualityLevelInfo_loc.dot(Field::pVideoProfile), "VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR",
-                                   pQualityLevelInfo->pVideoProfile, VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
+        skip |= ValidateStructType(pQualityLevelInfo_loc.dot(Field::pVideoProfile), pQualityLevelInfo->pVideoProfile,
+                                   VK_STRUCTURE_TYPE_VIDEO_PROFILE_INFO_KHR, true,
                                    "VUID-VkPhysicalDeviceVideoEncodeQualityLevelInfoKHR-pVideoProfile-parameter",
                                    "VUID-VkVideoProfileInfoKHR-sType-sType");
 
@@ -20160,11 +20020,10 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceVideoEncodeQualityLeve
                               kOptionalFlags, "VUID-VkVideoProfileInfoKHR-chromaBitDepth-parameter");
         }
     }
-    skip |=
-        ValidateStructType(loc.dot(Field::pQualityLevelProperties), "VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR",
-                           pQualityLevelProperties, VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR, true,
-                           "VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelProperties-parameter",
-                           "VUID-VkVideoEncodeQualityLevelPropertiesKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pQualityLevelProperties), pQualityLevelProperties,
+                               VK_STRUCTURE_TYPE_VIDEO_ENCODE_QUALITY_LEVEL_PROPERTIES_KHR, true,
+                               "VUID-vkGetPhysicalDeviceVideoEncodeQualityLevelPropertiesKHR-pQualityLevelProperties-parameter",
+                               "VUID-VkVideoEncodeQualityLevelPropertiesKHR-sType-sType");
     if (pQualityLevelProperties != nullptr) {
         [[maybe_unused]] const Location pQualityLevelProperties_loc = loc.dot(Field::pQualityLevelProperties);
         constexpr std::array allowed_structs_VkVideoEncodeQualityLevelPropertiesKHR = {
@@ -20188,8 +20047,7 @@ bool StatelessValidation::PreCallValidateGetEncodedVideoSessionParametersKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_encode_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_encode_queue});
-    skip |= ValidateStructType(loc.dot(Field::pVideoSessionParametersInfo),
-                               "VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR", pVideoSessionParametersInfo,
+    skip |= ValidateStructType(loc.dot(Field::pVideoSessionParametersInfo), pVideoSessionParametersInfo,
                                VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_GET_INFO_KHR, true,
                                "VUID-vkGetEncodedVideoSessionParametersKHR-pVideoSessionParametersInfo-parameter",
                                "VUID-VkVideoEncodeSessionParametersGetInfoKHR-sType-sType");
@@ -20208,8 +20066,8 @@ bool StatelessValidation::PreCallValidateGetEncodedVideoSessionParametersKHR(
         skip |= ValidateRequiredHandle(pVideoSessionParametersInfo_loc.dot(Field::videoSessionParameters),
                                        pVideoSessionParametersInfo->videoSessionParameters);
     }
-    skip |= ValidateStructType(loc.dot(Field::pFeedbackInfo), "VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR",
-                               pFeedbackInfo, VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR, false,
+    skip |= ValidateStructType(loc.dot(Field::pFeedbackInfo), pFeedbackInfo,
+                               VK_STRUCTURE_TYPE_VIDEO_ENCODE_SESSION_PARAMETERS_FEEDBACK_INFO_KHR, false,
                                "VUID-vkGetEncodedVideoSessionParametersKHR-pFeedbackInfo-parameter",
                                "VUID-VkVideoEncodeSessionParametersFeedbackInfoKHR-sType-sType");
     if (pFeedbackInfo != nullptr) {
@@ -20236,9 +20094,8 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_video_encode_queue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_video_encode_queue});
-    skip |= ValidateStructType(loc.dot(Field::pEncodeInfo), "VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR", pEncodeInfo,
-                               VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, true, "VUID-vkCmdEncodeVideoKHR-pEncodeInfo-parameter",
-                               "VUID-VkVideoEncodeInfoKHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pEncodeInfo), pEncodeInfo, VK_STRUCTURE_TYPE_VIDEO_ENCODE_INFO_KHR, true,
+                               "VUID-vkCmdEncodeVideoKHR-pEncodeInfo-parameter", "VUID-VkVideoEncodeInfoKHR-sType-sType");
     if (pEncodeInfo != nullptr) {
         [[maybe_unused]] const Location pEncodeInfo_loc = loc.dot(Field::pEncodeInfo);
         constexpr std::array allowed_structs_VkVideoEncodeInfoKHR = {VK_STRUCTURE_TYPE_VIDEO_ENCODE_H264_PICTURE_INFO_KHR,
@@ -20255,10 +20112,9 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
 
         skip |= ValidateRequiredHandle(pEncodeInfo_loc.dot(Field::dstBuffer), pEncodeInfo->dstBuffer);
 
-        skip |=
-            ValidateStructType(pEncodeInfo_loc.dot(Field::srcPictureResource), "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
-                               &(pEncodeInfo->srcPictureResource), VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
-                               kVUIDUndefined, "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
+        skip |= ValidateStructType(pEncodeInfo_loc.dot(Field::srcPictureResource), &(pEncodeInfo->srcPictureResource),
+                                   VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false, kVUIDUndefined,
+                                   "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
 
         skip |=
             ValidateStructPnext(pEncodeInfo_loc, pEncodeInfo->srcPictureResource.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -20271,10 +20127,10 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
         skip |=
             ValidateRequiredHandle(pEncodeInfo_loc.dot(Field::imageViewBinding), pEncodeInfo->srcPictureResource.imageViewBinding);
 
-        skip |= ValidateStructType(
-            pEncodeInfo_loc.dot(Field::pSetupReferenceSlot), "VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR",
-            pEncodeInfo->pSetupReferenceSlot, VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false,
-            "VUID-VkVideoEncodeInfoKHR-pSetupReferenceSlot-parameter", "VUID-VkVideoReferenceSlotInfoKHR-sType-sType");
+        skip |= ValidateStructType(pEncodeInfo_loc.dot(Field::pSetupReferenceSlot), pEncodeInfo->pSetupReferenceSlot,
+                                   VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false,
+                                   "VUID-VkVideoEncodeInfoKHR-pSetupReferenceSlot-parameter",
+                                   "VUID-VkVideoReferenceSlotInfoKHR-sType-sType");
 
         if (pEncodeInfo->pSetupReferenceSlot != nullptr) {
             [[maybe_unused]] const Location pSetupReferenceSlot_loc = pEncodeInfo_loc.dot(Field::pSetupReferenceSlot);
@@ -20290,8 +20146,8 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
                                         "VUID-VkVideoReferenceSlotInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
             skip |= ValidateStructType(
-                pSetupReferenceSlot_loc.dot(Field::pPictureResource), "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
-                pEncodeInfo->pSetupReferenceSlot->pPictureResource, VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
+                pSetupReferenceSlot_loc.dot(Field::pPictureResource), pEncodeInfo->pSetupReferenceSlot->pPictureResource,
+                VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
                 "VUID-VkVideoReferenceSlotInfoKHR-pPictureResource-parameter", "VUID-VkVideoPictureResourceInfoKHR-sType-sType");
 
             if (pEncodeInfo->pSetupReferenceSlot->pPictureResource != nullptr) {
@@ -20310,8 +20166,8 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
         }
 
         skip |= ValidateStructTypeArray(pEncodeInfo_loc.dot(Field::referenceSlotCount), pEncodeInfo_loc.dot(Field::pReferenceSlots),
-                                        "VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR", pEncodeInfo->referenceSlotCount,
-                                        pEncodeInfo->pReferenceSlots, VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
+                                        pEncodeInfo->referenceSlotCount, pEncodeInfo->pReferenceSlots,
+                                        VK_STRUCTURE_TYPE_VIDEO_REFERENCE_SLOT_INFO_KHR, false, true,
                                         "VUID-VkVideoReferenceSlotInfoKHR-sType-sType",
                                         "VUID-VkVideoEncodeInfoKHR-pReferenceSlots-parameter", kVUIDUndefined);
 
@@ -20331,7 +20187,6 @@ bool StatelessValidation::PreCallValidateCmdEncodeVideoKHR(VkCommandBuffer comma
                                             "VUID-VkVideoReferenceSlotInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
                 skip |= ValidateStructType(pReferenceSlots_loc.dot(Field::pPictureResource),
-                                           "VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR",
                                            pEncodeInfo->pReferenceSlots[referenceSlotIndex].pPictureResource,
                                            VK_STRUCTURE_TYPE_VIDEO_PICTURE_RESOURCE_INFO_KHR, false,
                                            "VUID-VkVideoReferenceSlotInfoKHR-pPictureResource-parameter",
@@ -20442,11 +20297,11 @@ bool StatelessValidation::PreCallValidateGetQueueCheckpointData2NV(VkQueue queue
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_synchronization2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_synchronization2});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pCheckpointDataCount), loc.dot(Field::pCheckpointData), "VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV",
-        pCheckpointDataCount, pCheckpointData, VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV, true, false, false,
-        "VUID-VkCheckpointData2NV-sType-sType", "VUID-vkGetQueueCheckpointData2NV-pCheckpointData-parameter",
-        "VUID-vkGetQueueCheckpointData2NV-pCheckpointDataCount-parameter", kVUIDUndefined);
+    skip |= ValidateStructTypeArray(loc.dot(Field::pCheckpointDataCount), loc.dot(Field::pCheckpointData), pCheckpointDataCount,
+                                    pCheckpointData, VK_STRUCTURE_TYPE_CHECKPOINT_DATA_2_NV, true, false, false,
+                                    "VUID-VkCheckpointData2NV-sType-sType",
+                                    "VUID-vkGetQueueCheckpointData2NV-pCheckpointData-parameter",
+                                    "VUID-vkGetQueueCheckpointData2NV-pCheckpointDataCount-parameter", kVUIDUndefined);
     if (pCheckpointData != nullptr) {
         for (uint32_t pCheckpointDataIndex = 0; pCheckpointDataIndex < *pCheckpointDataCount; ++pCheckpointDataIndex) {
             [[maybe_unused]] const Location pCheckpointData_loc = loc.dot(Field::pCheckpointData, pCheckpointDataIndex);
@@ -20589,9 +20444,8 @@ bool StatelessValidation::PreCallValidateGetRenderingAreaGranularityKHR(VkDevice
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance5))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance5});
-    skip |= ValidateStructType(loc.dot(Field::pRenderingAreaInfo), "VK_STRUCTURE_TYPE_RENDERING_AREA_INFO_KHR", pRenderingAreaInfo,
-                               VK_STRUCTURE_TYPE_RENDERING_AREA_INFO_KHR, true,
-                               "VUID-vkGetRenderingAreaGranularityKHR-pRenderingAreaInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pRenderingAreaInfo), pRenderingAreaInfo, VK_STRUCTURE_TYPE_RENDERING_AREA_INFO_KHR,
+                               true, "VUID-vkGetRenderingAreaGranularityKHR-pRenderingAreaInfo-parameter",
                                "VUID-VkRenderingAreaInfoKHR-sType-sType");
     if (pRenderingAreaInfo != nullptr) {
         [[maybe_unused]] const Location pRenderingAreaInfo_loc = loc.dot(Field::pRenderingAreaInfo);
@@ -20611,8 +20465,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance5))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance5});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_DEVICE_IMAGE_SUBRESOURCE_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_IMAGE_SUBRESOURCE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_DEVICE_IMAGE_SUBRESOURCE_INFO_KHR, true,
                                "VUID-vkGetDeviceImageSubresourceLayoutKHR-pInfo-parameter",
                                "VUID-VkDeviceImageSubresourceInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -20621,8 +20474,7 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDe
                                     "VUID-VkDeviceImageSubresourceInfoKHR-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
         skip |=
-            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO", pInfo->pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
+            ValidateStructType(pInfo_loc.dot(Field::pCreateInfo), pInfo->pCreateInfo, VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, true,
                                "VUID-VkDeviceImageSubresourceInfoKHR-pCreateInfo-parameter", "VUID-VkImageCreateInfo-sType-sType");
 
         if (pInfo->pCreateInfo != nullptr) {
@@ -20683,10 +20535,9 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDe
                                        pInfo->pCreateInfo->initialLayout, "VUID-VkImageCreateInfo-initialLayout-parameter");
         }
 
-        skip |= ValidateStructType(pInfo_loc.dot(Field::pSubresource), "VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR",
-                                   pInfo->pSubresource, VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, true,
-                                   "VUID-VkDeviceImageSubresourceInfoKHR-pSubresource-parameter",
-                                   "VUID-VkImageSubresource2KHR-sType-sType");
+        skip |= ValidateStructType(
+            pInfo_loc.dot(Field::pSubresource), pInfo->pSubresource, VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, true,
+            "VUID-VkDeviceImageSubresourceInfoKHR-pSubresource-parameter", "VUID-VkImageSubresource2KHR-sType-sType");
 
         if (pInfo->pSubresource != nullptr) {
             [[maybe_unused]] const Location pSubresource_loc = pInfo_loc.dot(Field::pSubresource);
@@ -20699,9 +20550,9 @@ bool StatelessValidation::PreCallValidateGetDeviceImageSubresourceLayoutKHR(VkDe
                               "VUID-VkImageSubresource-aspectMask-parameter", "VUID-VkImageSubresource-aspectMask-requiredbitmask");
         }
     }
-    skip |= ValidateStructType(
-        loc.dot(Field::pLayout), "VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR", pLayout, VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR,
-        true, "VUID-vkGetDeviceImageSubresourceLayoutKHR-pLayout-parameter", "VUID-VkSubresourceLayout2KHR-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pLayout), pLayout, VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, true,
+                               "VUID-vkGetDeviceImageSubresourceLayoutKHR-pLayout-parameter",
+                               "VUID-VkSubresourceLayout2KHR-sType-sType");
     if (pLayout != nullptr) {
         [[maybe_unused]] const Location pLayout_loc = loc.dot(Field::pLayout);
         constexpr std::array allowed_structs_VkSubresourceLayout2KHR = {VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT,
@@ -20725,8 +20576,7 @@ bool StatelessValidation::PreCallValidateGetImageSubresourceLayout2KHR(VkDevice 
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance5) && loc.function == vvl::Func::vkGetImageSubresourceLayout2KHR)
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance5});
     skip |= ValidateRequiredHandle(loc.dot(Field::image), image);
-    skip |= ValidateStructType(loc.dot(Field::pSubresource), "VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR", pSubresource,
-                               VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pSubresource), pSubresource, VK_STRUCTURE_TYPE_IMAGE_SUBRESOURCE_2_KHR, true,
                                "VUID-vkGetImageSubresourceLayout2KHR-pSubresource-parameter",
                                "VUID-VkImageSubresource2KHR-sType-sType");
     if (pSubresource != nullptr) {
@@ -20738,9 +20588,9 @@ bool StatelessValidation::PreCallValidateGetImageSubresourceLayout2KHR(VkDevice 
                               AllVkImageAspectFlagBits, pSubresource->imageSubresource.aspectMask, kRequiredFlags,
                               "VUID-VkImageSubresource-aspectMask-parameter", "VUID-VkImageSubresource-aspectMask-requiredbitmask");
     }
-    skip |= ValidateStructType(
-        loc.dot(Field::pLayout), "VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR", pLayout, VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR,
-        true, "VUID-vkGetImageSubresourceLayout2KHR-pLayout-parameter", "VUID-VkSubresourceLayout2KHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pLayout), pLayout, VK_STRUCTURE_TYPE_SUBRESOURCE_LAYOUT_2_KHR, true,
+                           "VUID-vkGetImageSubresourceLayout2KHR-pLayout-parameter", "VUID-VkSubresourceLayout2KHR-sType-sType");
     if (pLayout != nullptr) {
         [[maybe_unused]] const Location pLayout_loc = loc.dot(Field::pLayout);
         constexpr std::array allowed_structs_VkSubresourceLayout2KHR = {VK_STRUCTURE_TYPE_IMAGE_COMPRESSION_PROPERTIES_EXT,
@@ -20759,12 +20609,12 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceCooperativeMatrixPrope
     const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR",
-        pPropertyCount, pProperties, VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR, true, false, false,
-        "VUID-VkCooperativeMatrixPropertiesKHR-sType-sType",
-        "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR-pProperties-parameter",
-        "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR-pPropertyCount-parameter", kVUIDUndefined);
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+                                VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_KHR, true, false, false,
+                                "VUID-VkCooperativeMatrixPropertiesKHR-sType-sType",
+                                "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR-pProperties-parameter",
+                                "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesKHR-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
         for (uint32_t pPropertyIndex = 0; pPropertyIndex < *pPropertyCount; ++pPropertyIndex) {
             [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties, pPropertyIndex);
@@ -20808,11 +20658,11 @@ bool StatelessValidation::PreCallValidateGetCalibratedTimestampsKHR(VkDevice dev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_calibrated_timestamps) && loc.function == vvl::Func::vkGetCalibratedTimestampsKHR)
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_calibrated_timestamps});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::timestampCount), loc.dot(Field::pTimestampInfos), "VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR",
-        timestampCount, pTimestampInfos, VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR, true, true,
-        "VUID-VkCalibratedTimestampInfoKHR-sType-sType", "VUID-vkGetCalibratedTimestampsKHR-pTimestampInfos-parameter",
-        "VUID-vkGetCalibratedTimestampsKHR-timestampCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::timestampCount), loc.dot(Field::pTimestampInfos), timestampCount,
+                                    pTimestampInfos, VK_STRUCTURE_TYPE_CALIBRATED_TIMESTAMP_INFO_KHR, true, true,
+                                    "VUID-VkCalibratedTimestampInfoKHR-sType-sType",
+                                    "VUID-vkGetCalibratedTimestampsKHR-pTimestampInfos-parameter",
+                                    "VUID-vkGetCalibratedTimestampsKHR-timestampCount-arraylength");
     if (pTimestampInfos != nullptr) {
         for (uint32_t timestampIndex = 0; timestampIndex < timestampCount; ++timestampIndex) {
             [[maybe_unused]] const Location pTimestampInfos_loc = loc.dot(Field::pTimestampInfos, timestampIndex);
@@ -20840,10 +20690,9 @@ bool StatelessValidation::PreCallValidateCmdBindDescriptorSets2KHR(VkCommandBuff
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
-    skip |= ValidateStructType(loc.dot(Field::pBindDescriptorSetsInfo), "VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO_KHR",
-                               pBindDescriptorSetsInfo, VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO_KHR, true,
-                               "VUID-vkCmdBindDescriptorSets2KHR-pBindDescriptorSetsInfo-parameter",
-                               "VUID-VkBindDescriptorSetsInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pBindDescriptorSetsInfo), pBindDescriptorSetsInfo, VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_SETS_INFO_KHR, true,
+        "VUID-vkCmdBindDescriptorSets2KHR-pBindDescriptorSetsInfo-parameter", "VUID-VkBindDescriptorSetsInfoKHR-sType-sType");
     if (pBindDescriptorSetsInfo != nullptr) {
         [[maybe_unused]] const Location pBindDescriptorSetsInfo_loc = loc.dot(Field::pBindDescriptorSetsInfo);
         constexpr std::array allowed_structs_VkBindDescriptorSetsInfoKHR = {VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
@@ -20874,8 +20723,7 @@ bool StatelessValidation::PreCallValidateCmdPushConstants2KHR(VkCommandBuffer co
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
     skip |=
-        ValidateStructType(loc.dot(Field::pPushConstantsInfo), "VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO_KHR", pPushConstantsInfo,
-                           VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO_KHR, true,
+        ValidateStructType(loc.dot(Field::pPushConstantsInfo), pPushConstantsInfo, VK_STRUCTURE_TYPE_PUSH_CONSTANTS_INFO_KHR, true,
                            "VUID-vkCmdPushConstants2KHR-pPushConstantsInfo-parameter", "VUID-VkPushConstantsInfoKHR-sType-sType");
     if (pPushConstantsInfo != nullptr) {
         [[maybe_unused]] const Location pPushConstantsInfo_loc = loc.dot(Field::pPushConstantsInfo);
@@ -20906,10 +20754,9 @@ bool StatelessValidation::PreCallValidateCmdPushDescriptorSet2KHR(VkCommandBuffe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
-    skip |= ValidateStructType(loc.dot(Field::pPushDescriptorSetInfo), "VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_INFO_KHR",
-                               pPushDescriptorSetInfo, VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_INFO_KHR, true,
-                               "VUID-vkCmdPushDescriptorSet2KHR-pPushDescriptorSetInfo-parameter",
-                               "VUID-VkPushDescriptorSetInfoKHR-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pPushDescriptorSetInfo), pPushDescriptorSetInfo, VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_INFO_KHR, true,
+        "VUID-vkCmdPushDescriptorSet2KHR-pPushDescriptorSetInfo-parameter", "VUID-VkPushDescriptorSetInfoKHR-sType-sType");
     if (pPushDescriptorSetInfo != nullptr) {
         [[maybe_unused]] const Location pPushDescriptorSetInfo_loc = loc.dot(Field::pPushDescriptorSetInfo);
         constexpr std::array allowed_structs_VkPushDescriptorSetInfoKHR = {VK_STRUCTURE_TYPE_PIPELINE_LAYOUT_CREATE_INFO};
@@ -20924,12 +20771,12 @@ bool StatelessValidation::PreCallValidateCmdPushDescriptorSet2KHR(VkCommandBuffe
                               "VUID-VkPushDescriptorSetInfoKHR-stageFlags-parameter",
                               "VUID-VkPushDescriptorSetInfoKHR-stageFlags-requiredbitmask");
 
-        skip |= ValidateStructTypeArray(
-            pPushDescriptorSetInfo_loc.dot(Field::descriptorWriteCount), pPushDescriptorSetInfo_loc.dot(Field::pDescriptorWrites),
-            "VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET", pPushDescriptorSetInfo->descriptorWriteCount,
-            pPushDescriptorSetInfo->pDescriptorWrites, VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, true, true,
-            "VUID-VkWriteDescriptorSet-sType-sType", "VUID-VkPushDescriptorSetInfoKHR-pDescriptorWrites-parameter",
-            "VUID-VkPushDescriptorSetInfoKHR-descriptorWriteCount-arraylength");
+        skip |= ValidateStructTypeArray(pPushDescriptorSetInfo_loc.dot(Field::descriptorWriteCount),
+                                        pPushDescriptorSetInfo_loc.dot(Field::pDescriptorWrites),
+                                        pPushDescriptorSetInfo->descriptorWriteCount, pPushDescriptorSetInfo->pDescriptorWrites,
+                                        VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET, true, true, "VUID-VkWriteDescriptorSet-sType-sType",
+                                        "VUID-VkPushDescriptorSetInfoKHR-pDescriptorWrites-parameter",
+                                        "VUID-VkPushDescriptorSetInfoKHR-descriptorWriteCount-arraylength");
 
         if (pPushDescriptorSetInfo->pDescriptorWrites != nullptr) {
             for (uint32_t descriptorWriteIndex = 0; descriptorWriteIndex < pPushDescriptorSetInfo->descriptorWriteCount;
@@ -20969,8 +20816,7 @@ bool StatelessValidation::PreCallValidateCmdPushDescriptorSetWithTemplate2KHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
-    skip |= ValidateStructType(loc.dot(Field::pPushDescriptorSetWithTemplateInfo),
-                               "VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR", pPushDescriptorSetWithTemplateInfo,
+    skip |= ValidateStructType(loc.dot(Field::pPushDescriptorSetWithTemplateInfo), pPushDescriptorSetWithTemplateInfo,
                                VK_STRUCTURE_TYPE_PUSH_DESCRIPTOR_SET_WITH_TEMPLATE_INFO_KHR, true,
                                "VUID-vkCmdPushDescriptorSetWithTemplate2KHR-pPushDescriptorSetWithTemplateInfo-parameter",
                                "VUID-VkPushDescriptorSetWithTemplateInfoKHR-sType-sType");
@@ -21002,8 +20848,7 @@ bool StatelessValidation::PreCallValidateCmdSetDescriptorBufferOffsets2EXT(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
-    skip |= ValidateStructType(loc.dot(Field::pSetDescriptorBufferOffsetsInfo),
-                               "VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT", pSetDescriptorBufferOffsetsInfo,
+    skip |= ValidateStructType(loc.dot(Field::pSetDescriptorBufferOffsetsInfo), pSetDescriptorBufferOffsetsInfo,
                                VK_STRUCTURE_TYPE_SET_DESCRIPTOR_BUFFER_OFFSETS_INFO_EXT, true,
                                "VUID-vkCmdSetDescriptorBufferOffsets2EXT-pSetDescriptorBufferOffsetsInfo-parameter",
                                "VUID-VkSetDescriptorBufferOffsetsInfoEXT-sType-sType");
@@ -21044,12 +20889,11 @@ bool StatelessValidation::PreCallValidateCmdBindDescriptorBufferEmbeddedSamplers
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_maintenance6))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_maintenance6});
-    skip |= ValidateStructType(
-        loc.dot(Field::pBindDescriptorBufferEmbeddedSamplersInfo),
-        "VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT", pBindDescriptorBufferEmbeddedSamplersInfo,
-        VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT, true,
-        "VUID-vkCmdBindDescriptorBufferEmbeddedSamplers2EXT-pBindDescriptorBufferEmbeddedSamplersInfo-parameter",
-        "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pBindDescriptorBufferEmbeddedSamplersInfo), pBindDescriptorBufferEmbeddedSamplersInfo,
+                           VK_STRUCTURE_TYPE_BIND_DESCRIPTOR_BUFFER_EMBEDDED_SAMPLERS_INFO_EXT, true,
+                           "VUID-vkCmdBindDescriptorBufferEmbeddedSamplers2EXT-pBindDescriptorBufferEmbeddedSamplersInfo-parameter",
+                           "VUID-VkBindDescriptorBufferEmbeddedSamplersInfoEXT-sType-sType");
     if (pBindDescriptorBufferEmbeddedSamplersInfo != nullptr) {
         [[maybe_unused]] const Location pBindDescriptorBufferEmbeddedSamplersInfo_loc =
             loc.dot(Field::pBindDescriptorBufferEmbeddedSamplersInfo);
@@ -21080,9 +20924,8 @@ bool StatelessValidation::PreCallValidateCreateDebugReportCallbackEXT(VkInstance
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_report))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_report});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT, true,
-                               "VUID-vkCreateDebugReportCallbackEXT-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DEBUG_REPORT_CALLBACK_CREATE_INFO_EXT,
+                               true, "VUID-vkCreateDebugReportCallbackEXT-pCreateInfo-parameter",
                                "VUID-VkDebugReportCallbackCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -21187,8 +21030,7 @@ bool StatelessValidation::PreCallValidateDebugMarkerSetObjectTagEXT(VkDevice dev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_debug_marker))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_marker});
-    skip |= ValidateStructType(loc.dot(Field::pTagInfo), "VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT", pTagInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pTagInfo), pTagInfo, VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_TAG_INFO_EXT, true,
                                "VUID-vkDebugMarkerSetObjectTagEXT-pTagInfo-parameter",
                                "VUID-VkDebugMarkerObjectTagInfoEXT-sType-sType");
     if (pTagInfo != nullptr) {
@@ -21213,8 +21055,7 @@ bool StatelessValidation::PreCallValidateDebugMarkerSetObjectNameEXT(VkDevice de
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_debug_marker))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_marker});
-    skip |= ValidateStructType(loc.dot(Field::pNameInfo), "VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT", pNameInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pNameInfo), pNameInfo, VK_STRUCTURE_TYPE_DEBUG_MARKER_OBJECT_NAME_INFO_EXT, true,
                                "VUID-vkDebugMarkerSetObjectNameEXT-pNameInfo-parameter",
                                "VUID-VkDebugMarkerObjectNameInfoEXT-sType-sType");
     if (pNameInfo != nullptr) {
@@ -21239,8 +21080,7 @@ bool StatelessValidation::PreCallValidateCmdDebugMarkerBeginEXT(VkCommandBuffer 
     if (!IsExtEnabled(device_extensions.vk_ext_debug_marker))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_marker});
     skip |=
-        ValidateStructType(loc.dot(Field::pMarkerInfo), "VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT", pMarkerInfo,
-                           VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pMarkerInfo), pMarkerInfo, VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, true,
                            "VUID-vkCmdDebugMarkerBeginEXT-pMarkerInfo-parameter", "VUID-VkDebugMarkerMarkerInfoEXT-sType-sType");
     if (pMarkerInfo != nullptr) {
         [[maybe_unused]] const Location pMarkerInfo_loc = loc.dot(Field::pMarkerInfo);
@@ -21270,8 +21110,7 @@ bool StatelessValidation::PreCallValidateCmdDebugMarkerInsertEXT(VkCommandBuffer
     if (!IsExtEnabled(device_extensions.vk_ext_debug_marker))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_marker});
     skip |=
-        ValidateStructType(loc.dot(Field::pMarkerInfo), "VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT", pMarkerInfo,
-                           VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pMarkerInfo), pMarkerInfo, VK_STRUCTURE_TYPE_DEBUG_MARKER_MARKER_INFO_EXT, true,
                            "VUID-vkCmdDebugMarkerInsertEXT-pMarkerInfo-parameter", "VUID-VkDebugMarkerMarkerInfoEXT-sType-sType");
     if (pMarkerInfo != nullptr) {
         [[maybe_unused]] const Location pMarkerInfo_loc = loc.dot(Field::pMarkerInfo);
@@ -21378,9 +21217,8 @@ bool StatelessValidation::PreCallValidateCreateCuModuleNVX(VkDevice device, cons
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nvx_binary_import))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NVX_binary_import});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX", pCreateInfo,
-                               VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX, true, "VUID-vkCreateCuModuleNVX-pCreateInfo-parameter",
-                               "VUID-VkCuModuleCreateInfoNVX-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_CU_MODULE_CREATE_INFO_NVX, true,
+                               "VUID-vkCreateCuModuleNVX-pCreateInfo-parameter", "VUID-VkCuModuleCreateInfoNVX-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -21425,8 +21263,7 @@ bool StatelessValidation::PreCallValidateCreateCuFunctionNVX(VkDevice device, co
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nvx_binary_import))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NVX_binary_import});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX", pCreateInfo,
-                               VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_CU_FUNCTION_CREATE_INFO_NVX, true,
                                "VUID-vkCreateCuFunctionNVX-pCreateInfo-parameter", "VUID-VkCuFunctionCreateInfoNVX-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -21545,9 +21382,8 @@ bool StatelessValidation::PreCallValidateCmdCuLaunchKernelNVX(VkCommandBuffer co
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nvx_binary_import))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NVX_binary_import});
-    skip |= ValidateStructType(loc.dot(Field::pLaunchInfo), "VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX", pLaunchInfo,
-                               VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX, true, "VUID-vkCmdCuLaunchKernelNVX-pLaunchInfo-parameter",
-                               "VUID-VkCuLaunchInfoNVX-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pLaunchInfo), pLaunchInfo, VK_STRUCTURE_TYPE_CU_LAUNCH_INFO_NVX, true,
+                               "VUID-vkCmdCuLaunchKernelNVX-pLaunchInfo-parameter", "VUID-VkCuLaunchInfoNVX-sType-sType");
     if (pLaunchInfo != nullptr) {
         [[maybe_unused]] const Location pLaunchInfo_loc = loc.dot(Field::pLaunchInfo);
         skip |= ValidateStructPnext(pLaunchInfo_loc, pLaunchInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -21570,9 +21406,8 @@ bool StatelessValidation::PreCallValidateGetImageViewHandleNVX(VkDevice device, 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nvx_image_view_handle))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NVX_image_view_handle});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX", pInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX, true, "VUID-vkGetImageViewHandleNVX-pInfo-parameter",
-                               "VUID-VkImageViewHandleInfoNVX-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_IMAGE_VIEW_HANDLE_INFO_NVX, true,
+                               "VUID-vkGetImageViewHandleNVX-pInfo-parameter", "VUID-VkImageViewHandleInfoNVX-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -21594,8 +21429,7 @@ bool StatelessValidation::PreCallValidateGetImageViewAddressNVX(VkDevice device,
     if (!IsExtEnabled(device_extensions.vk_nvx_image_view_handle))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NVX_image_view_handle});
     skip |= ValidateRequiredHandle(loc.dot(Field::imageView), imageView);
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX", pProperties,
-                               VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX, true,
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_IMAGE_VIEW_ADDRESS_PROPERTIES_NVX, true,
                                "VUID-vkGetImageViewAddressNVX-pProperties-parameter",
                                "VUID-VkImageViewAddressPropertiesNVX-sType-sType");
     if (pProperties != nullptr) {
@@ -21661,10 +21495,9 @@ bool StatelessValidation::PreCallValidateCreateStreamDescriptorSurfaceGGP(VkInst
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ggp_stream_descriptor_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_GGP_stream_descriptor_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP",
-                               pCreateInfo, VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP, true,
-                               "VUID-vkCreateStreamDescriptorSurfaceGGP-pCreateInfo-parameter",
-                               "VUID-VkStreamDescriptorSurfaceCreateInfoGGP-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_STREAM_DESCRIPTOR_SURFACE_CREATE_INFO_GGP, true,
+        "VUID-vkCreateStreamDescriptorSurfaceGGP-pCreateInfo-parameter", "VUID-VkStreamDescriptorSurfaceCreateInfoGGP-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |=
@@ -21762,9 +21595,8 @@ bool StatelessValidation::PreCallValidateCreateViSurfaceNN(VkInstance instance, 
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_nn_vi_surface)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NN_vi_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN", pCreateInfo,
-                               VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN, true, "VUID-vkCreateViSurfaceNN-pCreateInfo-parameter",
-                               "VUID-VkViSurfaceCreateInfoNN-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_VI_SURFACE_CREATE_INFO_NN, true,
+                               "VUID-vkCreateViSurfaceNN-pCreateInfo-parameter", "VUID-VkViSurfaceCreateInfoNN-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -21810,8 +21642,8 @@ bool StatelessValidation::PreCallValidateCmdBeginConditionalRenderingEXT(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_conditional_rendering))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_conditional_rendering});
-    skip |= ValidateStructType(loc.dot(Field::pConditionalRenderingBegin), "VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT",
-                               pConditionalRenderingBegin, VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pConditionalRenderingBegin), pConditionalRenderingBegin,
+                               VK_STRUCTURE_TYPE_CONDITIONAL_RENDERING_BEGIN_INFO_EXT, true,
                                "VUID-vkCmdBeginConditionalRenderingEXT-pConditionalRenderingBegin-parameter",
                                "VUID-VkConditionalRenderingBeginInfoEXT-sType-sType");
     if (pConditionalRenderingBegin != nullptr) {
@@ -21906,10 +21738,10 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfaceCapabilities2EX
     if (!IsExtEnabled(instance_extensions.vk_ext_display_surface_counter))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_display_surface_counter});
     skip |= ValidateRequiredHandle(loc.dot(Field::surface), surface);
-    skip |= ValidateStructType(loc.dot(Field::pSurfaceCapabilities), "VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT",
-                               pSurfaceCapabilities, VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT, true,
-                               "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-pSurfaceCapabilities-parameter",
-                               "VUID-VkSurfaceCapabilities2EXT-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pSurfaceCapabilities), pSurfaceCapabilities, VK_STRUCTURE_TYPE_SURFACE_CAPABILITIES_2_EXT,
+                           true, "VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-pSurfaceCapabilities-parameter",
+                           "VUID-VkSurfaceCapabilities2EXT-sType-sType");
     if (pSurfaceCapabilities != nullptr) {
         [[maybe_unused]] const Location pSurfaceCapabilities_loc = loc.dot(Field::pSurfaceCapabilities);
         skip |= ValidateStructPnext(pSurfaceCapabilities_loc, pSurfaceCapabilities->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -21927,8 +21759,7 @@ bool StatelessValidation::PreCallValidateDisplayPowerControlEXT(VkDevice device,
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_display_control});
     skip |= ValidateRequiredHandle(loc.dot(Field::display), display);
     skip |=
-        ValidateStructType(loc.dot(Field::pDisplayPowerInfo), "VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT", pDisplayPowerInfo,
-                           VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pDisplayPowerInfo), pDisplayPowerInfo, VK_STRUCTURE_TYPE_DISPLAY_POWER_INFO_EXT, true,
                            "VUID-vkDisplayPowerControlEXT-pDisplayPowerInfo-parameter", "VUID-VkDisplayPowerInfoEXT-sType-sType");
     if (pDisplayPowerInfo != nullptr) {
         [[maybe_unused]] const Location pDisplayPowerInfo_loc = loc.dot(Field::pDisplayPowerInfo);
@@ -21948,8 +21779,7 @@ bool StatelessValidation::PreCallValidateRegisterDeviceEventEXT(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_display_control))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_display_control});
-    skip |= ValidateStructType(loc.dot(Field::pDeviceEventInfo), "VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT", pDeviceEventInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pDeviceEventInfo), pDeviceEventInfo, VK_STRUCTURE_TYPE_DEVICE_EVENT_INFO_EXT, true,
                                "VUID-vkRegisterDeviceEventEXT-pDeviceEventInfo-parameter", "VUID-VkDeviceEventInfoEXT-sType-sType");
     if (pDeviceEventInfo != nullptr) {
         [[maybe_unused]] const Location pDeviceEventInfo_loc = loc.dot(Field::pDeviceEventInfo);
@@ -21998,8 +21828,7 @@ bool StatelessValidation::PreCallValidateRegisterDisplayEventEXT(VkDevice device
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_display_control});
     skip |= ValidateRequiredHandle(loc.dot(Field::display), display);
     skip |=
-        ValidateStructType(loc.dot(Field::pDisplayEventInfo), "VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT", pDisplayEventInfo,
-                           VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pDisplayEventInfo), pDisplayEventInfo, VK_STRUCTURE_TYPE_DISPLAY_EVENT_INFO_EXT, true,
                            "VUID-vkRegisterDisplayEventEXT-pDisplayEventInfo-parameter", "VUID-VkDisplayEventInfoEXT-sType-sType");
     if (pDisplayEventInfo != nullptr) {
         [[maybe_unused]] const Location pDisplayEventInfo_loc = loc.dot(Field::pDisplayEventInfo);
@@ -22154,9 +21983,9 @@ bool StatelessValidation::PreCallValidateSetHdrMetadataEXT(VkDevice device, uint
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_hdr_metadata});
     skip |= ValidateHandleArray(loc.dot(Field::swapchainCount), loc.dot(Field::pSwapchains), swapchainCount, pSwapchains, true,
                                 true, "VUID-vkSetHdrMetadataEXT-swapchainCount-arraylength");
-    skip |= ValidateStructTypeArray(loc.dot(Field::swapchainCount), loc.dot(Field::pMetadata), "VK_STRUCTURE_TYPE_HDR_METADATA_EXT",
-                                    swapchainCount, pMetadata, VK_STRUCTURE_TYPE_HDR_METADATA_EXT, true, true,
-                                    "VUID-VkHdrMetadataEXT-sType-sType", "VUID-vkSetHdrMetadataEXT-pMetadata-parameter",
+    skip |= ValidateStructTypeArray(loc.dot(Field::swapchainCount), loc.dot(Field::pMetadata), swapchainCount, pMetadata,
+                                    VK_STRUCTURE_TYPE_HDR_METADATA_EXT, true, true, "VUID-VkHdrMetadataEXT-sType-sType",
+                                    "VUID-vkSetHdrMetadataEXT-pMetadata-parameter",
                                     "VUID-vkSetHdrMetadataEXT-swapchainCount-arraylength");
     if (pMetadata != nullptr) {
         for (uint32_t swapchainIndex = 0; swapchainIndex < swapchainCount; ++swapchainIndex) {
@@ -22176,8 +22005,7 @@ bool StatelessValidation::PreCallValidateCreateIOSSurfaceMVK(VkInstance instance
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_mvk_ios_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_MVK_ios_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK", pCreateInfo,
-                               VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_IOS_SURFACE_CREATE_INFO_MVK, true,
                                "VUID-vkCreateIOSSurfaceMVK-pCreateInfo-parameter", "VUID-VkIOSSurfaceCreateInfoMVK-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -22226,8 +22054,7 @@ bool StatelessValidation::PreCallValidateCreateMacOSSurfaceMVK(VkInstance instan
     if (!IsExtEnabled(instance_extensions.vk_mvk_macos_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_MVK_macos_surface});
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK", pCreateInfo,
-                           VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_MACOS_SURFACE_CREATE_INFO_MVK, true,
                            "VUID-vkCreateMacOSSurfaceMVK-pCreateInfo-parameter", "VUID-VkMacOSSurfaceCreateInfoMVK-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -22273,8 +22100,7 @@ bool StatelessValidation::PreCallValidateSetDebugUtilsObjectNameEXT(VkDevice dev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(loc.dot(Field::pNameInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT", pNameInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pNameInfo), pNameInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, true,
                                "VUID-vkSetDebugUtilsObjectNameEXT-pNameInfo-parameter",
                                "VUID-VkDebugUtilsObjectNameInfoEXT-sType-sType");
     if (pNameInfo != nullptr) {
@@ -22296,8 +22122,7 @@ bool StatelessValidation::PreCallValidateSetDebugUtilsObjectTagEXT(VkDevice devi
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
     skip |=
-        ValidateStructType(loc.dot(Field::pTagInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT", pTagInfo,
-                           VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pTagInfo), pTagInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_TAG_INFO_EXT, true,
                            "VUID-vkSetDebugUtilsObjectTagEXT-pTagInfo-parameter", "VUID-VkDebugUtilsObjectTagInfoEXT-sType-sType");
     if (pTagInfo != nullptr) {
         [[maybe_unused]] const Location pTagInfo_loc = loc.dot(Field::pTagInfo);
@@ -22321,8 +22146,7 @@ bool StatelessValidation::PreCallValidateQueueBeginDebugUtilsLabelEXT(VkQueue qu
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pLabelInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), pLabelInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
                                "VUID-vkQueueBeginDebugUtilsLabelEXT-pLabelInfo-parameter", "VUID-VkDebugUtilsLabelEXT-sType-sType");
     if (pLabelInfo != nullptr) {
         [[maybe_unused]] const Location pLabelInfo_loc = loc.dot(Field::pLabelInfo);
@@ -22350,9 +22174,9 @@ bool StatelessValidation::PreCallValidateQueueInsertDebugUtilsLabelEXT(VkQueue q
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(
-        loc.dot(Field::pLabelInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pLabelInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT,
-        true, "VUID-vkQueueInsertDebugUtilsLabelEXT-pLabelInfo-parameter", "VUID-VkDebugUtilsLabelEXT-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pLabelInfo), pLabelInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
+                           "VUID-vkQueueInsertDebugUtilsLabelEXT-pLabelInfo-parameter", "VUID-VkDebugUtilsLabelEXT-sType-sType");
     if (pLabelInfo != nullptr) {
         [[maybe_unused]] const Location pLabelInfo_loc = loc.dot(Field::pLabelInfo);
         skip |= ValidateStructPnext(pLabelInfo_loc, pLabelInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -22371,8 +22195,7 @@ bool StatelessValidation::PreCallValidateCmdBeginDebugUtilsLabelEXT(VkCommandBuf
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pLabelInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), pLabelInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
                                "VUID-vkCmdBeginDebugUtilsLabelEXT-pLabelInfo-parameter", "VUID-VkDebugUtilsLabelEXT-sType-sType");
     if (pLabelInfo != nullptr) {
         [[maybe_unused]] const Location pLabelInfo_loc = loc.dot(Field::pLabelInfo);
@@ -22402,8 +22225,7 @@ bool StatelessValidation::PreCallValidateCmdInsertDebugUtilsLabelEXT(VkCommandBu
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pLabelInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pLabelInfo), pLabelInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, true,
                                "VUID-vkCmdInsertDebugUtilsLabelEXT-pLabelInfo-parameter", "VUID-VkDebugUtilsLabelEXT-sType-sType");
     if (pLabelInfo != nullptr) {
         [[maybe_unused]] const Location pLabelInfo_loc = loc.dot(Field::pLabelInfo);
@@ -22425,9 +22247,8 @@ bool StatelessValidation::PreCallValidateCreateDebugUtilsMessengerEXT(VkInstance
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_debug_utils))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_debug_utils});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT, true,
-                               "VUID-vkCreateDebugUtilsMessengerEXT-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CREATE_INFO_EXT,
+                               true, "VUID-vkCreateDebugUtilsMessengerEXT-pCreateInfo-parameter",
                                "VUID-VkDebugUtilsMessengerCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -22533,10 +22354,9 @@ bool StatelessValidation::PreCallValidateSubmitDebugUtilsMessageEXT(VkInstance i
                           AllVkDebugUtilsMessageTypeFlagBitsEXT, messageTypes, kRequiredFlags,
                           "VUID-vkSubmitDebugUtilsMessageEXT-messageTypes-parameter",
                           "VUID-vkSubmitDebugUtilsMessageEXT-messageTypes-requiredbitmask");
-    skip |= ValidateStructType(loc.dot(Field::pCallbackData), "VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT",
-                               pCallbackData, VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT, true,
-                               "VUID-vkSubmitDebugUtilsMessageEXT-pCallbackData-parameter",
-                               "VUID-VkDebugUtilsMessengerCallbackDataEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCallbackData), pCallbackData, VK_STRUCTURE_TYPE_DEBUG_UTILS_MESSENGER_CALLBACK_DATA_EXT, true,
+        "VUID-vkSubmitDebugUtilsMessageEXT-pCallbackData-parameter", "VUID-VkDebugUtilsMessengerCallbackDataEXT-sType-sType");
     if (pCallbackData != nullptr) {
         [[maybe_unused]] const Location pCallbackData_loc = loc.dot(Field::pCallbackData);
         constexpr std::array allowed_structs_VkDebugUtilsMessengerCallbackDataEXT = {
@@ -22551,11 +22371,11 @@ bool StatelessValidation::PreCallValidateSubmitDebugUtilsMessageEXT(VkInstance i
         skip |= ValidateReservedFlags(pCallbackData_loc.dot(Field::flags), pCallbackData->flags,
                                       "VUID-VkDebugUtilsMessengerCallbackDataEXT-flags-zerobitmask");
 
-        skip |= ValidateStructTypeArray(pCallbackData_loc.dot(Field::queueLabelCount), pCallbackData_loc.dot(Field::pQueueLabels),
-                                        "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pCallbackData->queueLabelCount,
-                                        pCallbackData->pQueueLabels, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, false, true,
-                                        "VUID-VkDebugUtilsLabelEXT-sType-sType",
-                                        "VUID-VkDebugUtilsMessengerCallbackDataEXT-pQueueLabels-parameter", kVUIDUndefined);
+        skip |=
+            ValidateStructTypeArray(pCallbackData_loc.dot(Field::queueLabelCount), pCallbackData_loc.dot(Field::pQueueLabels),
+                                    pCallbackData->queueLabelCount, pCallbackData->pQueueLabels,
+                                    VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, false, true, "VUID-VkDebugUtilsLabelEXT-sType-sType",
+                                    "VUID-VkDebugUtilsMessengerCallbackDataEXT-pQueueLabels-parameter", kVUIDUndefined);
 
         if (pCallbackData->pQueueLabels != nullptr) {
             for (uint32_t queueLabelIndex = 0; queueLabelIndex < pCallbackData->queueLabelCount; ++queueLabelIndex) {
@@ -22570,11 +22390,11 @@ bool StatelessValidation::PreCallValidateSubmitDebugUtilsMessageEXT(VkInstance i
             }
         }
 
-        skip |= ValidateStructTypeArray(pCallbackData_loc.dot(Field::cmdBufLabelCount), pCallbackData_loc.dot(Field::pCmdBufLabels),
-                                        "VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT", pCallbackData->cmdBufLabelCount,
-                                        pCallbackData->pCmdBufLabels, VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, false, true,
-                                        "VUID-VkDebugUtilsLabelEXT-sType-sType",
-                                        "VUID-VkDebugUtilsMessengerCallbackDataEXT-pCmdBufLabels-parameter", kVUIDUndefined);
+        skip |=
+            ValidateStructTypeArray(pCallbackData_loc.dot(Field::cmdBufLabelCount), pCallbackData_loc.dot(Field::pCmdBufLabels),
+                                    pCallbackData->cmdBufLabelCount, pCallbackData->pCmdBufLabels,
+                                    VK_STRUCTURE_TYPE_DEBUG_UTILS_LABEL_EXT, false, true, "VUID-VkDebugUtilsLabelEXT-sType-sType",
+                                    "VUID-VkDebugUtilsMessengerCallbackDataEXT-pCmdBufLabels-parameter", kVUIDUndefined);
 
         if (pCallbackData->pCmdBufLabels != nullptr) {
             for (uint32_t cmdBufLabelIndex = 0; cmdBufLabelIndex < pCallbackData->cmdBufLabelCount; ++cmdBufLabelIndex) {
@@ -22590,8 +22410,8 @@ bool StatelessValidation::PreCallValidateSubmitDebugUtilsMessageEXT(VkInstance i
         }
 
         skip |= ValidateStructTypeArray(pCallbackData_loc.dot(Field::objectCount), pCallbackData_loc.dot(Field::pObjects),
-                                        "VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT", pCallbackData->objectCount,
-                                        pCallbackData->pObjects, VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, false, true,
+                                        pCallbackData->objectCount, pCallbackData->pObjects,
+                                        VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT, false, true,
                                         "VUID-VkDebugUtilsObjectNameInfoEXT-sType-sType",
                                         "VUID-VkDebugUtilsMessengerCallbackDataEXT-pObjects-parameter", kVUIDUndefined);
 
@@ -22620,10 +22440,10 @@ bool StatelessValidation::PreCallValidateGetAndroidHardwareBufferPropertiesANDRO
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_ANDROID_external_memory_android_hardware_buffer});
     skip |= ValidateRequiredPointer(loc.dot(Field::buffer), buffer,
                                     "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-buffer-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID",
-                               pProperties, VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID, true,
-                               "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-pProperties-parameter",
-                               "VUID-VkAndroidHardwareBufferPropertiesANDROID-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_ANDROID_HARDWARE_BUFFER_PROPERTIES_ANDROID,
+                           true, "VUID-vkGetAndroidHardwareBufferPropertiesANDROID-pProperties-parameter",
+                           "VUID-VkAndroidHardwareBufferPropertiesANDROID-sType-sType");
     if (pProperties != nullptr) {
         [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties);
         constexpr std::array allowed_structs_VkAndroidHardwareBufferPropertiesANDROID = {
@@ -22647,9 +22467,8 @@ bool StatelessValidation::PreCallValidateGetMemoryAndroidHardwareBufferANDROID(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_android_external_memory_android_hardware_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_ANDROID_external_memory_android_hardware_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID", pInfo,
-                               VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID, true,
-                               "VUID-vkGetMemoryAndroidHardwareBufferANDROID-pInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_MEMORY_GET_ANDROID_HARDWARE_BUFFER_INFO_ANDROID,
+                               true, "VUID-vkGetMemoryAndroidHardwareBufferANDROID-pInfo-parameter",
                                "VUID-VkMemoryGetAndroidHardwareBufferInfoANDROID-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -22674,8 +22493,7 @@ bool StatelessValidation::PreCallValidateCreateExecutionGraphPipelinesAMDX(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_amdx_shader_enqueue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_AMDX_shader_enqueue});
-    skip |= ValidateStructTypeArray(loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos),
-                                    "VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX", createInfoCount, pCreateInfos,
+    skip |= ValidateStructTypeArray(loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
                                     VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX, true, true,
                                     "VUID-VkExecutionGraphPipelineCreateInfoAMDX-sType-sType",
                                     "VUID-vkCreateExecutionGraphPipelinesAMDX-pCreateInfos-parameter",
@@ -22694,7 +22512,6 @@ bool StatelessValidation::PreCallValidateCreateExecutionGraphPipelinesAMDX(
                                         "VUID-VkExecutionGraphPipelineCreateInfoAMDX-sType-unique", VK_NULL_HANDLE, true);
 
             skip |= ValidateStructTypeArray(pCreateInfos_loc.dot(Field::stageCount), pCreateInfos_loc.dot(Field::pStages),
-                                            "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
                                             pCreateInfos[createInfoIndex].stageCount, pCreateInfos[createInfoIndex].pStages,
                                             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, false, false,
                                             "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
@@ -22760,11 +22577,10 @@ bool StatelessValidation::PreCallValidateCreateExecutionGraphPipelinesAMDX(
                 }
             }
 
-            skip |=
-                ValidateStructType(pCreateInfos_loc.dot(Field::pLibraryInfo), "VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR",
-                                   pCreateInfos[createInfoIndex].pLibraryInfo, VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR,
-                                   false, "VUID-VkExecutionGraphPipelineCreateInfoAMDX-pLibraryInfo-parameter",
-                                   "VUID-VkPipelineLibraryCreateInfoKHR-sType-sType");
+            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::pLibraryInfo), pCreateInfos[createInfoIndex].pLibraryInfo,
+                                       VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, false,
+                                       "VUID-VkExecutionGraphPipelineCreateInfoAMDX-pLibraryInfo-parameter",
+                                       "VUID-VkPipelineLibraryCreateInfoKHR-sType-sType");
 
             if (pCreateInfos[createInfoIndex].pLibraryInfo != nullptr) {
                 [[maybe_unused]] const Location pLibraryInfo_loc = pCreateInfos_loc.dot(Field::pLibraryInfo);
@@ -22819,9 +22635,8 @@ bool StatelessValidation::PreCallValidateGetExecutionGraphPipelineScratchSizeAMD
     if (!IsExtEnabled(device_extensions.vk_amdx_shader_enqueue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_AMDX_shader_enqueue});
     skip |= ValidateRequiredHandle(loc.dot(Field::executionGraph), executionGraph);
-    skip |= ValidateStructType(loc.dot(Field::pSizeInfo), "VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX", pSizeInfo,
-                               VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX, true,
-                               "VUID-vkGetExecutionGraphPipelineScratchSizeAMDX-pSizeInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pSizeInfo), pSizeInfo, VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_SCRATCH_SIZE_AMDX,
+                               true, "VUID-vkGetExecutionGraphPipelineScratchSizeAMDX-pSizeInfo-parameter",
                                "VUID-VkExecutionGraphPipelineScratchSizeAMDX-sType-sType");
     return skip;
 }
@@ -22834,9 +22649,8 @@ bool StatelessValidation::PreCallValidateGetExecutionGraphPipelineNodeIndexAMDX(
     if (!IsExtEnabled(device_extensions.vk_amdx_shader_enqueue))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_AMDX_shader_enqueue});
     skip |= ValidateRequiredHandle(loc.dot(Field::executionGraph), executionGraph);
-    skip |= ValidateStructType(loc.dot(Field::pNodeInfo), "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX",
-                               pNodeInfo, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX, true,
-                               "VUID-vkGetExecutionGraphPipelineNodeIndexAMDX-pNodeInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pNodeInfo), pNodeInfo, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_NODE_CREATE_INFO_AMDX,
+                               true, "VUID-vkGetExecutionGraphPipelineNodeIndexAMDX-pNodeInfo-parameter",
                                "VUID-VkPipelineShaderStageNodeCreateInfoAMDX-sType-sType");
     if (pNodeInfo != nullptr) {
         [[maybe_unused]] const Location pNodeInfo_loc = loc.dot(Field::pNodeInfo);
@@ -22908,10 +22722,9 @@ bool StatelessValidation::PreCallValidateCmdSetSampleLocationsEXT(VkCommandBuffe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_sample_locations))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_sample_locations});
-    skip |= ValidateStructType(loc.dot(Field::pSampleLocationsInfo), "VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT",
-                               pSampleLocationsInfo, VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, true,
-                               "VUID-vkCmdSetSampleLocationsEXT-pSampleLocationsInfo-parameter",
-                               "VUID-VkSampleLocationsInfoEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pSampleLocationsInfo), pSampleLocationsInfo, VK_STRUCTURE_TYPE_SAMPLE_LOCATIONS_INFO_EXT, true,
+        "VUID-vkCmdSetSampleLocationsEXT-pSampleLocationsInfo-parameter", "VUID-VkSampleLocationsInfoEXT-sType-sType");
     if (pSampleLocationsInfo != nullptr) {
         [[maybe_unused]] const Location pSampleLocationsInfo_loc = loc.dot(Field::pSampleLocationsInfo);
         skip |= ValidateStructPnext(pSampleLocationsInfo_loc, pSampleLocationsInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -22944,8 +22757,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceMultisamplePropertiesE
     skip |= ValidateFlags(loc.dot(Field::samples), vvl::FlagBitmask::VkSampleCountFlagBits, AllVkSampleCountFlagBits, samples,
                           kRequiredSingleBit, "VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-samples-parameter",
                           "VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-samples-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pMultisampleProperties), "VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT",
-                               pMultisampleProperties, VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pMultisampleProperties), pMultisampleProperties,
+                               VK_STRUCTURE_TYPE_MULTISAMPLE_PROPERTIES_EXT, true,
                                "VUID-vkGetPhysicalDeviceMultisamplePropertiesEXT-pMultisampleProperties-parameter",
                                "VUID-VkMultisamplePropertiesEXT-sType-sType");
     if (pMultisampleProperties != nullptr) {
@@ -22965,9 +22778,8 @@ bool StatelessValidation::PreCallValidateGetImageDrmFormatModifierPropertiesEXT(
     if (!IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_image_drm_format_modifier});
     skip |= ValidateRequiredHandle(loc.dot(Field::image), image);
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT",
-                               pProperties, VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT, true,
-                               "VUID-vkGetImageDrmFormatModifierPropertiesEXT-pProperties-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_IMAGE_DRM_FORMAT_MODIFIER_PROPERTIES_EXT,
+                               true, "VUID-vkGetImageDrmFormatModifierPropertiesEXT-pProperties-parameter",
                                "VUID-VkImageDrmFormatModifierPropertiesEXT-sType-sType");
     if (pProperties != nullptr) {
         [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties);
@@ -22987,8 +22799,7 @@ bool StatelessValidation::PreCallValidateCreateValidationCacheEXT(VkDevice devic
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_validation_cache))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_validation_cache});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_VALIDATION_CACHE_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_VALIDATION_CACHE_CREATE_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_VALIDATION_CACHE_CREATE_INFO_EXT, true,
                                "VUID-vkCreateValidationCacheEXT-pCreateInfo-parameter",
                                "VUID-VkValidationCacheCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -23187,9 +22998,8 @@ bool StatelessValidation::PreCallValidateCreateAccelerationStructureNV(VkDevice 
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_ray_tracing});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV", pCreateInfo,
-                               VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV, true,
-                               "VUID-vkCreateAccelerationStructureNV-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_NV,
+                               true, "VUID-vkCreateAccelerationStructureNV-pCreateInfo-parameter",
                                "VUID-VkAccelerationStructureCreateInfoNV-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -23201,17 +23011,17 @@ bool StatelessValidation::PreCallValidateCreateAccelerationStructureNV(VkDevice 
                                     "VUID-VkAccelerationStructureCreateInfoNV-pNext-pNext",
                                     "VUID-VkAccelerationStructureCreateInfoNV-sType-unique", VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::info), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV",
-                                   &(pCreateInfo->info), VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV, false, kVUIDUndefined,
+        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::info), &(pCreateInfo->info),
+                                   VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV, false, kVUIDUndefined,
                                    "VUID-VkAccelerationStructureInfoNV-sType-sType");
 
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->info.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                     "VUID-VkAccelerationStructureInfoNV-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructTypeArray(
-            pCreateInfo_loc.dot(Field::geometryCount), pCreateInfo_loc.dot(Field::pGeometries), "VK_STRUCTURE_TYPE_GEOMETRY_NV",
-            pCreateInfo->info.geometryCount, pCreateInfo->info.pGeometries, VK_STRUCTURE_TYPE_GEOMETRY_NV, false, true,
-            "VUID-VkGeometryNV-sType-sType", "VUID-VkAccelerationStructureInfoNV-pGeometries-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(pCreateInfo_loc.dot(Field::geometryCount), pCreateInfo_loc.dot(Field::pGeometries),
+                                        pCreateInfo->info.geometryCount, pCreateInfo->info.pGeometries,
+                                        VK_STRUCTURE_TYPE_GEOMETRY_NV, false, true, "VUID-VkGeometryNV-sType-sType",
+                                        "VUID-VkAccelerationStructureInfoNV-pGeometries-parameter", kVUIDUndefined);
 
         if (pCreateInfo->info.pGeometries != nullptr) {
             for (uint32_t geometryIndex = 0; geometryIndex < pCreateInfo->info.geometryCount; ++geometryIndex) {
@@ -23224,10 +23034,9 @@ bool StatelessValidation::PreCallValidateCreateAccelerationStructureNV(VkDevice 
                                            pCreateInfo->info.pGeometries[geometryIndex].geometryType,
                                            "VUID-VkGeometryNV-geometryType-parameter");
 
-                skip |= ValidateStructType(pGeometries_loc.dot(Field::triangles), "VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV",
-                                           &(pCreateInfo->info.pGeometries[geometryIndex].geometry.triangles),
-                                           VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV, false, kVUIDUndefined,
-                                           "VUID-VkGeometryTrianglesNV-sType-sType");
+                skip |= ValidateStructType(
+                    pGeometries_loc.dot(Field::triangles), &(pCreateInfo->info.pGeometries[geometryIndex].geometry.triangles),
+                    VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV, false, kVUIDUndefined, "VUID-VkGeometryTrianglesNV-sType-sType");
 
                 skip |= ValidateStructPnext(pGeometries_loc, pCreateInfo->info.pGeometries[geometryIndex].geometry.triangles.pNext,
                                             0, nullptr, GeneratedVulkanHeaderVersion, "VUID-VkGeometryTrianglesNV-pNext-pNext",
@@ -23241,10 +23050,9 @@ bool StatelessValidation::PreCallValidateCreateAccelerationStructureNV(VkDevice 
                                            pCreateInfo->info.pGeometries[geometryIndex].geometry.triangles.indexType,
                                            "VUID-VkGeometryTrianglesNV-indexType-parameter");
 
-                skip |= ValidateStructType(pGeometries_loc.dot(Field::aabbs), "VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV",
-                                           &(pCreateInfo->info.pGeometries[geometryIndex].geometry.aabbs),
-                                           VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV, false, kVUIDUndefined,
-                                           "VUID-VkGeometryAABBNV-sType-sType");
+                skip |= ValidateStructType(
+                    pGeometries_loc.dot(Field::aabbs), &(pCreateInfo->info.pGeometries[geometryIndex].geometry.aabbs),
+                    VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV, false, kVUIDUndefined, "VUID-VkGeometryAABBNV-sType-sType");
 
                 skip |= ValidateStructPnext(pGeometries_loc, pCreateInfo->info.pGeometries[geometryIndex].geometry.aabbs.pNext, 0,
                                             nullptr, GeneratedVulkanHeaderVersion, "VUID-VkGeometryAABBNV-pNext-pNext",
@@ -23330,9 +23138,8 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureMemoryRequireme
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_ray_tracing});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV", pInfo,
-                               VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV, true,
-                               "VUID-vkGetAccelerationStructureMemoryRequirementsNV-pInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_MEMORY_REQUIREMENTS_INFO_NV,
+                               true, "VUID-vkGetAccelerationStructureMemoryRequirementsNV-pInfo-parameter",
                                "VUID-VkAccelerationStructureMemoryRequirementsInfoNV-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -23356,11 +23163,11 @@ bool StatelessValidation::PreCallValidateBindAccelerationStructureMemoryNV(
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_ray_tracing});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), "VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_NV",
-        bindInfoCount, pBindInfos, VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_NV, true, true,
-        "VUID-VkBindAccelerationStructureMemoryInfoNV-sType-sType", "VUID-vkBindAccelerationStructureMemoryNV-pBindInfos-parameter",
-        "VUID-vkBindAccelerationStructureMemoryNV-bindInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::bindInfoCount), loc.dot(Field::pBindInfos), bindInfoCount, pBindInfos,
+                                    VK_STRUCTURE_TYPE_BIND_ACCELERATION_STRUCTURE_MEMORY_INFO_NV, true, true,
+                                    "VUID-VkBindAccelerationStructureMemoryInfoNV-sType-sType",
+                                    "VUID-vkBindAccelerationStructureMemoryNV-pBindInfos-parameter",
+                                    "VUID-vkBindAccelerationStructureMemoryNV-bindInfoCount-arraylength");
     if (pBindInfos != nullptr) {
         for (uint32_t bindInfoIndex = 0; bindInfoIndex < bindInfoCount; ++bindInfoIndex) {
             [[maybe_unused]] const Location pBindInfos_loc = loc.dot(Field::pBindInfos, bindInfoIndex);
@@ -23388,8 +23195,7 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructureNV(
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_ray_tracing});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV", pInfo,
-                               VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_INFO_NV, true,
                                "VUID-vkCmdBuildAccelerationStructureNV-pInfo-parameter",
                                "VUID-VkAccelerationStructureInfoNV-sType-sType");
     if (pInfo != nullptr) {
@@ -23397,10 +23203,10 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructureNV(
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                     "VUID-VkAccelerationStructureInfoNV-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructTypeArray(pInfo_loc.dot(Field::geometryCount), pInfo_loc.dot(Field::pGeometries),
-                                        "VK_STRUCTURE_TYPE_GEOMETRY_NV", pInfo->geometryCount, pInfo->pGeometries,
-                                        VK_STRUCTURE_TYPE_GEOMETRY_NV, false, true, "VUID-VkGeometryNV-sType-sType",
-                                        "VUID-VkAccelerationStructureInfoNV-pGeometries-parameter", kVUIDUndefined);
+        skip |=
+            ValidateStructTypeArray(pInfo_loc.dot(Field::geometryCount), pInfo_loc.dot(Field::pGeometries), pInfo->geometryCount,
+                                    pInfo->pGeometries, VK_STRUCTURE_TYPE_GEOMETRY_NV, false, true, "VUID-VkGeometryNV-sType-sType",
+                                    "VUID-VkAccelerationStructureInfoNV-pGeometries-parameter", kVUIDUndefined);
 
         if (pInfo->pGeometries != nullptr) {
             for (uint32_t geometryIndex = 0; geometryIndex < pInfo->geometryCount; ++geometryIndex) {
@@ -23413,10 +23219,9 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructureNV(
                     ValidateRangedEnum(pGeometries_loc.dot(Field::geometryType), vvl::Enum::VkGeometryTypeKHR,
                                        pInfo->pGeometries[geometryIndex].geometryType, "VUID-VkGeometryNV-geometryType-parameter");
 
-                skip |= ValidateStructType(pGeometries_loc.dot(Field::triangles), "VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV",
-                                           &(pInfo->pGeometries[geometryIndex].geometry.triangles),
-                                           VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV, false, kVUIDUndefined,
-                                           "VUID-VkGeometryTrianglesNV-sType-sType");
+                skip |= ValidateStructType(
+                    pGeometries_loc.dot(Field::triangles), &(pInfo->pGeometries[geometryIndex].geometry.triangles),
+                    VK_STRUCTURE_TYPE_GEOMETRY_TRIANGLES_NV, false, kVUIDUndefined, "VUID-VkGeometryTrianglesNV-sType-sType");
 
                 skip |= ValidateStructPnext(pGeometries_loc, pInfo->pGeometries[geometryIndex].geometry.triangles.pNext, 0, nullptr,
                                             GeneratedVulkanHeaderVersion, "VUID-VkGeometryTrianglesNV-pNext-pNext", kVUIDUndefined,
@@ -23430,9 +23235,9 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructureNV(
                                            pInfo->pGeometries[geometryIndex].geometry.triangles.indexType,
                                            "VUID-VkGeometryTrianglesNV-indexType-parameter");
 
-                skip |= ValidateStructType(pGeometries_loc.dot(Field::aabbs), "VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV",
-                                           &(pInfo->pGeometries[geometryIndex].geometry.aabbs), VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV,
-                                           false, kVUIDUndefined, "VUID-VkGeometryAABBNV-sType-sType");
+                skip |= ValidateStructType(pGeometries_loc.dot(Field::aabbs), &(pInfo->pGeometries[geometryIndex].geometry.aabbs),
+                                           VK_STRUCTURE_TYPE_GEOMETRY_AABB_NV, false, kVUIDUndefined,
+                                           "VUID-VkGeometryAABBNV-sType-sType");
 
                 skip |= ValidateStructPnext(pGeometries_loc, pInfo->pGeometries[geometryIndex].geometry.aabbs.pNext, 0, nullptr,
                                             GeneratedVulkanHeaderVersion, "VUID-VkGeometryAABBNV-pNext-pNext", kVUIDUndefined,
@@ -23489,11 +23294,11 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesNV(VkDevice de
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_ray_tracing)) skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_ray_tracing});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV",
-        createInfoCount, pCreateInfos, VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV, true, true,
-        "VUID-VkRayTracingPipelineCreateInfoNV-sType-sType", "VUID-vkCreateRayTracingPipelinesNV-pCreateInfos-parameter",
-        "VUID-vkCreateRayTracingPipelinesNV-createInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
+                                    VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_NV, true, true,
+                                    "VUID-VkRayTracingPipelineCreateInfoNV-sType-sType",
+                                    "VUID-vkCreateRayTracingPipelinesNV-pCreateInfos-parameter",
+                                    "VUID-vkCreateRayTracingPipelinesNV-createInfoCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t createInfoIndex = 0; createInfoIndex < createInfoCount; ++createInfoIndex) {
             [[maybe_unused]] const Location pCreateInfos_loc = loc.dot(Field::pCreateInfos, createInfoIndex);
@@ -23507,12 +23312,12 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesNV(VkDevice de
                                         "VUID-VkRayTracingPipelineCreateInfoNV-pNext-pNext",
                                         "VUID-VkRayTracingPipelineCreateInfoNV-sType-unique", VK_NULL_HANDLE, true);
 
-            skip |= ValidateStructTypeArray(
-                pCreateInfos_loc.dot(Field::stageCount), pCreateInfos_loc.dot(Field::pStages),
-                "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO", pCreateInfos[createInfoIndex].stageCount,
-                pCreateInfos[createInfoIndex].pStages, VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true,
-                "VUID-VkPipelineShaderStageCreateInfo-sType-sType", "VUID-VkRayTracingPipelineCreateInfoNV-pStages-parameter",
-                "VUID-VkRayTracingPipelineCreateInfoNV-stageCount-arraylength");
+            skip |= ValidateStructTypeArray(pCreateInfos_loc.dot(Field::stageCount), pCreateInfos_loc.dot(Field::pStages),
+                                            pCreateInfos[createInfoIndex].stageCount, pCreateInfos[createInfoIndex].pStages,
+                                            VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, true, true,
+                                            "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
+                                            "VUID-VkRayTracingPipelineCreateInfoNV-pStages-parameter",
+                                            "VUID-VkRayTracingPipelineCreateInfoNV-stageCount-arraylength");
 
             if (pCreateInfos[createInfoIndex].pStages != nullptr) {
                 for (uint32_t stageIndex = 0; stageIndex < pCreateInfos[createInfoIndex].stageCount; ++stageIndex) {
@@ -23574,12 +23379,12 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesNV(VkDevice de
                 }
             }
 
-            skip |= ValidateStructTypeArray(
-                pCreateInfos_loc.dot(Field::groupCount), pCreateInfos_loc.dot(Field::pGroups),
-                "VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV", pCreateInfos[createInfoIndex].groupCount,
-                pCreateInfos[createInfoIndex].pGroups, VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV, true, true,
-                "VUID-VkRayTracingShaderGroupCreateInfoNV-sType-sType", "VUID-VkRayTracingPipelineCreateInfoNV-pGroups-parameter",
-                "VUID-VkRayTracingPipelineCreateInfoNV-groupCount-arraylength");
+            skip |= ValidateStructTypeArray(pCreateInfos_loc.dot(Field::groupCount), pCreateInfos_loc.dot(Field::pGroups),
+                                            pCreateInfos[createInfoIndex].groupCount, pCreateInfos[createInfoIndex].pGroups,
+                                            VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_NV, true, true,
+                                            "VUID-VkRayTracingShaderGroupCreateInfoNV-sType-sType",
+                                            "VUID-VkRayTracingPipelineCreateInfoNV-pGroups-parameter",
+                                            "VUID-VkRayTracingPipelineCreateInfoNV-groupCount-arraylength");
 
             if (pCreateInfos[createInfoIndex].pGroups != nullptr) {
                 for (uint32_t groupIndex = 0; groupIndex < pCreateInfos[createInfoIndex].groupCount; ++groupIndex) {
@@ -23715,8 +23520,8 @@ bool StatelessValidation::PreCallValidateGetMemoryHostPointerPropertiesEXT(
                           "VUID-vkGetMemoryHostPointerPropertiesEXT-handleType-parameter");
     skip |= ValidateRequiredPointer(loc.dot(Field::pHostPointer), pHostPointer,
                                     "VUID-vkGetMemoryHostPointerPropertiesEXT-pHostPointer-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pMemoryHostPointerProperties), "VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT",
-                               pMemoryHostPointerProperties, VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pMemoryHostPointerProperties), pMemoryHostPointerProperties,
+                               VK_STRUCTURE_TYPE_MEMORY_HOST_POINTER_PROPERTIES_EXT, true,
                                "VUID-vkGetMemoryHostPointerPropertiesEXT-pMemoryHostPointerProperties-parameter",
                                "VUID-VkMemoryHostPointerPropertiesEXT-sType-sType");
     if (pMemoryHostPointerProperties != nullptr) {
@@ -23860,11 +23665,11 @@ bool StatelessValidation::PreCallValidateGetQueueCheckpointDataNV(VkQueue queue,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_diagnostic_checkpoints))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_diagnostic_checkpoints});
-    skip |= ValidateStructTypeArray(loc.dot(Field::pCheckpointDataCount), loc.dot(Field::pCheckpointData),
-                                    "VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV", pCheckpointDataCount, pCheckpointData,
-                                    VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, true, false, false, "VUID-VkCheckpointDataNV-sType-sType",
-                                    "VUID-vkGetQueueCheckpointDataNV-pCheckpointData-parameter",
-                                    "VUID-vkGetQueueCheckpointDataNV-pCheckpointDataCount-parameter", kVUIDUndefined);
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::pCheckpointDataCount), loc.dot(Field::pCheckpointData), pCheckpointDataCount,
+                                pCheckpointData, VK_STRUCTURE_TYPE_CHECKPOINT_DATA_NV, true, false, false,
+                                "VUID-VkCheckpointDataNV-sType-sType", "VUID-vkGetQueueCheckpointDataNV-pCheckpointData-parameter",
+                                "VUID-vkGetQueueCheckpointDataNV-pCheckpointDataCount-parameter", kVUIDUndefined);
     if (pCheckpointData != nullptr) {
         for (uint32_t pCheckpointDataIndex = 0; pCheckpointDataIndex < *pCheckpointDataCount; ++pCheckpointDataIndex) {
             [[maybe_unused]] const Location pCheckpointData_loc = loc.dot(Field::pCheckpointData, pCheckpointDataIndex);
@@ -23883,10 +23688,9 @@ bool StatelessValidation::PreCallValidateInitializePerformanceApiINTEL(VkDevice 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_intel_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_INTEL_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pInitializeInfo), "VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL",
-                               pInitializeInfo, VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL, true,
-                               "VUID-vkInitializePerformanceApiINTEL-pInitializeInfo-parameter",
-                               "VUID-VkInitializePerformanceApiInfoINTEL-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pInitializeInfo), pInitializeInfo, VK_STRUCTURE_TYPE_INITIALIZE_PERFORMANCE_API_INFO_INTEL, true,
+        "VUID-vkInitializePerformanceApiINTEL-pInitializeInfo-parameter", "VUID-VkInitializePerformanceApiInfoINTEL-sType-sType");
     if (pInitializeInfo != nullptr) {
         [[maybe_unused]] const Location pInitializeInfo_loc = loc.dot(Field::pInitializeInfo);
         skip |= ValidateStructPnext(pInitializeInfo_loc, pInitializeInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -23911,8 +23715,7 @@ bool StatelessValidation::PreCallValidateCmdSetPerformanceMarkerINTEL(VkCommandB
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_intel_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_INTEL_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pMarkerInfo), "VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL", pMarkerInfo,
-                               VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL, true,
+    skip |= ValidateStructType(loc.dot(Field::pMarkerInfo), pMarkerInfo, VK_STRUCTURE_TYPE_PERFORMANCE_MARKER_INFO_INTEL, true,
                                "VUID-vkCmdSetPerformanceMarkerINTEL-pMarkerInfo-parameter",
                                "VUID-VkPerformanceMarkerInfoINTEL-sType-sType");
     if (pMarkerInfo != nullptr) {
@@ -23930,9 +23733,8 @@ bool StatelessValidation::PreCallValidateCmdSetPerformanceStreamMarkerINTEL(VkCo
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_intel_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_INTEL_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pMarkerInfo), "VK_STRUCTURE_TYPE_PERFORMANCE_STREAM_MARKER_INFO_INTEL", pMarkerInfo,
-                               VK_STRUCTURE_TYPE_PERFORMANCE_STREAM_MARKER_INFO_INTEL, true,
-                               "VUID-vkCmdSetPerformanceStreamMarkerINTEL-pMarkerInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMarkerInfo), pMarkerInfo, VK_STRUCTURE_TYPE_PERFORMANCE_STREAM_MARKER_INFO_INTEL,
+                               true, "VUID-vkCmdSetPerformanceStreamMarkerINTEL-pMarkerInfo-parameter",
                                "VUID-VkPerformanceStreamMarkerInfoINTEL-sType-sType");
     if (pMarkerInfo != nullptr) {
         [[maybe_unused]] const Location pMarkerInfo_loc = loc.dot(Field::pMarkerInfo);
@@ -23949,9 +23751,8 @@ bool StatelessValidation::PreCallValidateCmdSetPerformanceOverrideINTEL(VkComman
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_intel_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_INTEL_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pOverrideInfo), "VK_STRUCTURE_TYPE_PERFORMANCE_OVERRIDE_INFO_INTEL", pOverrideInfo,
-                               VK_STRUCTURE_TYPE_PERFORMANCE_OVERRIDE_INFO_INTEL, true,
-                               "VUID-vkCmdSetPerformanceOverrideINTEL-pOverrideInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pOverrideInfo), pOverrideInfo, VK_STRUCTURE_TYPE_PERFORMANCE_OVERRIDE_INFO_INTEL,
+                               true, "VUID-vkCmdSetPerformanceOverrideINTEL-pOverrideInfo-parameter",
                                "VUID-VkPerformanceOverrideInfoINTEL-sType-sType");
     if (pOverrideInfo != nullptr) {
         [[maybe_unused]] const Location pOverrideInfo_loc = loc.dot(Field::pOverrideInfo);
@@ -23973,8 +23774,8 @@ bool StatelessValidation::PreCallValidateAcquirePerformanceConfigurationINTEL(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_intel_performance_query))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_INTEL_performance_query});
-    skip |= ValidateStructType(loc.dot(Field::pAcquireInfo), "VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL",
-                               pAcquireInfo, VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL, true,
+    skip |= ValidateStructType(loc.dot(Field::pAcquireInfo), pAcquireInfo,
+                               VK_STRUCTURE_TYPE_PERFORMANCE_CONFIGURATION_ACQUIRE_INFO_INTEL, true,
                                "VUID-vkAcquirePerformanceConfigurationINTEL-pAcquireInfo-parameter",
                                "VUID-VkPerformanceConfigurationAcquireInfoINTEL-sType-sType");
     if (pAcquireInfo != nullptr) {
@@ -24050,9 +23851,8 @@ bool StatelessValidation::PreCallValidateCreateImagePipeSurfaceFUCHSIA(VkInstanc
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_fuchsia_imagepipe_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_imagepipe_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA", pCreateInfo,
-                               VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA, true,
-                               "VUID-vkCreateImagePipeSurfaceFUCHSIA-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_IMAGEPIPE_SURFACE_CREATE_INFO_FUCHSIA,
+                               true, "VUID-vkCreateImagePipeSurfaceFUCHSIA-pCreateInfo-parameter",
                                "VUID-VkImagePipeSurfaceCreateInfoFUCHSIA-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -24101,8 +23901,7 @@ bool StatelessValidation::PreCallValidateCreateMetalSurfaceEXT(VkInstance instan
     if (!IsExtEnabled(instance_extensions.vk_ext_metal_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_metal_surface});
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT", pCreateInfo,
-                           VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_METAL_SURFACE_CREATE_INFO_EXT, true,
                            "VUID-vkCreateMetalSurfaceEXT-pCreateInfo-parameter", "VUID-VkMetalSurfaceCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -24167,9 +23966,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceCooperativeMatrixPrope
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV",
-        pPropertyCount, pProperties, VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, true, false, false,
-        "VUID-VkCooperativeMatrixPropertiesNV-sType-sType",
+        loc.dot(Field::pPropertyCount), loc.dot(Field::pProperties), pPropertyCount, pProperties,
+        VK_STRUCTURE_TYPE_COOPERATIVE_MATRIX_PROPERTIES_NV, true, false, false, "VUID-VkCooperativeMatrixPropertiesNV-sType-sType",
         "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesNV-pProperties-parameter",
         "VUID-vkGetPhysicalDeviceCooperativeMatrixPropertiesNV-pPropertyCount-parameter", kVUIDUndefined);
     if (pProperties != nullptr) {
@@ -24189,8 +23987,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSupportedFramebufferMi
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::pCombinationCount), loc.dot(Field::pCombinations),
-        "VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV", pCombinationCount, pCombinations,
+        loc.dot(Field::pCombinationCount), loc.dot(Field::pCombinations), pCombinationCount, pCombinations,
         VK_STRUCTURE_TYPE_FRAMEBUFFER_MIXED_SAMPLES_COMBINATION_NV, true, false, false,
         "VUID-VkFramebufferMixedSamplesCombinationNV-sType-sType",
         "VUID-vkGetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV-pCombinations-parameter",
@@ -24212,9 +24009,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceSurfacePresentModes2EX
     VkPresentModeKHR* pPresentModes, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), "VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR", pSurfaceInfo,
-                               VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR, true,
-                               "VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-pSurfaceInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pSurfaceInfo), pSurfaceInfo, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_SURFACE_INFO_2_KHR,
+                               true, "VUID-vkGetPhysicalDeviceSurfacePresentModes2EXT-pSurfaceInfo-parameter",
                                "VUID-VkPhysicalDeviceSurfaceInfo2KHR-sType-sType");
     if (pSurfaceInfo != nullptr) {
         [[maybe_unused]] const Location pSurfaceInfo_loc = loc.dot(Field::pSurfaceInfo);
@@ -24266,8 +24062,7 @@ bool StatelessValidation::PreCallValidateCreateHeadlessSurfaceEXT(VkInstance ins
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_headless_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_headless_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_HEADLESS_SURFACE_CREATE_INFO_EXT, true,
                                "VUID-vkCreateHeadlessSurfaceEXT-pCreateInfo-parameter",
                                "VUID-VkHeadlessSurfaceCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -24462,10 +24257,9 @@ bool StatelessValidation::PreCallValidateCopyMemoryToImageEXT(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_host_image_copy))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_host_image_copy});
-    skip |= ValidateStructType(loc.dot(Field::pCopyMemoryToImageInfo), "VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT",
-                               pCopyMemoryToImageInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT, true,
-                               "VUID-vkCopyMemoryToImageEXT-pCopyMemoryToImageInfo-parameter",
-                               "VUID-VkCopyMemoryToImageInfoEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCopyMemoryToImageInfo), pCopyMemoryToImageInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_IMAGE_INFO_EXT, true,
+        "VUID-vkCopyMemoryToImageEXT-pCopyMemoryToImageInfo-parameter", "VUID-VkCopyMemoryToImageInfoEXT-sType-sType");
     if (pCopyMemoryToImageInfo != nullptr) {
         [[maybe_unused]] const Location pCopyMemoryToImageInfo_loc = loc.dot(Field::pCopyMemoryToImageInfo);
         skip |=
@@ -24484,9 +24278,9 @@ bool StatelessValidation::PreCallValidateCopyMemoryToImageEXT(VkDevice device,
 
         skip |= ValidateStructTypeArray(
             pCopyMemoryToImageInfo_loc.dot(Field::regionCount), pCopyMemoryToImageInfo_loc.dot(Field::pRegions),
-            "VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT", pCopyMemoryToImageInfo->regionCount, pCopyMemoryToImageInfo->pRegions,
-            VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT, true, true, "VUID-VkMemoryToImageCopyEXT-sType-sType",
-            "VUID-VkCopyMemoryToImageInfoEXT-pRegions-parameter", "VUID-VkCopyMemoryToImageInfoEXT-regionCount-arraylength");
+            pCopyMemoryToImageInfo->regionCount, pCopyMemoryToImageInfo->pRegions, VK_STRUCTURE_TYPE_MEMORY_TO_IMAGE_COPY_EXT, true,
+            true, "VUID-VkMemoryToImageCopyEXT-sType-sType", "VUID-VkCopyMemoryToImageInfoEXT-pRegions-parameter",
+            "VUID-VkCopyMemoryToImageInfoEXT-regionCount-arraylength");
 
         if (pCopyMemoryToImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyMemoryToImageInfo->regionCount; ++regionIndex) {
@@ -24521,10 +24315,9 @@ bool StatelessValidation::PreCallValidateCopyImageToMemoryEXT(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_host_image_copy))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_host_image_copy});
-    skip |= ValidateStructType(loc.dot(Field::pCopyImageToMemoryInfo), "VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT",
-                               pCopyImageToMemoryInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT, true,
-                               "VUID-vkCopyImageToMemoryEXT-pCopyImageToMemoryInfo-parameter",
-                               "VUID-VkCopyImageToMemoryInfoEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCopyImageToMemoryInfo), pCopyImageToMemoryInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_MEMORY_INFO_EXT, true,
+        "VUID-vkCopyImageToMemoryEXT-pCopyImageToMemoryInfo-parameter", "VUID-VkCopyImageToMemoryInfoEXT-sType-sType");
     if (pCopyImageToMemoryInfo != nullptr) {
         [[maybe_unused]] const Location pCopyImageToMemoryInfo_loc = loc.dot(Field::pCopyImageToMemoryInfo);
         skip |=
@@ -24543,9 +24336,9 @@ bool StatelessValidation::PreCallValidateCopyImageToMemoryEXT(VkDevice device,
 
         skip |= ValidateStructTypeArray(
             pCopyImageToMemoryInfo_loc.dot(Field::regionCount), pCopyImageToMemoryInfo_loc.dot(Field::pRegions),
-            "VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT", pCopyImageToMemoryInfo->regionCount, pCopyImageToMemoryInfo->pRegions,
-            VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT, true, true, "VUID-VkImageToMemoryCopyEXT-sType-sType",
-            "VUID-VkCopyImageToMemoryInfoEXT-pRegions-parameter", "VUID-VkCopyImageToMemoryInfoEXT-regionCount-arraylength");
+            pCopyImageToMemoryInfo->regionCount, pCopyImageToMemoryInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_TO_MEMORY_COPY_EXT, true,
+            true, "VUID-VkImageToMemoryCopyEXT-sType-sType", "VUID-VkCopyImageToMemoryInfoEXT-pRegions-parameter",
+            "VUID-VkCopyImageToMemoryInfoEXT-regionCount-arraylength");
 
         if (pCopyImageToMemoryInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyImageToMemoryInfo->regionCount; ++regionIndex) {
@@ -24580,10 +24373,9 @@ bool StatelessValidation::PreCallValidateCopyImageToImageEXT(VkDevice device,
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_host_image_copy))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_host_image_copy});
-    skip |= ValidateStructType(loc.dot(Field::pCopyImageToImageInfo), "VK_STRUCTURE_TYPE_COPY_IMAGE_TO_IMAGE_INFO_EXT",
-                               pCopyImageToImageInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_IMAGE_INFO_EXT, true,
-                               "VUID-vkCopyImageToImageEXT-pCopyImageToImageInfo-parameter",
-                               "VUID-VkCopyImageToImageInfoEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pCopyImageToImageInfo), pCopyImageToImageInfo, VK_STRUCTURE_TYPE_COPY_IMAGE_TO_IMAGE_INFO_EXT, true,
+        "VUID-vkCopyImageToImageEXT-pCopyImageToImageInfo-parameter", "VUID-VkCopyImageToImageInfoEXT-sType-sType");
     if (pCopyImageToImageInfo != nullptr) {
         [[maybe_unused]] const Location pCopyImageToImageInfo_loc = loc.dot(Field::pCopyImageToImageInfo);
         skip |=
@@ -24606,11 +24398,11 @@ bool StatelessValidation::PreCallValidateCopyImageToImageEXT(VkDevice device,
             ValidateRangedEnum(pCopyImageToImageInfo_loc.dot(Field::dstImageLayout), vvl::Enum::VkImageLayout,
                                pCopyImageToImageInfo->dstImageLayout, "VUID-VkCopyImageToImageInfoEXT-dstImageLayout-parameter");
 
-        skip |= ValidateStructTypeArray(
-            pCopyImageToImageInfo_loc.dot(Field::regionCount), pCopyImageToImageInfo_loc.dot(Field::pRegions),
-            "VK_STRUCTURE_TYPE_IMAGE_COPY_2", pCopyImageToImageInfo->regionCount, pCopyImageToImageInfo->pRegions,
-            VK_STRUCTURE_TYPE_IMAGE_COPY_2, true, true, "VUID-VkImageCopy2-sType-sType",
-            "VUID-VkCopyImageToImageInfoEXT-pRegions-parameter", "VUID-VkCopyImageToImageInfoEXT-regionCount-arraylength");
+        skip |= ValidateStructTypeArray(pCopyImageToImageInfo_loc.dot(Field::regionCount),
+                                        pCopyImageToImageInfo_loc.dot(Field::pRegions), pCopyImageToImageInfo->regionCount,
+                                        pCopyImageToImageInfo->pRegions, VK_STRUCTURE_TYPE_IMAGE_COPY_2, true, true,
+                                        "VUID-VkImageCopy2-sType-sType", "VUID-VkCopyImageToImageInfoEXT-pRegions-parameter",
+                                        "VUID-VkCopyImageToImageInfoEXT-regionCount-arraylength");
 
         if (pCopyImageToImageInfo->pRegions != nullptr) {
             for (uint32_t regionIndex = 0; regionIndex < pCopyImageToImageInfo->regionCount; ++regionIndex) {
@@ -24650,10 +24442,9 @@ bool StatelessValidation::PreCallValidateTransitionImageLayoutEXT(VkDevice devic
     if (!IsExtEnabled(device_extensions.vk_ext_host_image_copy))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_host_image_copy});
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::transitionCount), loc.dot(Field::pTransitions), "VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT",
-        transitionCount, pTransitions, VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT, true, true,
-        "VUID-VkHostImageLayoutTransitionInfoEXT-sType-sType", "VUID-vkTransitionImageLayoutEXT-pTransitions-parameter",
-        "VUID-vkTransitionImageLayoutEXT-transitionCount-arraylength");
+        loc.dot(Field::transitionCount), loc.dot(Field::pTransitions), transitionCount, pTransitions,
+        VK_STRUCTURE_TYPE_HOST_IMAGE_LAYOUT_TRANSITION_INFO_EXT, true, true, "VUID-VkHostImageLayoutTransitionInfoEXT-sType-sType",
+        "VUID-vkTransitionImageLayoutEXT-pTransitions-parameter", "VUID-vkTransitionImageLayoutEXT-transitionCount-arraylength");
     if (pTransitions != nullptr) {
         for (uint32_t transitionIndex = 0; transitionIndex < transitionCount; ++transitionIndex) {
             [[maybe_unused]] const Location pTransitions_loc = loc.dot(Field::pTransitions, transitionIndex);
@@ -24701,9 +24492,8 @@ bool StatelessValidation::PreCallValidateReleaseSwapchainImagesEXT(VkDevice devi
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_swapchain_maintenance1))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_swapchain_maintenance1});
-    skip |= ValidateStructType(loc.dot(Field::pReleaseInfo), "VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_EXT", pReleaseInfo,
-                               VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_EXT, true,
-                               "VUID-vkReleaseSwapchainImagesEXT-pReleaseInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pReleaseInfo), pReleaseInfo, VK_STRUCTURE_TYPE_RELEASE_SWAPCHAIN_IMAGES_INFO_EXT,
+                               true, "VUID-vkReleaseSwapchainImagesEXT-pReleaseInfo-parameter",
                                "VUID-VkReleaseSwapchainImagesInfoEXT-sType-sType");
     if (pReleaseInfo != nullptr) {
         [[maybe_unused]] const Location pReleaseInfo_loc = loc.dot(Field::pReleaseInfo);
@@ -24727,8 +24517,7 @@ bool StatelessValidation::PreCallValidateGetGeneratedCommandsMemoryRequirementsN
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV", pInfo,
-                               VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_GENERATED_COMMANDS_MEMORY_REQUIREMENTS_INFO_NV, true,
                                "VUID-vkGetGeneratedCommandsMemoryRequirementsNV-pInfo-parameter",
                                "VUID-VkGeneratedCommandsMemoryRequirementsInfoNV-sType-sType");
     if (pInfo != nullptr) {
@@ -24743,9 +24532,8 @@ bool StatelessValidation::PreCallValidateGetGeneratedCommandsMemoryRequirementsN
 
         skip |= ValidateRequiredHandle(pInfo_loc.dot(Field::indirectCommandsLayout), pInfo->indirectCommandsLayout);
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetGeneratedCommandsMemoryRequirementsNV-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetGeneratedCommandsMemoryRequirementsNV-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -24766,10 +24554,9 @@ bool StatelessValidation::PreCallValidateCmdPreprocessGeneratedCommandsNV(VkComm
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands});
-    skip |= ValidateStructType(loc.dot(Field::pGeneratedCommandsInfo), "VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV",
-                               pGeneratedCommandsInfo, VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV, true,
-                               "VUID-vkCmdPreprocessGeneratedCommandsNV-pGeneratedCommandsInfo-parameter",
-                               "VUID-VkGeneratedCommandsInfoNV-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pGeneratedCommandsInfo), pGeneratedCommandsInfo, VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV, true,
+        "VUID-vkCmdPreprocessGeneratedCommandsNV-pGeneratedCommandsInfo-parameter", "VUID-VkGeneratedCommandsInfoNV-sType-sType");
     if (pGeneratedCommandsInfo != nullptr) {
         [[maybe_unused]] const Location pGeneratedCommandsInfo_loc = loc.dot(Field::pGeneratedCommandsInfo);
         skip |=
@@ -24810,10 +24597,9 @@ bool StatelessValidation::PreCallValidateCmdExecuteGeneratedCommandsNV(VkCommand
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands});
     skip |= ValidateBool32(loc.dot(Field::isPreprocessed), isPreprocessed);
-    skip |= ValidateStructType(loc.dot(Field::pGeneratedCommandsInfo), "VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV",
-                               pGeneratedCommandsInfo, VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV, true,
-                               "VUID-vkCmdExecuteGeneratedCommandsNV-pGeneratedCommandsInfo-parameter",
-                               "VUID-VkGeneratedCommandsInfoNV-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pGeneratedCommandsInfo), pGeneratedCommandsInfo, VK_STRUCTURE_TYPE_GENERATED_COMMANDS_INFO_NV, true,
+        "VUID-vkCmdExecuteGeneratedCommandsNV-pGeneratedCommandsInfo-parameter", "VUID-VkGeneratedCommandsInfoNV-sType-sType");
     if (pGeneratedCommandsInfo != nullptr) {
         [[maybe_unused]] const Location pGeneratedCommandsInfo_loc = loc.dot(Field::pGeneratedCommandsInfo);
         skip |=
@@ -24868,9 +24654,8 @@ bool StatelessValidation::PreCallValidateCreateIndirectCommandsLayoutNV(VkDevice
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV",
-                               pCreateInfo, VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV, true,
-                               "VUID-vkCreateIndirectCommandsLayoutNV-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_CREATE_INFO_NV,
+                               true, "VUID-vkCreateIndirectCommandsLayoutNV-pCreateInfo-parameter",
                                "VUID-VkIndirectCommandsLayoutCreateInfoNV-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -24885,12 +24670,11 @@ bool StatelessValidation::PreCallValidateCreateIndirectCommandsLayoutNV(VkDevice
                                    pCreateInfo->pipelineBindPoint,
                                    "VUID-VkIndirectCommandsLayoutCreateInfoNV-pipelineBindPoint-parameter");
 
-        skip |= ValidateStructTypeArray(pCreateInfo_loc.dot(Field::tokenCount), pCreateInfo_loc.dot(Field::pTokens),
-                                        "VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_TOKEN_NV", pCreateInfo->tokenCount,
-                                        pCreateInfo->pTokens, VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_TOKEN_NV, true, true,
-                                        "VUID-VkIndirectCommandsLayoutTokenNV-sType-sType",
-                                        "VUID-VkIndirectCommandsLayoutCreateInfoNV-pTokens-parameter",
-                                        "VUID-VkIndirectCommandsLayoutCreateInfoNV-tokenCount-arraylength");
+        skip |= ValidateStructTypeArray(
+            pCreateInfo_loc.dot(Field::tokenCount), pCreateInfo_loc.dot(Field::pTokens), pCreateInfo->tokenCount,
+            pCreateInfo->pTokens, VK_STRUCTURE_TYPE_INDIRECT_COMMANDS_LAYOUT_TOKEN_NV, true, true,
+            "VUID-VkIndirectCommandsLayoutTokenNV-sType-sType", "VUID-VkIndirectCommandsLayoutCreateInfoNV-pTokens-parameter",
+            "VUID-VkIndirectCommandsLayoutCreateInfoNV-tokenCount-arraylength");
 
         if (pCreateInfo->pTokens != nullptr) {
             for (uint32_t tokenIndex = 0; tokenIndex < pCreateInfo->tokenCount; ++tokenIndex) {
@@ -25005,9 +24789,8 @@ bool StatelessValidation::PreCallValidateCmdSetDepthBias2EXT(VkCommandBuffer com
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_depth_bias_control))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_depth_bias_control});
-    skip |= ValidateStructType(loc.dot(Field::pDepthBiasInfo), "VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT", pDepthBiasInfo,
-                               VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT, true, "VUID-vkCmdSetDepthBias2EXT-pDepthBiasInfo-parameter",
-                               "VUID-VkDepthBiasInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pDepthBiasInfo), pDepthBiasInfo, VK_STRUCTURE_TYPE_DEPTH_BIAS_INFO_EXT, true,
+                               "VUID-vkCmdSetDepthBias2EXT-pDepthBiasInfo-parameter", "VUID-VkDepthBiasInfoEXT-sType-sType");
     if (pDepthBiasInfo != nullptr) {
         [[maybe_unused]] const Location pDepthBiasInfo_loc = loc.dot(Field::pDepthBiasInfo);
         constexpr std::array allowed_structs_VkDepthBiasInfoEXT = {VK_STRUCTURE_TYPE_DEPTH_BIAS_REPRESENTATION_INFO_EXT};
@@ -25092,8 +24875,7 @@ bool StatelessValidation::PreCallValidateCreateCudaModuleNV(VkDevice device, con
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_cuda_kernel_launch))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_cuda_kernel_launch});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_CUDA_MODULE_CREATE_INFO_NV", pCreateInfo,
-                               VK_STRUCTURE_TYPE_CUDA_MODULE_CREATE_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_CUDA_MODULE_CREATE_INFO_NV, true,
                                "VUID-vkCreateCudaModuleNV-pCreateInfo-parameter", "VUID-VkCudaModuleCreateInfoNV-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -25153,8 +24935,7 @@ bool StatelessValidation::PreCallValidateCreateCudaFunctionNV(VkDevice device, c
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_cuda_kernel_launch))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_cuda_kernel_launch});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_CUDA_FUNCTION_CREATE_INFO_NV", pCreateInfo,
-                               VK_STRUCTURE_TYPE_CUDA_FUNCTION_CREATE_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_CUDA_FUNCTION_CREATE_INFO_NV, true,
                                "VUID-vkCreateCudaFunctionNV-pCreateInfo-parameter", "VUID-VkCudaFunctionCreateInfoNV-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -25273,9 +25054,8 @@ bool StatelessValidation::PreCallValidateCmdCudaLaunchKernelNV(VkCommandBuffer c
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_cuda_kernel_launch))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_cuda_kernel_launch});
-    skip |= ValidateStructType(loc.dot(Field::pLaunchInfo), "VK_STRUCTURE_TYPE_CUDA_LAUNCH_INFO_NV", pLaunchInfo,
-                               VK_STRUCTURE_TYPE_CUDA_LAUNCH_INFO_NV, true, "VUID-vkCmdCudaLaunchKernelNV-pLaunchInfo-parameter",
-                               "VUID-VkCudaLaunchInfoNV-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pLaunchInfo), pLaunchInfo, VK_STRUCTURE_TYPE_CUDA_LAUNCH_INFO_NV, true,
+                               "VUID-vkCmdCudaLaunchKernelNV-pLaunchInfo-parameter", "VUID-VkCudaLaunchInfoNV-sType-sType");
     if (pLaunchInfo != nullptr) {
         [[maybe_unused]] const Location pLaunchInfo_loc = loc.dot(Field::pLaunchInfo);
         skip |= ValidateStructPnext(pLaunchInfo_loc, pLaunchInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -25293,10 +25073,9 @@ bool StatelessValidation::PreCallValidateExportMetalObjectsEXT(VkDevice device, 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_metal_objects))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_metal_objects});
-    skip |= ValidateStructType(loc.dot(Field::pMetalObjectsInfo), "VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT",
-                               pMetalObjectsInfo, VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT, true,
-                               "VUID-vkExportMetalObjectsEXT-pMetalObjectsInfo-parameter",
-                               "VUID-VkExportMetalObjectsInfoEXT-sType-sType");
+    skip |= ValidateStructType(
+        loc.dot(Field::pMetalObjectsInfo), pMetalObjectsInfo, VK_STRUCTURE_TYPE_EXPORT_METAL_OBJECTS_INFO_EXT, true,
+        "VUID-vkExportMetalObjectsEXT-pMetalObjectsInfo-parameter", "VUID-VkExportMetalObjectsInfoEXT-sType-sType");
     if (!skip) skip |= manual_PreCallValidateExportMetalObjectsEXT(device, pMetalObjectsInfo, error_obj);
     return skip;
 }
@@ -25334,9 +25113,8 @@ bool StatelessValidation::PreCallValidateGetDescriptorEXT(VkDevice device, const
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pDescriptorInfo), "VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT", pDescriptorInfo,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT, true, "VUID-vkGetDescriptorEXT-pDescriptorInfo-parameter",
-                               "VUID-VkDescriptorGetInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pDescriptorInfo), pDescriptorInfo, VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT, true,
+                               "VUID-vkGetDescriptorEXT-pDescriptorInfo-parameter", "VUID-VkDescriptorGetInfoEXT-sType-sType");
     if (pDescriptorInfo != nullptr) {
         [[maybe_unused]] const Location pDescriptorInfo_loc = loc.dot(Field::pDescriptorInfo);
         skip |= ValidateStructPnext(pDescriptorInfo_loc, pDescriptorInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -25359,10 +25137,9 @@ bool StatelessValidation::PreCallValidateCmdBindDescriptorBuffersEXT(VkCommandBu
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
     skip |= ValidateStructTypeArray(
-        loc.dot(Field::bufferCount), loc.dot(Field::pBindingInfos), "VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT",
-        bufferCount, pBindingInfos, VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT, true, true,
-        "VUID-VkDescriptorBufferBindingInfoEXT-sType-sType", "VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-parameter",
-        "VUID-vkCmdBindDescriptorBuffersEXT-bufferCount-arraylength");
+        loc.dot(Field::bufferCount), loc.dot(Field::pBindingInfos), bufferCount, pBindingInfos,
+        VK_STRUCTURE_TYPE_DESCRIPTOR_BUFFER_BINDING_INFO_EXT, true, true, "VUID-VkDescriptorBufferBindingInfoEXT-sType-sType",
+        "VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-parameter", "VUID-vkCmdBindDescriptorBuffersEXT-bufferCount-arraylength");
     if (pBindingInfos != nullptr) {
         for (uint32_t bufferIndex = 0; bufferIndex < bufferCount; ++bufferIndex) {
             [[maybe_unused]] const Location pBindingInfos_loc = loc.dot(Field::pBindingInfos, bufferIndex);
@@ -25421,8 +25198,7 @@ bool StatelessValidation::PreCallValidateGetBufferOpaqueCaptureDescriptorDataEXT
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_BUFFER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_BUFFER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
                                "VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
                                "VUID-VkBufferCaptureDescriptorDataInfoEXT-sType-sType");
     if (pInfo != nullptr) {
@@ -25443,8 +25219,7 @@ bool StatelessValidation::PreCallValidateGetImageOpaqueCaptureDescriptorDataEXT(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_IMAGE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_IMAGE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
                                "VUID-vkGetImageOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
                                "VUID-VkImageCaptureDescriptorDataInfoEXT-sType-sType");
     if (pInfo != nullptr) {
@@ -25464,8 +25239,7 @@ bool StatelessValidation::PreCallValidateGetImageViewOpaqueCaptureDescriptorData
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_IMAGE_VIEW_CAPTURE_DESCRIPTOR_DATA_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_IMAGE_VIEW_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_IMAGE_VIEW_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
                                "VUID-vkGetImageViewOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
                                "VUID-VkImageViewCaptureDescriptorDataInfoEXT-sType-sType");
     if (pInfo != nullptr) {
@@ -25487,8 +25261,7 @@ bool StatelessValidation::PreCallValidateGetSamplerOpaqueCaptureDescriptorDataEX
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_SAMPLER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_SAMPLER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_SAMPLER_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
                                "VUID-vkGetSamplerOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
                                "VUID-VkSamplerCaptureDescriptorDataInfoEXT-sType-sType");
     if (pInfo != nullptr) {
@@ -25510,10 +25283,10 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureOpaqueCaptureDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_descriptor_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_descriptor_buffer});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT",
-                               pInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT, true,
-                               "VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
-                               "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CAPTURE_DESCRIPTOR_DATA_INFO_EXT,
+                           true, "VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-pInfo-parameter",
+                           "VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -25547,12 +25320,10 @@ bool StatelessValidation::PreCallValidateGetDeviceFaultInfoEXT(VkDevice device, 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_device_fault))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_device_fault});
-    skip |= ValidateStructType(loc.dot(Field::pFaultCounts), "VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT", pFaultCounts,
-                               VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pFaultCounts), pFaultCounts, VK_STRUCTURE_TYPE_DEVICE_FAULT_COUNTS_EXT, true,
                                "VUID-vkGetDeviceFaultInfoEXT-pFaultCounts-parameter", "VUID-VkDeviceFaultCountsEXT-sType-sType");
-    skip |= ValidateStructType(loc.dot(Field::pFaultInfo), "VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT", pFaultInfo,
-                               VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT, false, "VUID-vkGetDeviceFaultInfoEXT-pFaultInfo-parameter",
-                               "VUID-VkDeviceFaultInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pFaultInfo), pFaultInfo, VK_STRUCTURE_TYPE_DEVICE_FAULT_INFO_EXT, false,
+                               "VUID-vkGetDeviceFaultInfoEXT-pFaultInfo-parameter", "VUID-VkDeviceFaultInfoEXT-sType-sType");
     if (pFaultInfo != nullptr) {
         [[maybe_unused]] const Location pFaultInfo_loc = loc.dot(Field::pFaultInfo);
         skip |= ValidateStructPnext(pFaultInfo_loc, pFaultInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -25588,8 +25359,7 @@ bool StatelessValidation::PreCallValidateCreateDirectFBSurfaceEXT(VkInstance ins
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(instance_extensions.vk_ext_directfb_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_directfb_surface});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_DIRECTFB_SURFACE_CREATE_INFO_EXT, true,
                                "VUID-vkCreateDirectFBSurfaceEXT-pCreateInfo-parameter",
                                "VUID-VkDirectFBSurfaceCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -25653,9 +25423,9 @@ bool StatelessValidation::PreCallValidateCmdSetVertexInputEXT(
         skip |=
             OutputExtensionError(loc, {vvl::Extension::_VK_EXT_vertex_input_dynamic_state, vvl::Extension::_VK_EXT_shader_object});
     skip |= ValidateStructTypeArray(loc.dot(Field::vertexBindingDescriptionCount), loc.dot(Field::pVertexBindingDescriptions),
-                                    "VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT", vertexBindingDescriptionCount,
-                                    pVertexBindingDescriptions, VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, false,
-                                    true, "VUID-VkVertexInputBindingDescription2EXT-sType-sType",
+                                    vertexBindingDescriptionCount, pVertexBindingDescriptions,
+                                    VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, false, true,
+                                    "VUID-VkVertexInputBindingDescription2EXT-sType-sType",
                                     "VUID-vkCmdSetVertexInputEXT-pVertexBindingDescriptions-parameter", kVUIDUndefined);
     if (pVertexBindingDescriptions != nullptr) {
         for (uint32_t vertexBindingDescriptionIndex = 0; vertexBindingDescriptionIndex < vertexBindingDescriptionCount;
@@ -25668,9 +25438,9 @@ bool StatelessValidation::PreCallValidateCmdSetVertexInputEXT(
         }
     }
     skip |= ValidateStructTypeArray(loc.dot(Field::vertexAttributeDescriptionCount), loc.dot(Field::pVertexAttributeDescriptions),
-                                    "VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT", vertexAttributeDescriptionCount,
-                                    pVertexAttributeDescriptions, VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT, false,
-                                    true, "VUID-VkVertexInputAttributeDescription2EXT-sType-sType",
+                                    vertexAttributeDescriptionCount, pVertexAttributeDescriptions,
+                                    VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT, false, true,
+                                    "VUID-VkVertexInputAttributeDescription2EXT-sType-sType",
                                     "VUID-vkCmdSetVertexInputEXT-pVertexAttributeDescriptions-parameter", kVUIDUndefined);
     if (pVertexAttributeDescriptions != nullptr) {
         for (uint32_t vertexAttributeDescriptionIndex = 0; vertexAttributeDescriptionIndex < vertexAttributeDescriptionCount;
@@ -25697,8 +25467,8 @@ bool StatelessValidation::PreCallValidateGetMemoryZirconHandleFUCHSIA(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_fuchsia_external_memory))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_external_memory});
-    skip |= ValidateStructType(loc.dot(Field::pGetZirconHandleInfo), "VK_STRUCTURE_TYPE_MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA",
-                               pGetZirconHandleInfo, VK_STRUCTURE_TYPE_MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA, true,
+    skip |= ValidateStructType(loc.dot(Field::pGetZirconHandleInfo), pGetZirconHandleInfo,
+                               VK_STRUCTURE_TYPE_MEMORY_GET_ZIRCON_HANDLE_INFO_FUCHSIA, true,
                                "VUID-vkGetMemoryZirconHandleFUCHSIA-pGetZirconHandleInfo-parameter",
                                "VUID-VkMemoryGetZirconHandleInfoFUCHSIA-sType-sType");
     if (pGetZirconHandleInfo != nullptr) {
@@ -25729,8 +25499,7 @@ bool StatelessValidation::PreCallValidateGetMemoryZirconHandlePropertiesFUCHSIA(
                           AllVkExternalMemoryHandleTypeFlagBits, handleType, kRequiredSingleBit,
                           "VUID-vkGetMemoryZirconHandlePropertiesFUCHSIA-handleType-parameter",
                           "VUID-vkGetMemoryZirconHandlePropertiesFUCHSIA-handleType-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pMemoryZirconHandleProperties),
-                               "VK_STRUCTURE_TYPE_MEMORY_ZIRCON_HANDLE_PROPERTIES_FUCHSIA", pMemoryZirconHandleProperties,
+    skip |= ValidateStructType(loc.dot(Field::pMemoryZirconHandleProperties), pMemoryZirconHandleProperties,
                                VK_STRUCTURE_TYPE_MEMORY_ZIRCON_HANDLE_PROPERTIES_FUCHSIA, true,
                                "VUID-vkGetMemoryZirconHandlePropertiesFUCHSIA-pMemoryZirconHandleProperties-parameter",
                                "VUID-VkMemoryZirconHandlePropertiesFUCHSIA-sType-sType");
@@ -25750,8 +25519,7 @@ bool StatelessValidation::PreCallValidateImportSemaphoreZirconHandleFUCHSIA(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_fuchsia_external_semaphore))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_external_semaphore});
-    skip |= ValidateStructType(loc.dot(Field::pImportSemaphoreZirconHandleInfo),
-                               "VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_ZIRCON_HANDLE_INFO_FUCHSIA", pImportSemaphoreZirconHandleInfo,
+    skip |= ValidateStructType(loc.dot(Field::pImportSemaphoreZirconHandleInfo), pImportSemaphoreZirconHandleInfo,
                                VK_STRUCTURE_TYPE_IMPORT_SEMAPHORE_ZIRCON_HANDLE_INFO_FUCHSIA, true,
                                "VUID-vkImportSemaphoreZirconHandleFUCHSIA-pImportSemaphoreZirconHandleInfo-parameter",
                                "VUID-VkImportSemaphoreZirconHandleInfoFUCHSIA-sType-sType");
@@ -25784,8 +25552,8 @@ bool StatelessValidation::PreCallValidateGetSemaphoreZirconHandleFUCHSIA(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_fuchsia_external_semaphore))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_external_semaphore});
-    skip |= ValidateStructType(loc.dot(Field::pGetZirconHandleInfo), "VK_STRUCTURE_TYPE_SEMAPHORE_GET_ZIRCON_HANDLE_INFO_FUCHSIA",
-                               pGetZirconHandleInfo, VK_STRUCTURE_TYPE_SEMAPHORE_GET_ZIRCON_HANDLE_INFO_FUCHSIA, true,
+    skip |= ValidateStructType(loc.dot(Field::pGetZirconHandleInfo), pGetZirconHandleInfo,
+                               VK_STRUCTURE_TYPE_SEMAPHORE_GET_ZIRCON_HANDLE_INFO_FUCHSIA, true,
                                "VUID-vkGetSemaphoreZirconHandleFUCHSIA-pGetZirconHandleInfo-parameter",
                                "VUID-VkSemaphoreGetZirconHandleInfoFUCHSIA-sType-sType");
     if (pGetZirconHandleInfo != nullptr) {
@@ -25815,9 +25583,8 @@ bool StatelessValidation::PreCallValidateCreateBufferCollectionFUCHSIA(VkDevice 
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_fuchsia_buffer_collection))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_buffer_collection});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CREATE_INFO_FUCHSIA", pCreateInfo,
-                               VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CREATE_INFO_FUCHSIA, true,
-                               "VUID-vkCreateBufferCollectionFUCHSIA-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CREATE_INFO_FUCHSIA,
+                               true, "VUID-vkCreateBufferCollectionFUCHSIA-pCreateInfo-parameter",
                                "VUID-VkBufferCollectionCreateInfoFUCHSIA-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -25862,8 +25629,8 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionImageConstraintsFUCH
     if (!IsExtEnabled(device_extensions.vk_fuchsia_buffer_collection))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_buffer_collection});
     skip |= ValidateRequiredHandle(loc.dot(Field::collection), collection);
-    skip |= ValidateStructType(loc.dot(Field::pImageConstraintsInfo), "VK_STRUCTURE_TYPE_IMAGE_CONSTRAINTS_INFO_FUCHSIA",
-                               pImageConstraintsInfo, VK_STRUCTURE_TYPE_IMAGE_CONSTRAINTS_INFO_FUCHSIA, true,
+    skip |= ValidateStructType(loc.dot(Field::pImageConstraintsInfo), pImageConstraintsInfo,
+                               VK_STRUCTURE_TYPE_IMAGE_CONSTRAINTS_INFO_FUCHSIA, true,
                                "VUID-vkSetBufferCollectionImageConstraintsFUCHSIA-pImageConstraintsInfo-parameter",
                                "VUID-VkImageConstraintsInfoFUCHSIA-sType-sType");
     if (pImageConstraintsInfo != nullptr) {
@@ -25872,13 +25639,13 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionImageConstraintsFUCH
             ValidateStructPnext(pImageConstraintsInfo_loc, pImageConstraintsInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                 "VUID-VkImageConstraintsInfoFUCHSIA-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructTypeArray(
-            pImageConstraintsInfo_loc.dot(Field::formatConstraintsCount), pImageConstraintsInfo_loc.dot(Field::pFormatConstraints),
-            "VK_STRUCTURE_TYPE_IMAGE_FORMAT_CONSTRAINTS_INFO_FUCHSIA", pImageConstraintsInfo->formatConstraintsCount,
-            pImageConstraintsInfo->pFormatConstraints, VK_STRUCTURE_TYPE_IMAGE_FORMAT_CONSTRAINTS_INFO_FUCHSIA, true, true,
-            "VUID-VkImageFormatConstraintsInfoFUCHSIA-sType-sType",
-            "VUID-VkImageConstraintsInfoFUCHSIA-pFormatConstraints-parameter",
-            "VUID-VkImageConstraintsInfoFUCHSIA-formatConstraintsCount-arraylength");
+        skip |= ValidateStructTypeArray(pImageConstraintsInfo_loc.dot(Field::formatConstraintsCount),
+                                        pImageConstraintsInfo_loc.dot(Field::pFormatConstraints),
+                                        pImageConstraintsInfo->formatConstraintsCount, pImageConstraintsInfo->pFormatConstraints,
+                                        VK_STRUCTURE_TYPE_IMAGE_FORMAT_CONSTRAINTS_INFO_FUCHSIA, true, true,
+                                        "VUID-VkImageFormatConstraintsInfoFUCHSIA-sType-sType",
+                                        "VUID-VkImageConstraintsInfoFUCHSIA-pFormatConstraints-parameter",
+                                        "VUID-VkImageConstraintsInfoFUCHSIA-formatConstraintsCount-arraylength");
 
         if (pImageConstraintsInfo->pFormatConstraints != nullptr) {
             for (uint32_t formatConstraintsIndex = 0; formatConstraintsIndex < pImageConstraintsInfo->formatConstraintsCount;
@@ -25890,10 +25657,10 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionImageConstraintsFUCH
                                             GeneratedVulkanHeaderVersion, "VUID-VkImageFormatConstraintsInfoFUCHSIA-pNext-pNext",
                                             kVUIDUndefined, VK_NULL_HANDLE, true);
 
-                skip |= ValidateStructType(
-                    pFormatConstraints_loc.dot(Field::imageCreateInfo), "VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO",
-                    &(pImageConstraintsInfo->pFormatConstraints[formatConstraintsIndex].imageCreateInfo),
-                    VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, false, kVUIDUndefined, "VUID-VkImageCreateInfo-sType-sType");
+                skip |= ValidateStructType(pFormatConstraints_loc.dot(Field::imageCreateInfo),
+                                           &(pImageConstraintsInfo->pFormatConstraints[formatConstraintsIndex].imageCreateInfo),
+                                           VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO, false, kVUIDUndefined,
+                                           "VUID-VkImageCreateInfo-sType-sType");
 
                 constexpr std::array allowed_structs_VkImageCreateInfo = {
                     VK_STRUCTURE_TYPE_BUFFER_COLLECTION_IMAGE_CREATE_INFO_FUCHSIA,
@@ -25974,7 +25741,6 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionImageConstraintsFUCH
 
                 skip |= ValidateStructTypeArray(
                     pFormatConstraints_loc.dot(Field::colorSpaceCount), pFormatConstraints_loc.dot(Field::pColorSpaces),
-                    "VK_STRUCTURE_TYPE_SYSMEM_COLOR_SPACE_FUCHSIA",
                     pImageConstraintsInfo->pFormatConstraints[formatConstraintsIndex].colorSpaceCount,
                     pImageConstraintsInfo->pFormatConstraints[formatConstraintsIndex].pColorSpaces,
                     VK_STRUCTURE_TYPE_SYSMEM_COLOR_SPACE_FUCHSIA, true, true, "VUID-VkSysmemColorSpaceFUCHSIA-sType-sType",
@@ -25998,7 +25764,6 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionImageConstraintsFUCH
         }
 
         skip |= ValidateStructType(pImageConstraintsInfo_loc.dot(Field::bufferCollectionConstraints),
-                                   "VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA",
                                    &(pImageConstraintsInfo->bufferCollectionConstraints),
                                    VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA, false, kVUIDUndefined,
                                    "VUID-VkBufferCollectionConstraintsInfoFUCHSIA-sType-sType");
@@ -26022,8 +25787,8 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionBufferConstraintsFUC
     if (!IsExtEnabled(device_extensions.vk_fuchsia_buffer_collection))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_buffer_collection});
     skip |= ValidateRequiredHandle(loc.dot(Field::collection), collection);
-    skip |= ValidateStructType(loc.dot(Field::pBufferConstraintsInfo), "VK_STRUCTURE_TYPE_BUFFER_CONSTRAINTS_INFO_FUCHSIA",
-                               pBufferConstraintsInfo, VK_STRUCTURE_TYPE_BUFFER_CONSTRAINTS_INFO_FUCHSIA, true,
+    skip |= ValidateStructType(loc.dot(Field::pBufferConstraintsInfo), pBufferConstraintsInfo,
+                               VK_STRUCTURE_TYPE_BUFFER_CONSTRAINTS_INFO_FUCHSIA, true,
                                "VUID-vkSetBufferCollectionBufferConstraintsFUCHSIA-pBufferConstraintsInfo-parameter",
                                "VUID-VkBufferConstraintsInfoFUCHSIA-sType-sType");
     if (pBufferConstraintsInfo != nullptr) {
@@ -26032,9 +25797,9 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionBufferConstraintsFUC
             ValidateStructPnext(pBufferConstraintsInfo_loc, pBufferConstraintsInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
                                 "VUID-VkBufferConstraintsInfoFUCHSIA-pNext-pNext", kVUIDUndefined, VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructType(pBufferConstraintsInfo_loc.dot(Field::createInfo), "VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO",
-                                   &(pBufferConstraintsInfo->createInfo), VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, false,
-                                   kVUIDUndefined, "VUID-VkBufferCreateInfo-sType-sType");
+        skip |=
+            ValidateStructType(pBufferConstraintsInfo_loc.dot(Field::createInfo), &(pBufferConstraintsInfo->createInfo),
+                               VK_STRUCTURE_TYPE_BUFFER_CREATE_INFO, false, kVUIDUndefined, "VUID-VkBufferCreateInfo-sType-sType");
 
         constexpr std::array allowed_structs_VkBufferCreateInfo = {VK_STRUCTURE_TYPE_BUFFER_COLLECTION_BUFFER_CREATE_INFO_FUCHSIA,
                                                                    VK_STRUCTURE_TYPE_BUFFER_DEVICE_ADDRESS_CREATE_INFO_EXT,
@@ -26063,7 +25828,6 @@ bool StatelessValidation::PreCallValidateSetBufferCollectionBufferConstraintsFUC
                           "VUID-VkBufferConstraintsInfoFUCHSIA-requiredFormatFeatures-parameter");
 
         skip |= ValidateStructType(pBufferConstraintsInfo_loc.dot(Field::bufferCollectionConstraints),
-                                   "VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA",
                                    &(pBufferConstraintsInfo->bufferCollectionConstraints),
                                    VK_STRUCTURE_TYPE_BUFFER_COLLECTION_CONSTRAINTS_INFO_FUCHSIA, false, kVUIDUndefined,
                                    "VUID-VkBufferCollectionConstraintsInfoFUCHSIA-sType-sType");
@@ -26120,9 +25884,8 @@ bool StatelessValidation::PreCallValidateGetBufferCollectionPropertiesFUCHSIA(Vk
     if (!IsExtEnabled(device_extensions.vk_fuchsia_buffer_collection))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_FUCHSIA_buffer_collection});
     skip |= ValidateRequiredHandle(loc.dot(Field::collection), collection);
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_BUFFER_COLLECTION_PROPERTIES_FUCHSIA", pProperties,
-                               VK_STRUCTURE_TYPE_BUFFER_COLLECTION_PROPERTIES_FUCHSIA, true,
-                               "VUID-vkGetBufferCollectionPropertiesFUCHSIA-pProperties-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_BUFFER_COLLECTION_PROPERTIES_FUCHSIA,
+                               true, "VUID-vkGetBufferCollectionPropertiesFUCHSIA-pProperties-parameter",
                                "VUID-VkBufferCollectionPropertiesFUCHSIA-sType-sType");
     if (pProperties != nullptr) {
         [[maybe_unused]] const Location pProperties_loc = loc.dot(Field::pProperties);
@@ -26175,8 +25938,8 @@ bool StatelessValidation::PreCallValidateGetMemoryRemoteAddressNV(VkDevice devic
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_external_memory_rdma))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_external_memory_rdma});
-    skip |= ValidateStructType(loc.dot(Field::pMemoryGetRemoteAddressInfo), "VK_STRUCTURE_TYPE_MEMORY_GET_REMOTE_ADDRESS_INFO_NV",
-                               pMemoryGetRemoteAddressInfo, VK_STRUCTURE_TYPE_MEMORY_GET_REMOTE_ADDRESS_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pMemoryGetRemoteAddressInfo), pMemoryGetRemoteAddressInfo,
+                               VK_STRUCTURE_TYPE_MEMORY_GET_REMOTE_ADDRESS_INFO_NV, true,
                                "VUID-vkGetMemoryRemoteAddressNV-pMemoryGetRemoteAddressInfo-parameter",
                                "VUID-VkMemoryGetRemoteAddressInfoNV-sType-sType");
     if (pMemoryGetRemoteAddressInfo != nullptr) {
@@ -26271,8 +26034,7 @@ bool StatelessValidation::PreCallValidateCreateScreenSurfaceQNX(VkInstance insta
     if (!IsExtEnabled(instance_extensions.vk_qnx_screen_surface))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_QNX_screen_surface});
     skip |=
-        ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX", pCreateInfo,
-                           VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX, true,
+        ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SCREEN_SURFACE_CREATE_INFO_QNX, true,
                            "VUID-vkCreateScreenSurfaceQNX-pCreateInfo-parameter", "VUID-VkScreenSurfaceCreateInfoQNX-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -26367,9 +26129,8 @@ bool StatelessValidation::PreCallValidateCreateMicromapEXT(VkDevice device, cons
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT", pCreateInfo,
-                               VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT, true, "VUID-vkCreateMicromapEXT-pCreateInfo-parameter",
-                               "VUID-VkMicromapCreateInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_MICROMAP_CREATE_INFO_EXT, true,
+                               "VUID-vkCreateMicromapEXT-pCreateInfo-parameter", "VUID-VkMicromapCreateInfoEXT-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
         skip |= ValidateStructPnext(pCreateInfo_loc, pCreateInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -26455,8 +26216,8 @@ bool StatelessValidation::PreCallValidateCmdBuildMicromapsEXT(VkCommandBuffer co
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), "VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT",
-                                    infoCount, pInfos, VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true, true,
+    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), infoCount, pInfos,
+                                    VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true, true,
                                     "VUID-VkMicromapBuildInfoEXT-sType-sType", "VUID-vkCmdBuildMicromapsEXT-pInfos-parameter",
                                     "VUID-vkCmdBuildMicromapsEXT-infoCount-arraylength");
     if (pInfos != nullptr) {
@@ -26497,10 +26258,10 @@ bool StatelessValidation::PreCallValidateBuildMicromapsEXT(VkDevice device, VkDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), "VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT",
-                                    infoCount, pInfos, VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true, true,
-                                    "VUID-VkMicromapBuildInfoEXT-sType-sType", "VUID-vkBuildMicromapsEXT-pInfos-parameter",
-                                    "VUID-vkBuildMicromapsEXT-infoCount-arraylength");
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), infoCount, pInfos,
+                                VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true, true, "VUID-VkMicromapBuildInfoEXT-sType-sType",
+                                "VUID-vkBuildMicromapsEXT-pInfos-parameter", "VUID-vkBuildMicromapsEXT-infoCount-arraylength");
     if (pInfos != nullptr) {
         for (uint32_t infoIndex = 0; infoIndex < infoCount; ++infoIndex) {
             [[maybe_unused]] const Location pInfos_loc = loc.dot(Field::pInfos, infoIndex);
@@ -26538,9 +26299,8 @@ bool StatelessValidation::PreCallValidateCopyMicromapEXT(VkDevice device, VkDefe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT, true, "VUID-vkCopyMicromapEXT-pInfo-parameter",
-                               "VUID-VkCopyMicromapInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT, true,
+                               "VUID-vkCopyMicromapEXT-pInfo-parameter", "VUID-VkCopyMicromapInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -26563,8 +26323,7 @@ bool StatelessValidation::PreCallValidateCopyMicromapToMemoryEXT(VkDevice device
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT, true,
                                "VUID-vkCopyMicromapToMemoryEXT-pInfo-parameter", "VUID-VkCopyMicromapToMemoryInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -26586,8 +26345,7 @@ bool StatelessValidation::PreCallValidateCopyMemoryToMicromapEXT(VkDevice device
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT, true,
                                "VUID-vkCopyMemoryToMicromapEXT-pInfo-parameter", "VUID-VkCopyMemoryToMicromapInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -26626,9 +26384,8 @@ bool StatelessValidation::PreCallValidateCmdCopyMicromapEXT(VkCommandBuffer comm
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT, true, "VUID-vkCmdCopyMicromapEXT-pInfo-parameter",
-                               "VUID-VkCopyMicromapInfoEXT-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MICROMAP_INFO_EXT, true,
+                               "VUID-vkCmdCopyMicromapEXT-pInfo-parameter", "VUID-VkCopyMicromapInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
         skip |= ValidateStructPnext(pInfo_loc, pInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -26652,8 +26409,7 @@ bool StatelessValidation::PreCallValidateCmdCopyMicromapToMemoryEXT(VkCommandBuf
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
     skip |=
-        ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT", pInfo,
-                           VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MICROMAP_TO_MEMORY_INFO_EXT, true,
                            "VUID-vkCmdCopyMicromapToMemoryEXT-pInfo-parameter", "VUID-VkCopyMicromapToMemoryInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -26676,8 +26432,7 @@ bool StatelessValidation::PreCallValidateCmdCopyMemoryToMicromapEXT(VkCommandBuf
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
     skip |=
-        ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT", pInfo,
-                           VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_MICROMAP_INFO_EXT, true,
                            "VUID-vkCmdCopyMemoryToMicromapEXT-pInfo-parameter", "VUID-VkCopyMemoryToMicromapInfoEXT-sType-sType");
     if (pInfo != nullptr) {
         [[maybe_unused]] const Location pInfo_loc = loc.dot(Field::pInfo);
@@ -26716,8 +26471,7 @@ bool StatelessValidation::PreCallValidateGetDeviceMicromapCompatibilityEXT(VkDev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_opacity_micromap))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
-    skip |= ValidateStructType(loc.dot(Field::pVersionInfo), "VK_STRUCTURE_TYPE_MICROMAP_VERSION_INFO_EXT", pVersionInfo,
-                               VK_STRUCTURE_TYPE_MICROMAP_VERSION_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pVersionInfo), pVersionInfo, VK_STRUCTURE_TYPE_MICROMAP_VERSION_INFO_EXT, true,
                                "VUID-vkGetDeviceMicromapCompatibilityEXT-pVersionInfo-parameter",
                                "VUID-VkMicromapVersionInfoEXT-sType-sType");
     if (pVersionInfo != nullptr) {
@@ -26743,8 +26497,7 @@ bool StatelessValidation::PreCallValidateGetMicromapBuildSizesEXT(VkDevice devic
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_opacity_micromap});
     skip |= ValidateRangedEnum(loc.dot(Field::buildType), vvl::Enum::VkAccelerationStructureBuildTypeKHR, buildType,
                                "VUID-vkGetMicromapBuildSizesEXT-buildType-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pBuildInfo), "VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT", pBuildInfo,
-                               VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pBuildInfo), pBuildInfo, VK_STRUCTURE_TYPE_MICROMAP_BUILD_INFO_EXT, true,
                                "VUID-vkGetMicromapBuildSizesEXT-pBuildInfo-parameter", "VUID-VkMicromapBuildInfoEXT-sType-sType");
     if (pBuildInfo != nullptr) {
         [[maybe_unused]] const Location pBuildInfo_loc = loc.dot(Field::pBuildInfo);
@@ -26773,8 +26526,7 @@ bool StatelessValidation::PreCallValidateGetMicromapBuildSizesEXT(VkDevice devic
         }
     }
     skip |=
-        ValidateStructType(loc.dot(Field::pSizeInfo), "VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT", pSizeInfo,
-                           VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT, true,
+        ValidateStructType(loc.dot(Field::pSizeInfo), pSizeInfo, VK_STRUCTURE_TYPE_MICROMAP_BUILD_SIZES_INFO_EXT, true,
                            "VUID-vkGetMicromapBuildSizesEXT-pSizeInfo-parameter", "VUID-VkMicromapBuildSizesInfoEXT-sType-sType");
     return skip;
 }
@@ -26818,8 +26570,8 @@ bool StatelessValidation::PreCallValidateGetDescriptorSetLayoutHostMappingInfoVA
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_valve_descriptor_set_host_mapping))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_VALVE_descriptor_set_host_mapping});
-    skip |= ValidateStructType(loc.dot(Field::pBindingReference), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_BINDING_REFERENCE_VALVE",
-                               pBindingReference, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_BINDING_REFERENCE_VALVE, true,
+    skip |= ValidateStructType(loc.dot(Field::pBindingReference), pBindingReference,
+                               VK_STRUCTURE_TYPE_DESCRIPTOR_SET_BINDING_REFERENCE_VALVE, true,
                                "VUID-vkGetDescriptorSetLayoutHostMappingInfoVALVE-pBindingReference-parameter",
                                "VUID-VkDescriptorSetBindingReferenceVALVE-sType-sType");
     if (pBindingReference != nullptr) {
@@ -26830,8 +26582,8 @@ bool StatelessValidation::PreCallValidateGetDescriptorSetLayoutHostMappingInfoVA
         skip |=
             ValidateRequiredHandle(pBindingReference_loc.dot(Field::descriptorSetLayout), pBindingReference->descriptorSetLayout);
     }
-    skip |= ValidateStructType(loc.dot(Field::pHostMapping), "VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE",
-                               pHostMapping, VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE, true,
+    skip |= ValidateStructType(loc.dot(Field::pHostMapping), pHostMapping,
+                               VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_HOST_MAPPING_INFO_VALVE, true,
                                "VUID-vkGetDescriptorSetLayoutHostMappingInfoVALVE-pHostMapping-parameter",
                                "VUID-VkDescriptorSetLayoutHostMappingInfoVALVE-sType-sType");
     return skip;
@@ -26928,8 +26680,7 @@ bool StatelessValidation::PreCallValidateGetPipelineIndirectMemoryRequirementsNV
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands_compute))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands_compute});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO, true,
                                "VUID-vkGetPipelineIndirectMemoryRequirementsNV-pCreateInfo-parameter",
                                "VUID-VkComputePipelineCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -26947,9 +26698,9 @@ bool StatelessValidation::PreCallValidateGetPipelineIndirectMemoryRequirementsNV
                                     "VUID-VkComputePipelineCreateInfo-pNext-pNext", "VUID-VkComputePipelineCreateInfo-sType-unique",
                                     VK_NULL_HANDLE, true);
 
-        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::stage), "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
-                                   &(pCreateInfo->stage), VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, false,
-                                   kVUIDUndefined, "VUID-VkPipelineShaderStageCreateInfo-sType-sType");
+        skip |= ValidateStructType(pCreateInfo_loc.dot(Field::stage), &(pCreateInfo->stage),
+                                   VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, false, kVUIDUndefined,
+                                   "VUID-VkPipelineShaderStageCreateInfo-sType-sType");
 
         constexpr std::array allowed_structs_VkPipelineShaderStageCreateInfo = {
             VK_STRUCTURE_TYPE_DEBUG_UTILS_OBJECT_NAME_INFO_EXT,
@@ -27000,9 +26751,8 @@ bool StatelessValidation::PreCallValidateGetPipelineIndirectMemoryRequirementsNV
 
         skip |= ValidateRequiredHandle(pCreateInfo_loc.dot(Field::layout), pCreateInfo->layout);
     }
-    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), "VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2", pMemoryRequirements,
-                               VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2, true,
-                               "VUID-vkGetPipelineIndirectMemoryRequirementsNV-pMemoryRequirements-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pMemoryRequirements), pMemoryRequirements, VK_STRUCTURE_TYPE_MEMORY_REQUIREMENTS_2,
+                               true, "VUID-vkGetPipelineIndirectMemoryRequirementsNV-pMemoryRequirements-parameter",
                                "VUID-VkMemoryRequirements2-sType-sType");
     if (pMemoryRequirements != nullptr) {
         [[maybe_unused]] const Location pMemoryRequirements_loc = loc.dot(Field::pMemoryRequirements);
@@ -27037,8 +26787,7 @@ bool StatelessValidation::PreCallValidateGetPipelineIndirectDeviceAddressNV(VkDe
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_device_generated_commands_compute))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_device_generated_commands_compute});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV", pInfo,
-                               VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_PIPELINE_INDIRECT_DEVICE_ADDRESS_INFO_NV, true,
                                "VUID-vkGetPipelineIndirectDeviceAddressNV-pInfo-parameter",
                                "VUID-VkPipelineIndirectDeviceAddressInfoNV-sType-sType");
     if (pInfo != nullptr) {
@@ -27494,8 +27243,7 @@ bool StatelessValidation::PreCallValidateGetShaderModuleIdentifierEXT(VkDevice d
     if (!IsExtEnabled(device_extensions.vk_ext_shader_module_identifier))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_shader_module_identifier});
     skip |= ValidateRequiredHandle(loc.dot(Field::shaderModule), shaderModule);
-    skip |= ValidateStructType(loc.dot(Field::pIdentifier), "VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT", pIdentifier,
-                               VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pIdentifier), pIdentifier, VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, true,
                                "VUID-vkGetShaderModuleIdentifierEXT-pIdentifier-parameter",
                                "VUID-VkShaderModuleIdentifierEXT-sType-sType");
     if (pIdentifier != nullptr) {
@@ -27514,8 +27262,7 @@ bool StatelessValidation::PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_shader_module_identifier))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_shader_module_identifier});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO", pCreateInfo,
-                               VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, true,
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_SHADER_MODULE_CREATE_INFO, true,
                                "VUID-vkGetShaderModuleCreateInfoIdentifierEXT-pCreateInfo-parameter",
                                "VUID-VkShaderModuleCreateInfo-sType-sType");
     if (pCreateInfo != nullptr) {
@@ -27527,8 +27274,7 @@ bool StatelessValidation::PreCallValidateGetShaderModuleCreateInfoIdentifierEXT(
                               &pCreateInfo->pCode, true, true, "VUID-VkShaderModuleCreateInfo-codeSize-01085",
                               "VUID-VkShaderModuleCreateInfo-pCode-parameter");
     }
-    skip |= ValidateStructType(loc.dot(Field::pIdentifier), "VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT", pIdentifier,
-                               VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, true,
+    skip |= ValidateStructType(loc.dot(Field::pIdentifier), pIdentifier, VK_STRUCTURE_TYPE_SHADER_MODULE_IDENTIFIER_EXT, true,
                                "VUID-vkGetShaderModuleCreateInfoIdentifierEXT-pIdentifier-parameter",
                                "VUID-VkShaderModuleIdentifierEXT-sType-sType");
     if (pIdentifier != nullptr) {
@@ -27544,8 +27290,8 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceOpticalFlowImageFormat
     VkOpticalFlowImageFormatPropertiesNV* pImageFormatProperties, const ErrorObject& error_obj) const {
     bool skip = false;
     [[maybe_unused]] const Location loc = error_obj.location;
-    skip |= ValidateStructType(loc.dot(Field::pOpticalFlowImageFormatInfo), "VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV",
-                               pOpticalFlowImageFormatInfo, VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV, true,
+    skip |= ValidateStructType(loc.dot(Field::pOpticalFlowImageFormatInfo), pOpticalFlowImageFormatInfo,
+                               VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_INFO_NV, true,
                                "VUID-vkGetPhysicalDeviceOpticalFlowImageFormatsNV-pOpticalFlowImageFormatInfo-parameter",
                                "VUID-VkOpticalFlowImageFormatInfoNV-sType-sType");
     if (pOpticalFlowImageFormatInfo != nullptr) {
@@ -27558,8 +27304,7 @@ bool StatelessValidation::PreCallValidateGetPhysicalDeviceOpticalFlowImageFormat
                               "VUID-VkOpticalFlowImageFormatInfoNV-usage-parameter",
                               "VUID-VkOpticalFlowImageFormatInfoNV-usage-requiredbitmask");
     }
-    skip |= ValidateStructTypeArray(loc.dot(Field::pFormatCount), loc.dot(Field::pImageFormatProperties),
-                                    "VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV", pFormatCount,
+    skip |= ValidateStructTypeArray(loc.dot(Field::pFormatCount), loc.dot(Field::pImageFormatProperties), pFormatCount,
                                     pImageFormatProperties, VK_STRUCTURE_TYPE_OPTICAL_FLOW_IMAGE_FORMAT_PROPERTIES_NV, true, false,
                                     false, "VUID-VkOpticalFlowImageFormatPropertiesNV-sType-sType",
                                     "VUID-vkGetPhysicalDeviceOpticalFlowImageFormatsNV-pImageFormatProperties-parameter",
@@ -27584,9 +27329,8 @@ bool StatelessValidation::PreCallValidateCreateOpticalFlowSessionNV(VkDevice dev
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_nv_optical_flow))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_optical_flow});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_INFO_NV", pCreateInfo,
-                               VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_INFO_NV, true,
-                               "VUID-vkCreateOpticalFlowSessionNV-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_OPTICAL_FLOW_SESSION_CREATE_INFO_NV,
+                               true, "VUID-vkCreateOpticalFlowSessionNV-pCreateInfo-parameter",
                                "VUID-VkOpticalFlowSessionCreateInfoNV-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -27714,8 +27458,7 @@ bool StatelessValidation::PreCallValidateCmdOpticalFlowExecuteNV(VkCommandBuffer
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_optical_flow});
     skip |= ValidateRequiredHandle(loc.dot(Field::session), session);
     skip |=
-        ValidateStructType(loc.dot(Field::pExecuteInfo), "VK_STRUCTURE_TYPE_OPTICAL_FLOW_EXECUTE_INFO_NV", pExecuteInfo,
-                           VK_STRUCTURE_TYPE_OPTICAL_FLOW_EXECUTE_INFO_NV, true,
+        ValidateStructType(loc.dot(Field::pExecuteInfo), pExecuteInfo, VK_STRUCTURE_TYPE_OPTICAL_FLOW_EXECUTE_INFO_NV, true,
                            "VUID-vkCmdOpticalFlowExecuteNV-pExecuteInfo-parameter", "VUID-VkOpticalFlowExecuteInfoNV-sType-sType");
     if (pExecuteInfo != nullptr) {
         [[maybe_unused]] const Location pExecuteInfo_loc = loc.dot(Field::pExecuteInfo);
@@ -27750,10 +27493,10 @@ bool StatelessValidation::PreCallValidateCreateShadersEXT(VkDevice device, uint3
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_ext_shader_object))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_EXT_shader_object});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT", createInfoCount,
-        pCreateInfos, VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT, true, true, "VUID-VkShaderCreateInfoEXT-sType-sType",
-        "VUID-vkCreateShadersEXT-pCreateInfos-parameter", "VUID-vkCreateShadersEXT-createInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
+                                    VK_STRUCTURE_TYPE_SHADER_CREATE_INFO_EXT, true, true, "VUID-VkShaderCreateInfoEXT-sType-sType",
+                                    "VUID-vkCreateShadersEXT-pCreateInfos-parameter",
+                                    "VUID-vkCreateShadersEXT-createInfoCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t createInfoIndex = 0; createInfoIndex < createInfoCount; ++createInfoIndex) {
             [[maybe_unused]] const Location pCreateInfos_loc = loc.dot(Field::pCreateInfos, createInfoIndex);
@@ -27926,11 +27669,11 @@ bool StatelessValidation::PreCallValidateGetFramebufferTilePropertiesQCOM(VkDevi
     if (!IsExtEnabled(device_extensions.vk_qcom_tile_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_QCOM_tile_properties});
     skip |= ValidateRequiredHandle(loc.dot(Field::framebuffer), framebuffer);
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::pPropertiesCount), loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM", pPropertiesCount,
-        pProperties, VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, true, false, false, "VUID-VkTilePropertiesQCOM-sType-sType",
-        "VUID-vkGetFramebufferTilePropertiesQCOM-pProperties-parameter",
-        "VUID-vkGetFramebufferTilePropertiesQCOM-pPropertiesCount-parameter", kVUIDUndefined);
+    skip |=
+        ValidateStructTypeArray(loc.dot(Field::pPropertiesCount), loc.dot(Field::pProperties), pPropertiesCount, pProperties,
+                                VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, true, false, false, "VUID-VkTilePropertiesQCOM-sType-sType",
+                                "VUID-vkGetFramebufferTilePropertiesQCOM-pProperties-parameter",
+                                "VUID-vkGetFramebufferTilePropertiesQCOM-pPropertiesCount-parameter", kVUIDUndefined);
     return skip;
 }
 
@@ -27942,9 +27685,9 @@ bool StatelessValidation::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(V
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_qcom_tile_properties))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_QCOM_tile_properties});
-    skip |= ValidateStructType(
-        loc.dot(Field::pRenderingInfo), "VK_STRUCTURE_TYPE_RENDERING_INFO", pRenderingInfo, VK_STRUCTURE_TYPE_RENDERING_INFO, true,
-        "VUID-vkGetDynamicRenderingTilePropertiesQCOM-pRenderingInfo-parameter", "VUID-VkRenderingInfo-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pRenderingInfo), pRenderingInfo, VK_STRUCTURE_TYPE_RENDERING_INFO, true,
+                               "VUID-vkGetDynamicRenderingTilePropertiesQCOM-pRenderingInfo-parameter",
+                               "VUID-VkRenderingInfo-sType-sType");
     if (pRenderingInfo != nullptr) {
         [[maybe_unused]] const Location pRenderingInfo_loc = loc.dot(Field::pRenderingInfo);
         constexpr std::array allowed_structs_VkRenderingInfo = {
@@ -27967,11 +27710,11 @@ bool StatelessValidation::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(V
 
         // No xml-driven validation
 
-        skip |= ValidateStructTypeArray(
-            pRenderingInfo_loc.dot(Field::colorAttachmentCount), pRenderingInfo_loc.dot(Field::pColorAttachments),
-            "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO", pRenderingInfo->colorAttachmentCount, pRenderingInfo->pColorAttachments,
-            VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false, true, "VUID-VkRenderingAttachmentInfo-sType-sType",
-            "VUID-VkRenderingInfo-pColorAttachments-parameter", kVUIDUndefined);
+        skip |= ValidateStructTypeArray(pRenderingInfo_loc.dot(Field::colorAttachmentCount),
+                                        pRenderingInfo_loc.dot(Field::pColorAttachments), pRenderingInfo->colorAttachmentCount,
+                                        pRenderingInfo->pColorAttachments, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false, true,
+                                        "VUID-VkRenderingAttachmentInfo-sType-sType",
+                                        "VUID-VkRenderingInfo-pColorAttachments-parameter", kVUIDUndefined);
 
         if (pRenderingInfo->pColorAttachments != nullptr) {
             for (uint32_t colorAttachmentIndex = 0; colorAttachmentIndex < pRenderingInfo->colorAttachmentCount;
@@ -28006,8 +27749,8 @@ bool StatelessValidation::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(V
             }
         }
 
-        skip |= ValidateStructType(pRenderingInfo_loc.dot(Field::pDepthAttachment), "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO",
-                                   pRenderingInfo->pDepthAttachment, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
+        skip |= ValidateStructType(pRenderingInfo_loc.dot(Field::pDepthAttachment), pRenderingInfo->pDepthAttachment,
+                                   VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
                                    "VUID-VkRenderingInfo-pDepthAttachment-parameter", "VUID-VkRenderingAttachmentInfo-sType-sType");
 
         if (pRenderingInfo->pDepthAttachment != nullptr) {
@@ -28039,8 +27782,8 @@ bool StatelessValidation::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(V
         }
 
         skip |=
-            ValidateStructType(pRenderingInfo_loc.dot(Field::pStencilAttachment), "VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO",
-                               pRenderingInfo->pStencilAttachment, VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
+            ValidateStructType(pRenderingInfo_loc.dot(Field::pStencilAttachment), pRenderingInfo->pStencilAttachment,
+                               VK_STRUCTURE_TYPE_RENDERING_ATTACHMENT_INFO, false,
                                "VUID-VkRenderingInfo-pStencilAttachment-parameter", "VUID-VkRenderingAttachmentInfo-sType-sType");
 
         if (pRenderingInfo->pStencilAttachment != nullptr) {
@@ -28072,9 +27815,9 @@ bool StatelessValidation::PreCallValidateGetDynamicRenderingTilePropertiesQCOM(V
             // No xml-driven validation
         }
     }
-    skip |= ValidateStructType(
-        loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM", pProperties, VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM,
-        true, "VUID-vkGetDynamicRenderingTilePropertiesQCOM-pProperties-parameter", "VUID-VkTilePropertiesQCOM-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_TILE_PROPERTIES_QCOM, true,
+                               "VUID-vkGetDynamicRenderingTilePropertiesQCOM-pProperties-parameter",
+                               "VUID-VkTilePropertiesQCOM-sType-sType");
     return skip;
 }
 
@@ -28087,8 +27830,7 @@ bool StatelessValidation::PreCallValidateSetLatencySleepModeNV(VkDevice device, 
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_low_latency2});
     skip |= ValidateRequiredHandle(loc.dot(Field::swapchain), swapchain);
     skip |=
-        ValidateStructType(loc.dot(Field::pSleepModeInfo), "VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV", pSleepModeInfo,
-                           VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV, true,
+        ValidateStructType(loc.dot(Field::pSleepModeInfo), pSleepModeInfo, VK_STRUCTURE_TYPE_LATENCY_SLEEP_MODE_INFO_NV, true,
                            "VUID-vkSetLatencySleepModeNV-pSleepModeInfo-parameter", "VUID-VkLatencySleepModeInfoNV-sType-sType");
     if (pSleepModeInfo != nullptr) {
         [[maybe_unused]] const Location pSleepModeInfo_loc = loc.dot(Field::pSleepModeInfo);
@@ -28107,9 +27849,8 @@ bool StatelessValidation::PreCallValidateLatencySleepNV(VkDevice device, VkSwapc
     if (!IsExtEnabled(device_extensions.vk_nv_low_latency2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_low_latency2});
     skip |= ValidateRequiredHandle(loc.dot(Field::swapchain), swapchain);
-    skip |= ValidateStructType(loc.dot(Field::pSleepInfo), "VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV", pSleepInfo,
-                               VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV, true, "VUID-vkLatencySleepNV-pSleepInfo-parameter",
-                               "VUID-VkLatencySleepInfoNV-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pSleepInfo), pSleepInfo, VK_STRUCTURE_TYPE_LATENCY_SLEEP_INFO_NV, true,
+                               "VUID-vkLatencySleepNV-pSleepInfo-parameter", "VUID-VkLatencySleepInfoNV-sType-sType");
     if (pSleepInfo != nullptr) {
         [[maybe_unused]] const Location pSleepInfo_loc = loc.dot(Field::pSleepInfo);
         skip |= ValidateRequiredHandle(pSleepInfo_loc.dot(Field::signalSemaphore), pSleepInfo->signalSemaphore);
@@ -28125,10 +27866,9 @@ bool StatelessValidation::PreCallValidateSetLatencyMarkerNV(VkDevice device, VkS
     if (!IsExtEnabled(device_extensions.vk_nv_low_latency2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_low_latency2});
     skip |= ValidateRequiredHandle(loc.dot(Field::swapchain), swapchain);
-    skip |=
-        ValidateStructType(loc.dot(Field::pLatencyMarkerInfo), "VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV", pLatencyMarkerInfo,
-                           VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV, true,
-                           "VUID-vkSetLatencyMarkerNV-pLatencyMarkerInfo-parameter", "VUID-VkSetLatencyMarkerInfoNV-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pLatencyMarkerInfo), pLatencyMarkerInfo, VK_STRUCTURE_TYPE_SET_LATENCY_MARKER_INFO_NV,
+                               true, "VUID-vkSetLatencyMarkerNV-pLatencyMarkerInfo-parameter",
+                               "VUID-VkSetLatencyMarkerInfoNV-sType-sType");
     if (pLatencyMarkerInfo != nullptr) {
         [[maybe_unused]] const Location pLatencyMarkerInfo_loc = loc.dot(Field::pLatencyMarkerInfo);
         skip |= ValidateRangedEnum(pLatencyMarkerInfo_loc.dot(Field::marker), vvl::Enum::VkLatencyMarkerNV,
@@ -28145,10 +27885,9 @@ bool StatelessValidation::PreCallValidateGetLatencyTimingsNV(VkDevice device, Vk
     if (!IsExtEnabled(device_extensions.vk_nv_low_latency2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_low_latency2});
     skip |= ValidateRequiredHandle(loc.dot(Field::swapchain), swapchain);
-    skip |=
-        ValidateStructType(loc.dot(Field::pLatencyMarkerInfo), "VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV", pLatencyMarkerInfo,
-                           VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV, true,
-                           "VUID-vkGetLatencyTimingsNV-pLatencyMarkerInfo-parameter", "VUID-VkGetLatencyMarkerInfoNV-sType-sType");
+    skip |= ValidateStructType(loc.dot(Field::pLatencyMarkerInfo), pLatencyMarkerInfo, VK_STRUCTURE_TYPE_GET_LATENCY_MARKER_INFO_NV,
+                               true, "VUID-vkGetLatencyTimingsNV-pLatencyMarkerInfo-parameter",
+                               "VUID-VkGetLatencyMarkerInfoNV-sType-sType");
     return skip;
 }
 
@@ -28159,8 +27898,7 @@ bool StatelessValidation::PreCallValidateQueueNotifyOutOfBandNV(VkQueue queue, c
     if (!IsExtEnabled(device_extensions.vk_nv_low_latency2))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_NV_low_latency2});
     skip |=
-        ValidateStructType(loc.dot(Field::pQueueTypeInfo), "VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV", pQueueTypeInfo,
-                           VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV, true,
+        ValidateStructType(loc.dot(Field::pQueueTypeInfo), pQueueTypeInfo, VK_STRUCTURE_TYPE_OUT_OF_BAND_QUEUE_TYPE_INFO_NV, true,
                            "VUID-vkQueueNotifyOutOfBandNV-pQueueTypeInfo-parameter", "VUID-VkOutOfBandQueueTypeInfoNV-sType-sType");
     if (pQueueTypeInfo != nullptr) {
         [[maybe_unused]] const Location pQueueTypeInfo_loc = loc.dot(Field::pQueueTypeInfo);
@@ -28191,8 +27929,7 @@ bool StatelessValidation::PreCallValidateGetScreenBufferPropertiesQNX(VkDevice d
     if (!IsExtEnabled(device_extensions.vk_qnx_external_memory_screen_buffer))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_QNX_external_memory_screen_buffer});
     skip |= ValidateRequiredPointer(loc.dot(Field::buffer), buffer, "VUID-vkGetScreenBufferPropertiesQNX-buffer-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pProperties), "VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX", pProperties,
-                               VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX, true,
+    skip |= ValidateStructType(loc.dot(Field::pProperties), pProperties, VK_STRUCTURE_TYPE_SCREEN_BUFFER_PROPERTIES_QNX, true,
                                "VUID-vkGetScreenBufferPropertiesQNX-pProperties-parameter",
                                "VUID-VkScreenBufferPropertiesQNX-sType-sType");
     if (pProperties != nullptr) {
@@ -28217,9 +27954,8 @@ bool StatelessValidation::PreCallValidateCreateAccelerationStructureKHR(VkDevice
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR", pCreateInfo,
-                               VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR, true,
-                               "VUID-vkCreateAccelerationStructureKHR-pCreateInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pCreateInfo), pCreateInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_CREATE_INFO_KHR,
+                               true, "VUID-vkCreateAccelerationStructureKHR-pCreateInfo-parameter",
                                "VUID-VkAccelerationStructureCreateInfoKHR-sType-sType");
     if (pCreateInfo != nullptr) {
         [[maybe_unused]] const Location pCreateInfo_loc = loc.dot(Field::pCreateInfo);
@@ -28319,11 +28055,11 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::infoCount), loc.dot(Field::pInfos), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR",
-        infoCount, pInfos, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true, true,
-        "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType", "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-parameter",
-        "VUID-vkCmdBuildAccelerationStructuresKHR-infoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), infoCount, pInfos,
+                                    VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true, true,
+                                    "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType",
+                                    "VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-parameter",
+                                    "VUID-vkCmdBuildAccelerationStructuresKHR-infoCount-arraylength");
     if (pInfos != nullptr) {
         for (uint32_t infoIndex = 0; infoIndex < infoCount; ++infoIndex) {
             [[maybe_unused]] const Location pInfos_loc = loc.dot(Field::pInfos, infoIndex);
@@ -28338,12 +28074,11 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresKHR(
                                   AllVkBuildAccelerationStructureFlagBitsKHR, pInfos[infoIndex].flags, kOptionalFlags,
                                   "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
 
-            skip |=
-                ValidateStructTypeArray(pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries),
-                                        "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
-                                        pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false,
-                                        false, "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
-                                        "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
+            skip |= ValidateStructTypeArray(
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries), pInfos[infoIndex].geometryCount,
+                pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
+                "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
+                "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
 
             if (pInfos[infoIndex].pGeometries != nullptr) {
                 for (uint32_t geometryIndex = 0; geometryIndex < pInfos[infoIndex].geometryCount; ++geometryIndex) {
@@ -28363,8 +28098,7 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresKHR(
             }
 
             skip |= ValidateStructPointerTypeArray(
-                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries),
-                "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries), pInfos[infoIndex].geometryCount,
                 pInfos[infoIndex].ppGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
                 "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
                 "VUID-VkAccelerationStructureBuildGeometryInfoKHR-ppGeometries-parameter", kVUIDUndefined);
@@ -28410,8 +28144,7 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresIndirectK
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos),
-                                    "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR", infoCount, pInfos,
+    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), infoCount, pInfos,
                                     VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true, true,
                                     "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType",
                                     "VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pInfos-parameter",
@@ -28430,12 +28163,11 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresIndirectK
                                   AllVkBuildAccelerationStructureFlagBitsKHR, pInfos[infoIndex].flags, kOptionalFlags,
                                   "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
 
-            skip |=
-                ValidateStructTypeArray(pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries),
-                                        "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
-                                        pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false,
-                                        false, "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
-                                        "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
+            skip |= ValidateStructTypeArray(
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries), pInfos[infoIndex].geometryCount,
+                pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
+                "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
+                "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
 
             if (pInfos[infoIndex].pGeometries != nullptr) {
                 for (uint32_t geometryIndex = 0; geometryIndex < pInfos[infoIndex].geometryCount; ++geometryIndex) {
@@ -28455,8 +28187,7 @@ bool StatelessValidation::PreCallValidateCmdBuildAccelerationStructuresIndirectK
             }
 
             skip |= ValidateStructPointerTypeArray(
-                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries),
-                "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries), pInfos[infoIndex].geometryCount,
                 pInfos[infoIndex].ppGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
                 "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
                 "VUID-VkAccelerationStructureBuildGeometryInfoKHR-ppGeometries-parameter", kVUIDUndefined);
@@ -28502,11 +28233,11 @@ bool StatelessValidation::PreCallValidateBuildAccelerationStructuresKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::infoCount), loc.dot(Field::pInfos), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR",
-        infoCount, pInfos, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true, true,
-        "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType", "VUID-vkBuildAccelerationStructuresKHR-pInfos-parameter",
-        "VUID-vkBuildAccelerationStructuresKHR-infoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::infoCount), loc.dot(Field::pInfos), infoCount, pInfos,
+                                    VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true, true,
+                                    "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType",
+                                    "VUID-vkBuildAccelerationStructuresKHR-pInfos-parameter",
+                                    "VUID-vkBuildAccelerationStructuresKHR-infoCount-arraylength");
     if (pInfos != nullptr) {
         for (uint32_t infoIndex = 0; infoIndex < infoCount; ++infoIndex) {
             [[maybe_unused]] const Location pInfos_loc = loc.dot(Field::pInfos, infoIndex);
@@ -28521,12 +28252,11 @@ bool StatelessValidation::PreCallValidateBuildAccelerationStructuresKHR(
                                   AllVkBuildAccelerationStructureFlagBitsKHR, pInfos[infoIndex].flags, kOptionalFlags,
                                   "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
 
-            skip |=
-                ValidateStructTypeArray(pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries),
-                                        "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
-                                        pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false,
-                                        false, "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
-                                        "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
+            skip |= ValidateStructTypeArray(
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::pGeometries), pInfos[infoIndex].geometryCount,
+                pInfos[infoIndex].pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
+                "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
+                "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
 
             if (pInfos[infoIndex].pGeometries != nullptr) {
                 for (uint32_t geometryIndex = 0; geometryIndex < pInfos[infoIndex].geometryCount; ++geometryIndex) {
@@ -28546,8 +28276,7 @@ bool StatelessValidation::PreCallValidateBuildAccelerationStructuresKHR(
             }
 
             skip |= ValidateStructPointerTypeArray(
-                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries),
-                "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pInfos[infoIndex].geometryCount,
+                pInfos_loc.dot(Field::geometryCount), pInfos_loc.dot(Field::ppGeometries), pInfos[infoIndex].geometryCount,
                 pInfos[infoIndex].ppGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
                 "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
                 "VUID-VkAccelerationStructureBuildGeometryInfoKHR-ppGeometries-parameter", kVUIDUndefined);
@@ -28592,8 +28321,7 @@ bool StatelessValidation::PreCallValidateCopyAccelerationStructureKHR(VkDevice d
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR, true,
                                "VUID-vkCopyAccelerationStructureKHR-pInfo-parameter",
                                "VUID-VkCopyAccelerationStructureInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28619,8 +28347,7 @@ bool StatelessValidation::PreCallValidateCopyAccelerationStructureToMemoryKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, true,
                                "VUID-vkCopyAccelerationStructureToMemoryKHR-pInfo-parameter",
                                "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28645,8 +28372,7 @@ bool StatelessValidation::PreCallValidateCopyMemoryToAccelerationStructureKHR(
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR, true,
                                "VUID-vkCopyMemoryToAccelerationStructureKHR-pInfo-parameter",
                                "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28692,8 +28418,7 @@ bool StatelessValidation::PreCallValidateCmdCopyAccelerationStructureKHR(VkComma
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_INFO_KHR, true,
                                "VUID-vkCmdCopyAccelerationStructureKHR-pInfo-parameter",
                                "VUID-VkCopyAccelerationStructureInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28718,8 +28443,7 @@ bool StatelessValidation::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_ACCELERATION_STRUCTURE_TO_MEMORY_INFO_KHR, true,
                                "VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-parameter",
                                "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28743,8 +28467,7 @@ bool StatelessValidation::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_COPY_MEMORY_TO_ACCELERATION_STRUCTURE_INFO_KHR, true,
                                "VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-parameter",
                                "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28768,8 +28491,7 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureDeviceAddressKH
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR", pInfo,
-                               VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, true,
+    skip |= ValidateStructType(loc.dot(Field::pInfo), pInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR, true,
                                "VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-parameter",
                                "VUID-VkAccelerationStructureDeviceAddressInfoKHR-sType-sType");
     if (pInfo != nullptr) {
@@ -28809,10 +28531,10 @@ bool StatelessValidation::PreCallValidateGetDeviceAccelerationStructureCompatibi
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_acceleration_structure))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
-    skip |= ValidateStructType(loc.dot(Field::pVersionInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_VERSION_INFO_KHR",
-                               pVersionInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_VERSION_INFO_KHR, true,
-                               "VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-pVersionInfo-parameter",
-                               "VUID-VkAccelerationStructureVersionInfoKHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pVersionInfo), pVersionInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_VERSION_INFO_KHR,
+                           true, "VUID-vkGetDeviceAccelerationStructureCompatibilityKHR-pVersionInfo-parameter",
+                           "VUID-VkAccelerationStructureVersionInfoKHR-sType-sType");
     if (pVersionInfo != nullptr) {
         [[maybe_unused]] const Location pVersionInfo_loc = loc.dot(Field::pVersionInfo);
         skip |= ValidateStructPnext(pVersionInfo_loc, pVersionInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -28838,10 +28560,10 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureBuildSizesKHR(
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_acceleration_structure});
     skip |= ValidateRangedEnum(loc.dot(Field::buildType), vvl::Enum::VkAccelerationStructureBuildTypeKHR, buildType,
                                "VUID-vkGetAccelerationStructureBuildSizesKHR-buildType-parameter");
-    skip |= ValidateStructType(loc.dot(Field::pBuildInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR",
-                               pBuildInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR, true,
-                               "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-parameter",
-                               "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType");
+    skip |=
+        ValidateStructType(loc.dot(Field::pBuildInfo), pBuildInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_GEOMETRY_INFO_KHR,
+                           true, "VUID-vkGetAccelerationStructureBuildSizesKHR-pBuildInfo-parameter",
+                           "VUID-VkAccelerationStructureBuildGeometryInfoKHR-sType-sType");
     if (pBuildInfo != nullptr) {
         [[maybe_unused]] const Location pBuildInfo_loc = loc.dot(Field::pBuildInfo);
         skip |= ValidateStructPnext(pBuildInfo_loc, pBuildInfo->pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -28856,9 +28578,9 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureBuildSizesKHR(
                               "VUID-VkAccelerationStructureBuildGeometryInfoKHR-flags-parameter");
 
         skip |= ValidateStructTypeArray(pBuildInfo_loc.dot(Field::geometryCount), pBuildInfo_loc.dot(Field::pGeometries),
-                                        "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pBuildInfo->geometryCount,
-                                        pBuildInfo->pGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false,
-                                        false, "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
+                                        pBuildInfo->geometryCount, pBuildInfo->pGeometries,
+                                        VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
+                                        "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
                                         "VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-parameter", kVUIDUndefined);
 
         if (pBuildInfo->pGeometries != nullptr) {
@@ -28878,12 +28600,11 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureBuildSizesKHR(
             }
         }
 
-        skip |= ValidateStructPointerTypeArray(pBuildInfo_loc.dot(Field::geometryCount), pBuildInfo_loc.dot(Field::ppGeometries),
-                                               "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR", pBuildInfo->geometryCount,
-                                               pBuildInfo->ppGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR,
-                                               false, false, "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
-                                               "VUID-VkAccelerationStructureBuildGeometryInfoKHR-ppGeometries-parameter",
-                                               kVUIDUndefined);
+        skip |= ValidateStructPointerTypeArray(
+            pBuildInfo_loc.dot(Field::geometryCount), pBuildInfo_loc.dot(Field::ppGeometries), pBuildInfo->geometryCount,
+            pBuildInfo->ppGeometries, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_GEOMETRY_KHR, false, false,
+            "VUID-VkAccelerationStructureGeometryKHR-sType-sType",
+            "VUID-VkAccelerationStructureBuildGeometryInfoKHR-ppGeometries-parameter", kVUIDUndefined);
 
         if (pBuildInfo->ppGeometries != nullptr) {
             for (uint32_t geometryIndex = 0; geometryIndex < pBuildInfo->geometryCount; ++geometryIndex) {
@@ -28902,9 +28623,8 @@ bool StatelessValidation::PreCallValidateGetAccelerationStructureBuildSizesKHR(
             }
         }
     }
-    skip |= ValidateStructType(loc.dot(Field::pSizeInfo), "VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR",
-                               pSizeInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR, true,
-                               "VUID-vkGetAccelerationStructureBuildSizesKHR-pSizeInfo-parameter",
+    skip |= ValidateStructType(loc.dot(Field::pSizeInfo), pSizeInfo, VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_BUILD_SIZES_INFO_KHR,
+                               true, "VUID-vkGetAccelerationStructureBuildSizesKHR-pSizeInfo-parameter",
                                "VUID-VkAccelerationStructureBuildSizesInfoKHR-sType-sType");
     if (pSizeInfo != nullptr) {
         [[maybe_unused]] const Location pSizeInfo_loc = loc.dot(Field::pSizeInfo);
@@ -28965,11 +28685,11 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
     [[maybe_unused]] const Location loc = error_obj.location;
     if (!IsExtEnabled(device_extensions.vk_khr_ray_tracing_pipeline))
         skip |= OutputExtensionError(loc, {vvl::Extension::_VK_KHR_ray_tracing_pipeline});
-    skip |= ValidateStructTypeArray(
-        loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), "VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR",
-        createInfoCount, pCreateInfos, VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR, true, true,
-        "VUID-VkRayTracingPipelineCreateInfoKHR-sType-sType", "VUID-vkCreateRayTracingPipelinesKHR-pCreateInfos-parameter",
-        "VUID-vkCreateRayTracingPipelinesKHR-createInfoCount-arraylength");
+    skip |= ValidateStructTypeArray(loc.dot(Field::createInfoCount), loc.dot(Field::pCreateInfos), createInfoCount, pCreateInfos,
+                                    VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR, true, true,
+                                    "VUID-VkRayTracingPipelineCreateInfoKHR-sType-sType",
+                                    "VUID-vkCreateRayTracingPipelinesKHR-pCreateInfos-parameter",
+                                    "VUID-vkCreateRayTracingPipelinesKHR-createInfoCount-arraylength");
     if (pCreateInfos != nullptr) {
         for (uint32_t createInfoIndex = 0; createInfoIndex < createInfoCount; ++createInfoIndex) {
             [[maybe_unused]] const Location pCreateInfos_loc = loc.dot(Field::pCreateInfos, createInfoIndex);
@@ -28984,7 +28704,6 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
                                         "VUID-VkRayTracingPipelineCreateInfoKHR-sType-unique", VK_NULL_HANDLE, true);
 
             skip |= ValidateStructTypeArray(pCreateInfos_loc.dot(Field::stageCount), pCreateInfos_loc.dot(Field::pStages),
-                                            "VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO",
                                             pCreateInfos[createInfoIndex].stageCount, pCreateInfos[createInfoIndex].pStages,
                                             VK_STRUCTURE_TYPE_PIPELINE_SHADER_STAGE_CREATE_INFO, false, true,
                                             "VUID-VkPipelineShaderStageCreateInfo-sType-sType",
@@ -29051,7 +28770,6 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
             }
 
             skip |= ValidateStructTypeArray(pCreateInfos_loc.dot(Field::groupCount), pCreateInfos_loc.dot(Field::pGroups),
-                                            "VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR",
                                             pCreateInfos[createInfoIndex].groupCount, pCreateInfos[createInfoIndex].pGroups,
                                             VK_STRUCTURE_TYPE_RAY_TRACING_SHADER_GROUP_CREATE_INFO_KHR, false, true,
                                             "VUID-VkRayTracingShaderGroupCreateInfoKHR-sType-sType",
@@ -29071,10 +28789,10 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
                 }
             }
 
-            skip |= ValidateStructType(
-                pCreateInfos_loc.dot(Field::pLibraryInfo), "VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR",
-                pCreateInfos[createInfoIndex].pLibraryInfo, VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, false,
-                "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-parameter", "VUID-VkPipelineLibraryCreateInfoKHR-sType-sType");
+            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::pLibraryInfo), pCreateInfos[createInfoIndex].pLibraryInfo,
+                                       VK_STRUCTURE_TYPE_PIPELINE_LIBRARY_CREATE_INFO_KHR, false,
+                                       "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInfo-parameter",
+                                       "VUID-VkPipelineLibraryCreateInfoKHR-sType-sType");
 
             if (pCreateInfos[createInfoIndex].pLibraryInfo != nullptr) {
                 [[maybe_unused]] const Location pLibraryInfo_loc = pCreateInfos_loc.dot(Field::pLibraryInfo);
@@ -29087,11 +28805,11 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
                                       "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
             }
 
-            skip |= ValidateStructType(
-                pCreateInfos_loc.dot(Field::pLibraryInterface), "VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR",
-                pCreateInfos[createInfoIndex].pLibraryInterface, VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR,
-                false, "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInterface-parameter",
-                "VUID-VkRayTracingPipelineInterfaceCreateInfoKHR-sType-sType");
+            skip |=
+                ValidateStructType(pCreateInfos_loc.dot(Field::pLibraryInterface), pCreateInfos[createInfoIndex].pLibraryInterface,
+                                   VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_INTERFACE_CREATE_INFO_KHR, false,
+                                   "VUID-VkRayTracingPipelineCreateInfoKHR-pLibraryInterface-parameter",
+                                   "VUID-VkRayTracingPipelineInterfaceCreateInfoKHR-sType-sType");
 
             if (pCreateInfos[createInfoIndex].pLibraryInterface != nullptr) {
                 [[maybe_unused]] const Location pLibraryInterface_loc = pCreateInfos_loc.dot(Field::pLibraryInterface);
@@ -29101,11 +28819,10 @@ bool StatelessValidation::PreCallValidateCreateRayTracingPipelinesKHR(VkDevice d
                                         kVUIDUndefined, VK_NULL_HANDLE, true);
             }
 
-            skip |= ValidateStructType(
-                pCreateInfos_loc.dot(Field::pDynamicState), "VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO",
-                pCreateInfos[createInfoIndex].pDynamicState, VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, false,
-                "VUID-VkRayTracingPipelineCreateInfoKHR-pDynamicState-parameter",
-                "VUID-VkPipelineDynamicStateCreateInfo-sType-sType");
+            skip |= ValidateStructType(pCreateInfos_loc.dot(Field::pDynamicState), pCreateInfos[createInfoIndex].pDynamicState,
+                                       VK_STRUCTURE_TYPE_PIPELINE_DYNAMIC_STATE_CREATE_INFO, false,
+                                       "VUID-VkRayTracingPipelineCreateInfoKHR-pDynamicState-parameter",
+                                       "VUID-VkPipelineDynamicStateCreateInfo-sType-sType");
 
             if (pCreateInfos[createInfoIndex].pDynamicState != nullptr) {
                 [[maybe_unused]] const Location pDynamicState_loc = pCreateInfos_loc.dot(Field::pDynamicState);
@@ -29279,8 +28996,7 @@ bool StatelessValidation::PreCallValidateCmdDrawMeshTasksIndirectCountEXT(VkComm
 bool StatelessValidation::ValidatePipelineViewportStateCreateInfo(const VkPipelineViewportStateCreateInfo& info,
                                                                   const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_VIEWPORT_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineViewportStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineViewportStateCreateInfo = {
@@ -29302,8 +29018,7 @@ bool StatelessValidation::ValidatePipelineViewportStateCreateInfo(const VkPipeli
 bool StatelessValidation::ValidatePipelineTessellationStateCreateInfo(const VkPipelineTessellationStateCreateInfo& info,
                                                                       const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_TESSELLATION_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineTessellationStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineTessellationStateCreateInfo = {
@@ -29321,8 +29036,7 @@ bool StatelessValidation::ValidatePipelineTessellationStateCreateInfo(const VkPi
 bool StatelessValidation::ValidatePipelineVertexInputStateCreateInfo(const VkPipelineVertexInputStateCreateInfo& info,
                                                                      const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineVertexInputStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineVertexInputStateCreateInfo = {
@@ -29369,8 +29083,7 @@ bool StatelessValidation::ValidatePipelineVertexInputStateCreateInfo(const VkPip
 bool StatelessValidation::ValidatePipelineMultisampleStateCreateInfo(const VkPipelineMultisampleStateCreateInfo& info,
                                                                      const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_MULTISAMPLE_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineMultisampleStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineMultisampleStateCreateInfo = {
@@ -29405,8 +29118,7 @@ bool StatelessValidation::ValidatePipelineMultisampleStateCreateInfo(const VkPip
 bool StatelessValidation::ValidatePipelineColorBlendStateCreateInfo(const VkPipelineColorBlendStateCreateInfo& info,
                                                                     const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_COLOR_BLEND_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineColorBlendStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineColorBlendStateCreateInfo = {
@@ -29463,8 +29175,7 @@ bool StatelessValidation::ValidatePipelineColorBlendStateCreateInfo(const VkPipe
 bool StatelessValidation::ValidatePipelineDepthStencilStateCreateInfo(const VkPipelineDepthStencilStateCreateInfo& info,
                                                                       const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_DEPTH_STENCIL_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineDepthStencilStateCreateInfo-sType-sType");
 
     skip |= ValidateStructPnext(loc, info.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -29513,8 +29224,7 @@ bool StatelessValidation::ValidatePipelineDepthStencilStateCreateInfo(const VkPi
 bool StatelessValidation::ValidatePipelineInputAssemblyStateCreateInfo(const VkPipelineInputAssemblyStateCreateInfo& info,
                                                                        const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_INPUT_ASSEMBLY_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineInputAssemblyStateCreateInfo-sType-sType");
 
     skip |= ValidateStructPnext(loc, info.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,
@@ -29532,8 +29242,7 @@ bool StatelessValidation::ValidatePipelineInputAssemblyStateCreateInfo(const VkP
 bool StatelessValidation::ValidatePipelineRasterizationStateCreateInfo(const VkPipelineRasterizationStateCreateInfo& info,
                                                                        const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO", &info,
-                               VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_PIPELINE_RASTERIZATION_STATE_CREATE_INFO, false, kVUIDUndefined,
                                "VUID-VkPipelineRasterizationStateCreateInfo-sType-sType");
 
     constexpr std::array allowed_structs_VkPipelineRasterizationStateCreateInfo = {
@@ -29571,8 +29280,7 @@ bool StatelessValidation::ValidatePipelineRasterizationStateCreateInfo(const VkP
 }
 bool StatelessValidation::ValidateDescriptorAddressInfoEXT(const VkDescriptorAddressInfoEXT& info, const Location& loc) const {
     bool skip = false;
-    skip |= ValidateStructType(loc, "VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT", &info,
-                               VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT, false, kVUIDUndefined,
+    skip |= ValidateStructType(loc, &info, VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT, false, kVUIDUndefined,
                                "VUID-VkDescriptorAddressInfoEXT-sType-sType");
 
     skip |= ValidateStructPnext(loc, info.pNext, 0, nullptr, GeneratedVulkanHeaderVersion,

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -815,18 +815,18 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                             count_required_vuid = self.GetVuid(callerName, f"{member.length}-arraylength")
                             # This is an array of struct pointers
                             if member.cDeclaration.count('*') == 2:
-                                usedLines.append(f'skip |= ValidateStructPointerTypeArray({errorLoc}.dot(Field::{lengthMember.name}), {errorLoc}.dot(Field::{member.name}), "{struct.sType}", {valuePrefix}{lengthMember.name}, {valuePrefix}{member.name}, {struct.sType}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_required_vuid});\n')
+                                usedLines.append(f'skip |= ValidateStructPointerTypeArray({errorLoc}.dot(Field::{lengthMember.name}), {errorLoc}.dot(Field::{member.name}), {valuePrefix}{lengthMember.name}, {valuePrefix}{member.name}, {struct.sType}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_required_vuid});\n')
                             # This is an array with a pointer to a count value
                             elif lengthMember.pointer:
                                 # When the length parameter is a pointer, there is an extra Boolean parameter in the function call to indicate if it is required
                                 count_ptr_required_vuid = self.GetVuid(callerName, f"{member.length}-parameter")
-                                usedLines.append(f'skip |= ValidateStructTypeArray({errorLoc}.dot(Field::{member.length}), {errorLoc}.dot(Field::{member.name}), "{struct.sType}", {valuePrefix}{member.length}, {valuePrefix}{member.name}, {struct.sType}, {lenPtrRequired}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_ptr_required_vuid}, {count_required_vuid});\n')
+                                usedLines.append(f'skip |= ValidateStructTypeArray({errorLoc}.dot(Field::{member.length}), {errorLoc}.dot(Field::{member.name}), {valuePrefix}{member.length}, {valuePrefix}{member.name}, {struct.sType}, {lenPtrRequired}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_ptr_required_vuid}, {count_required_vuid});\n')
                             # This is an array with an integer count value
                             else:
-                                usedLines.append(f'skip |= ValidateStructTypeArray({errorLoc}.dot(Field::{member.length}), {errorLoc}.dot(Field::{member.name}), "{struct.sType}", {valuePrefix}{member.length}, {valuePrefix}{member.name}, {struct.sType}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_required_vuid});\n')
+                                usedLines.append(f'skip |= ValidateStructTypeArray({errorLoc}.dot(Field::{member.length}), {errorLoc}.dot(Field::{member.name}), {valuePrefix}{member.length}, {valuePrefix}{member.name}, {struct.sType}, {lenValueRequired}, {valueRequired}, {stypeVUID}, {paramVUID}, {count_required_vuid});\n')
                         # This is an individual struct
                         else:
-                            usedLines.append(f'skip |= ValidateStructType({errorLoc}.dot(Field::{member.name}), "{struct.sType}", {valuePrefix}{member.name}, {struct.sType}, {valueRequired}, {paramVUID}, {stypeVUID});\n')
+                            usedLines.append(f'skip |= ValidateStructType({errorLoc}.dot(Field::{member.name}), {valuePrefix}{member.name}, {struct.sType}, {valueRequired}, {paramVUID}, {stypeVUID});\n')
                     # If this is an input handle array that is not allowed to contain NULL handles, verify that none of the handles are VK_NULL_HANDLE
                     elif member.type in self.vk.handles and member.const and not self.isHandleOptional(member, lengthMember):
                         if not lengthMember:
@@ -923,11 +923,11 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
                     if member.type in self.vk.structs and self.vk.structs[member.type].sType:
                         vuid = self.GetVuid(member.type, "sType-sType")
                         sType = self.vk.structs[member.type].sType
-                        usedLines.append(f'skip |= ValidateStructType({errorLoc}.dot(Field::{member.name}), "{sType}", &({valuePrefix}{member.name}), {sType}, false, kVUIDUndefined, {vuid});\n')
+                        usedLines.append(f'skip |= ValidateStructType({errorLoc}.dot(Field::{member.name}), &({valuePrefix}{member.name}), {sType}, false, kVUIDUndefined, {vuid});\n')
                     elif member.name == 'sType' and structTypeName in self.generateStructHelper:
                         # special case when dealing with isolated struct helper functions
                         vuid = self.GetVuid(struct.name, "sType-sType")
-                        usedLines.append(f'skip |= ValidateStructType(loc, "{struct.sType}", &info, {struct.sType}, false, kVUIDUndefined, {vuid});\n')
+                        usedLines.append(f'skip |= ValidateStructType(loc, &info, {struct.sType}, false, kVUIDUndefined, {vuid});\n')
                     elif member.type in self.vk.handles:
                         if not member.optional:
                             usedLines.append(f'skip |= ValidateRequiredHandle({errorLoc}.dot(Field::{member.name}), {valuePrefix}{member.name});\n')


### PR DESCRIPTION
I noticed we were passing in both the sType enum  and string, but we can just go `string_VkStructureType` and save a LOT of strings being passed around