### PR TITLE
layers: Cleanup Sampler in Stateless

### DIFF
--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -120,14 +120,223 @@ bool StatelessValidation::ValidateCoarseSampleOrderCustomNV(const VkCoarseSample
     return skip;
 }
 
+// VK_EXT_sampler_filter_minmax
+bool StatelessValidation::ValidateSamplerFilterMinMax(const VkSamplerCreateInfo &create_info,
+                                                      const Location &create_info_loc) const {
+    bool skip = false;
+    const auto *sampler_reduction = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(create_info.pNext);
+    if (!sampler_reduction) return skip;
+
+    if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
+        if ((api_version >= VK_API_VERSION_1_2) && !enabled_features.samplerFilterMinmax) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-pNext-06726", device,
+                             create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                             "is %s but samplerFilterMinmax feature was not enabled.",
+                             string_VkSamplerReductionMode(sampler_reduction->reductionMode));
+        } else if ((api_version < VK_API_VERSION_1_2) && !IsExtEnabled(device_extensions.vk_ext_sampler_filter_minmax)) {
+            // NOTE: technically this VUID is only if the corresponding _feature_ is not enabled, and only if on api_version
+            // >= 1.2, but there doesn't appear to be a similar VUID for when api_version < 1.2
+            skip |=
+                LogError("VUID-VkSamplerCreateInfo-pNext-06726", device,
+                         create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                         "is %s, but extension %s is not enabled.", string_VkSamplerReductionMode(sampler_reduction->reductionMode),
+                         VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME);
+        }
+
+        if (vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(create_info.pNext)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-None-01647", device,
+                             create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                             "is %s but a VkSamplerYcbcrConversionInfo structure is also linked in the pNext chain of the "
+                             "VkSamplerCreateInfo structure.",
+                             string_VkSamplerReductionMode(sampler_reduction->reductionMode));
+        }
+
+        if (create_info.compareEnable == VK_TRUE) {
+            skip |=
+                LogError("VUID-VkSamplerCreateInfo-compareEnable-01423", device,
+                         create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                         "is %s but compareEnable is VK_TRUE.", string_VkSamplerReductionMode(sampler_reduction->reductionMode));
+        }
+
+        // This VU is the one feature difference between the IMG and EXT version of the extension
+        if (create_info.magFilter == VK_FILTER_CUBIC_IMG || create_info.minFilter == VK_FILTER_CUBIC_IMG) {
+            if (!IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
+                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-07911", device,
+                                 create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
+                                 "is %s, magFilter is %s and minFilter is %s, but "
+                                 "extension %s is not enabled.",
+                                 string_VkSamplerReductionMode(sampler_reduction->reductionMode),
+                                 string_VkFilter(create_info.magFilter), string_VkFilter(create_info.minFilter),
+                                 VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
+            }
+        }
+    }
+
+    return skip;
+}
+
+// VK_EXT_custom_border_color
+bool StatelessValidation::ValidateSamplerCustomBoarderColor(const VkSamplerCreateInfo &create_info,
+                                                            const Location &create_info_loc) const {
+    bool skip = false;
+
+    if (create_info.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT || create_info.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
+        if (!enabled_features.customBorderColors) {
+            skip |=
+                LogError("VUID-VkSamplerCreateInfo-customBorderColors-04085", device, create_info_loc.dot(Field::borderColor),
+                         "is %s but customBorderColors feature was not enabled.", string_VkBorderColor(create_info.borderColor));
+        }
+
+        auto custom_create_info = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(create_info.pNext);
+        if (!custom_create_info) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, create_info_loc.dot(Field::borderColor),
+                             "is %s but there is no VkSamplerCustomBorderColorCreateInfoEXT "
+                             "struct in pNext chain.",
+                             string_VkBorderColor(create_info.borderColor));
+        } else {
+            if ((custom_create_info->format != VK_FORMAT_UNDEFINED) && !vkuFormatIsDepthAndStencil(custom_create_info->format) &&
+                ((create_info.borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT &&
+                  !vkuFormatIsSampledInt(custom_create_info->format)) ||
+                 (create_info.borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT &&
+                  !vkuFormatIsSampledFloat(custom_create_info->format)))) {
+                skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605", device,
+                                 create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
+                                 "%s does not match borderColor (%s).", string_VkFormat(custom_create_info->format),
+                                 string_VkBorderColor(create_info.borderColor));
+            }
+
+            if (custom_create_info->format == VK_FORMAT_UNDEFINED && !enabled_features.customBorderColorWithoutFormat) {
+                skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04014", device,
+                                 create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
+                                 "is VK_FORMAT_UNDEFINED but the "
+                                 "customBorderColorWithoutFormat feature was not enabled.");
+            }
+        }
+    }
+
+    return skip;
+}
+
+// VK_EXT_fragment_density_map
+bool StatelessValidation::ValidateSamplerSubsampled(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const {
+    bool skip = false;
+    if ((create_info.flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) == 0) return skip;
+
+    if (create_info.minFilter != create_info.magFilter) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                         "minFilter (%s) and magFilter (%s) are not equal.",
+                         string_VkFilter(create_info.minFilter), string_VkFilter(create_info.magFilter));
+    }
+    if (create_info.mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                         "mipmapMode (%s) is not VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                         string_VkSamplerMipmapMode(create_info.mipmapMode));
+    }
+    if (create_info.minLod != 0.0 || create_info.maxLod != 0.0) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
+                         "minLod (%f) and maxLod (%f) are not zero.",
+                         create_info.minLod, create_info.maxLod);
+    }
+    if (((create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+         (create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
+        ((create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+         (create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
+        skip |=
+            LogError("VUID-VkSamplerCreateInfo-flags-02577", device, create_info_loc.dot(Field::flags),
+                     "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, so "
+                     "addressModeU (%s) and addressModeV (%s) must be "
+                     "CLAMP_TO_EDGE or CLAMP_TO_BORDER",
+                     string_VkSamplerAddressMode(create_info.addressModeU), string_VkSamplerAddressMode(create_info.addressModeV));
+    }
+    if (create_info.anisotropyEnable) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                         "but anisotropyEnable is VK_TRUE.");
+    }
+    if (create_info.compareEnable) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                         "but compareEnable is VK_TRUE.");
+    }
+    if (create_info.unnormalizedCoordinates) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
+                         "but unnormalizedCoordinates is VK_TRUE.");
+    }
+
+    return skip;
+}
+
+// VK_QCOM_image_processing
+bool StatelessValidation::ValidateSamplerImageProcessingQCOM(const VkSamplerCreateInfo &create_info,
+                                                             const Location &create_info_loc) const {
+    bool skip = false;
+    if ((create_info.flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) == 0) return skip;
+
+    if ((create_info.minFilter != VK_FILTER_NEAREST) || (create_info.magFilter != VK_FILTER_NEAREST)) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, so "
+                         "minFilter (%s) must be VK_FILTER_NEAREST and "
+                         "magFilter (%s) must be VK_FILTER_NEAREST.",
+                         string_VkFilter(create_info.minFilter), string_VkFilter(create_info.magFilter));
+    }
+    if (create_info.mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, so "
+                         "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
+                         string_VkSamplerMipmapMode(create_info.mipmapMode));
+    }
+    if ((create_info.minLod != 0) || (create_info.maxLod != 0)) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, so "
+                         "minLod (%f) and maxLod (%f) must be 0.",
+                         create_info.minLod, create_info.maxLod);
+    }
+    if (((create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+         (create_info.addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
+        ((create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
+         (create_info.addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
+        skip |=
+            LogError("VUID-VkSamplerCreateInfo-flags-06967", device, create_info_loc.dot(Field::flags),
+                     "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, so "
+                     "addressModeU (%s) and addressModeV (%s) must be either "
+                     "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
+                     string_VkSamplerAddressMode(create_info.addressModeU), string_VkSamplerAddressMode(create_info.addressModeV));
+    }
+    if (((create_info.addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
+         (create_info.addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) &&
+        (create_info.borderColor != VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06968", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                         "so if either addressModeU (%s) or addressModeV (%s) is "
+                         "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, then"
+                         "borderColor (%s) must be VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK.",
+                         string_VkSamplerAddressMode(create_info.addressModeU),
+                         string_VkSamplerAddressMode(create_info.addressModeV), string_VkBorderColor(create_info.borderColor));
+    }
+    if (create_info.anisotropyEnable) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                         "but anisotropyEnable is VK_TRUE.");
+    }
+    if (create_info.compareEnable) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
+                         "but compareEnable is VK_TRUE.");
+    }
+
+    return skip;
+}
+
 bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                                               const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
                                                               const ErrorObject &error_obj) const {
     bool skip = false;
+    if (!pCreateInfo) return skip;
 
-    if (pCreateInfo == nullptr) {
-        return skip;
-    }
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     const auto &limits = device_limits;
 
@@ -186,42 +395,33 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         }
     }
 
-    // If compareEnable is VK_TRUE, compareOp must be a valid VkCompareOp value
-    const auto *sampler_reduction = vku::FindStructInPNextChain<VkSamplerReductionModeCreateInfo>(pCreateInfo->pNext);
     if (pCreateInfo->compareEnable == VK_TRUE) {
         skip |= ValidateRangedEnum(create_info_loc.dot(Field::compareOp), vvl::Enum::VkCompareOp, pCreateInfo->compareOp,
                                    "VUID-VkSamplerCreateInfo-compareEnable-01080");
-        if (sampler_reduction != nullptr) {
-            if (sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-compareEnable-01423", device,
-                                 create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
-                                 "is %s but compareEnable is VK_TRUE.",
-                                 string_VkSamplerReductionMode(sampler_reduction->reductionMode));
-            }
-        }
-    }
-    if (sampler_reduction && sampler_reduction->reductionMode != VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE) {
-        // This VU is the one feature difference between the IMG and EXT version of the extension
-        if (pCreateInfo->magFilter == VK_FILTER_CUBIC_IMG || pCreateInfo->minFilter == VK_FILTER_CUBIC_IMG) {
-            if (!IsExtEnabled(device_extensions.vk_ext_filter_cubic)) {
-                skip |= LogError("VUID-VkSamplerCreateInfo-magFilter-07911", device,
-                                 create_info_loc.pNext(Struct::VkSamplerReductionModeCreateInfo, Field::reductionMode),
-                                 "is %s, magFilter is %s and minFilter is %s, but "
-                                 "extension %s is not enabled.",
-                                 string_VkSamplerReductionMode(sampler_reduction->reductionMode),
-                                 string_VkFilter(pCreateInfo->magFilter), string_VkFilter(pCreateInfo->minFilter),
-                                 VK_EXT_FILTER_CUBIC_EXTENSION_NAME);
-            }
-        }
     }
 
-    // If any of addressModeU, addressModeV or addressModeW are VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, borderColor must be a
-    // valid VkBorderColor value
     if ((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
         (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
         (pCreateInfo->addressModeW == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) {
         skip |= ValidateRangedEnum(create_info_loc.dot(Field::borderColor), vvl::Enum::VkBorderColor, pCreateInfo->borderColor,
                                    "VUID-VkSamplerCreateInfo-addressModeU-01078");
+    }
+
+    if (enabled_features.samplerMirrorClampToEdge == VK_FALSE) {
+        // Only display at most one of address mode error otherwise it turns into spam
+        if (pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-addressModeU-01079", device, create_info_loc.dot(Field::addressModeU),
+                             "is VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE but the "
+                             "VK_KHR_sampler_mirror_clamp_to_edge extension or samplerMirrorClampToEdge feature was not enabled.");
+        } else if (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-addressModeU-01079", device, create_info_loc.dot(Field::addressModeV),
+                             "is VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE but the "
+                             "VK_KHR_sampler_mirror_clamp_to_edge extension or samplerMirrorClampToEdge feature was not enabled.");
+        } else if (pCreateInfo->addressModeW == VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-addressModeU-01079", device, create_info_loc.dot(Field::addressModeW),
+                             "is VK_SAMPLER_ADDRESS_MODE_MIRROR_CLAMP_TO_EDGE but the "
+                             "VK_KHR_sampler_mirror_clamp_to_edge extension or samplerMirrorClampToEdge feature was not enabled.");
+        }
     }
 
     // Checks for the IMG cubic filtering extension
@@ -246,15 +446,14 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
                          "(%f) is greater than maxSamplerLodBias (%f)", pCreateInfo->mipLodBias, limits.maxSamplerLodBias);
     }
 
-    const auto *sampler_conversion = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
-    if (sampler_conversion != nullptr) {
+    if (vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext)) {
         if ((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
             (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) ||
             (pCreateInfo->addressModeW != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) || (pCreateInfo->anisotropyEnable != VK_FALSE) ||
             (pCreateInfo->unnormalizedCoordinates != VK_FALSE)) {
             skip |= LogError(
                 "VUID-VkSamplerCreateInfo-addressModeU-01646", device, create_info_loc,
-                "vkCreateSampler():  SamplerYCbCrConversion is enabled: "
+                "SamplerYCbCrConversion is enabled: "
                 "addressModeU (%s), addressModeV (%s), addressModeW (%s) must be CLAMP_TO_EDGE, and anisotropyEnable (%s) "
                 "and unnormalizedCoordinates (%s) must be VK_FALSE.",
                 string_VkSamplerAddressMode(pCreateInfo->addressModeU), string_VkSamplerAddressMode(pCreateInfo->addressModeV),
@@ -263,77 +462,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         }
     }
 
-    if (pCreateInfo->flags & VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT) {
-        if (pCreateInfo->minFilter != pCreateInfo->magFilter) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02574", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                             "minFilter (%s) and magFilter (%s) must be equal.",
-                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
-        }
-        if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02575", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                             "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                             string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
-        }
-        if (pCreateInfo->minLod != 0.0 || pCreateInfo->maxLod != 0.0) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02576", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, but "
-                             "minLod (%f) and maxLod (%f) must be zero.",
-                             pCreateInfo->minLod, pCreateInfo->maxLod);
-        }
-        if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-             (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
-            ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-             (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02577", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                             "addressModeU (%s) and addressModeV (%s) must be "
-                             "CLAMP_TO_EDGE or CLAMP_TO_BORDER",
-                             string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                             string_VkSamplerAddressMode(pCreateInfo->addressModeV));
-        }
-        if (pCreateInfo->anisotropyEnable) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02578", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                             "but anisotropyEnable is VK_TRUE.");
-        }
-        if (pCreateInfo->compareEnable) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02579", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                             "but compareEnable is VK_TRUE.");
-        }
-        if (pCreateInfo->unnormalizedCoordinates) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-02580", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_SUBSAMPLED_BIT_EXT, "
-                             "but unnormalizedCoordinates is VK_TRUE.");
-        }
-    }
-
-    if (pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT ||
-        pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT) {
-        auto custom_create_info = vku::FindStructInPNextChain<VkSamplerCustomBorderColorCreateInfoEXT>(pCreateInfo->pNext);
-        if (!custom_create_info) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-borderColor-04011", device, create_info_loc.dot(Field::borderColor),
-                             "is %s but there is no VkSamplerCustomBorderColorCreateInfoEXT "
-                             "struct in pNext chain.",
-                             string_VkBorderColor(pCreateInfo->borderColor));
-        } else {
-            if ((custom_create_info->format != VK_FORMAT_UNDEFINED) && !vkuFormatIsDepthAndStencil(custom_create_info->format) &&
-                ((pCreateInfo->borderColor == VK_BORDER_COLOR_INT_CUSTOM_EXT && !vkuFormatIsSampledInt(custom_create_info->format)) ||
-                 (pCreateInfo->borderColor == VK_BORDER_COLOR_FLOAT_CUSTOM_EXT &&
-                  !vkuFormatIsSampledFloat(custom_create_info->format)))) {
-                skip |= LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-07605", device,
-                                 create_info_loc.pNext(Struct::VkSamplerCustomBorderColorCreateInfoEXT, Field::format),
-                                 "%s does not match borderColor (%s).", string_VkFormat(custom_create_info->format),
-                                 string_VkBorderColor(pCreateInfo->borderColor));
-            }
-        }
-    }
-
-    const auto *border_color_component_mapping =
-        vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(pCreateInfo->pNext);
-    if (border_color_component_mapping) {
+    if (vku::FindStructInPNextChain<VkSamplerBorderColorComponentMappingCreateInfoEXT>(pCreateInfo->pNext)) {
         if (!enabled_features.borderColorSwizzle) {
             skip |=
                 LogError("VUID-VkSamplerBorderColorComponentMappingCreateInfoEXT-borderColorSwizzle-06437", device, create_info_loc,
@@ -342,61 +471,31 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         }
     }
 
-    // VK_QCOM_image_processing
-    if ((pCreateInfo->flags & VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM) != 0) {
-        if ((pCreateInfo->minFilter != VK_FILTER_NEAREST) || (pCreateInfo->magFilter != VK_FILTER_NEAREST)) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06964", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "minFilter (%s) must be VK_FILTER_NEAREST and "
-                             "magFilter (%s) must be VK_FILTER_NEAREST.",
-                             string_VkFilter(pCreateInfo->minFilter), string_VkFilter(pCreateInfo->magFilter));
-        }
-        if (pCreateInfo->mipmapMode != VK_SAMPLER_MIPMAP_MODE_NEAREST) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06965", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "mipmapMode (%s) must be VK_SAMPLER_MIPMAP_MODE_NEAREST.",
-                             string_VkSamplerMipmapMode(pCreateInfo->mipmapMode));
-        }
-        if ((pCreateInfo->minLod != 0) || (pCreateInfo->maxLod != 0)) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06966", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "minLod (%f) and maxLod (%f) must be 0.",
-                             pCreateInfo->minLod, pCreateInfo->maxLod);
-        }
-        if (((pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-             (pCreateInfo->addressModeU != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) ||
-            ((pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE) &&
-             (pCreateInfo->addressModeV != VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER))) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06967", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "addressModeU (%s) and addressModeV (%s) must be either "
-                             "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE or VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER.",
-                             string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                             string_VkSamplerAddressMode(pCreateInfo->addressModeV));
-        }
-        if (((pCreateInfo->addressModeU == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER) ||
-             (pCreateInfo->addressModeV == VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER)) &&
-            (pCreateInfo->borderColor != VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK)) {
-            skip |=
-                LogError("VUID-VkSamplerCreateInfo-flags-06968", device, create_info_loc.dot(Field::flags),
-                         "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                         "and if addressModeU (%s) or addressModeV (%s) are "
-                         "VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_BORDER, then"
-                         "borderColor (%s) must be VK_BORDER_COLOR_FLOAT_TRANSPARENT_BLACK.",
-                         string_VkSamplerAddressMode(pCreateInfo->addressModeU),
-                         string_VkSamplerAddressMode(pCreateInfo->addressModeV), string_VkBorderColor(pCreateInfo->borderColor));
-        }
-        if (pCreateInfo->anisotropyEnable) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06969", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "but anisotropyEnable is VK_TRUE.");
-        }
-        if (pCreateInfo->compareEnable) {
-            skip |= LogError("VUID-VkSamplerCreateInfo-flags-06970", device, create_info_loc.dot(Field::flags),
-                             "includes VK_SAMPLER_CREATE_IMAGE_PROCESSING_BIT_QCOM, "
-                             "but compareEnable is VK_TRUE.");
+    if ((pCreateInfo->flags & VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT) && (!enabled_features.nonSeamlessCubeMap)) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-nonSeamlessCubeMap-06788", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_NON_SEAMLESS_CUBE_MAP_BIT_EXT but the "
+                         "nonSeamlessCubeMap feature was not enabled.");
+    }
+
+    if ((pCreateInfo->flags & VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT) &&
+        !enabled_features.descriptorBufferCaptureReplay) {
+        skip |= LogError("VUID-VkSamplerCreateInfo-flags-08110", device, create_info_loc.dot(Field::flags),
+                         "includes VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT but descriptorBufferCaptureReplay "
+                         "feature was not enabled.");
+    }
+
+    if (vku::FindStructInPNextChain<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(pCreateInfo->pNext)) {
+        if (!(pCreateInfo->flags & VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT)) {
+            skip |= LogError("VUID-VkSamplerCreateInfo-pNext-08111", device, create_info_loc.dot(Field::flags),
+                             "is %s but VkOpaqueCaptureDescriptorDataCreateInfoEXT is in pNext chain.",
+                             string_VkSamplerCreateFlags(pCreateInfo->flags).c_str());
         }
     }
+
+    skip |= ValidateSamplerFilterMinMax(*pCreateInfo, create_info_loc);
+    skip |= ValidateSamplerCustomBoarderColor(*pCreateInfo, create_info_loc);
+    skip |= ValidateSamplerSubsampled(*pCreateInfo, create_info_loc);
+    skip |= ValidateSamplerImageProcessingQCOM(*pCreateInfo, create_info_loc);
 
     return skip;
 }

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -591,6 +591,10 @@ class StatelessValidation : public ValidationObject {
                                                       const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
                                                       const ErrorObject &error_obj) const;
 
+    bool ValidateSamplerFilterMinMax(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateSamplerCustomBoarderColor(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateSamplerSubsampled(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateSamplerImageProcessingQCOM(const VkSamplerCreateInfo &create_info, const Location &create_info_loc) const;
     bool manual_PreCallValidateCreateSampler(VkDevice device, const VkSamplerCreateInfo *pCreateInfo,
                                              const VkAllocationCallbacks *pAllocator, VkSampler *pSampler,
                                              const ErrorObject &error_obj) const;


### PR DESCRIPTION
The `vkCreateSampler` logic was split between CoreChecks and Stateless with no reason. Even inside Stateless it has evidence of it slowly just growing and things slapped together

This moves most logic over to Stateless (because it is) and adds more proper separation of the logic (avoiding a lot of unnecessary  nesting)