### PR TITLE
layers: Remove extra feature struct in stateless

### DIFF
--- a/layers/stateless/sl_buffer.cpp
+++ b/layers/stateless/sl_buffer.cpp
@@ -47,17 +47,17 @@ bool StatelessValidation::manual_PreCallValidateCreateBuffer(VkDevice device, co
         }
     }
 
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_BINDING_BIT) && (!enabled_features.sparseBinding)) {
         skip |= LogError("VUID-VkBufferCreateInfo-flags-00915", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_BINDING_BIT, but the sparseBinding feature is not enabled.");
     }
 
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!physical_device_features.sparseResidencyBuffer)) {
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT) && (!enabled_features.sparseResidencyBuffer)) {
         skip |= LogError("VUID-VkBufferCreateInfo-flags-00916", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT, but the sparseResidencyBuffer feature is not enabled.");
     }
 
-    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+    if ((pCreateInfo->flags & VK_BUFFER_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.sparseResidencyAliased)) {
         skip |= LogError("VUID-VkBufferCreateInfo-flags-00917", device, create_info_loc.dot(Field::flags),
                          "includes VK_BUFFER_CREATE_SPARSE_ALIASED_BIT, but the sparseResidencyAliased feature is not enabled.");
     };

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -728,13 +728,13 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
         skip |= ValidateBool32(inheritance_loc.dot(Field::occlusionQueryEnable), info->occlusionQueryEnable);
 
         // Explicit VUs
-        if (!physical_device_features.inheritedQueries && info->occlusionQueryEnable == VK_TRUE) {
+        if (!enabled_features.inheritedQueries && info->occlusionQueryEnable == VK_TRUE) {
             skip |= LogError(
                 "VUID-VkCommandBufferInheritanceInfo-occlusionQueryEnable-00056", commandBuffer, error_obj.location,
                 "Inherited queries feature is disabled, but pBeginInfo->pInheritanceInfo->occlusionQueryEnable is VK_TRUE.");
         }
 
-        if (physical_device_features.inheritedQueries) {
+        if (enabled_features.inheritedQueries) {
             skip |= ValidateFlags(inheritance_loc.dot(Field::queryFlags), vvl::FlagBitmask::VkQueryControlFlagBits,
                                   AllVkQueryControlFlagBits, info->queryFlags, kOptionalFlags,
                                   "VUID-VkCommandBufferInheritanceInfo-queryFlags-00057");
@@ -743,7 +743,7 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
                                           "VUID-VkCommandBufferInheritanceInfo-queryFlags-02788");
         }
 
-        if (physical_device_features.pipelineStatisticsQuery) {
+        if (enabled_features.pipelineStatisticsQuery) {
             skip |=
                 ValidateFlags(inheritance_loc.dot(Field::pipelineStatistics), vvl::FlagBitmask::VkQueryPipelineStatisticFlagBits,
                               AllVkQueryPipelineStatisticFlagBits, info->pipelineStatistics, kOptionalFlags,
@@ -765,7 +765,7 @@ bool StatelessValidation::manual_PreCallValidateBeginCommandBuffer(VkCommandBuff
         }
 
         auto p_inherited_viewport_scissor_info = vku::FindStructInPNextChain<VkCommandBufferInheritanceViewportScissorInfoNV>(info->pNext);
-        if (p_inherited_viewport_scissor_info != nullptr && !physical_device_features.multiViewport &&
+        if (p_inherited_viewport_scissor_info != nullptr && !enabled_features.multiViewport &&
             p_inherited_viewport_scissor_info->viewportScissor2D == VK_TRUE &&
             p_inherited_viewport_scissor_info->viewportDepthCount != 1) {
             skip |= LogError("VUID-VkCommandBufferInheritanceViewportScissorInfoNV-viewportScissor2D-04783", commandBuffer,

--- a/layers/stateless/sl_cmd_buffer_dynamic.cpp
+++ b/layers/stateless/sl_cmd_buffer_dynamic.cpp
@@ -24,7 +24,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewportWithCount(VkComman
                                                                         const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (viewportCount != 1) {
             skip |= LogError("VUID-vkCmdSetViewportWithCount-viewportCount-03395", commandBuffer,
                              error_obj.location.dot(Field::viewportCount),
@@ -55,7 +55,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissorWithCount(VkCommand
                                                                        const VkRect2D *pScissors,
                                                                        const ErrorObject &error_obj) const {
     bool skip = false;
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (scissorCount != 1) {
             skip |= LogError("VUID-vkCmdSetScissorWithCount-scissorCount-03398", commandBuffer,
                              error_obj.location.dot(Field::scissorCount),
@@ -341,7 +341,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetExclusiveScissorNV(VkComma
                                                                          const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (firstExclusiveScissor != 0) {
             skip |= LogError("VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02035", commandBuffer,
                              error_obj.location.dot(Field::firstExclusiveScissor),
@@ -417,7 +417,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewportShadingRatePalette
     const VkShadingRatePaletteNV *pShadingRatePalettes, const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (firstViewport != 0) {
             skip |= LogError("VUID-vkCmdSetViewportShadingRatePaletteNV-firstViewport-02068", commandBuffer,
                              error_obj.location.dot(Field::firstViewport),
@@ -467,7 +467,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetViewport(VkCommandBuffer c
                                                                const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (firstViewport != 0) {
             skip |=
                 LogError("VUID-vkCmdSetViewport-firstViewport-01224", commandBuffer, error_obj.location.dot(Field::firstViewport),
@@ -503,7 +503,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetScissor(VkCommandBuffer co
                                                               const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.multiViewport) {
+    if (!enabled_features.multiViewport) {
         if (firstScissor != 0) {
             skip |= LogError("VUID-vkCmdSetScissor-firstScissor-00593", commandBuffer, error_obj.location.dot(Field::firstScissor),
                              "is %" PRIu32 " but the multiViewport feature was not enabled.", firstScissor);
@@ -560,7 +560,7 @@ bool StatelessValidation::manual_PreCallValidateCmdSetLineWidth(VkCommandBuffer 
                                                                 const ErrorObject &error_obj) const {
     bool skip = false;
 
-    if (!physical_device_features.wideLines && (lineWidth != 1.0f)) {
+    if (!enabled_features.wideLines && (lineWidth != 1.0f)) {
         skip |= LogError("VUID-vkCmdSetLineWidth-lineWidth-00788", commandBuffer, error_obj.location.dot(Field::lineWidth),
                          "is %f (not 1.0), but wideLines was not enabled.", lineWidth);
     }

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -129,7 +129,6 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         return skip;
     }
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-    const auto &features = physical_device_features;
     const auto &limits = device_limits;
 
     if (pCreateInfo->anisotropyEnable == VK_TRUE) {
@@ -140,7 +139,7 @@ bool StatelessValidation::manual_PreCallValidateCreateSampler(VkDevice device, c
         }
 
         // Anistropy cannot be enabled in sampler unless enabled as a feature
-        if (features.samplerAnisotropy == VK_FALSE) {
+        if (enabled_features.samplerAnisotropy == VK_FALSE) {
             skip |=
                 LogError("VUID-VkSamplerCreateInfo-anisotropyEnable-01070", device, create_info_loc.dot(Field::anisotropyEnable),
                          "is VK_TRUE but the samplerAnisotropy feature was not enabled.");

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -155,13 +155,13 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                          string_VkImageType(pCreateInfo->imageType));
     }
 
-    if ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!physical_device_features.sparseBinding)) {
+    if ((image_flags & VK_IMAGE_CREATE_SPARSE_BINDING_BIT) && (!enabled_features.sparseBinding)) {
         skip |= LogError("VUID-VkImageCreateInfo-flags-00969", device, create_info_loc.dot(Field::flags),
                          "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT, but the "
                          "sparseBinding feature was not enabled.");
     }
 
-    if ((image_flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!physical_device_features.sparseResidencyAliased)) {
+    if ((image_flags & VK_IMAGE_CREATE_SPARSE_ALIASED_BIT) && (!enabled_features.sparseResidencyAliased)) {
         skip |= LogError("VUID-VkImageCreateInfo-flags-01924", device, create_info_loc.dot(Field::flags),
                          "includes VK_IMAGE_CREATE_SPARSE_ALIASED_BIT but the sparseResidencyAliased feature was not enabled.");
     }
@@ -189,14 +189,14 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         }
 
         // Sparse 2D image when device doesn't support it
-        if ((!physical_device_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
+        if ((!enabled_features.sparseResidencyImage2D) && (VK_IMAGE_TYPE_2D == pCreateInfo->imageType)) {
             skip |= LogError("VUID-VkImageCreateInfo-imageType-00971", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D, but "
                              "sparseResidencyImage2D feature was not enabled.");
         }
 
         // Sparse 3D image when device doesn't support it
-        if ((!physical_device_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
+        if ((!enabled_features.sparseResidencyImage3D) && (VK_IMAGE_TYPE_3D == pCreateInfo->imageType)) {
             skip |= LogError("VUID-VkImageCreateInfo-imageType-00972", device, create_info_loc.dot(Field::flags),
                              "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_3D, but "
                              "sparseResidencyImage3D feature was not enabled.");
@@ -204,19 +204,19 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
         // Multi-sample 2D image when device doesn't support it
         if (VK_IMAGE_TYPE_2D == pCreateInfo->imageType) {
-            if ((!physical_device_features.sparseResidency2Samples) && (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
+            if ((!enabled_features.sparseResidency2Samples) && (VK_SAMPLE_COUNT_2_BIT == pCreateInfo->samples)) {
                 skip |= LogError("VUID-VkImageCreateInfo-imageType-00973", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                  "VK_SAMPLE_COUNT_2_BIT, but sparseResidency2Samples feature was not enabled.");
-            } else if ((!physical_device_features.sparseResidency4Samples) && (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
+            } else if ((!enabled_features.sparseResidency4Samples) && (VK_SAMPLE_COUNT_4_BIT == pCreateInfo->samples)) {
                 skip |= LogError("VUID-VkImageCreateInfo-imageType-00974", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                  "VK_SAMPLE_COUNT_4_BIT, but sparseResidency4Samples feature was not enabled.");
-            } else if ((!physical_device_features.sparseResidency8Samples) && (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
+            } else if ((!enabled_features.sparseResidency8Samples) && (VK_SAMPLE_COUNT_8_BIT == pCreateInfo->samples)) {
                 skip |= LogError("VUID-VkImageCreateInfo-imageType-00975", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                  "VK_SAMPLE_COUNT_8_BIT, but sparseResidency8Samples feature was not enabled.");
-            } else if ((!physical_device_features.sparseResidency16Samples) && (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
+            } else if ((!enabled_features.sparseResidency16Samples) && (VK_SAMPLE_COUNT_16_BIT == pCreateInfo->samples)) {
                 skip |= LogError("VUID-VkImageCreateInfo-imageType-00976", device, create_info_loc.dot(Field::flags),
                                  "includes VK_IMAGE_CREATE_SPARSE_BINDING_BIT and imageType is VK_IMAGE_TYPE_2D and samples is "
                                  "VK_SAMPLE_COUNT_16_BIT, but sparseResidency16Samples feature was not enabled.");
@@ -318,7 +318,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
                 }
             }
 
-            if (!physical_device_features.shaderStorageImageMultisample &&
+            if (!enabled_features.shaderStorageImageMultisample &&
                 ((image_stencil_struct->stencilUsage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
                 (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
                 skip |= LogError("VUID-VkImageCreateInfo-format-02538", device,
@@ -362,7 +362,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
         }
     }
 
-    if ((!physical_device_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
+    if ((!enabled_features.shaderStorageImageMultisample) && ((pCreateInfo->usage & VK_IMAGE_USAGE_STORAGE_BIT) != 0) &&
         (pCreateInfo->samples != VK_SAMPLE_COUNT_1_BIT)) {
         skip |= LogError("VUID-VkImageCreateInfo-usage-00968", device, create_info_loc.dot(Field::usage),
                          "includes VK_IMAGE_USAGE_STORAGE_BIT and imageType is %s, but shaderStorageImageMultisample feature "
@@ -687,7 +687,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImageView(VkDevice device,
     }
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
     // Validate feature set if using CUBE_ARRAY
-    if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (physical_device_features.imageCubeArray == false)) {
+    if ((pCreateInfo->viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) && (!enabled_features.imageCubeArray)) {
         skip |= LogError("VUID-VkImageViewCreateInfo-viewType-01004", pCreateInfo->image, create_info_loc.dot(Field::viewType),
                          "is VK_IMAGE_VIEW_TYPE_CUBE_ARRAY but the imageCubeArray feature is not enabled.");
     }

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -439,20 +439,6 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
     stateless_validation->phys_dev_ext_props = this->phys_dev_ext_props;
 
     GetEnabledDeviceFeatures(pCreateInfo, &stateless_validation->enabled_features, api_version);
-
-    // Save app-enabled features in this device's validation object
-    // The enabled features can come from either pEnabledFeatures, or from the pNext chain
-    const auto *features2 = vku::FindStructInPNextChain<VkPhysicalDeviceFeatures2>(pCreateInfo->pNext);
-    vku::safe_VkPhysicalDeviceFeatures2 tmp_features2_state;
-    tmp_features2_state.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FEATURES_2;
-    if (features2) {
-        tmp_features2_state.features = features2->features;
-    } else if (pCreateInfo->pEnabledFeatures) {
-        tmp_features2_state.features = *pCreateInfo->pEnabledFeatures;
-    } else {
-        tmp_features2_state.features = {};
-    }
-    stateless_validation->physical_device_features2 = tmp_features2_state;
 }
 
 bool StatelessValidation::manual_PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,

--- a/layers/stateless/sl_pipeline.cpp
+++ b/layers/stateless/sl_pipeline.cpp
@@ -633,7 +633,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                 const auto *depth_clip_control_struct =
                     vku::FindStructInPNextChain<VkPipelineViewportDepthClipControlCreateInfoEXT>(viewport_state.pNext);
 
-                if (!physical_device_features.multiViewport) {
+                if (!enabled_features.multiViewport) {
                     if (exclusive_scissor_struct && (exclusive_scissor_struct->exclusiveScissorCount != 0 &&
                                                      exclusive_scissor_struct->exclusiveScissorCount != 1)) {
                         skip |=
@@ -674,7 +674,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                          "can't be 0 unless VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT is used.");
                     }
 
-                    if (!physical_device_features.multiViewport && (viewport_state.viewportCount > 1)) {
+                    if (!enabled_features.multiViewport && (viewport_state.viewportCount > 1)) {
                         skip |= LogError("VUID-VkPipelineViewportStateCreateInfo-viewportCount-01216", device,
                                          viewport_loc.dot(Field::viewportCount),
                                          "is %" PRIu32 " but multiViewport feature is not enabled.", viewport_state.viewportCount);
@@ -702,7 +702,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                                          "can't be 0 unless VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT is used.");
                     }
 
-                    if (!physical_device_features.multiViewport && (viewport_state.scissorCount > 1)) {
+                    if (!enabled_features.multiViewport && (viewport_state.scissorCount > 1)) {
                         skip |= LogError("VUID-VkPipelineViewportStateCreateInfo-scissorCount-01217", device,
                                          viewport_loc.dot(Field::scissorCount),
                                          "is %" PRIu32 " but multiViewport feature is not enabled.", viewport_state.scissorCount);
@@ -897,7 +897,7 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
                 skip |= ValidatePipelineMultisampleStateCreateInfo(*create_info.pMultisampleState, ms_loc);
 
                 if (create_info.pMultisampleState->sampleShadingEnable == VK_TRUE) {
-                    if (!physical_device_features.sampleRateShading) {
+                    if (!enabled_features.sampleRateShading) {
                         skip |= LogError("VUID-VkPipelineMultisampleStateCreateInfo-sampleShadingEnable-00784", device,
                                          ms_loc.dot(Field::sampleShadingEnable),
                                          "is VK_TRUE but the sampleRateShading feature was not enabled.");
@@ -983,13 +983,13 @@ bool StatelessValidation::manual_PreCallValidateCreateGraphicsPipelines(
 
             if ((create_info.pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL) &&
                 (create_info.pRasterizationState->polygonMode != VK_POLYGON_MODE_FILL_RECTANGLE_NV) &&
-                (physical_device_features.fillModeNonSolid == false)) {
+                (!enabled_features.fillModeNonSolid)) {
                 skip |= LogError("VUID-VkPipelineRasterizationStateCreateInfo-polygonMode-01507", device,
                                  rasterization_loc.dot(Field::polygonMode), "is %s, but fillModeNonSolid feature is note enabled.",
                                  string_VkPolygonMode(create_info.pRasterizationState->polygonMode));
             }
 
-            if (!vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_LINE_WIDTH) && !physical_device_features.wideLines &&
+            if (!vvl::Contains(dynamic_state_map, VK_DYNAMIC_STATE_LINE_WIDTH) && !enabled_features.wideLines &&
                 (create_info.pRasterizationState->lineWidth != 1.0f)) {
                 skip |= LogError("VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-00749", device,
                                  rasterization_loc.dot(Field::lineWidth),

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -33,8 +33,6 @@ class StatelessValidation : public ValidationObject {
 
   public:
     VkPhysicalDeviceLimits device_limits = {};
-    vku::safe_VkPhysicalDeviceFeatures2 physical_device_features2;
-    const VkPhysicalDeviceFeatures &physical_device_features = physical_device_features2.features;
     vvl::unordered_map<VkPhysicalDevice, VkPhysicalDeviceProperties *> physical_device_properties_map;
     vvl::unordered_map<VkPhysicalDevice, vvl::unordered_set<vvl::Extension>> device_extensions_enumerated{};
     // We have a copy of this in Stateless and ValidationStateTracker, could move the ValidationObject, but we don't have a way to


### PR DESCRIPTION
We had an extra `safe_VkPhysicalDeviceFeatures2` in stateless, but now can just use `DeviceFeature enabled_features` instead