### PR TITLE
tests: Add support for regex lookup in error msg

### DIFF
--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -19,6 +19,7 @@
 
 #include "test_common.h"
 #include <unordered_set>
+#include <regex>
 
 // ErrorMonitor Usage:
 //
@@ -50,8 +51,11 @@ class ErrorMonitor {
     // ErrorMonitor will look for an error message containing the specified string(s)
     void SetDesiredFailureMsg(const VkFlags msg_flags, const char *const msg_string);
     void SetDesiredFailureMsg(const VkFlags msg_flags, const std::string &msg);
+    void SetDesiredFailureMsgRegex(const VkFlags msg_flags, const char *vuid, std::string msg_regex);
     // Most tests check for kErrorBit so default to just using it
     void SetDesiredError(const char *msg, uint32_t count = 1);
+    // Regex uses modified ECMAScript regular expression grammar https://eel.is/c++draft/re.grammar
+    void SetDesiredErrorRegex(const char *vuid, std::string msg_regex, uint32_t count = 1);
     // And use this for warnings
     void SetDesiredWarning(const char *msg, uint32_t count = 1);
 
@@ -63,7 +67,7 @@ class ErrorMonitor {
     // Set an error that should not cause a test failure
     void SetAllowedFailureMsg(const char *const msg);
 
-    VkBool32 CheckForDesiredMsg(const char *const msg_string);
+    VkBool32 CheckForDesiredMsg(const char *vuid, const char *const msg_string);
     VkDebugReportFlagsEXT GetMessageFlags();
     void SetError(const char *const errorString);
     void SetBailout(std::atomic<bool> *bailout);
@@ -97,8 +101,25 @@ class ErrorMonitor {
 #endif
 
     VkFlags message_flags_{};
-    std::unordered_multiset<std::string> desired_message_strings_;
-    std::unordered_multiset<std::string> failure_message_strings_;
+    std::vector<std::string> failure_message_strings_;
+    struct VuidAndMessage {
+        std::string_view vuid;
+        enum MsgType { Undefined, String, Regex } msg_type = Undefined;
+        std::string msg_string;  // also used to store regex string
+        std::regex msg_regex;
+        void SetMsgString(std::string msg) {
+            msg_type = MsgType::String;
+            msg_string = std::move(msg);
+        }
+        void SetMsgRegex(std::string regex) {
+            msg_type = MsgType::Regex;
+            msg_string = regex;
+            msg_regex = regex;
+        }
+        bool Search(const char *vuid, std::string_view msg) const;
+        std::string Print() const;
+    };
+    std::vector<VuidAndMessage> desired_messages_;
     std::vector<std::string> ignore_message_strings_;
     std::vector<std::string> allowed_message_strings_;
     mutable std::mutex mutex_;

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -241,7 +241,9 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirectCount-countBuffer-03122");
+    m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndirectCount-countBuffer-03122",
+                                         "Indirect draw count of 2 would exceed buffer size 16 of buffer .* stride = 16 offset = 0 "
+                                         ".* = 36");
     uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
     *count_ptr = 2;
     count_buffer.memory().unmap();


### PR DESCRIPTION
Proposal for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8140

For now only tried it in NegativeGpuAVIndirectBuffer.DrawCount