### PR TITLE
tests: Remove pNext warning for VkValidationFeaturesEXT

### DIFF
--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -62,8 +62,6 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
     features.pEnabledValidationFeatures = enabled;
     vert_create_info.pNext = &features;
 
-    // TODO - Once the spec is changed to allow this, the SetUnexpectedError call can be removed
-    m_errorMonitor->SetUnexpectedError("VUID-VkShaderCreateInfoEXT-pNext-pNext");
     const vkt::Shader vertShader(*m_device, vert_create_info);
     const vkt::Shader fragShader(*m_device, frag_create_info);
 


### PR DESCRIPTION
I got the implicit VU to allow for `VkValidationFeaturesEXT` in Shader Object

![image](https://github.com/KhronosGroup/Vulkan-ValidationLayers/assets/115671160/759c5ad1-4cc8-44ef-b981-f80e85e620b1)
