### PR TITLE
layers: Create combined dynamic state draw check

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -95,7 +95,10 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDynamicStateIsSet(const CBDynamicFlags& state_status_cb, CBDynamicState dynamic_state,
                                    const vvl::CommandBuffer& cb_state, const LogObjectList& objlist, const Location& loc,
                                    const char* vuid) const;
+    bool ValidateDynamicStateIsSet(const LastBound& last_bound_state, const CBDynamicFlags& state_status_cb,
+                                   CBDynamicState dynamic_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateGraphicsDynamicStatePipelineSetStatus(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsDynamicStateValue(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateGraphicsDynamicStateViewportScissor(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawDynamicState(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;

--- a/layers/drawdispatch/drawdispatch_vuids.cpp
+++ b/layers/drawdispatch/drawdispatch_vuids.cpp
@@ -267,9 +267,7 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDraw-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDraw-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDraw-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDraw-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDraw-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDraw-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDraw-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDraw-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDraw-None-08625";
@@ -278,7 +276,6 @@ struct DispatchVuidsCmdDraw : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDraw-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDraw-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDraw-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDraw-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDraw-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDraw-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDraw-None-08634";
@@ -581,9 +578,7 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawMultiEXT-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawMultiEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMultiEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMultiEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMultiEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMultiEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMultiEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMultiEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMultiEXT-None-08625";
@@ -592,7 +587,6 @@ struct DispatchVuidsCmdDrawMultiEXT : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMultiEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMultiEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMultiEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMultiEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMultiEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMultiEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMultiEXT-None-08634";
@@ -896,9 +890,7 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndexed-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndexed-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndexed-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndexed-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndexed-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndexed-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndexed-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndexed-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndexed-None-08625";
@@ -907,7 +899,6 @@ struct DispatchVuidsCmdDrawIndexed : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndexed-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndexed-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndexed-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndexed-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndexed-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndexed-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndexed-None-08634";
@@ -1211,9 +1202,7 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawMultiIndexedEXT-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMultiIndexedEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMultiIndexedEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMultiIndexedEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMultiIndexedEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMultiIndexedEXT-None-08625";
@@ -1222,7 +1211,6 @@ struct DispatchVuidsCmdDrawMultiIndexedEXT : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMultiIndexedEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMultiIndexedEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMultiIndexedEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMultiIndexedEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMultiIndexedEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMultiIndexedEXT-None-08634";
@@ -1526,9 +1514,7 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndirect-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndirect-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndirect-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndirect-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndirect-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndirect-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndirect-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndirect-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndirect-None-08625";
@@ -1537,7 +1523,6 @@ struct DispatchVuidsCmdDrawIndirect : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndirect-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndirect-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndirect-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndirect-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndirect-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndirect-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndirect-None-08634";
@@ -1840,9 +1825,7 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndexedIndirect-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndexedIndirect-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndexedIndirect-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndexedIndirect-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndexedIndirect-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndexedIndirect-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndexedIndirect-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndexedIndirect-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndexedIndirect-None-08625";
@@ -1851,7 +1834,6 @@ struct DispatchVuidsCmdDrawIndexedIndirect : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndexedIndirect-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndexedIndirect-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndexedIndirect-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndexedIndirect-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndexedIndirect-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndexedIndirect-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndexedIndirect-None-08634";
@@ -2253,9 +2235,7 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndirectCount-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndirectCount-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndirectCount-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndirectCount-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndirectCount-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndirectCount-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndirectCount-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndirectCount-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndirectCount-None-08625";
@@ -2264,7 +2244,6 @@ struct DispatchVuidsCmdDrawIndirectCount : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndirectCount-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndirectCount-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndirectCount-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndirectCount-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndirectCount-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndirectCount-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndirectCount-None-08634";
@@ -2570,9 +2549,7 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndexedIndirectCount-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndexedIndirectCount-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndexedIndirectCount-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndexedIndirectCount-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndexedIndirectCount-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndexedIndirectCount-None-08625";
@@ -2581,7 +2558,6 @@ struct DispatchVuidsCmdDrawIndexedIndirectCount : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndexedIndirectCount-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndexedIndirectCount-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndexedIndirectCount-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndexedIndirectCount-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndexedIndirectCount-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndexedIndirectCount-None-08634";
@@ -3065,9 +3041,7 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksNV-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksNV-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksNV-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksNV-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksNV-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksNV-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksNV-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksNV-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksNV-None-08625";
@@ -3076,7 +3050,6 @@ struct DispatchVuidsCmdDrawMeshTasksNV: DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksNV-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksNV-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksNV-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksNV-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksNV-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksNV-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksNV-None-08634";
@@ -3365,9 +3338,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08625";
@@ -3376,7 +3347,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectNV: DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksIndirectNV-None-08634";
@@ -3668,9 +3638,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08625";
@@ -3679,7 +3647,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountNV : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksIndirectCountNV-None-08634";
@@ -3965,9 +3932,7 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksEXT-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksEXT-None-08625";
@@ -3976,7 +3941,6 @@ struct DispatchVuidsCmdDrawMeshTasksEXT: DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksEXT-None-08634";
@@ -4265,9 +4229,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08625";
@@ -4276,7 +4238,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectEXT: DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksIndirectEXT-None-08634";
@@ -4568,9 +4529,7 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         set_attachment_feedback_loop_enable_08880 = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08880";
         set_line_width_08617                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08625";
@@ -4579,7 +4538,6 @@ struct DispatchVuidsCmdDrawMeshTasksIndirectCountEXT : DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawMeshTasksIndirectCountEXT-None-08634";
@@ -4879,9 +4837,7 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         draw_shaders_no_task_mesh_08885          = "VUID-vkCmdDrawIndirectByteCountEXT-None-08885";
         set_line_width_08617                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08617";
         set_line_width_08618                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08618";
-        set_depth_bias_08620                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08620";
         set_blend_constants_08621                = "VUID-vkCmdDrawIndirectByteCountEXT-None-08621";
-        set_depth_bounds_08622                   = "VUID-vkCmdDrawIndirectByteCountEXT-None-08622";
         set_stencil_compare_mask_08623           = "VUID-vkCmdDrawIndirectByteCountEXT-None-08623";
         set_stencil_write_mask_08624             = "VUID-vkCmdDrawIndirectByteCountEXT-None-08624";
         set_stencil_reference_08625              = "VUID-vkCmdDrawIndirectByteCountEXT-None-08625";
@@ -4890,7 +4846,6 @@ struct DispatchVuidsCmdDrawIndirectByteCountEXT: DrawDispatchVuid {
         set_front_face_08628                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08628";
         set_depth_test_enable_08629              = "VUID-vkCmdDrawIndirectByteCountEXT-None-08629";
         set_depth_write_enable_08630             = "VUID-vkCmdDrawIndirectByteCountEXT-None-08630";
-        set_depth_comapre_op_08631               = "VUID-vkCmdDrawIndirectByteCountEXT-None-08631";
         set_depth_bounds_test_enable_08632       = "VUID-vkCmdDrawIndirectByteCountEXT-None-08632";
         set_stencil_test_enable_08633            = "VUID-vkCmdDrawIndirectByteCountEXT-None-08633";
         set_stencil_op_08634                     = "VUID-vkCmdDrawIndirectByteCountEXT-None-08634";

--- a/layers/drawdispatch/drawdispatch_vuids.h
+++ b/layers/drawdispatch/drawdispatch_vuids.h
@@ -286,9 +286,7 @@ struct DrawDispatchVuid {
     const char* draw_shaders_no_task_mesh_08885 = kVUIDUndefined;
     const char* set_line_width_08617 = kVUIDUndefined;
     const char* set_line_width_08618 = kVUIDUndefined;
-    const char* set_depth_bias_08620 = kVUIDUndefined;
     const char* set_blend_constants_08621 = kVUIDUndefined;
-    const char* set_depth_bounds_08622 = kVUIDUndefined;
     const char* set_stencil_compare_mask_08623 = kVUIDUndefined;
     const char* set_stencil_write_mask_08624 = kVUIDUndefined;
     const char* set_stencil_reference_08625 = kVUIDUndefined;
@@ -297,7 +295,6 @@ struct DrawDispatchVuid {
     const char* set_front_face_08628 = kVUIDUndefined;
     const char* set_depth_test_enable_08629 = kVUIDUndefined;
     const char* set_depth_write_enable_08630 = kVUIDUndefined;
-    const char* set_depth_comapre_op_08631 = kVUIDUndefined;
     const char* set_depth_bounds_test_enable_08632 = kVUIDUndefined;
     const char* set_stencil_test_enable_08633 = kVUIDUndefined;
     const char* set_stencil_op_08634 = kVUIDUndefined;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -822,7 +822,9 @@ void LastBound::Reset() {
 
 bool LastBound::IsDepthTestEnable() const {
     if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE)) {
-        return cb_state.dynamic_state_value.depth_test_enable;
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE)) {
+            return cb_state.dynamic_state_value.depth_test_enable;
+        }
     } else {
         if (pipeline_state->DepthStencilState()) {
             return pipeline_state->DepthStencilState()->depthTestEnable;
@@ -833,7 +835,9 @@ bool LastBound::IsDepthTestEnable() const {
 
 bool LastBound::IsDepthBoundTestEnable() const {
     if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)) {
-        return cb_state.dynamic_state_value.depth_bounds_test_enable;
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)) {
+            return cb_state.dynamic_state_value.depth_bounds_test_enable;
+        }
     } else {
         if (pipeline_state->DepthStencilState()) {
             return pipeline_state->DepthStencilState()->depthBoundsTestEnable;
@@ -847,14 +851,36 @@ bool LastBound::IsDepthWriteEnable() const {
     if (!IsDepthTestEnable()) {
         return false;
     }
-    return (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE))
-               ? cb_state.dynamic_state_value.depth_write_enable
-               : pipeline_state->DepthStencilState()->depthWriteEnable;
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE)) {
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE)) {
+            return cb_state.dynamic_state_value.depth_write_enable;
+        }
+    } else {
+        if (pipeline_state->DepthStencilState()) {
+            return pipeline_state->DepthStencilState()->depthWriteEnable;
+        }
+    }
+    return false;
+}
+
+bool LastBound::IsDepthBiasEnable() const {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE)) {
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE)) {
+            return cb_state.dynamic_state_value.depth_bias_enable;
+        }
+    } else {
+        if (pipeline_state->RasterizationState()) {
+            return pipeline_state->RasterizationState()->depthBiasEnable;
+        }
+    }
+    return false;
 }
 
 bool LastBound::IsStencilTestEnable() const {
     if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE)) {
-        return cb_state.dynamic_state_value.stencil_test_enable;
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_STENCIL_TEST_ENABLE)) {
+            return cb_state.dynamic_state_value.stencil_test_enable;
+        }
     } else {
         if (pipeline_state->DepthStencilState()) {
             return pipeline_state->DepthStencilState()->stencilTestEnable;
@@ -864,11 +890,14 @@ bool LastBound::IsStencilTestEnable() const {
 }
 
 VkStencilOpState LastBound::GetStencilOpStateFront() const {
-    VkStencilOpState front = pipeline_state->DepthStencilState()->front;
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
+    VkStencilOpState front = {};
+    if (pipeline_state) {
+        front = pipeline_state->DepthStencilState()->front;
+    }
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
         front.writeMask = cb_state.dynamic_state_value.write_mask_front;
     }
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP)) {
         front.failOp = cb_state.dynamic_state_value.fail_op_front;
         front.passOp = cb_state.dynamic_state_value.pass_op_front;
         front.depthFailOp = cb_state.dynamic_state_value.depth_fail_op_front;
@@ -877,11 +906,14 @@ VkStencilOpState LastBound::GetStencilOpStateFront() const {
 }
 
 VkStencilOpState LastBound::GetStencilOpStateBack() const {
-    VkStencilOpState back = pipeline_state->DepthStencilState()->back;
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
+    VkStencilOpState back = {};
+    if (pipeline_state) {
+        back = pipeline_state->DepthStencilState()->back;
+    }
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK)) {
         back.writeMask = cb_state.dynamic_state_value.write_mask_back;
     }
-    if (pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP)) {
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_STENCIL_OP)) {
         back.failOp = cb_state.dynamic_state_value.fail_op_back;
         back.passOp = cb_state.dynamic_state_value.pass_op_back;
         back.depthFailOp = cb_state.dynamic_state_value.depth_fail_op_back;
@@ -904,9 +936,14 @@ VkSampleCountFlagBits LastBound::GetRasterizationSamples() const {
 }
 
 bool LastBound::IsRasterizationDisabled() const {
-    return (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE))
-               ? cb_state.dynamic_state_value.rasterizer_discard_enable
-               : pipeline_state->RasterizationDisabled();
+    if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {
+            return cb_state.dynamic_state_value.rasterizer_discard_enable;
+        }
+    } else {
+        return (pipeline_state->RasterizationDisabled());
+    }
+    return false;
 }
 
 VkColorComponentFlags LastBound::GetColorWriteMask(uint32_t i) const {
@@ -924,7 +961,9 @@ VkColorComponentFlags LastBound::GetColorWriteMask(uint32_t i) const {
 
 bool LastBound::IsColorWriteEnabled(uint32_t i) const {
     if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT)) {
-        return cb_state.dynamic_state_value.color_write_enabled[i];
+        if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT)) {
+            return cb_state.dynamic_state_value.color_write_enabled[i];
+        }
     } else {
         if (pipeline_state->ColorBlendState()) {
             auto color_write =

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -671,6 +671,7 @@ struct LastBound {
     bool IsDepthTestEnable() const;
     bool IsDepthBoundTestEnable() const;
     bool IsDepthWriteEnable() const;
+    bool IsDepthBiasEnable() const;
     bool IsStencilTestEnable() const;
     VkStencilOpState GetStencilOpStateFront() const;
     VkStencilOpState GetStencilOpStateBack() const;

--- a/layers/vulkan/generated/dynamic_state_helper.cpp
+++ b/layers/vulkan/generated/dynamic_state_helper.cpp
@@ -22,6 +22,7 @@
 // NOLINTBEGIN
 
 #include "core_checks/core_validation.h"
+#include "state_tracker/pipeline_state.h"
 
 VkDynamicState ConvertToDynamicState(CBDynamicState dynamic_state) {
     switch (dynamic_state) {
@@ -588,6 +589,56 @@ std::string DescribeDynamicStateCommand(CBDynamicState dynamic_state) {
     // Currently only exception that has 2 commands that can set it
     if (dynamic_state == CB_DYNAMIC_STATE_DEPTH_BIAS) {
         ss << " or " << String(vvl::Func::vkCmdSetDepthBias2EXT);
+    }
+
+    return ss.str();
+}
+
+std::string DescribeDynamicStateDependency(CBDynamicState dynamic_state, const vvl::Pipeline* pipeline) {
+    std::stringstream ss;
+    switch (dynamic_state) {
+        case CB_DYNAMIC_STATE_DEPTH_BIAS:
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {
+                ss << "vkCmdSetRasterizerDiscardEnable last set rasterizerDiscardEnable to VK_FALSE.\n";
+            } else {
+                ss << "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable was VK_FALSE in the last bound graphics "
+                      "pipeline.\n";
+            }
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BIAS_ENABLE)) {
+                ss << "vkCmdSetDepthBiasEnable last set depthTestEnable to VK_TRUE.\n";
+            } else {
+                ss << "VkPipelineRasterizationStateCreateInfo::depthTestEnable was VK_TRUE in the last bound graphics pipeline.\n";
+            }
+            break;
+        case CB_DYNAMIC_STATE_DEPTH_BOUNDS:
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {
+                ss << "vkCmdSetRasterizerDiscardEnable last set rasterizerDiscardEnable to VK_FALSE.\n";
+            } else {
+                ss << "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable was VK_FALSE in the last bound graphics "
+                      "pipeline.\n";
+            }
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE)) {
+                ss << "vkCmdSetDepthBoundsTestEnable last set depthBoundsTestEnable to VK_TRUE.\n";
+            } else {
+                ss << "VkPipelineDepthStencilStateCreateInfo::depthBoundsTestEnable was VK_TRUE in the last bound graphics "
+                      "pipeline.\n";
+            }
+            break;
+        case CB_DYNAMIC_STATE_DEPTH_COMPARE_OP:
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE)) {
+                ss << "vkCmdSetRasterizerDiscardEnable last set rasterizerDiscardEnable to VK_FALSE.\n";
+            } else {
+                ss << "VkPipelineRasterizationStateCreateInfo::rasterizerDiscardEnable was VK_FALSE in the last bound graphics "
+                      "pipeline.\n";
+            }
+            if (!pipeline || pipeline->IsDynamic(CB_DYNAMIC_STATE_DEPTH_TEST_ENABLE)) {
+                ss << "vkCmdSetDepthTestEnable last set depthTestEnable to VK_TRUE.\n";
+            } else {
+                ss << "VkPipelineDepthStencilStateCreateInfo::depthTestEnable was VK_TRUE in the last bound graphics pipeline.\n";
+            }
+            break;
+        default:
+            ss << "(Unknown Dynamic State)";
     }
 
     return ss.str();

--- a/layers/vulkan/generated/dynamic_state_helper.h
+++ b/layers/vulkan/generated/dynamic_state_helper.h
@@ -24,6 +24,10 @@
 #pragma once
 #include <bitset>
 
+namespace vvl {
+class Pipeline;
+}  // namespace vvl
+
 // Reorders VkDynamicState so it can be a bitset
 typedef enum CBDynamicState {
     CB_DYNAMIC_STATE_VIEWPORT = 1,
@@ -104,10 +108,11 @@ typedef enum CBDynamicState {
 using CBDynamicFlags = std::bitset<CB_DYNAMIC_STATE_STATUS_NUM>;
 VkDynamicState ConvertToDynamicState(CBDynamicState dynamic_state);
 CBDynamicState ConvertToCBDynamicState(VkDynamicState dynamic_state);
-const char *DynamicStateToString(CBDynamicState dynamic_state);
-std::string DynamicStatesToString(CBDynamicFlags const &dynamic_states);
-std::string DynamicStatesCommandsToString(CBDynamicFlags const &dynamic_states);
+const char* DynamicStateToString(CBDynamicState dynamic_state);
+std::string DynamicStatesToString(CBDynamicFlags const& dynamic_states);
+std::string DynamicStatesCommandsToString(CBDynamicFlags const& dynamic_states);
 
 std::string DescribeDynamicStateCommand(CBDynamicState dynamic_state);
+std::string DescribeDynamicStateDependency(CBDynamicState dynamic_state, const vvl::Pipeline* pipeline);
 
 // NOLINTEND

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -3499,7 +3499,7 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyLineCmdSetLineWidthEXT) {
 TEST_F(NegativeShaderObject, MissingCmdSetDepthBiasEXT) {
     TEST_DESCRIPTION("Draw with shader objects without setting vkCmdSetDepthBiasEXT.");
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08620");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07834");
 
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
@@ -3564,7 +3564,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetBlendConstantsEXT) {
 TEST_F(NegativeShaderObject, MissingCmdSetDepthBoundsEXT) {
     TEST_DESCRIPTION("Draw with shader objects without setting vkCmdSetDepthBoundsEXT.");
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08622");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07836");
 
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
@@ -3778,7 +3778,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthWriteEnableEXT) {
 TEST_F(NegativeShaderObject, MissingCmdSetDepthCompareOp) {
     TEST_DESCRIPTION("Draw with shader objects without setting vkCmdSetDepthCompareOp.");
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08631");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07845");
 
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();


### PR DESCRIPTION
This change is from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6345 (and there are more coming, just doing 3 to start)

The overall goal is to combine all the drawtime dynamic state checks from Shader Object and Pipeline into a single check