### PR TITLE
gpu: Fix enabled_features

### DIFF
--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -68,8 +68,8 @@ void Validator::PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physi
         if (device_props->limits.maxBoundDescriptorSets > 1) {
             device_props->limits.maxBoundDescriptorSets -= 1;
         } else {
-            LogWarning("WARNING-GPU-Assisted-Validation-Setup", physicalDevice, record_obj.location,
-                       "Unable to reserve descriptor binding slot on a device with only one slot.");
+            InternalWarning(physicalDevice, record_obj.location,
+                            "Unable to reserve descriptor binding slot on a device with only one slot.");
         }
     }
 
@@ -84,8 +84,8 @@ void Validator::PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice phys
         if (device_props2->properties.limits.maxBoundDescriptorSets > 1) {
             device_props2->properties.limits.maxBoundDescriptorSets -= 1;
         } else {
-            LogWarning("WARNING-GPU-Assisted-Validation-Setup", physicalDevice, record_obj.location,
-                       "Unable to reserve descriptor binding slot on a device with only one slot.");
+            InternalWarning(physicalDevice, record_obj.location,
+                            "Unable to reserve descriptor binding slot on a device with only one slot.");
         }
     }
     // override all possible places maxUpdateAfterBindDescriptorsInAllPools can be set

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -44,8 +44,7 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     // This option was published when Debug PrintF came out, leave to not break people's flow
     // Deprecated right after the 1.3.280 SDK release
     if (!GetEnvironment("DEBUG_PRINTF_TO_STDOUT").empty()) {
-        LogWarning("WARNING-DEBUG-PRINTF", device, loc,
-                   "DEBUG_PRINTF_TO_STDOUT was set, this is deprecated, please use VK_LAYER_PRINTF_TO_STDOUT");
+        InternalWarning(device, loc, "DEBUG_PRINTF_TO_STDOUT was set, this is deprecated, please use VK_LAYER_PRINTF_TO_STDOUT");
         use_stdout = true;
     }
 
@@ -404,8 +403,8 @@ void Validator::AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueu
         index += debug_record->size;
     }
     if ((index - spvtools::kDebugOutputDataOffset) != expect) {
-        LogWarning("WARNING-DEBUG-PRINTF", queue, loc,
-                   "WARNING - Debug Printf message was truncated, likely due to a buffer size that was too small for the message");
+        InternalWarning(queue, loc,
+                        "Debug Printf message was truncated, likely due to a buffer size that was too small for the message");
     }
     memset(debug_output_buffer, 0, 4 * (debug_output_buffer[spvtools::kDebugOutputSizeOffset] + spvtools::kDebugOutputDataOffset));
 }

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -146,6 +146,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                       const RecordObject &record_obj) override;
 
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message, bool vma_fail = false) const;
+    void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     bool CheckForGpuAvEnabled(const void *pNext);
 
   protected:

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -621,7 +621,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     // Save local info in device object
     device_interceptor->api_version = device_interceptor->device_extensions.InitFromDeviceCreateInfo(
-        &instance_interceptor->instance_extensions, effective_api_version, pCreateInfo);
+        &instance_interceptor->instance_extensions, effective_api_version,
+        reinterpret_cast<VkDeviceCreateInfo*>(&modified_create_info));
     device_interceptor->device_extensions = device_extensions;
 
     layer_init_device_dispatch_table(*pDevice, &device_interceptor->device_dispatch_table, fpGetDeviceProcAddr);
@@ -655,7 +656,9 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
 
     for (ValidationObject* intercept : instance_interceptor->object_dispatch) {
         auto lock = intercept->WriteLock();
-        intercept->PostCallRecordCreateDevice(gpu, pCreateInfo, pAllocator, pDevice, record_obj);
+        // Send down modified create info as we want to mark enabled features that we sent down on behalf of the app
+        intercept->PostCallRecordCreateDevice(gpu, reinterpret_cast<VkDeviceCreateInfo*>(&modified_create_info), pAllocator,
+                                              pDevice, record_obj);
     }
 
     device_interceptor->InitObjectDispatchVectors();

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1297,7 +1297,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
 
                 // Save local info in device object
                 device_interceptor->api_version = device_interceptor->device_extensions.InitFromDeviceCreateInfo(
-                    &instance_interceptor->instance_extensions, effective_api_version, pCreateInfo);
+                    &instance_interceptor->instance_extensions, effective_api_version, reinterpret_cast<VkDeviceCreateInfo*>(&modified_create_info));
                 device_interceptor->device_extensions = device_extensions;
 
                 layer_init_device_dispatch_table(*pDevice, &device_interceptor->device_dispatch_table, fpGetDeviceProcAddr);
@@ -1331,7 +1331,8 @@ class LayerChassisOutputGenerator(BaseGenerator):
 
                 for (ValidationObject* intercept : instance_interceptor->object_dispatch) {
                     auto lock = intercept->WriteLock();
-                    intercept->PostCallRecordCreateDevice(gpu, pCreateInfo, pAllocator, pDevice, record_obj);
+                    // Send down modified create info as we want to mark enabled features that we sent down on behalf of the app
+                    intercept->PostCallRecordCreateDevice(gpu, reinterpret_cast<VkDeviceCreateInfo*>(&modified_create_info), pAllocator, pDevice, record_obj);
                 }
 
                 device_interceptor->InitObjectDispatchVectors();


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8001

This correctly passes down the `VkDeviceCreateInfo` down to GPU so `enabled_features` works as expected