### PR TITLE
layers: Add GetFragmentEntryPoint helper

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -760,10 +760,10 @@ bool CoreChecks::ValidateGraphicsDynamicStateValue(const LastBound& last_bound_s
     {
         const bool dyn_depth_write_enable = pipeline.IsDynamic(CB_DYNAMIC_STATE_DEPTH_WRITE_ENABLE);
         const bool dyn_stencil_write_mask = pipeline.IsDynamic(CB_DYNAMIC_STATE_STENCIL_WRITE_MASK);
-        if ((dyn_depth_write_enable || dyn_stencil_write_mask) &&
-            (pipeline.fragment_shader_state && pipeline.fragment_shader_state->fragment_entry_point)) {
-            auto entrypoint = pipeline.fragment_shader_state->fragment_entry_point;
-            const bool mode_early_fragment_test = entrypoint->execution_mode.Has(spirv::ExecutionModeSet::early_fragment_test_bit);
+        auto fragment_entry_point = last_bound_state.GetFragmentEntryPoint();
+        if ((dyn_depth_write_enable || dyn_stencil_write_mask) && fragment_entry_point) {
+            const bool mode_early_fragment_test =
+                fragment_entry_point->execution_mode.Has(spirv::ExecutionModeSet::early_fragment_test_bit);
             const bool depth_read =
                 pipeline.fragment_shader_state->fragment_shader->spirv->static_data_.has_shader_tile_image_depth_read;
             const bool stencil_read =

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -1941,14 +1941,7 @@ bool CoreChecks::ValidateDrawDualSourceBlend(const LastBound &last_bound_state, 
     const auto *pipeline = last_bound_state.pipeline_state;
     if (pipeline && !pipeline->ColorBlendState()) return skip;
 
-    const spirv::EntryPoint *fragment_entry_point = nullptr;
-    if (pipeline && pipeline->fragment_shader_state) {
-        fragment_entry_point = pipeline->fragment_shader_state->fragment_entry_point.get();
-    } else {
-        if (const auto *shader_object = last_bound_state.GetShaderState(ShaderObjectStage::FRAGMENT)) {
-            fragment_entry_point = shader_object->entrypoint.get();
-        }
-    }
+    const spirv::EntryPoint *fragment_entry_point = last_bound_state.GetFragmentEntryPoint();
     if (!fragment_entry_point) return skip;
 
     uint32_t max_fragment_location = 0;

--- a/layers/state_tracker/pipeline_state.cpp
+++ b/layers/state_tracker/pipeline_state.cpp
@@ -1227,3 +1227,12 @@ std::string LastBound::DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderO
     }
     return ss.str();
 }
+
+const spirv::EntryPoint *LastBound::GetFragmentEntryPoint() const {
+    if (pipeline_state && pipeline_state->fragment_shader_state) {
+        return pipeline_state->fragment_shader_state->fragment_entry_point.get();
+    } else if (const auto *shader_object = GetShaderState(ShaderObjectStage::FRAGMENT)) {
+        return shader_object->entrypoint.get();
+    }
+    return nullptr;
+}

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -708,6 +708,8 @@ struct LastBound {
     bool IsBoundSetCompatible(uint32_t set, const vvl::ShaderObject &shader_object_state) const;
     std::string DescribeNonCompatibleSet(uint32_t set, const vvl::PipelineLayout &pipeline_layout) const;
     std::string DescribeNonCompatibleSet(uint32_t set, const vvl::ShaderObject &shader_object_state) const;
+
+    const spirv::EntryPoint *GetFragmentEntryPoint() const;
 };
 
 static inline bool IsPipelineLayoutSetCompat(uint32_t set, const vvl::PipelineLayout *a, const vvl::PipelineLayout *b) {


### PR DESCRIPTION
We often will need the fragment shader info at drawtime, this adds a proper helper as the info might be from a pipeline and/or `VkShaderEXT`