### PR TITLE
tests: Remove VK_LAYER_TESTS_VALIDATION_FEATURES

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -153,34 +153,6 @@ VkInstanceCreateInfo VkRenderFramework::GetInstanceCreateInfo() const {
     return info;
 }
 
-void *VkRenderFramework::SetupValidationSettings(void *first_pnext) {
-    auto validation = GetEnvironment("VK_LAYER_TESTS_VALIDATION_FEATURES");
-    vvl::ToLower(validation);
-    VkValidationFeaturesEXT *features = vku::FindStructInPNextChain<VkValidationFeaturesEXT>(first_pnext);
-    if (validation == "all" || validation == "core" || validation == "none") {
-        if (!features) {
-            features = &m_validation_features;
-            features->sType = VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT;
-            features->pNext = first_pnext;
-            first_pnext = features;
-        }
-
-        if (validation == "all") {
-            features->enabledValidationFeatureCount = 4;
-            features->pEnabledValidationFeatures = validation_enable_all;
-            features->disabledValidationFeatureCount = 0;
-        } else if (validation == "core") {
-            features->disabledValidationFeatureCount = 0;
-        } else if (validation == "none") {
-            features->disabledValidationFeatureCount = 1;
-            features->pDisabledValidationFeatures = &validation_disable_all;
-            features->enabledValidationFeatureCount = 0;
-        }
-    }
-
-    return first_pnext;
-}
-
 void VkRenderFramework::InitFramework(void *instance_pnext) {
     ASSERT_EQ((VkInstance)0, instance_);
 
@@ -241,10 +213,6 @@ void VkRenderFramework::InitFramework(void *instance_pnext) {
     RemoveIf(m_instance_extension_names, ExtensionNotSupportedWithReporting);
 
     auto ici = GetInstanceCreateInfo();
-
-    // If is validation features then check for disabled validation
-
-    instance_pnext = SetupValidationSettings(instance_pnext);
 
     // concatenate pNexts
     void *last_pnext = nullptr;

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -155,8 +155,6 @@ class VkRenderFramework : public VkTestFramework {
     // struct, so be sure to call SetTargetApiVersion before
     void AddDisabledFeature(vkt::Feature feature);
 
-    void *SetupValidationSettings(void *first_pnext);
-
     template <typename GLSLContainer>
     std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const GLSLContainer &code,
                                     const spv_target_env env = SPV_ENV_VULKAN_1_0) {
@@ -244,13 +242,6 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<const char *> m_wsi_extensions;
     // Device extensions to enable
     std::vector<const char *> m_device_extension_names;
-
-    VkValidationFeaturesEXT m_validation_features;
-    VkValidationFeatureEnableEXT validation_enable_all[4] = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_BEST_PRACTICES_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT,
-                                                             VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
-    VkValidationFeatureDisableEXT validation_disable_all = VK_VALIDATION_FEATURE_DISABLE_ALL_EXT;
 
   private:
     // TODO - move to own helper logic


### PR DESCRIPTION
`VK_LAYER_TESTS_VALIDATION_FEATURES` was not working and seems to be left from a long time ago

If a dev wanted to set the features it could just use `VK_LAYER_DISABLES`/`VK_LAYER_ENABLES` anyways