### PR TITLE
layers: Remove unused unistd.h includes

### DIFF
--- a/layers/gpu/core/gpuav.cpp
+++ b/layers/gpu/core/gpuav.cpp
@@ -22,9 +22,6 @@
 
 #include <cmath>
 #include <fstream>
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-#include <unistd.h>
-#endif
 
 namespace gpuav {
 

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -17,9 +17,6 @@
 
 #include <cmath>
 #include <fstream>
-#if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__)
-#include <unistd.h>
-#endif
 #include "utils/cast_utils.h"
 #include "state_tracker/shader_stage_state.h"
 #include "utils/hash_util.h"


### PR DESCRIPTION
The sources seem to build fine even without them (at least on Linux), so drop these OS-specific includes.