### PR TITLE
Add StatelessData when shader is inline in pNext

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -861,7 +861,7 @@ class BestPractices : public ValidationStateTracker {
                                                                std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
                                                                std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                std::shared_ptr<const vvl::PipelineLayout>&& layout,
-                                                               spirv::StatelessData* stateless_data,
+                                                               spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages],
                                                                ShaderModuleUniqueIds* shader_unique_id_map) const final;
 
   private:

--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -861,6 +861,7 @@ class BestPractices : public ValidationStateTracker {
                                                                std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
                                                                std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                               spirv::StatelessData* stateless_data,
                                                                ShaderModuleUniqueIds* shader_unique_id_map) const final;
 
   private:

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -263,12 +263,10 @@ bp_state::Pipeline::Pipeline(const ValidationStateTracker& state_data, const VkG
                     shader_unique_id_map),
       access_framebuffer_attachments(GetAttachmentAccess(*this)) {}
 
-std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                                                                          std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                          std::shared_ptr<const vvl::RenderPass>&& render_pass,
-                                                                          std::shared_ptr<const vvl::PipelineLayout>&& layout,
-                                                                          spirv::StatelessData* stateless_data,
-                                                                          ShaderModuleUniqueIds* shader_unique_id_map) const {
+std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(
+    const VkGraphicsPipelineCreateInfo* pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
+    std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
+    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds* shader_unique_id_map) const {
     return std::static_pointer_cast<vvl::Pipeline>(std::make_shared<bp_state::Pipeline>(
         *this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), shader_unique_id_map));
 }

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -259,13 +259,15 @@ bp_state::Pipeline::Pipeline(const ValidationStateTracker& state_data, const VkG
                              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache,
                              std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout,
                              ShaderModuleUniqueIds* shader_unique_id_map)
-    : vvl::Pipeline(state_data, pCreateInfo, std::move(pipe_cache), std::move(rpstate), std::move(layout), shader_unique_id_map),
+    : vvl::Pipeline(state_data, pCreateInfo, std::move(pipe_cache), std::move(rpstate), std::move(layout), nullptr,
+                    shader_unique_id_map),
       access_framebuffer_attachments(GetAttachmentAccess(*this)) {}
 
 std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
                                                                           std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
                                                                           std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                           std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                          spirv::StatelessData* stateless_data,
                                                                           ShaderModuleUniqueIds* shader_unique_id_map) const {
     return std::static_pointer_cast<vvl::Pipeline>(std::make_shared<bp_state::Pipeline>(
         *this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout), shader_unique_id_map));

--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -81,9 +81,9 @@ struct CreateGraphicsPipelines {
     std::vector<vku::safe_VkGraphicsPipelineCreateInfo> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;
     const VkGraphicsPipelineCreateInfo* pCreateInfos;
-    // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
-    bool passed_in_shader_stage_ci;
-    spirv::StatelessData stateless_data[spirv::kCommonMaxGraphicsShaderStages];
+    // Used to know if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
+    bool passed_in_shader_stage_ci = false;
+    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages];
 
     CreateGraphicsPipelines(const VkGraphicsPipelineCreateInfo* create_info) { pCreateInfos = create_info; }
 };
@@ -92,8 +92,8 @@ struct CreateComputePipelines {
     std::vector<vku::safe_VkComputePipelineCreateInfo> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkComputePipelineCreateInfo* pCreateInfos;
-    // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
-    bool passed_in_shader_stage_ci;
+    // Used to know if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
+    bool passed_in_shader_stage_ci = false;
     spirv::StatelessData stateless_data;
 
     CreateComputePipelines(const VkComputePipelineCreateInfo* create_info) { pCreateInfos = create_info; }
@@ -103,7 +103,7 @@ struct CreateRayTracingPipelinesNV {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
-    bool passed_in_shader_stage_ci;
+    bool passed_in_shader_stage_ci = false;
 
     CreateRayTracingPipelinesNV(const VkRayTracingPipelineCreateInfoNV* create_info) { pCreateInfos = create_info; }
 };
@@ -112,7 +112,7 @@ struct CreateRayTracingPipelinesKHR {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos;
-    bool passed_in_shader_stage_ci;
+    bool passed_in_shader_stage_ci = false;
 
     CreateRayTracingPipelinesKHR(const VkRayTracingPipelineCreateInfoKHR* create_info) { pCreateInfos = create_info; }
 };

--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -81,24 +81,36 @@ struct CreateGraphicsPipelines {
     std::vector<vku::safe_VkGraphicsPipelineCreateInfo> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;
     const VkGraphicsPipelineCreateInfo* pCreateInfos;
+    // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
+    spirv::StatelessData stateless_data[spirv::kCommonMaxShaderStages];
+
+    CreateGraphicsPipelines(const VkGraphicsPipelineCreateInfo* create_info) { pCreateInfos = create_info; }
 };
 
 struct CreateComputePipelines {
     std::vector<vku::safe_VkComputePipelineCreateInfo> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkComputePipelineCreateInfo* pCreateInfos;
+    // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
+    spirv::StatelessData stateless_data;
+
+    CreateComputePipelines(const VkComputePipelineCreateInfo* create_info) { pCreateInfos = create_info; }
 };
 
 struct CreateRayTracingPipelinesNV {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
+
+    CreateRayTracingPipelinesNV(const VkRayTracingPipelineCreateInfoNV* create_info) { pCreateInfos = create_info; }
 };
 
 struct CreateRayTracingPipelinesKHR {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos;
+
+    CreateRayTracingPipelinesKHR(const VkRayTracingPipelineCreateInfoKHR* create_info) { pCreateInfos = create_info; }
 };
 
 struct CreatePipelineLayout {

--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -82,7 +82,8 @@ struct CreateGraphicsPipelines {
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;
     const VkGraphicsPipelineCreateInfo* pCreateInfos;
     // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
-    spirv::StatelessData stateless_data[spirv::kCommonMaxShaderStages];
+    bool passed_in_shader_stage_ci;
+    spirv::StatelessData stateless_data[spirv::kCommonMaxGraphicsShaderStages];
 
     CreateGraphicsPipelines(const VkGraphicsPipelineCreateInfo* create_info) { pCreateInfos = create_info; }
 };
@@ -92,6 +93,7 @@ struct CreateComputePipelines {
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkComputePipelineCreateInfo* pCreateInfos;
     // Used to if VkShaderModuleCreateInfo is passed down VkPipelineShaderStageCreateInfo
+    bool passed_in_shader_stage_ci;
     spirv::StatelessData stateless_data;
 
     CreateComputePipelines(const VkComputePipelineCreateInfo* create_info) { pCreateInfos = create_info; }
@@ -101,6 +103,7 @@ struct CreateRayTracingPipelinesNV {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoNV* pCreateInfos;
+    bool passed_in_shader_stage_ci;
 
     CreateRayTracingPipelinesNV(const VkRayTracingPipelineCreateInfoNV* create_info) { pCreateInfos = create_info; }
 };
@@ -109,6 +112,7 @@ struct CreateRayTracingPipelinesKHR {
     std::vector<vku::safe_VkRayTracingPipelineCreateInfoCommon> modified_create_infos;
     std::vector<ShaderModuleUniqueIds> shader_unique_id_maps;  // not used, here for template function
     const VkRayTracingPipelineCreateInfoKHR* pCreateInfos;
+    bool passed_in_shader_stage_ci;
 
     CreateRayTracingPipelinesKHR(const VkRayTracingPipelineCreateInfoKHR* create_info) { pCreateInfos = create_info; }
 };

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -54,6 +54,14 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
                 vku::FindStructInPNextChain<VkPipelineRobustnessCreateInfoEXT>(pCreateInfos[i].pNext)) {
             skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, create_info_loc);
         }
+
+        // From dumping traces, we found almost all apps only create a 1 pipeline at a time. To greatly simplify the logic, only
+        // check the stateless validation in the pNext chain for the first pipeline. (The core issue is because we parse the SPIR-V
+        // at state tracking time, and we state track pipelines first)
+        if (i == 0 && chassis_state.stateless_data.pipeline_pnext_module) {
+            skip |= ValidateSpirvStateless(*chassis_state.stateless_data.pipeline_pnext_module, chassis_state.stateless_data,
+                                           create_info_loc.dot(Field::stage).pNext(Struct::VkShaderModuleCreateInfo, Field::pCode));
+        }
     }
     return skip;
 }

--- a/layers/core_checks/cc_pipeline_compute.cpp
+++ b/layers/core_checks/cc_pipeline_compute.cpp
@@ -55,7 +55,7 @@ bool CoreChecks::PreCallValidateCreateComputePipelines(VkDevice device, VkPipeli
             skip |= ValidatePipelineRobustnessCreateInfo(*pipeline, *pipeline_robustness_info, create_info_loc);
         }
 
-        // From dumping traces, we found almost all apps only create a 1 pipeline at a time. To greatly simplify the logic, only
+        // From dumping traces, we found almost all apps only create one pipeline at a time. To greatly simplify the logic, only
         // check the stateless validation in the pNext chain for the first pipeline. (The core issue is because we parse the SPIR-V
         // at state tracking time, and we state track pipelines first)
         if (i == 0 && chassis_state.stateless_data.pipeline_pnext_module) {

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -48,11 +48,11 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
         skip |= ValidateGraphicsPipeline(*pipeline_states[i].get(), create_info_loc);
         skip |= ValidateGraphicsPipelineDerivatives(pipeline_states, i, create_info_loc);
 
-        // From dumping traces, we found almost all apps only create a 1 pipeline at a time. To greatly simplify the logic, only
+        // From dumping traces, we found almost all apps only create one pipeline at a time. To greatly simplify the logic, only
         // check the stateless validation in the pNext chain for the first pipeline. (The core issue is because we parse the SPIR-V
         // at state tracking time, and we state track pipelines first)
         if (i == 0) {
-            uint32_t stage_count = std::min(pCreateInfos[0].stageCount, spirv::kCommonMaxGraphicsShaderStages);
+            uint32_t stage_count = std::min(pCreateInfos[0].stageCount, kCommonMaxGraphicsShaderStages);
             for (uint32_t stage = 0; stage < stage_count; stage++) {
                 if (chassis_state.stateless_data[stage].pipeline_pnext_module) {
                     skip |= ValidateSpirvStateless(

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -52,7 +52,8 @@ bool CoreChecks::PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipel
         // check the stateless validation in the pNext chain for the first pipeline. (The core issue is because we parse the SPIR-V
         // at state tracking time, and we state track pipelines first)
         if (i == 0) {
-            for (uint32_t stage = 0; stage < pCreateInfos[0].stageCount; stage++) {
+            uint32_t stage_count = std::min(pCreateInfos[0].stageCount, spirv::kCommonMaxGraphicsShaderStages);
+            for (uint32_t stage = 0; stage < stage_count; stage++) {
                 if (chassis_state.stateless_data[stage].pipeline_pnext_module) {
                     skip |= ValidateSpirvStateless(
                         *chassis_state.stateless_data[stage].pipeline_pnext_module, chassis_state.stateless_data[stage],

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2875,6 +2875,8 @@ bool CoreChecks::ValidateEmitMeshTasksSize(const spirv::Module &module_state, co
 bool CoreChecks::ValidateSpirvStateless(const spirv::Module &module_state, const spirv::StatelessData &stateless_data,
                                         const Location &loc) const {
     bool skip = false;
+    if (!module_state.valid_spirv) return skip;
+
     skip |= ValidateShaderClock(module_state, stateless_data, loc);
     skip |= ValidateAtomicsTypes(module_state, stateless_data, loc);
     skip |= ValidateVariables(module_state, loc);

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2883,11 +2883,10 @@ bool CoreChecks::ValidateSpirvStateless(const spirv::Module &module_state, const
         skip |= ValidateTransformFeedbackDecorations(module_state, loc);
     }
 
-    const bool has_pipeline = loc.function == Func::vkCreateShaderModule;
     // The following tries to limit the number of passes through the shader module.
     // It save a good amount of memory and complex state tracking to just check these in a 2nd pass
     for (const spirv::Instruction &insn : module_state.GetInstructions()) {
-        skip |= ValidateShaderCapabilitiesAndExtensions(insn, has_pipeline, loc);
+        skip |= ValidateShaderCapabilitiesAndExtensions(insn, loc);
         skip |= ValidateTexelOffsetLimits(module_state, insn, loc);
         skip |= ValidateMemoryScope(module_state, insn, loc);
         skip |= ValidateSubgroupRotateClustered(module_state, insn, loc);

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -670,7 +670,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateTexelOffsetLimits(const spirv::Module& module_state, const spirv::Instruction& insn, const Location& loc) const;
 
     // Auto-generated helper functions
-    bool ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction& insn, const bool pipeline, const Location& loc) const;
+    bool ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction& insn, const Location& loc) const;
     VkFormat CompatibleSpirvImageFormat(uint32_t spirv_image_format) const;
 
     bool ValidateShaderStageInputOutputLimits(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -310,7 +310,7 @@ void Validator::AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueu
             shader_object_handle = it->second.shader_object;
             instrumented_spirv = it->second.instrumented_spirv;
         }
-        assert(instrumented_spirv.size() != 0);
+        ASSERT_AND_RETURN(!instrumented_spirv.empty());
         std::vector<spirv::Instruction> instructions;
         spirv::GenerateInstructions(instrumented_spirv, instructions);
 
@@ -387,10 +387,10 @@ void Validator::AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueu
                                       common_message);
             UtilGenerateSourceMessages(instructions, &debug_output_buffer[index], true, filename_message, source_message);
             if (use_stdout) {
-                std::cout << "WARNING-DEBUG-PRINTF " << common_message.c_str() << " " << shader_message.str().c_str() << " "
-                          << filename_message.c_str() << " " << source_message.c_str();
+                std::cout << "WARNING-DEBUG-PRINTF " << shader_message.str().c_str() << "\n"
+                          << common_message.c_str() << " " << filename_message.c_str() << " " << source_message.c_str();
             } else {
-                LogInfo("WARNING-DEBUG-PRINTF", queue, loc, "%s %s %s%s", common_message.c_str(), shader_message.str().c_str(),
+                LogInfo("WARNING-DEBUG-PRINTF", queue, loc, "%s\n%s%s%s", shader_message.str().c_str(), common_message.c_str(),
                         filename_message.c_str(), source_message.c_str());
             }
         } else {

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -714,8 +714,7 @@ void GpuShaderInstrumentor::PreCallRecordPipelineCreations(uint32_t count, const
                     // Skip if we are in selective mode
                     if (gpuav_settings.select_instrumented_shaders && !CheckForGpuAvEnabled(sm_ci->pNext)) continue;
                 } else {
-                    // If missing VkShaderModuleCreateInfo, for sure in GPL and not only want to check if there would be a shader
-                    // anyway
+                    // We only get here if using GPL, but if here with a linking pipeline, everything is already handled
                     if (pipe->HasFullState() || (!pipe->pre_raster_state && !pipe->fragment_shader_state)) break;
                 }
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -29,6 +29,15 @@ class Validator;
 }
 
 namespace gpu {
+
+// There are 3 ways to have a null VkShaderModule
+// 1. Use GPL for something like Vertex Input which won't have a shader
+// 2. Use Shader Objects
+// 3. Use VK_KHR_maintenance5 and inline your VkShaderModuleCreateInfo via VkPipelineShaderStageCreateInfo::pNext
+//
+// The first is handled because you have to link it in the end, but we need a way to differentiate 2 and 3
+static const VkShaderModule kPipelineStageInfoHandle = CastFromUint64<VkShaderModule>(0xEEEEEEEEEEEEEEEE);
+
 class SpirvCache {
   public:
     void Add(uint32_t hash, std::vector<uint32_t> spirv);
@@ -151,7 +160,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     template <typename CreateInfo, typename SafeCreateInfo>
     void PostCallRecordPipelineCreations(const uint32_t count, const CreateInfo *pCreateInfos,
                                          const VkAllocationCallbacks *pAllocator, VkPipeline *pPipelines,
-                                         const SafeCreateInfo &modified_create_infos);
+                                         const SafeCreateInfo &modified_create_infos, bool passed_in_shader_stage_ci);
 
     // GPU-AV and DebugPrint are going to have a different way to do the actual shader instrumentation logic
     virtual bool InstrumentShader(const vvl::span<const uint32_t> &input, uint32_t unique_shader_id, const Location &loc,

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -527,10 +527,9 @@ std::shared_ptr<VertexInputState> Pipeline::CreateVertexInputState(const Pipelin
 }
 
 // static
-std::shared_ptr<PreRasterState> Pipeline::CreatePreRasterState(const Pipeline &p, const ValidationStateTracker &state,
-                                                               const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                               const std::shared_ptr<const vvl::RenderPass> &rp,
-                                                               spirv::StatelessData *stateless_data) {
+std::shared_ptr<PreRasterState> Pipeline::CreatePreRasterState(
+    const Pipeline &p, const ValidationStateTracker &state, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
+    const std::shared_ptr<const vvl::RenderPass> &rp, spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     const auto lib_type = GetGraphicsLibType(create_info);
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_PRE_RASTERIZATION_SHADERS_BIT_EXT) {  // Pre-raster graphics library
         return std::make_shared<PreRasterState>(p, state, create_info, rp, stateless_data);
@@ -555,7 +554,7 @@ std::shared_ptr<PreRasterState> Pipeline::CreatePreRasterState(const Pipeline &p
 std::shared_ptr<FragmentShaderState> Pipeline::CreateFragmentShaderState(
     const Pipeline &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
     const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp,
-    spirv::StatelessData *stateless_data) {
+    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     const auto lib_type = GetGraphicsLibType(create_info);
 
     if (lib_type & VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT) {  // Fragment shader graphics library
@@ -675,8 +674,8 @@ std::shared_ptr<const vvl::ShaderModule> Pipeline::GetSubStateShader(VkShaderSta
 
 Pipeline::Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
                    std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
-                   std::shared_ptr<const vvl::PipelineLayout> &&layout, spirv::StatelessData *stateless_data,
-                   ShaderModuleUniqueIds *shader_unique_id_map)
+                   std::shared_ptr<const vvl::PipelineLayout> &&layout,
+                   spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds *shader_unique_id_map)
     : StateObject(static_cast<VkPipeline>(VK_NULL_HANDLE), kVulkanObjectTypePipeline),
       rp_state(rpstate),
       create_info(MakeGraphicsCreateInfo(*pCreateInfo, rpstate, state_data)),

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -134,17 +134,21 @@ class Pipeline : public StateObject {
     // Executable or legacy pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
-             std::shared_ptr<const vvl::PipelineLayout> &&layout, ShaderModuleUniqueIds *shader_unique_id_map = nullptr);
+             std::shared_ptr<const vvl::PipelineLayout> &&layout, spirv::StatelessData *stateless_data,
+             ShaderModuleUniqueIds *shader_unique_id_map = nullptr);
 
     // Compute pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkComputePipelineCreateInfo *pCreateInfo,
-             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout);
+             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
+             spirv::StatelessData *stateless_data);
 
     Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoKHR *pCreateInfo,
-             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout);
+             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
+             spirv::StatelessData *stateless_data);
 
     Pipeline(const ValidationStateTracker &state_data, const VkRayTracingPipelineCreateInfoNV *pCreateInfo,
-             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout);
+             std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::PipelineLayout> &&layout,
+             spirv::StatelessData *stateless_data);
 
     VkPipeline VkHandle() const { return handle_.Cast<VkPipeline>(); }
 
@@ -388,6 +392,7 @@ class Pipeline : public StateObject {
     const VkPipelineRenderingCreateInfo *GetPipelineRenderingCreateInfo() const { return rendering_create_info; }
 
     static std::vector<ShaderStageState> GetStageStates(const ValidationStateTracker &state_data, const Pipeline &pipe_state,
+                                                        spirv::StatelessData *stateless_data,
                                                         ShaderModuleUniqueIds *shader_unique_id_map);
 
     // Return true if for a given PSO, the given state enum is dynamic, else return false
@@ -530,10 +535,12 @@ class Pipeline : public StateObject {
                                                                     const vku::safe_VkGraphicsPipelineCreateInfo &create_info);
     static std::shared_ptr<PreRasterState> CreatePreRasterState(const Pipeline &p, const ValidationStateTracker &state,
                                                                 const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                const std::shared_ptr<const vvl::RenderPass> &rp);
+                                                                const std::shared_ptr<const vvl::RenderPass> &rp,
+                                                                spirv::StatelessData *stateless_data);
     static std::shared_ptr<FragmentShaderState> CreateFragmentShaderState(
         const Pipeline &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
-        const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp);
+        const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp,
+        spirv::StatelessData *stateless_data);
     static std::shared_ptr<FragmentOutputState> CreateFragmentOutputState(
         const Pipeline &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
         const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp);

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -134,7 +134,8 @@ class Pipeline : public StateObject {
     // Executable or legacy pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
-             std::shared_ptr<const vvl::PipelineLayout> &&layout, spirv::StatelessData *stateless_data,
+             std::shared_ptr<const vvl::PipelineLayout> &&layout,
+             spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages],
              ShaderModuleUniqueIds *shader_unique_id_map = nullptr);
 
     // Compute pipeline
@@ -533,14 +534,13 @@ class Pipeline : public StateObject {
   protected:
     static std::shared_ptr<VertexInputState> CreateVertexInputState(const Pipeline &p, const ValidationStateTracker &state,
                                                                     const vku::safe_VkGraphicsPipelineCreateInfo &create_info);
-    static std::shared_ptr<PreRasterState> CreatePreRasterState(const Pipeline &p, const ValidationStateTracker &state,
-                                                                const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                                const std::shared_ptr<const vvl::RenderPass> &rp,
-                                                                spirv::StatelessData *stateless_data);
+    static std::shared_ptr<PreRasterState> CreatePreRasterState(
+        const Pipeline &p, const ValidationStateTracker &state, const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
+        const std::shared_ptr<const vvl::RenderPass> &rp, spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
     static std::shared_ptr<FragmentShaderState> CreateFragmentShaderState(
         const Pipeline &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
         const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp,
-        spirv::StatelessData *stateless_data);
+        spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
     static std::shared_ptr<FragmentOutputState> CreateFragmentOutputState(
         const Pipeline &p, const ValidationStateTracker &state, const VkGraphicsPipelineCreateInfo &create_info,
         const vku::safe_VkGraphicsPipelineCreateInfo &safe_create_info, const std::shared_ptr<const vvl::RenderPass> &rp);

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -84,7 +84,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTrac
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)) {
                 // don't need to worry about GroupDecoration in GPL
                 spirv::StatelessData *stateless_data_stage =
-                    (stateless_data && i < spirv::kCommonMaxShaderStages) ? &stateless_data[i] : nullptr;
+                    (stateless_data && i < spirv::kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                 auto spirv_module = std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
                 module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);
                 if (stateless_data_stage) {
@@ -198,7 +198,7 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext)) {
                     // don't need to worry about GroupDecoration in GPL
                     spirv::StatelessData *stateless_data_stage =
-                        (stateless_data && i < spirv::kCommonMaxShaderStages) ? &stateless_data[i] : nullptr;
+                        (stateless_data && i < spirv::kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                     auto spirv_module =
                         std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
                     module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -57,7 +57,7 @@ VertexInputState::VertexInputState(const vvl::Pipeline &p, const vku::safe_VkGra
 
 PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &state_data,
                                const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp,
-                               spirv::StatelessData *stateless_data)
+                               spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages])
     : PipelineSubState(p),
       pipeline_layout(state_data.Get<vvl::PipelineLayout>(create_info.layout)),
       viewport_state(create_info.pViewportState),
@@ -84,7 +84,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTrac
             if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(stage_ci.pNext)) {
                 // don't need to worry about GroupDecoration in GPL
                 spirv::StatelessData *stateless_data_stage =
-                    (stateless_data && i < spirv::kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
+                    (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                 auto spirv_module = std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
                 module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);
                 if (stateless_data_stage) {
@@ -187,7 +187,8 @@ std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI
 
 template <typename CreateInfo>
 void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
-                                  const CreateInfo &create_info, spirv::StatelessData *stateless_data) {
+                                  const CreateInfo &create_info,
+                                  spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {
         if (create_info.pStages[i].stage == VK_SHADER_STAGE_FRAGMENT_BIT) {
             auto module_state = state_data.Get<vvl::ShaderModule>(create_info.pStages[i].module);
@@ -198,7 +199,7 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                 if (const auto shader_ci = vku::FindStructInPNextChain<VkShaderModuleCreateInfo>(create_info.pStages[i].pNext)) {
                     // don't need to worry about GroupDecoration in GPL
                     spirv::StatelessData *stateless_data_stage =
-                        (stateless_data && i < spirv::kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
+                        (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                     auto spirv_module =
                         std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
                     module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);
@@ -233,14 +234,14 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
 // static
 void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
                                                 const VkGraphicsPipelineCreateInfo &create_info,
-                                                spirv::StatelessData *stateless_data) {
+                                                spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(fs_state, state_data, create_info, stateless_data);
 }
 
 // static
 void FragmentShaderState::SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
                                                 const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                                                spirv::StatelessData *stateless_data) {
+                                                spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) {
     SetFragmentShaderInfoPrivate(fs_state, state_data, create_info, stateless_data);
 }
 

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -145,10 +145,11 @@ struct FragmentShaderState : public PipelineSubState {
 
   private:
     static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
-                                      const VkGraphicsPipelineCreateInfo &create_info, spirv::StatelessData *stateless_data);
+                                      const VkGraphicsPipelineCreateInfo &create_info,
+                                      spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
     static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
                                       const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
-                                      spirv::StatelessData *stateless_data);
+                                      spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
 };
 
 template <typename CreateInfo>

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -32,6 +32,7 @@ struct ShaderModule;
 
 namespace spirv {
 struct EntryPoint;
+struct StatelessData;
 }  // namespace spirv
 
 template <typename CreateInfoType>
@@ -69,7 +70,8 @@ struct VertexInputState : public PipelineSubState {
 
 struct PreRasterState : public PipelineSubState {
     PreRasterState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data,
-                   const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp);
+                   const vku::safe_VkGraphicsPipelineCreateInfo &create_info, std::shared_ptr<const vvl::RenderPass> rp,
+                   spirv::StatelessData *stateless_data);
 
     static inline VkShaderStageFlags ValidShaderStages() {
         return VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT |
@@ -116,7 +118,7 @@ struct FragmentShaderState : public PipelineSubState {
 
     template <typename CreateInfo>
     FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data, const CreateInfo &create_info,
-                        std::shared_ptr<const vvl::RenderPass> rp)
+                        std::shared_ptr<const vvl::RenderPass> rp, spirv::StatelessData *stateless_data)
         : FragmentShaderState(p, dev_data, rp, create_info.subpass, create_info.layout) {
         if (create_info.pMultisampleState) {
             ms_state = ToSafeMultisampleState(*create_info.pMultisampleState);
@@ -124,7 +126,7 @@ struct FragmentShaderState : public PipelineSubState {
         if (create_info.pDepthStencilState) {
             ds_state = ToSafeDepthStencilState(*create_info.pDepthStencilState);
         }
-        FragmentShaderState::SetFragmentShaderInfo(*this, dev_data, create_info);
+        FragmentShaderState::SetFragmentShaderInfo(*this, dev_data, create_info, stateless_data);
     }
 
     static inline VkShaderStageFlags ValidShaderStages() { return VK_SHADER_STAGE_FRAGMENT_BIT; }
@@ -143,9 +145,10 @@ struct FragmentShaderState : public PipelineSubState {
 
   private:
     static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
-                                      const VkGraphicsPipelineCreateInfo &create_info);
+                                      const VkGraphicsPipelineCreateInfo &create_info, spirv::StatelessData *stateless_data);
     static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
-                                      const vku::safe_VkGraphicsPipelineCreateInfo &create_info);
+                                      const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
+                                      spirv::StatelessData *stateless_data);
 };
 
 template <typename CreateInfo>

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -38,6 +38,9 @@ struct Module;
 
 static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
+// It is very rare to have more then 3 stages (really only geo/tess) and better to save memory/time for the 99% use cases
+static const uint32_t kCommonMaxShaderStages = 3;
+
 // This is the common info for both OpDecorate and OpMemberDecorate
 // Used to keep track of all decorations applied to any instruction
 struct DecorationBase {
@@ -536,6 +539,9 @@ struct EntryPoint {
 
 // Info to capture while parsing the SPIR-V, but will only be used by ValidateSpirvStateless and don't need to save after
 struct StatelessData {
+    // Used if the Shader Module is being passed in VkPipelineShaderStageCreateInfo
+    std::shared_ptr<spirv::Module> pipeline_pnext_module;
+
     // These instruction mapping were designed to quickly find the few instructions without having to loop the entire pass
     // In theory, these could be removed checked during the 2nd pass in ValidateSpirvStateless()
     // TODO - Get perf numbers if better to understand if these make sense here

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -38,9 +38,6 @@ struct Module;
 
 static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
-// It is very rare to have more then 3 stages (really only geo/tess) and better to save memory/time for the 99% use cases
-static const uint32_t kCommonMaxGraphicsShaderStages = 3;
-
 // This is the common info for both OpDecorate and OpMemberDecorate
 // Used to keep track of all decorations applied to any instruction
 struct DecorationBase {

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -39,7 +39,7 @@ struct Module;
 static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
 // It is very rare to have more then 3 stages (really only geo/tess) and better to save memory/time for the 99% use cases
-static const uint32_t kCommonMaxShaderStages = 3;
+static const uint32_t kCommonMaxGraphicsShaderStages = 3;
 
 // This is the common info for both OpDecorate and OpMemberDecorate
 // Used to keep track of all decorations applied to any instruction

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1879,7 +1879,7 @@ void ValidationStateTracker::PreCallRecordDestroyPipelineCache(VkDevice device, 
 std::shared_ptr<vvl::Pipeline> ValidationStateTracker::CreateGraphicsPipelineState(
     const VkGraphicsPipelineCreateInfo *pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::RenderPass> &&render_pass, std::shared_ptr<const vvl::PipelineLayout> &&layout,
-    spirv::StatelessData *stateless_data, ShaderModuleUniqueIds *shader_unique_id_map) const {
+    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds *shader_unique_id_map) const {
     return std::make_shared<vvl::Pipeline>(*this, pCreateInfo, std::move(pipeline_cache), std::move(render_pass), std::move(layout),
                                            stateless_data, shader_unique_id_map);
 }

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -755,12 +755,10 @@ class ValidationStateTracker : public ValidationObject {
     void PreCallRecordDestroyPipelineCache(VkDevice device, VkPipelineCache pipelineCache, const VkAllocationCallbacks* pAllocator,
                                            const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* pCreateInfo,
-                                                                       std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                       std::shared_ptr<const vvl::RenderPass>&& render_pass,
-                                                                       std::shared_ptr<const vvl::PipelineLayout>&& layout,
-                                                                       spirv::StatelessData* stateless_data,
-                                                                       ShaderModuleUniqueIds* shader_unique_id_map) const;
+    virtual std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(
+        const VkGraphicsPipelineCreateInfo* pCreateInfo, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
+        std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
+        spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds* shader_unique_id_map) const;
 
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -75,6 +75,10 @@ namespace chassis {
 struct CreateShaderModule;
 }  // namespace chassis
 
+namespace spirv {
+struct StatelessData;
+}  // namespace spirv
+
 // This is duplicated here because Best Practice pipeline is a derivative of vvl::Pipeline and we have a virtual function that needs
 // to know this. Idealy this will probably never need to change often, so likely won't cause issues
 using ShaderModuleUniqueIds = std::unordered_map<VkShaderStageFlagBits, uint32_t>;
@@ -698,7 +702,8 @@ class ValidationStateTracker : public ValidationObject {
 
     virtual std::shared_ptr<vvl::Pipeline> CreateComputePipelineState(const VkComputePipelineCreateInfo* pCreateInfo,
                                                                       std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                      std::shared_ptr<const vvl::PipelineLayout>&& layout) const;
+                                                                      std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                      spirv::StatelessData* stateless_data) const;
     bool PreCallValidateCreateComputePipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                const VkComputePipelineCreateInfo* pCreateInfos,
                                                const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
@@ -754,6 +759,7 @@ class ValidationStateTracker : public ValidationObject {
                                                                        std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
                                                                        std::shared_ptr<const vvl::RenderPass>&& render_pass,
                                                                        std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                       spirv::StatelessData* stateless_data,
                                                                        ShaderModuleUniqueIds* shader_unique_id_map) const;
 
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
@@ -813,7 +819,8 @@ class ValidationStateTracker : public ValidationObject {
 
     virtual std::shared_ptr<vvl::Pipeline> CreateRayTracingPipelineState(const VkRayTracingPipelineCreateInfoNV* pCreateInfo,
                                                                          std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                         std::shared_ptr<const vvl::PipelineLayout>&& layout) const;
+                                                                         std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                         spirv::StatelessData* stateless_data) const;
     bool PreCallValidateCreateRayTracingPipelinesNV(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                     const VkRayTracingPipelineCreateInfoNV* pCreateInfos,
                                                     const VkAllocationCallbacks* pAllocator, VkPipeline* pPipelines,
@@ -826,7 +833,8 @@ class ValidationStateTracker : public ValidationObject {
                                                    chassis::CreateRayTracingPipelinesNV& chassis_state) override;
     virtual std::shared_ptr<vvl::Pipeline> CreateRayTracingPipelineState(const VkRayTracingPipelineCreateInfoKHR* pCreateInfo,
                                                                          std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                                         std::shared_ptr<const vvl::PipelineLayout>&& layout) const;
+                                                                         std::shared_ptr<const vvl::PipelineLayout>&& layout,
+                                                                         spirv::StatelessData* stateless_data) const;
     bool PreCallValidateCreateRayTracingPipelinesKHR(VkDevice device, VkDeferredOperationKHR deferredOperation,
                                                      VkPipelineCache pipelineCache, uint32_t count,
                                                      const VkRayTracingPipelineCreateInfoKHR* pCreateInfos,

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -92,6 +92,9 @@ static inline VkOffset3D CastTo3D(const VkOffset2D &d2) {
     return d3;
 }
 
+// It is very rare to have more than 3 stages (really only geo/tess) and better to save memory/time for the 99% use cases
+static const uint32_t kCommonMaxGraphicsShaderStages = 3;
+
 typedef void *dispatch_key;
 static inline dispatch_key GetDispatchKey(const void *object) { return (dispatch_key) * (VkLayerDispatchTable **)object; }
 

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -720,8 +720,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateGraphicsPipelines(VkDevice device, VkPipeli
     ErrorObject error_obj(vvl::Func::vkCreateGraphicsPipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
     PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-    chassis::CreateGraphicsPipelines chassis_state{};
-    chassis_state.pCreateInfos = pCreateInfos;
+    chassis::CreateGraphicsPipelines chassis_state(pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
@@ -761,8 +760,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateComputePipelines(VkDevice device, VkPipelin
     ErrorObject error_obj(vvl::Func::vkCreateComputePipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
     PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-    chassis::CreateComputePipelines chassis_state{};
-    chassis_state.pCreateInfos = pCreateInfos;
+    chassis::CreateComputePipelines chassis_state(pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
@@ -800,8 +798,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesNV(VkDevice device, VkPi
     ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesNV, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
     PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-    chassis::CreateRayTracingPipelinesNV chassis_state{};
-    chassis_state.pCreateInfos = pCreateInfos;
+    chassis::CreateRayTracingPipelinesNV chassis_state(pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();
@@ -841,8 +838,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateRayTracingPipelinesKHR(VkDevice device, VkD
     ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesKHR, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
     PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-    chassis::CreateRayTracingPipelinesKHR chassis_state{};
-    chassis_state.pCreateInfos = pCreateInfos;
+    chassis::CreateRayTracingPipelinesKHR chassis_state(pCreateInfos);
 
     for (const ValidationObject* intercept : layer_data->object_dispatch) {
         auto lock = intercept->ReadLock();

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -1065,9 +1065,9 @@ static inline std::string SpvExtensionRequirments(std::string_view extension) {
 }
 // clang-format on
 
-bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction &insn, const bool pipeline,
-                                                         const Location &loc) const {
+bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction &insn, const Location &loc) const {
     bool skip = false;
+    const bool pipeline = loc.function != vvl::Func::vkCreateShadersEXT;
 
     if (insn.Opcode() == spv::OpCapability) {
         // All capabilities are generated so if it is not in the list it is not supported by Vulkan

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1396,8 +1396,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 ErrorObject error_obj(vvl::Func::vkCreateGraphicsPipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-                chassis::CreateGraphicsPipelines chassis_state{};
-                chassis_state.pCreateInfos = pCreateInfos;
+                chassis::CreateGraphicsPipelines chassis_state(pCreateInfos);
 
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();
@@ -1434,8 +1433,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 ErrorObject error_obj(vvl::Func::vkCreateComputePipelines, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-                chassis::CreateComputePipelines chassis_state{};
-                chassis_state.pCreateInfos = pCreateInfos;
+                chassis::CreateComputePipelines chassis_state(pCreateInfos);
 
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();
@@ -1471,8 +1469,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesNV, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-                chassis::CreateRayTracingPipelinesNV chassis_state{};
-                chassis_state.pCreateInfos = pCreateInfos;
+                chassis::CreateRayTracingPipelinesNV chassis_state(pCreateInfos);
 
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();
@@ -1510,8 +1507,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 ErrorObject error_obj(vvl::Func::vkCreateRayTracingPipelinesKHR, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
-                chassis::CreateRayTracingPipelinesKHR chassis_state{};
-                chassis_state.pCreateInfos = pCreateInfos;
+                chassis::CreateRayTracingPipelinesKHR chassis_state(pCreateInfos);
 
                 for (const ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->ReadLock();

--- a/scripts/generators/spirv_validation_generator.py
+++ b/scripts/generators/spirv_validation_generator.py
@@ -302,8 +302,9 @@ static inline std::string SpvExtensionRequirments(std::string_view extension) {
         #
         # The main function to validate all the extensions and capabilities
         out.append('''
-            bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction &insn, const bool pipeline, const Location& loc) const {
+            bool CoreChecks::ValidateShaderCapabilitiesAndExtensions(const spirv::Instruction &insn,  const Location& loc) const {
                 bool skip = false;
+                const bool pipeline = loc.function != vvl::Func::vkCreateShadersEXT;
 
                 if (insn.Opcode() == spv::OpCapability) {
                     // All capabilities are generated so if it is not in the list it is not supported by Vulkan

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1656,8 +1656,7 @@ TEST_F(NegativeDebugPrintf, LocalSizeId) {
     m_errorMonitor->VerifyFound();
 }
 
-// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8103
-TEST_F(NegativeDebugPrintf, DISABLED_Maintenance5) {
+TEST_F(NegativeDebugPrintf, Maintenance5) {
     TEST_DESCRIPTION("Test SPIRV is still checked if using new pNext in VkPipelineShaderStageCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -685,8 +685,7 @@ TEST_F(NegativeShaderCompute, LocalSizeIdExecutionMode) {
     m_errorMonitor->VerifyFound();
 }
 
-// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8103
-TEST_F(NegativeShaderCompute, DISABLED_LocalSizeIdExecutionModeMaintenance5) {
+TEST_F(NegativeShaderCompute, LocalSizeIdExecutionModeMaintenance5) {
     TEST_DESCRIPTION("Test SPIRV is still checked if using new pNext in VkPipelineShaderStageCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -610,8 +610,7 @@ TEST_F(NegativeShaderSpirv, Storage8and16bitCapability) {
     }
 }
 
-// TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8103
-TEST_F(NegativeShaderSpirv, DISABLED_SpirvStatelessMaintenance5) {
+TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
     TEST_DESCRIPTION("Test SPIRV is still checked if using new pNext in VkPipelineShaderStageCreateInfo");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
@@ -649,7 +648,7 @@ TEST_F(NegativeShaderSpirv, DISABLED_SpirvStatelessMaintenance5) {
     pipe.gp_ci_.pStages = &stage_ci;
     pipe.dsl_bindings_ = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr}};
 
-    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-storageBuffer8BitAccess-06328");  // feature
+    m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-uniformAndStorageBuffer8BitAccess-06329");  // feature
     m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740", 2);     // Int8
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8103

`VK_KHR_maintenance5` and `VK_EXT_graphics_pipeline_library` added the ability to pass `VkShaderModuleCreateInfo` in the `pNext` of `VkPipelineShaderStageCreateInfo` (removing the need creating a `VkShaderModule`)

We did not have this all plumbed out. This adds full support for it now