### PR TITLE
gpu: Fix maxBoundDescriptorSets logic

### DIFF
--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -232,9 +232,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
     void PreCallRecordCmdTraceRaysIndirect2KHR(VkCommandBuffer commandBuffer, VkDeviceAddress indirectDeviceAddress,
                                                const RecordObject& record_obj) final;
 
-    void PostCallRecordGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
-                                                   VkPhysicalDeviceProperties* pPhysicalDeviceProperties,
-                                                   const RecordObject& record_obj) final;
     void PostCallRecordGetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
                                                     VkPhysicalDeviceProperties2* pPhysicalDeviceProperties2,
                                                     const RecordObject& record_obj) final;

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -177,11 +177,11 @@ bool StatelessValidation::manual_PreCallValidateCreateInstance(const VkInstanceC
                     break;
             }
         }
-        if (reserve_slot && !gpu_assisted) {
+        if (reserve_slot && !gpu_assisted && !debug_printf) {
             skip |= LogError("VUID-VkValidationFeaturesEXT-pEnabledValidationFeatures-02967", instance,
                              create_info_loc.pNext(Struct::VkValidationFeaturesEXT, Field::pEnabledValidationFeatures),
                              "includes VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT but no "
-                             "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT.");
+                             "VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT or VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT.");
         }
         if (gpu_assisted && debug_printf) {
             skip |= LogError(

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -263,7 +263,7 @@ class GpuAVRayQueryTest : public GpuAVTest {
 
 class DebugPrintfTests : public VkLayerTest {
   public:
-    void InitDebugPrintfFramework(void *p_next = nullptr);
+    void InitDebugPrintfFramework(void *p_next = nullptr, bool reserve_slot = false);
 };
 
 class VkSyncValTest : public VkLayerTest {

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -231,6 +231,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     RETURN_IF_SKIP(InitGpuAvFramework());
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
@@ -290,8 +291,10 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     for (uint32_t i = 0; i < set_count; i++) {
         layouts[i] = &descriptor_set.layout_;
     }
-    // Expect error since GPU-AV cannot add debug descriptor to layout
-    m_errorMonitor->SetDesiredError("UNASSIGNED-GPU-Assisted-Validation");
+    // Expect warning since GPU-AV cannot add debug descriptor to layout
+    m_errorMonitor->SetDesiredWarning(
+        "This Pipeline Layout has too many descriptor sets that will not allow GPU shader instrumentation to be setup for "
+        "pipelines created with it");
     vkt::PipelineLayout pl_layout(*m_device, layouts);
     m_errorMonitor->VerifyFound();
 
@@ -304,7 +307,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         void main() {
             u_index.index = inlineubo.val;
         }
-        )glsl";
+    )glsl";
 
     {
         CreateComputePipelineHelper pipe(*this);


### PR DESCRIPTION
Was trying to solve https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7178 but first needed to improve the logic around `maxBoundDescriptorSets`

This unifies things between GPU-AV and DebugPrintF as well as adds proper testing to make sure things are working as expected