### PR TITLE
layers: Remove old Sync Val enable enum

### DIFF
--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -208,16 +208,6 @@ void SetValidationFeatureEnable(CHECK_ENABLED &enable_data, const VkValidationFe
     }
 }
 
-void SetValidationFeatureEnable2(CHECK_ENABLED &enable_data, const VkValidationFeatureEnable feature_enable) {
-    switch (feature_enable) {
-        case VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION:
-            enable_data[sync_validation] = true;
-            break;
-        default:
-            break;
-    }
-}
-
 // Set the local disable flag for settings specified through the VK_EXT_validation_flags extension
 void SetValidationFlags(CHECK_DISABLED &disables, const VkValidationFlagsEXT *val_flags_struct) {
     for (uint32_t i = 0; i < val_flags_struct->disabledValidationCheckCount; ++i) {
@@ -277,11 +267,6 @@ void SetLocalEnableSetting(std::string list_of_enables, const std::string &delim
             auto result = VkValFeatureEnableLookup.find(token);
             if (result != VkValFeatureEnableLookup.end()) {
                 SetValidationFeatureEnable(enables, result->second);
-            } else {
-                auto result2 = VkValFeatureEnableLookup2.find(token);
-                if (result2 != VkValFeatureEnableLookup2.end()) {
-                    SetValidationFeatureEnable2(enables, result2->second);
-                }
             }
         } else if (token.find("VALIDATION_CHECK_ENABLE_") != std::string::npos) {
             auto result = ValidationEnableLookup.find(token);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -45,10 +45,6 @@ enum ValidationCheckEnables {
     VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ALL,
 };
 
-enum VkValidationFeatureEnable {
-    VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION,
-};
-
 // CHECK_DISABLED and CHECK_ENABLED vectors are containers for bools that can opt in or out of specific classes of validation
 // checks. Enum values can be specified via the vk_layer_settings.txt config file or at CreateInstance time via the
 // VK_EXT_validation_features extension that can selectively disable or enable checks.
@@ -124,10 +120,6 @@ static const vvl::unordered_map<std::string, VkValidationFeatureEnableEXT> VkVal
     {"VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT", VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT},
 };
 
-static const vvl::unordered_map<std::string, VkValidationFeatureEnable> VkValFeatureEnableLookup2 = {
-    {"VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION", VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION},
-};
-
 static const vvl::unordered_map<std::string, ValidationCheckDisables> ValidationDisableLookup = {
     {"VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE", VALIDATION_CHECK_DISABLE_COMMAND_BUFFER_STATE},
     {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
@@ -171,7 +163,7 @@ static const std::vector<std::string> EnableFlagNameHelper = {
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_IMG",                         // vendor_specific_img,
     "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_NVIDIA",                      // vendor_specific_nvidia,
     "VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT",                       // debug_printf,
-    "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION",             // sync_validation,
+    "VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT",         // sync_validation,
 };
 
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);


### PR DESCRIPTION
@jzulauf-lunarg @mark-lunarg so I just came across https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/1976 and there is both a `VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION` and `VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT` that was added. 

But the logic for `SetValidationFeatureEnable2` make no sense because `VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION` is `0` but it will hit `VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT` first (that is also `0`)

... basically I think I should be able to remove `SetValidationFeatureEnable2`and the original `VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION`