### PR TITLE
gpu: Fix missing SPV_KHR_physical_storage_buffer

### DIFF
--- a/layers/gpu/spirv/module.h
+++ b/layers/gpu/spirv/module.h
@@ -77,6 +77,7 @@ class Module {
     // Helpers
     bool HasCapability(spv::Capability capability);
     void AddCapability(spv::Capability capability);
+    void AddExtension(const char* extension);
 
   private:
     // provides a way to map back and know which original SPIR-V this was from


### PR DESCRIPTION
was getting spirv-val errors from instrumented shaders 

> 1st operand of Capability: operand PhysicalStorageBufferAddresses(5347) requires one of these extensions: SPV_EXT_physical_storage_buffer SPV_KHR_physical_storage_buffer
  OpCapability PhysicalStorageBufferAddresses

so now add `OpExtension` if we are adding the `OpCapability` for the user