### PR TITLE
layers: Fix checks with runtime arrays

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -343,7 +343,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                       string_SpvDim(dim), is_image_array);
         }
 
-        if ((variable->info.image_format_type & image_view_state->descriptor_format_bits) == 0) {
+        // Because you can have a runtime array with different types in it, without extensive GPU-AV tracking, we have no way to
+        // detect if the types match up in a given index
+        if (variable->array_length != spirv::kRuntimeArray &&
+            ((variable->info.image_format_type & image_view_state->descriptor_format_bits) == 0)) {
             const bool signed_override =
                 ((variable->info.image_format_type & spirv::NumericTypeUint) && variable->info.is_sign_extended);
             const bool unsigned_override =

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1856,6 +1856,8 @@ const Instruction& ResourceInterfaceVariable::FindBaseType(ResourceInterfaceVari
             // currently just tracks 1D arrays
             if (type->Opcode() == spv::OpTypeArray && variable.array_length == 0) {
                 variable.array_length = module_state.GetConstantValueById(type->Word(3));
+            } else if (type->Opcode() == spv::OpTypeRuntimeArray) {
+                variable.array_length = spirv::kRuntimeArray;
             }
 
             if (type->Opcode() == spv::OpTypeSampledImage) {
@@ -1964,7 +1966,9 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
         if (is_sampled_without_sampler) {
             if (info.image_dim == spv::DimSubpassData) {
                 is_input_attachment = true;
-                input_attachment_index_read.resize(array_length);  // is zero if runtime array
+                if (array_length != spirv::kRuntimeArray) {
+                    input_attachment_index_read.resize(array_length);
+                }
             } else if (info.image_dim == spv::DimBuffer) {
                 is_storage_texel_buffer = true;
             } else {
@@ -1987,7 +1991,7 @@ ResourceInterfaceVariable::ResourceInterfaceVariable(const Module& module_state,
                 info.is_zero_extended |= image_access.is_zero_extended;
                 access_mask |= image_access.access_mask;
 
-                if (array_length > 1) {
+                if (array_length > 1 && array_length != spirv::kRuntimeArray) {
                     image_access_chain_indexes.insert(image_access.image_access_chain_index);
                 }
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -38,6 +38,9 @@ struct Module;
 
 static constexpr uint32_t kInvalidValue = std::numeric_limits<uint32_t>::max();
 
+// Need to find a way to know if actually array lenght of zero, or a runtime array.
+static constexpr uint32_t kRuntimeArray = std::numeric_limits<uint32_t>::max();
+
 // This is the common info for both OpDecorate and OpMemberDecorate
 // Used to keep track of all decorations applied to any instruction
 struct DecorationBase {
@@ -371,6 +374,7 @@ struct StageInterfaceVariable : public VariableBase {
 // at draw/submit time we can cross reference with the last bound descriptor.
 struct ResourceInterfaceVariable : public VariableBase {
     // If the type is a OpTypeArray save the length
+    // Will be kRuntimeArray (non-zero) for runtime arrays
     uint32_t array_length;
 
     bool is_sampled_image;  // OpTypeSampledImage


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7677

We didn't have `OpTypeRuntimeArray` tracked well, but as shown, for some VUs, it is just not possible without a lot of GPU-AV tracking, but for now want to just remove the false positive for the edge case and keep things working for the other 99% cases