### PR TITLE
layers: Improve VU 08600

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -528,8 +528,10 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateDrawShaderObjectPushConstantAndLayout(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateDrawShaderObjectMesh(const LastBound& last_bound_state, const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionState(const vvl::CommandBuffer& cb_state, const VkPipelineBindPoint bind_point, const Location& loc) const;
-    bool ValidateActionStateDescriptors(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
-                                        const vvl::Pipeline* pipeline, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateActionStateDescriptorsPipeline(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                                const vvl::Pipeline& pipeline, const vvl::DrawDispatchVuid& vuid) const;
+    bool ValidateActionStateDescriptorsShaderObject(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,
+                                                    const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStatePushConstant(const LastBound& last_bound_state, const vvl::Pipeline* pipeline,
                                          const vvl::DrawDispatchVuid& vuid) const;
     bool ValidateActionStateProtectedMemory(const LastBound& last_bound_state, const VkPipelineBindPoint bind_point,

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1155,7 +1155,7 @@ void CommandBuffer::PushDescriptorSetState(VkPipelineBindPoint pipelineBindPoint
     auto &last_bound = lastBound[lv_bind_point];
     auto &push_descriptor_set = last_bound.push_descriptor_set;
     // If we are disturbing the current push_desriptor_set clear it
-    if (!push_descriptor_set || !IsBoundSetCompatible(set, last_bound, pipeline_layout)) {
+    if (!push_descriptor_set || !last_bound.IsBoundSetCompatible(set, pipeline_layout)) {
         last_bound.UnbindAndResetPushDescriptorSet(dev_data.CreateDescriptorSet(VK_NULL_HANDLE, nullptr, dsl, 0));
     }
 

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -210,6 +210,8 @@ class DescriptorSetLayoutDef {
     };
     const BindingTypeStats &GetBindingTypeStats() const { return binding_type_stats_; }
 
+    std::string DescribeDifference(uint32_t index, const DescriptorSetLayoutDef &other) const;
+
   private:
     // Only the first three data members are used for hash and equality checks, the other members are derived from them, and are
     // used to speed up the various lookups/queries/validations

--- a/layers/state_tracker/pipeline_layout_state.cpp
+++ b/layers/state_tracker/pipeline_layout_state.cpp
@@ -63,6 +63,24 @@ bool PipelineLayoutCompatDef::operator==(const PipelineLayoutCompatDef &other) c
     return true;
 }
 
+std::string PipelineLayoutCompatDef::DescribeDifference(const PipelineLayoutCompatDef &other) const {
+    std::ostringstream ss;
+    if (set != other.set) {
+        ss << "The set " << set << " is different from the non-compatible pipeline layout (" << other.set << ")\n";
+    } else if (push_constant_ranges != other.push_constant_ranges) {
+        ss << "The set push constant ranges is different from the non-compatible pipeline layout push constant ranges\n";
+    } else {
+        const auto &descriptor_set_layouts = *set_layouts_id.get();
+        const auto &other_ds_layouts = *other.set_layouts_id.get();
+        for (uint32_t i = 0; i <= set; i++) {
+            if (descriptor_set_layouts[i] != other_ds_layouts[i]) {
+                return descriptor_set_layouts[i]->DescribeDifference(i, *other_ds_layouts[i]);
+            }
+        }
+    }
+    return ss.str();
+}
+
 static PipelineLayoutCompatId GetCanonicalId(const uint32_t set_index, const PushConstantRangesId &pcr_id,
                                              const PipelineLayoutSetLayoutsId &set_layouts_id) {
     return pipeline_layout_compat_dict.LookUp(PipelineLayoutCompatDef(set_index, pcr_id, set_layouts_id));

--- a/layers/state_tracker/pipeline_layout_state.h
+++ b/layers/state_tracker/pipeline_layout_state.h
@@ -56,7 +56,9 @@ struct PipelineLayoutCompatDef {
     PipelineLayoutCompatDef(const uint32_t set_index, const PushConstantRangesId pcr_id, const PipelineLayoutSetLayoutsId sl_id)
         : set(set_index), push_constant_ranges(pcr_id), set_layouts_id(sl_id) {}
     size_t hash() const;
+
     bool operator==(const PipelineLayoutCompatDef &other) const;
+    std::string DescribeDifference(const PipelineLayoutCompatDef &other) const;
 };
 
 // Canonical dictionary for PipelineLayoutCompat records

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -1094,3 +1094,43 @@ bool LastBound::IsAnyGraphicsShaderBound() const {
         IsValidShaderBound(ShaderObjectStage::TASK) ||
         IsValidShaderBound(ShaderObjectStage::MESH);
 }
+
+bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const {
+    if ((set >= per_set.size()) || (set >= pipeline_layout.set_compat_ids.size())) {
+        return false;
+    }
+    return (*(per_set[set].compat_id_for_set) == *(pipeline_layout.set_compat_ids[set]));
+}
+
+bool LastBound::IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject &shader_object_state) const {
+    if ((set >= per_set.size()) || (set >= shader_object_state.set_compat_ids.size())) {
+        return false;
+    }
+    return (*(per_set[set].compat_id_for_set) == *(shader_object_state.set_compat_ids[set]));
+};
+
+std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const {
+    std::ostringstream ss;
+    if (set >= per_set.size()) {
+        ss << "The set (" << set << ") is out of bounds for the number of sets bound (" << per_set.size() << ")\n";
+    } else if (set >= pipeline_layout.set_compat_ids.size()) {
+        ss << "The set (" << set << ") is out of bounds for the number of sets in the non-compatible VkPipelineLayout ("
+           << pipeline_layout.set_compat_ids.size() << ")\n";
+    } else {
+        return per_set[set].compat_id_for_set->DescribeDifference(*(pipeline_layout.set_compat_ids[set]));
+    }
+    return ss.str();
+}
+
+std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject &shader_object_state) const {
+    std::ostringstream ss;
+    if (set >= per_set.size()) {
+        ss << "The set (" << set << ") is out of bounds for the number of sets bound (" << per_set.size() << ")\n";
+    } else if (set >= shader_object_state.set_compat_ids.size()) {
+        ss << "The set (" << set << ") is out of bounds for the number of sets in the non-compatible VkDescriptorSetLayout ("
+           << shader_object_state.set_compat_ids.size() << ")\n";
+    } else {
+        return per_set[set].compat_id_for_set->DescribeDifference(*(shader_object_state.set_compat_ids[set]));
+    }
+    return ss.str();
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -697,14 +697,12 @@ struct LastBound {
     bool IsValidShaderOrNullBound(ShaderObjectStage stage) const;
     std::vector<vvl::ShaderObject *> GetAllBoundGraphicsShaders();
     bool IsAnyGraphicsShaderBound() const;
-};
 
-static inline bool IsBoundSetCompatible(uint32_t set, const LastBound &last_bound, const vvl::PipelineLayout &pipeline_layout) {
-    if ((set >= last_bound.per_set.size()) || (set >= pipeline_layout.set_compat_ids.size())) {
-        return false;
-    }
-    return (*(last_bound.per_set[set].compat_id_for_set) == *(pipeline_layout.set_compat_ids[set]));
-}
+    bool IsBoundSetCompatible(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const;
+    bool IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject &shader_object_state) const;
+    std::string DescribeNonCompatibleSet(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const;
+    std::string DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject &shader_object_state) const;
+};
 
 static inline bool IsPipelineLayoutSetCompat(uint32_t set, const vvl::PipelineLayout *a, const vvl::PipelineLayout *b) {
     if (!a || !b) {

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -371,23 +371,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
 
     // Descriptor sets
     {
+        vkt::Buffer buffer(*m_device, 8, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
         OneOffDescriptorSet descriptor_set{m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}}};
-
-        VkBufferCreateInfo bci = vku::InitStructHelper();
-        bci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-        bci.size = 8;
-        vkt::Buffer buffer(*m_device, bci);
-        VkDescriptorBufferInfo buffer_info;
-        buffer_info.buffer = buffer.handle();
-        buffer_info.offset = 0;
-        buffer_info.range = VK_WHOLE_SIZE;
-        VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
-        descriptor_write.dstSet = descriptor_set.set_;
-        descriptor_write.dstBinding = 0;
-        descriptor_write.descriptorCount = 1;
-        descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        descriptor_write.pBufferInfo = &buffer_info;
-        vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
+        descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE);
+        descriptor_set.UpdateDescriptorSets();
 
         VkPipelineLayoutCreateInfo pipeline_layout_info = vku::InitStructHelper();
         pipeline_layout_info.setLayoutCount = 1;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8100

Create a set of `Describe*` functions to help go over which part of the sets are not compatible

The logic for matching layout compatibility has not changed in years, so I doubt neither will the `Describe*` logic after this (but kept it next to it incase it did)