### PR TITLE
gpu: Fix user push constants restore - and state tracking in Core validation

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -417,7 +417,6 @@ class BestPractices : public ValidationStateTracker {
                                        const VkSubpassEndInfo* pSubpassEndInfo, const RecordObject& record_obj) override;
     void RecordCmdNextSubpass(VkCommandBuffer commandBuffer);
 
-    void RecordCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t offset, uint32_t size);
     void PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout, VkShaderStageFlags stageFlags,
                                         uint32_t offset, uint32_t size, const void* pValues,
                                         const RecordObject& record_obj) override;

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -667,32 +667,16 @@ void BestPractices::RecordCmdNextSubpass(VkCommandBuffer commandBuffer) {
     }
 }
 
-void BestPractices::RecordCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t offset, uint32_t size) {
-    auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-    if (cb_state->push_constant_ranges_layout && !cb_state->push_constant_ranges_layout->empty()) {
-        // only reset if a found the push constant have been disturbed
-        if (cb_state->push_constant_data_chunks.size() != cb_state->push_constant_data_set.size()) {
-            cb_state->push_constant_data_set.resize(
-                cb_state->push_constant_data_chunks.size(),
-                0);  // #ARNO_TODO will probably need to modify bp::CommandBuffer::push_constant_data_set
-        }
-        std::fill(cb_state->push_constant_data_set.begin() + offset, cb_state->push_constant_data_set.begin() + offset + size,
-                  uint8_t(1));
-    }
-}
-
 void BestPractices::PostCallRecordCmdPushConstants(VkCommandBuffer commandBuffer, VkPipelineLayout layout,
                                                    VkShaderStageFlags stageFlags, uint32_t offset, uint32_t size,
                                                    const void* pValues, const RecordObject& record_obj) {
     StateTracker::PostCallRecordCmdPushConstants(commandBuffer, layout, stageFlags, offset, size, pValues, record_obj);
-    RecordCmdPushConstants(commandBuffer, offset, size);
 }
 
 void BestPractices::PostCallRecordCmdPushConstants2KHR(VkCommandBuffer commandBuffer,
                                                        const VkPushConstantsInfoKHR* pPushConstantsInfo,
                                                        const RecordObject& record_obj) {
     StateTracker::PostCallRecordCmdPushConstants2KHR(commandBuffer, pPushConstantsInfo, record_obj);
-    RecordCmdPushConstants(commandBuffer, pPushConstantsInfo->offset, pPushConstantsInfo->size);
 }
 
 void BestPractices::PostRecordCmdBeginRenderPass(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin) {

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -669,10 +669,12 @@ void BestPractices::RecordCmdNextSubpass(VkCommandBuffer commandBuffer) {
 
 void BestPractices::RecordCmdPushConstants(VkCommandBuffer commandBuffer, uint32_t offset, uint32_t size) {
     auto cb_state = GetWrite<bp_state::CommandBuffer>(commandBuffer);
-    if (cb_state->push_constant_data_ranges && !cb_state->push_constant_data_ranges->empty()) {
+    if (cb_state->push_constant_ranges_layout && !cb_state->push_constant_ranges_layout->empty()) {
         // only reset if a found the push constant have been disturbed
-        if (cb_state->push_constant_data.size() != cb_state->push_constant_data_set.size()) {
-            cb_state->push_constant_data_set.resize(cb_state->push_constant_data.size(), 0);
+        if (cb_state->push_constant_data_chunks.size() != cb_state->push_constant_data_set.size()) {
+            cb_state->push_constant_data_set.resize(
+                cb_state->push_constant_data_chunks.size(),
+                0);  // #ARNO_TODO will probably need to modify bp::CommandBuffer::push_constant_data_set
         }
         std::fill(cb_state->push_constant_data_set.begin() + offset, cb_state->push_constant_data_set.begin() + offset + size,
                   uint8_t(1));

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -198,8 +198,10 @@ class CommandBuffer : public vvl::CommandBuffer {
     bool uses_vertex_buffer = false;
     uint32_t small_indexed_draw_call_count = 0;
 
-    std::vector<uint8_t> push_constant_data_set;
-    void UnbindResources() { push_constant_data_set.clear(); }
+    // This function used to not be empty. It has been left empty because
+    // the logic to decide to call this function is not simple, so adding this
+    // function back could tedious.
+    void UnbindResources() {}
 
     struct SignalingInfo {
         // True, if the event's first state change within a command buffer is a signal (SetEvent)

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -4382,7 +4382,7 @@ bool CoreChecks::ValidateCmdPushConstants(VkCommandBuffer commandBuffer, VkPipel
     if (!layout_state) return skip;  // dynamicPipelineLayout feature
 
     const bool is_2 = loc.function != Func::vkCmdPushConstants;
-    const auto &ranges = *layout_state->push_constant_ranges;
+    const auto &ranges = *layout_state->push_constant_ranges_layout;
     VkShaderStageFlags found_stages = 0;
     for (const auto &range : ranges) {
         if ((offset >= range.offset) && (offset + size <= range.offset + range.size)) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -777,9 +777,10 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
         }
 
         // Push Constants must match regardless of VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT
-        if (!pre_raster_info.layout->push_constant_ranges->empty() && !frag_shader_info.layout->push_constant_ranges->empty()) {
-            const uint32_t pre_raster_count = static_cast<uint32_t>(pre_raster_info.layout->push_constant_ranges->size());
-            const uint32_t frag_shader_count = static_cast<uint32_t>(frag_shader_info.layout->push_constant_ranges->size());
+        if (!pre_raster_info.layout->push_constant_ranges_layout->empty() &&
+            !frag_shader_info.layout->push_constant_ranges_layout->empty()) {
+            const uint32_t pre_raster_count = static_cast<uint32_t>(pre_raster_info.layout->push_constant_ranges_layout->size());
+            const uint32_t frag_shader_count = static_cast<uint32_t>(frag_shader_info.layout->push_constant_ranges_layout->size());
 
             if (pre_raster_count != frag_shader_count) {
                 const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"
@@ -792,8 +793,8 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                                  pre_raster_count, frag_shader_count);
             } else {
                 for (uint32_t i = 0; i < pre_raster_count; i++) {
-                    VkPushConstantRange pre_raster_range = pre_raster_info.layout->push_constant_ranges->at(i);
-                    VkPushConstantRange frag_shader_range = frag_shader_info.layout->push_constant_ranges->at(i);
+                    VkPushConstantRange pre_raster_range = pre_raster_info.layout->push_constant_ranges_layout->at(i);
+                    VkPushConstantRange frag_shader_range = frag_shader_info.layout->push_constant_ranges_layout->at(i);
                     if (pre_raster_range.stageFlags != frag_shader_range.stageFlags ||
                         pre_raster_range.offset != frag_shader_range.offset || pre_raster_range.size != frag_shader_range.size) {
                         const char *vuid = only_libs ? "VUID-VkGraphicsPipelineCreateInfo-pLibraries-06621"

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -115,7 +115,8 @@ bool CoreChecks::ValidatePushConstantUsage(const spirv::Module &module_state, co
         return skip;
     }
 
-    std::vector<VkPushConstantRange> const *push_constant_ranges = pipeline.PipelineLayoutState()->push_constant_ranges.get();
+    std::vector<VkPushConstantRange> const *push_constant_ranges =
+        pipeline.PipelineLayoutState()->push_constant_ranges_layout.get();
 
     std::string vuid;
     switch (pipeline.GetCreateInfoSType()) {

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
@@ -37,13 +37,12 @@ class RestorablePipelineState {
     VkCommandBuffer cmd_buffer_;
     VkPipelineBindPoint pipeline_bind_point_ = VK_PIPELINE_BIND_POINT_MAX_ENUM;
     VkPipeline pipeline_ = VK_NULL_HANDLE;
-    VkPipelineLayout pipeline_layout = VK_NULL_HANDLE;
+    VkPipelineLayout desc_set_pipeline_layout_ = VK_NULL_HANDLE;
     std::vector<std::pair<VkDescriptorSet, uint32_t>> descriptor_sets_;
     std::vector<std::vector<uint32_t>> dynamic_offsets_;
     uint32_t push_descriptor_set_index_ = 0;
     std::vector<vku::safe_VkWriteDescriptorSet> push_descriptor_set_writes_;
-    std::vector<uint8_t> push_constants_data_;
-    PushConstantRangesId push_constants_ranges_;
+    std::vector<vvl::CommandBuffer::PushConstantData> push_constants_data_;
     std::vector<vvl::ShaderObject*> shader_objects_;
 };
 

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -691,15 +691,16 @@ void Validator::AllocateDebugPrintfResources(const VkCommandBuffer cmd_buffer, c
     DispatchUpdateDescriptorSets(device, desc_count, &desc_writes, 0, nullptr);
 
     const auto pipeline_layout =
-        pipeline_state ? pipeline_state->PipelineLayoutState() : Get<vvl::PipelineLayout>(last_bound.pipeline_layout);
+        pipeline_state ? pipeline_state->PipelineLayoutState() : Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
     if (pipeline_layout) {
         // If GPL is used, it's possible the pipeline layout used at pipeline creation time is null. If CmdBindDescriptorSets has
         // not been called yet (i.e., state.pipeline_null), then fall back to the layout associated with pre-raster state.
         // PipelineLayoutState should be used for the purposes of determining the number of sets in the layout, but this layout
         // may be a "pseudo layout" used to represent the union of pre-raster and fragment shader layouts, and therefore have a
         // null handle.
-        const auto pipeline_layout_handle =
-            (last_bound.pipeline_layout) ? last_bound.pipeline_layout : pipeline_state->PreRasterPipelineLayoutState()->VkHandle();
+        const auto pipeline_layout_handle = (last_bound.desc_set_pipeline_layout)
+                                                ? last_bound.desc_set_pipeline_layout
+                                                : pipeline_state->PreRasterPipelineLayoutState()->VkHandle();
         if (pipeline_layout->set_layouts.size() <= desc_set_bind_index_) {
             DispatchCmdBindDescriptorSets(cmd_buffer, bind_point, pipeline_layout_handle, desc_set_bind_index_, 1, desc_sets.data(),
                                           0, nullptr);

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -271,16 +271,16 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
         DispatchUpdateDescriptorSets(gpuav.device, static_cast<uint32_t>(desc_writes.size()), desc_writes.data(), 0, nullptr);
     }
 
-    const auto pipeline_layout =
-        pipeline_state ? pipeline_state->PipelineLayoutState() : gpuav.Get<vvl::PipelineLayout>(last_bound.pipeline_layout);
+    const auto pipeline_layout = pipeline_state ? pipeline_state->PipelineLayoutState()
+                                                : gpuav.Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
     // If GPL is used, it's possible the pipeline layout used at pipeline creation time is null. If CmdBindDescriptorSets has
     // not been called yet (i.e., state.pipeline_null), then fall back to the layout associated with pre-raster state.
     // PipelineLayoutState should be used for the purposes of determining the number of sets in the layout, but this layout
     // may be a "pseudo layout" used to represent the union of pre-raster and fragment shader layouts, and therefore have a
     // null handle.
     VkPipelineLayout pipeline_layout_handle = VK_NULL_HANDLE;
-    if (last_bound.pipeline_layout) {
-        pipeline_layout_handle = last_bound.pipeline_layout;
+    if (last_bound.desc_set_pipeline_layout) {
+        pipeline_layout_handle = last_bound.desc_set_pipeline_layout;
     } else if (pipeline_state && !pipeline_state->PreRasterPipelineLayoutState()->Destroyed()) {
         pipeline_layout_handle = pipeline_state->PreRasterPipelineLayoutState()->VkHandle();
     }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -506,8 +506,14 @@ class CommandBuffer : public RefcountedStateObject {
     // Cache of current insert label...
     LoggingLabel debug_label;
 
-    std::vector<uint8_t> push_constant_data;
-    PushConstantRangesId push_constant_data_ranges;
+    struct PushConstantData {
+        VkPipelineLayout layout = VK_NULL_HANDLE;
+        VkShaderStageFlags stage_flags = 0;
+        uint32_t offset = 0;
+        std::vector<std::byte> values{};
+    };
+    std::vector<PushConstantData> push_constant_data_chunks;
+    PushConstantRangesId push_constant_ranges_layout;
 
     // Video coding related state tracking
     std::shared_ptr<vvl::VideoSession> bound_video_session;
@@ -562,7 +568,7 @@ class CommandBuffer : public RefcountedStateObject {
 
     void IncrementResources();
 
-    void ResetPushConstantDataIfIncompatible(const vvl::PipelineLayout *pipeline_layout_state);
+    void ResetPushConstantRangesLayoutIfIncompatible(const vvl::PipelineLayout &pipeline_layout_state);
 
     std::shared_ptr<const ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(VkImage image) const;
     std::shared_ptr<ImageSubresourceLayoutMap> GetImageSubresourceLayoutMap(const vvl::Image &image_state);

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -106,8 +106,8 @@ PushConstantRangesId GetCanonicalId(uint32_t pushConstantRangeCount, const VkPus
 static PushConstantRangesId GetPushConstantRangesFromLayouts(const vvl::span<const vvl::PipelineLayout *const> &layouts) {
     PushConstantRangesId ret{};
     for (const auto *layout : layouts) {
-        if (layout && layout->push_constant_ranges) {
-            ret = layout->push_constant_ranges;
+        if (layout && layout->push_constant_ranges_layout) {
+            ret = layout->push_constant_ranges_layout;
 
             if (ret->size() > 0) {
                 return ret;
@@ -198,15 +198,15 @@ PipelineLayout::PipelineLayout(ValidationStateTracker &dev_data, VkPipelineLayou
                                const VkPipelineLayoutCreateInfo *pCreateInfo)
     : StateObject(handle, kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(dev_data, pCreateInfo)),
-      push_constant_ranges(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)),
+      push_constant_ranges_layout(GetCanonicalId(pCreateInfo->pushConstantRangeCount, pCreateInfo->pPushConstantRanges)),
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout)),
       create_flags(pCreateInfo->flags) {}
 
 PipelineLayout::PipelineLayout(const vvl::span<const PipelineLayout *const> &layouts)
     : StateObject(static_cast<VkPipelineLayout>(VK_NULL_HANDLE), kVulkanObjectTypePipelineLayout),
       set_layouts(GetSetLayouts(layouts)),
-      push_constant_ranges(GetPushConstantRangesFromLayouts(layouts)),  // TODO is this correct?
-      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges)),
+      push_constant_ranges_layout(GetPushConstantRangesFromLayouts(layouts)),  // TODO is this correct?
+      set_compat_ids(GetCompatForSet(set_layouts, push_constant_ranges_layout)),
       create_flags(GetCreateFlags(layouts)) {}
 
 }  // namespace vvl

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -73,7 +73,7 @@ class PipelineLayout : public StateObject {
     using SetLayoutVector = std::vector<std::shared_ptr<vvl::DescriptorSetLayout const>>;
     const SetLayoutVector set_layouts;
     // canonical form IDs for the "compatible for set" contents
-    const PushConstantRangesId push_constant_ranges;
+    const PushConstantRangesId push_constant_ranges_layout;
     // table of "compatible for set N" cannonical forms for trivial accept validation
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
     VkPipelineLayoutCreateFlags create_flags;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -811,7 +811,7 @@ void LastBound::UnbindAndResetPushDescriptorSet(std::shared_ptr<vvl::DescriptorS
 
 void LastBound::Reset() {
     pipeline_state = nullptr;
-    pipeline_layout = VK_NULL_HANDLE;
+    desc_set_pipeline_layout = VK_NULL_HANDLE;
     if (push_descriptor_set) {
         cb_state.RemoveChild(push_descriptor_set);
         push_descriptor_set->Destroy();

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -628,17 +628,17 @@ struct LastBound {
     LastBound(vvl::CommandBuffer &cb) : cb_state(cb) {}
 
     vvl::CommandBuffer &cb_state;
-    vvl::Pipeline *pipeline_state{nullptr};
+    vvl::Pipeline *pipeline_state = nullptr;
     // All shader stages for a used pipeline bind point must be bound to with a valid shader or VK_NULL_HANDLE
     // We have to track shader_object_bound, because shader_object_states will be nullptr when VK_NULL_HANDLE is used
     bool shader_object_bound[kShaderObjectStageCount]{false};
     vvl::ShaderObject *shader_object_states[kShaderObjectStageCount]{nullptr};
-    VkPipelineLayout pipeline_layout{VK_NULL_HANDLE};
+    VkPipelineLayout desc_set_pipeline_layout = VK_NULL_HANDLE;
     std::shared_ptr<vvl::DescriptorSet> push_descriptor_set;
 
     struct DescriptorBufferBinding {
-        uint32_t index{0};
-        VkDeviceSize offset{0};
+        uint32_t index = 0;
+        VkDeviceSize offset = 0;
     };
     // Ordered bound set tracking where index is set# that given set is bound to
     struct PER_SET {


### PR DESCRIPTION
- Push constants state restoration was not working correctly
- Reworked the state tracking, also in best practices
- Added 2 tests, `RestorePushConstants` is not working on my PC, vertex shader runs correctly but no fragment are emitted when doing an indirect draw. Things work as expected when doing a normal draw. It is not related to GPU-AV, as disabling it does not solve the problem. My indirect buffer looks ok, so I will see what CI tells me.

Will see if it closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8120