### PR TITLE
layers: Add Variable Debug names to errors

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -810,8 +810,8 @@ bool CoreChecks::ValidateDrawState(const DescriptorSet &descriptor_set, uint32_t
         const auto *binding = descriptor_set.GetBinding(binding_pair.first);
         if (!binding) {  //  End at construction is the condition for an invalid binding.
             auto set = descriptor_set.Handle();
-            result |= LogError(vuids.descriptor_buffer_bit_set_08114, set, loc, "%s binding #%" PRIu32 " is invalid.",
-                               FormatHandle(set).c_str(), binding_pair.first);
+            result |= LogError(vuids.descriptor_buffer_bit_set_08114, set, loc, "%s %s is invalid.", FormatHandle(set).c_str(),
+                               binding_pair.second.variable->DescribeDescriptor().c_str());
             return result;
         }
 

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -1740,32 +1740,28 @@ bool CoreChecks::ValidateShaderDescriptorVariable(const spirv::Module &module_st
         if (!binding) {
             const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07988, objlist, loc,
-                             "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32
-                             "] (type `%s`) but was not declared in the pipeline layout.",
-                             string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
+                             "SPIR-V (%s) uses descriptor %s (type %s) but was not declared in the pipeline layout.",
+                             string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                              string_DescriptorTypeSet(descriptor_type_set).c_str());
         } else if (~binding->stageFlags & variable.stage) {
             const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07988, objlist, loc,
-                             "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32
-                             "] (type `%s`) but the VkDescriptorSetLayoutBinding::stageFlags was %s.",
-                             string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
+                             "SPIR-V (%s) uses descriptor %s (type %s) but the VkDescriptorSetLayoutBinding::stageFlags was %s.",
+                             string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                              string_DescriptorTypeSet(descriptor_type_set).c_str(),
                              string_VkShaderStageFlags(binding->stageFlags).c_str());
         } else if ((binding->descriptorType != VK_DESCRIPTOR_TYPE_MUTABLE_EXT) &&
                    (descriptor_type_set.find(binding->descriptorType) == descriptor_type_set.end())) {
             const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |=
-                LogError(vuid_07990, objlist, loc,
-                         "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32 "] of type %s but expected %s.",
-                         string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
+                LogError(vuid_07990, objlist, loc, "SPIR-V (%s) uses descriptor %s of type %s but expected %s.",
+                         string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                          string_VkDescriptorType(binding->descriptorType), string_DescriptorTypeSet(descriptor_type_set).c_str());
         } else if (binding->descriptorCount < required_descriptor_count) {
             const LogObjectList objlist(module_state.handle(), pipeline.PipelineLayoutState()->Handle());
             skip |= LogError(vuid_07991, objlist, loc,
-                             "SPIR-V (%s) uses descriptor slot [Set %" PRIu32 " Binding %" PRIu32 "] with %" PRIu32
-                             " descriptors, but requires at least %" PRIu32 ".",
-                             string_VkShaderStageFlagBits(variable.stage), variable.decorations.set, variable.decorations.binding,
+                             "SPIR-V (%s) uses descriptor %s with %" PRIu32 " descriptors, but requires at least %" PRIu32 ".",
+                             string_VkShaderStageFlagBits(variable.stage), variable.DescribeDescriptor().c_str(),
                              binding->descriptorCount, required_descriptor_count);
         }
 

--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -28,6 +28,43 @@
 #include "state_tracker/shader_module.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 
+// This seems like it could be useful elsewhere, but until find another spot, just keep here.
+static const char *GetActionType(vvl::Func command) {
+    switch (command) {
+        case vvl::Func::vkCmdDispatch:
+        case vvl::Func::vkCmdDispatchIndirect:
+        case vvl::Func::vkCmdDispatchBase:
+        case vvl::Func::vkCmdDispatchBaseKHR:
+        case vvl::Func::vkCmdDispatchGraphAMDX:
+        case vvl::Func::vkCmdDispatchGraphIndirectAMDX:
+        case vvl::Func::vkCmdDispatchGraphIndirectCountAMDX:
+            return "dispatch";
+        case vvl::Func::vkCmdTraceRaysNV:
+        case vvl::Func::vkCmdTraceRaysKHR:
+        case vvl::Func::vkCmdTraceRaysIndirectKHR:
+        case vvl::Func::vkCmdTraceRaysIndirect2KHR:
+            return "trace rays";
+        default:
+            return "draw";
+    }
+}
+
+std::string vvl::DescriptorValidator::DescribeDescriptor(const DescriptorBindingInfo &binding_info, uint32_t index) const {
+    std::stringstream ss;
+    ss << FormatHandle(descriptor_set.Handle()) << " [Set " << set_index << ", Binding " << binding_info.first << ", Index "
+       << index;
+
+    // If multiple variables tied to a binding, don't attempt to detect which one
+    if (binding_info.second.size() == 1) {
+        auto variable = binding_info.second[0].variable;
+        if (variable && !variable->debug_name.empty()) {
+            ss << ", variable \"" << variable->debug_name << "\"";
+        }
+    }
+    ss << "]";
+    return ss.str();
+}
+
 vvl::DescriptorValidator::DescriptorValidator(ValidationStateTracker &dev, vvl::CommandBuffer &cb, vvl::DescriptorSet &set,
                                               uint32_t set_index_, VkFramebuffer fb, const Location &l)
     : dev_state(dev), cb_state(cb), descriptor_set(set), set_index(set_index_), framebuffer(fb), loc(l), vuids(GetDrawDispatchVuid(loc.function)) {}
@@ -40,10 +77,10 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
 
         if (!binding.updated[index]) {
             auto set = descriptor_set.Handle();
-            return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
-                            FormatHandle(set).c_str(), binding_info.first, index);
+            return dev_state.LogError(
+                vuids.descriptor_buffer_bit_set_08114, set, loc,
+                "the descriptor %s is being used in %s but has never been updated via vkUpdateDescriptorSets() or a similar call.",
+                DescribeDescriptor(binding_info, index).c_str(), GetActionType(loc.function));
         }
         skip |= ValidateDescriptor(binding_info, index, binding.type, descriptor);
     }
@@ -90,10 +127,10 @@ bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &
 
         if (!binding.updated[index]) {
             auto set = descriptor_set.Handle();
-            return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") is being used in draw but has never been updated via vkUpdateDescriptorSets() or a similar call.",
-                            FormatHandle(set).c_str(), binding_info.first, index);
+            return dev_state.LogError(
+                vuids.descriptor_buffer_bit_set_08114, set, loc,
+                "the descriptor %s is being used in %s but has never been updated via vkUpdateDescriptorSets() or a similar call.",
+                DescribeDescriptor(binding_info, index).c_str(), GetActionType(loc.function));
         }
         skip |= ValidateDescriptor(binding_info, index, binding.type, descriptor);
     }
@@ -154,9 +191,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     if ((!buffer_node && !dev_state.enabled_features.nullDescriptor) || (buffer_node && buffer_node->Destroyed())) {
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                        ") is using buffer %s that is invalid or has been destroyed.",
-                        FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(buffer).c_str());
+                                  "the descriptor %s is using buffer %s that is invalid or has been destroyed.",
+                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str());
     }
 
     if (buffer == VK_NULL_HANDLE) {
@@ -166,9 +202,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         for (const auto &binding : buffer_node->GetInvalidMemory()) {
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                      ") is using buffer %s that references invalid memory %s.",
-                                      FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(buffer).c_str(),
+                                      "the descriptor %s is using buffer %s that references invalid memory %s.",
+                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str(),
                                       FormatHandle(binding->Handle()).c_str());
         }
     }
@@ -284,9 +319,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
 
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                        ") is using imageView %s that is invalid or has been destroyed.",
-                        FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str());
+                                  "the descriptor %s is using imageView %s that is invalid or has been destroyed.",
+                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str());
     }
 
     if (image_view == VK_NULL_HANDLE) {
@@ -338,11 +372,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (!valid_dim) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
-            return dev_state.LogError(vuids.image_view_dim_07752, objlist, loc,
-                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                      ") ImageView type is %s but the OpTypeImage has (Dim = %s) and (Arrayed = %" PRIu32 ").",
-                                      FormatHandle(set).c_str(), binding, index, string_VkImageViewType(image_view_ci.viewType),
-                                      string_SpvDim(dim), is_image_array);
+            return dev_state.LogError(
+                vuids.image_view_dim_07752, objlist, loc,
+                "the descriptor %s ImageView type is %s but the OpTypeImage has (Dim = %s) and (Arrayed = %" PRIu32 ").",
+                DescribeDescriptor(binding_info, index).c_str(), string_VkImageViewType(image_view_ci.viewType), string_SpvDim(dim),
+                is_image_array);
         }
 
         // Because you can have a runtime array with different types in it, without extensive GPU-AV tracking, we have no way to
@@ -357,9 +391,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.image_view_numeric_format_07753, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") requires %s component type, but bound descriptor format is %s.",
-                                          FormatHandle(set).c_str(), binding, index,
+                                          "the descriptor %s requires %s component type, but bound descriptor format is %s.",
+                                          DescribeDescriptor(binding_info, index).c_str(),
                                           spirv::string_NumericType(variable->info.image_format_type),
                                           string_VkFormat(image_view_ci.format));
             }
@@ -370,30 +403,28 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (variable->image_sampled_type_width != 64) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
-                return dev_state.LogError(
-                    vuids.image_view_access_64_04470, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") has a 64-bit component ImageView format (%s) but the OpTypeImage's Sampled Type has a width of %" PRIu32 ".",
-                    FormatHandle(set).c_str(), binding, index, string_VkFormat(image_view_ci.format),
-                    variable->image_sampled_type_width);
+                return dev_state.LogError(vuids.image_view_access_64_04470, objlist, loc,
+                                          "the descriptor %s has a 64-bit component ImageView format (%s) but the OpTypeImage's "
+                                          "Sampled Type has a width of %" PRIu32 ".",
+                                          DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(image_view_ci.format),
+                                          variable->image_sampled_type_width);
             } else if (!dev_state.enabled_features.sparseImageInt64Atomics && image_view_state->image_state->sparse_residency) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, image_view_state->image_state->Handle());
-                return dev_state.LogError(vuids.image_view_sparse_64_04474, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") has a OpTypeImage's Sampled Type has a width of 64 backed by a sparse Image, but "
-                                "sparseImageInt64Atomics is not enabled.",
-                                FormatHandle(set).c_str(), binding, index);
+                return dev_state.LogError(
+                    vuids.image_view_sparse_64_04474, objlist, loc,
+                    "the descriptor %s has a OpTypeImage's Sampled Type has a width of 64 backed by a sparse Image, but "
+                    "sparseImageInt64Atomics is not enabled.",
+                    DescribeDescriptor(binding_info, index).c_str());
             }
         } else if (!image_format_width_64 && variable->image_sampled_type_width != 32) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
-            return dev_state.LogError(
-                vuids.image_view_access_32_04471, objlist, loc,
-                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                ") has a 32-bit component ImageView format (%s) but the OpTypeImage's Sampled Type has a width of %" PRIu32 ".",
-                FormatHandle(set).c_str(), binding, index, string_VkFormat(image_view_ci.format),
-                variable->image_sampled_type_width);
+            return dev_state.LogError(vuids.image_view_access_32_04471, objlist, loc,
+                                      "the descriptor %s has a 32-bit component ImageView format (%s) but the OpTypeImage's "
+                                      "Sampled Type has a width of %" PRIu32 ".",
+                                      DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(image_view_ci.format),
+                                      variable->image_sampled_type_width);
         }
     }
 
@@ -423,35 +454,33 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     // Verify Sample counts
     if (variable->IsImage() && !variable->info.is_multisampled && image_view_state->samples != VK_SAMPLE_COUNT_1_BIT) {
         auto set = descriptor_set.Handle();
-        return dev_state.LogError("VUID-RuntimeSpirv-samples-08725", set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") has image created with %s.",
-                        FormatHandle(set).c_str(), binding, index, string_VkSampleCountFlagBits(image_view_state->samples));
+        return dev_state.LogError("VUID-RuntimeSpirv-samples-08725", set, loc, "the descriptor %s has image created with %s.",
+                                  DescribeDescriptor(binding_info, index).c_str(),
+                                  string_VkSampleCountFlagBits(image_view_state->samples));
     }
     if (variable->IsImage() && variable->info.is_multisampled && image_view_state->samples == VK_SAMPLE_COUNT_1_BIT) {
         auto set = descriptor_set.Handle();
         return dev_state.LogError("VUID-RuntimeSpirv-samples-08726", set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") has image created with VK_SAMPLE_COUNT_1_BIT.",
-                        FormatHandle(set).c_str(), binding, index);
+                                  "the descriptor %s has image created with VK_SAMPLE_COUNT_1_BIT.",
+                                  DescribeDescriptor(binding_info, index).c_str());
     }
 
     if (image_view_state->samplerConversion) {
         if (variable->info.is_not_sampler_sampled) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
-            return dev_state.LogError(
-                vuids.image_ycbcr_sampled_06550, set, loc,
-                "the image descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                ") was created with a sampler Ycbcr conversion, but was accessed with a non OpImage*Sample* command.",
-                FormatHandle(set).c_str(), binding, index);
+            return dev_state.LogError(vuids.image_ycbcr_sampled_06550, set, loc,
+                                      "the image descriptor %s was created with a sampler Ycbcr conversion, but was accessed with "
+                                      "a non OpImage*Sample* command.",
+                                      DescribeDescriptor(binding_info, index).c_str());
         }
         if (variable->info.is_sampler_offset) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
-            return dev_state.LogError(
-                vuids.image_ycbcr_offset_06551, set, loc,
-                "the image descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                ") was created with a sampler Ycbcr conversion, but was accessed with ConstOffset/Offset image operands.",
-                FormatHandle(set).c_str(), binding, index);
+            return dev_state.LogError(vuids.image_ycbcr_offset_06551, set, loc,
+                                      "the image descriptor %s was created with a sampler Ycbcr conversion, but was accessed with "
+                                      "ConstOffset/Offset image operands.",
+                                      DescribeDescriptor(binding_info, index).c_str());
         }
     }
 
@@ -460,13 +489,12 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         !(image_view_state->format_features & VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, image_view);
-        return dev_state.LogError(vuids.imageview_atomic_02691, objlist, loc,
-                                  "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                  ") has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
-                                  "(supported features: %s).",
-                                  FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                  string_VkFormat(image_view_ci.format),
-                                  string_VkFormatFeatureFlags2(image_view_state->format_features).c_str());
+        return dev_state.LogError(
+            vuids.imageview_atomic_02691, objlist, loc,
+            "the descriptor %s has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
+            "(supported features: %s).",
+            DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+            string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(image_view_state->format_features).c_str());
     }
 
     // When KHR_format_feature_flags2 is supported, the read/write without
@@ -480,39 +508,38 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 !(format_features & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT)) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
-                return dev_state.LogError(
-                    vuids.storage_image_read_without_format_07028, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") has %s with format of %s which doesn't support VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT.\n"
-                    "(supported features: %s).",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                    string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(format_features).c_str());
+                return dev_state.LogError(vuids.storage_image_read_without_format_07028, objlist, loc,
+                                          "the descriptor %s has %s with format of %s which doesn't support "
+                                          "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT.\n"
+                                          "(supported features: %s).",
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                          string_VkFormat(image_view_ci.format),
+                                          string_VkFormatFeatureFlags2(format_features).c_str());
             }
 
             if ((variable->info.is_write_without_format) &&
                 !(format_features & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT)) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
-                return dev_state.LogError(
-                    vuids.storage_image_write_without_format_07027, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") has %s with format of %s which doesn't support VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT.\n"
-                    "(supported features: %s).",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                    string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(format_features).c_str());
+                return dev_state.LogError(vuids.storage_image_write_without_format_07027, objlist, loc,
+                                          "the descriptor %s has %s with format of %s which doesn't support "
+                                          "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT.\n"
+                                          "(supported features: %s).",
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                          string_VkFormat(image_view_ci.format),
+                                          string_VkFormatFeatureFlags2(format_features).c_str());
             }
         }
 
         if ((variable->info.is_dref) && !(format_features & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT)) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
-            return dev_state.LogError(
-                vuids.depth_compare_sample_06479, objlist, loc,
-                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                ") has %s with format of %s which doesn't support VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT in.\n"
-                "i(supported features: %s)",
-                FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(), string_VkFormat(image_view_ci.format),
-                string_VkFormatFeatureFlags2(format_features).c_str());
+            return dev_state.LogError(vuids.depth_compare_sample_06479, objlist, loc,
+                                      "the descriptor %s has %s with format of %s which doesn't support "
+                                      "VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT in.\n"
+                                      "i(supported features: %s)",
+                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                      string_VkFormat(image_view_ci.format), string_VkFormatFeatureFlags2(format_features).c_str());
         }
     }
 
@@ -550,18 +577,16 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_subpass_write_06539, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which will be read from as %s attachment %" PRIu32 ".",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                    FormatHandle(framebuffer).c_str(), att_index);
+                                              "the descriptor %s has %s which will be read from as %s attachment %" PRIu32 ".",
+                                              DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                              FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
                     return dev_state.LogError(
                         vuids.image_subresources_subpass_write_06539, objlist, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                        ") has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.",
-                        FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                        "the descriptor %s has %s which will be overlap read from as %s in %s attachment %" PRIu32 " overlap.",
+                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
                         FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(), att_index);
                 }
             }
@@ -571,19 +596,17 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer);
                     return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
-                                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                    ") has %s which is written to but is also %s attachment %" PRIu32 ".",
-                                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                    FormatHandle(framebuffer).c_str(), att_index);
+                                              "the descriptor %s has %s which is written to but is also %s attachment %" PRIu32 ".",
+                                              DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                                              FormatHandle(framebuffer).c_str(), att_index);
                 } else if (overlapping_view) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, image_view, framebuffer, view_state->Handle());
-                    return dev_state.LogError(vuids.image_subresources_render_pass_write_06537, objlist, loc,
-                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                              ") has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".",
-                                              FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                              FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(),
-                                              att_index);
+                    return dev_state.LogError(
+                        vuids.image_subresources_render_pass_write_06537, objlist, loc,
+                        "the descriptor %s has %s which overlaps writes to %s but is also %s attachment %" PRIu32 ".",
+                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                        FormatHandle(view_state->Handle()).c_str(), FormatHandle(framebuffer).c_str(), att_index);
                 }
             }
         }
@@ -615,13 +638,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 image_view_format == VK_FORMAT_B5G5R5A1_UNORM_PACK16 || image_view_format == VK_FORMAT_A1B5G5R5_UNORM_PACK16_KHR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                return dev_state.LogError(
-                    "VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") has %s which has a custom border color with format = VK_FORMAT_UNDEFINED and is used to sample an image "
-                    "view %s with format %s",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
-                    FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
+                return dev_state.LogError("VUID-VkSamplerCustomBorderColorCreateInfoEXT-format-04015", objlist, loc,
+                                          "the descriptor %s has %s which has a custom border color with format = "
+                                          "VK_FORMAT_UNDEFINED and is used to sample an image "
+                                          "view %s with format %s",
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str(),
+                                          FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
         const VkFilter sampler_mag_filter = sampler_state->create_info.magFilter;
@@ -639,22 +662,22 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_filter_sampler_04553, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
+                                          "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with compareEnable is set "
                                           "to VK_FALSE, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str(),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
             if (sampler_state->create_info.mipmapMode == VK_SAMPLER_MIPMAP_MODE_LINEAR) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_04770, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
+                                          "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
                                           "compareEnable is set to VK_FALSE, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str(),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
         }
@@ -666,11 +689,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_filter_sampler_09598, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s which is set to use VK_FILTER_LINEAR with reductionMode is set "
+                                          "the descriptor %s has %s which is set to use VK_FILTER_LINEAR with reductionMode is set "
                                           "to %s, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str(),
                                           string_VkSamplerReductionMode(sampler_reduction->reductionMode),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
@@ -678,11 +701,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(vuids.linear_mipmap_sampler_09599, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
+                                          "the descriptor %s has %s which is set to use VK_SAMPLER_MIPMAP_MODE_LINEAR with "
                                           "reductionMode is set to %s, but image view's (%s) format (%s) does not contain "
                                           "VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT in its format features.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(),
+                                          FormatHandle(sampler_state->Handle()).c_str(),
                                           string_VkSamplerReductionMode(sampler_reduction->reductionMode),
                                           FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_format));
             }
@@ -694,10 +717,9 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
                 return dev_state.LogError(
                     vuids.cubic_sampler_02692, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
+                    "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT, then image view's (%s) format (%s) "
                     "MUST contain VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT in its format features.",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(sampler_state->Handle()).c_str(),
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
                     FormatHandle(image_view_state->Handle()).c_str(), string_VkFormat(image_view_state->create_info.format));
             }
 
@@ -710,26 +732,24 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     !image_view_state->filter_cubic_props.filterCubicMinmax) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                    return dev_state.LogError(vuids.filter_cubic_min_max_02695, objlist, loc,
-                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
-                                              "(%s) doesn't support filterCubicMinmax.",
-                                              FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->Handle()).c_str(),
-                                              string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
-                                              FormatHandle(image_view_state->Handle()).c_str());
+                    return dev_state.LogError(
+                        vuids.filter_cubic_min_max_02695, objlist, loc,
+                        "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT & %s, but image view "
+                        "(%s) doesn't support filterCubicMinmax.",
+                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
+                        string_VkSamplerReductionMode(reduction_mode_info->reductionMode),
+                        FormatHandle(image_view_state->Handle()).c_str());
                 }
 
                 if (!image_view_state->filter_cubic_props.filterCubic) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                    return dev_state.LogError(vuids.filter_cubic_02694, objlist, loc,
-                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
-                                              "doesn't support filterCubic.",
-                                              FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->Handle()).c_str(),
-                                              FormatHandle(image_view_state->Handle()).c_str());
+                    return dev_state.LogError(
+                        vuids.filter_cubic_02694, objlist, loc,
+                        "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT, but image view (%s) "
+                        "doesn't support filterCubic.",
+                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
+                        FormatHandle(image_view_state->Handle()).c_str());
                 }
             }
 
@@ -739,14 +759,13 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                     image_view_state->create_info.viewType == VK_IMAGE_VIEW_TYPE_CUBE_ARRAY) {
                     auto set = descriptor_set.Handle();
                     const LogObjectList objlist(set, sampler_state->Handle(), image_view_state->Handle());
-                    return dev_state.LogError(vuids.img_filter_cubic_02693, objlist, loc,
-                                              "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                              ") has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
-                                              "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
-                                              FormatHandle(set).c_str(), binding, index,
-                                              FormatHandle(sampler_state->Handle()).c_str(),
-                                              FormatHandle(image_view_state->Handle()).c_str(),
-                                              string_VkImageViewType(image_view_state->create_info.viewType));
+                    return dev_state.LogError(
+                        vuids.img_filter_cubic_02693, objlist, loc,
+                        "the descriptor %s has %s which is set to use VK_FILTER_CUBIC_EXT while the VK_IMG_filter_cubic "
+                        "extension is enabled, but image view (%s) has an invalid imageViewType (%s).",
+                        DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler_state->Handle()).c_str(),
+                        FormatHandle(image_view_state->Handle()).c_str(),
+                        string_VkImageViewType(image_view_state->create_info.viewType));
                 }
             }
         }
@@ -767,12 +786,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, sampler_state->Handle(), image_state->Handle(), image_view_state->Handle());
             return dev_state.LogError(vuids.corner_sampled_address_mode_02696, objlist, loc,
-                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                      ") image (%s) in image view (%s) is created with flag "
+                                      "the descriptor %s image (%s) in image view (%s) is created with flag "
                                       "VK_IMAGE_CREATE_CORNER_SAMPLED_BIT_NV and can only be sampled using "
                                       "VK_SAMPLER_ADDRESS_MODE_CLAMP_EDGE, but sampler (%s) has "
                                       "pCreateInfo->addressMode%s set to %s.",
-                                      FormatHandle(set).c_str(), binding, index, FormatHandle(image_state->Handle()).c_str(),
+                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_state->Handle()).c_str(),
                                       FormatHandle(image_view_state->Handle()).c_str(),
                                       FormatHandle(sampler_state->Handle()).c_str(), address_mode_letter.c_str(),
                                       string_VkSamplerAddressMode(address_mode));
@@ -788,9 +806,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
-                    vuids.sampler_imageview_type_08609, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") Image View %s, type %s, is used by %s.",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                    vuids.sampler_imageview_type_08609, objlist, loc, "the descriptor %s Image View %s, type %s, is used by %s.",
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
                     string_VkImageViewType(image_view_ci.viewType), FormatHandle(sampler_state->Handle()).c_str());
             }
 
@@ -800,10 +817,9 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
                     vuids.unnormalized_coordinates_09635, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") Image View %s was created with levelCount of %s, but the sampler (%s) was created with "
+                    "the descriptor %s Image View %s was created with levelCount of %s, but the sampler (%s) was created with "
                     "unnormalizedCoordinates.",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
                     string_LevelCount(image_view_state->image_state->create_info, image_view_ci.subresourceRange).c_str(),
                     FormatHandle(sampler_state->Handle()).c_str());
             }
@@ -813,10 +829,9 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(
                     vuids.unnormalized_coordinates_09635, objlist, loc,
-                    "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") Image View %s was created with layerCount of %s, but the sampler (%s) was created with "
+                    "the descriptor %s Image View %s was created with layerCount of %s, but the sampler (%s) was created with "
                     "unnormalizedCoordinates.",
-                    FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
                     string_LayerCount(image_view_state->image_state->create_info, image_view_ci.subresourceRange).c_str(),
                     FormatHandle(sampler_state->Handle()).c_str());
             }
@@ -827,9 +842,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
                 return dev_state.LogError(vuids.sampler_implicitLod_dref_proj_08610, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") Image View %s is used by %s that uses invalid operator.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
+                                          "the descriptor %s Image View %s is used by %s that uses invalid operator.",
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
                                           FormatHandle(sampler_state->Handle()).c_str());
             }
 
@@ -838,11 +852,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (variable->info.is_sampler_bias_offset) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
-                return dev_state.LogError(vuids.sampler_bias_offset_08611, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") Image View %s is used by %s that uses invalid bias or offset operator.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(image_view).c_str(),
-                                          FormatHandle(sampler_state->Handle()).c_str());
+                return dev_state.LogError(
+                    vuids.sampler_bias_offset_08611, objlist, loc,
+                    "the descriptor %s Image View %s is used by %s that uses invalid bias or offset operator.",
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(image_view).c_str(),
+                    FormatHandle(sampler_state->Handle()).c_str());
             }
         }
 
@@ -850,20 +864,18 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             if (variable->info.is_not_sampler_sampled) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
-                return dev_state.LogError(
-                    vuids.image_ycbcr_sampled_06550, set, loc,
-                    "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") was created with a sampler Ycbcr conversion, but was accessed with a non OpImage*Sample* command.",
-                    FormatHandle(set).c_str(), binding, index);
+                return dev_state.LogError(vuids.image_ycbcr_sampled_06550, set, loc,
+                                          "the sampler descriptor %s was created with a sampler Ycbcr conversion, but was accessed "
+                                          "with a non OpImage*Sample* command.",
+                                          DescribeDescriptor(binding_info, index).c_str());
             }
             if (variable->info.is_sampler_offset) {
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view, sampler_state->Handle());
-                return dev_state.LogError(
-                    vuids.image_ycbcr_offset_06551, set, loc,
-                    "the sampler descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                    ") was created with a sampler Ycbcr conversion, but was accessed with ConstOffset/Offset image operands.",
-                    FormatHandle(set).c_str(), binding, index);
+                return dev_state.LogError(vuids.image_ycbcr_offset_06551, set, loc,
+                                          "the sampler descriptor %s was created with a sampler Ycbcr conversion, but was accessed "
+                                          "with ConstOffset/Offset image operands.",
+                                          DescribeDescriptor(binding_info, index).c_str());
             }
         }
     }
@@ -875,20 +887,19 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, image_view);
                 return dev_state.LogError(vuids.storage_image_write_texel_count_08796, objlist, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") VkImageView is mapped to a OpImage format of VK_FORMAT_A8_UNORM_KHR, but the OpImageWrite Texel "
-                                "operand only contains %" PRIu32 " components.",
-                                FormatHandle(set).c_str(), binding, index, texel_component_count);
+                                          "the descriptor %s VkImageView is mapped to a OpImage format of VK_FORMAT_A8_UNORM_KHR, "
+                                          "but the OpImageWrite Texel "
+                                          "operand only contains %" PRIu32 " components.",
+                                          DescribeDescriptor(binding_info, index).c_str(), texel_component_count);
             }
         } else if (texel_component_count < format_component_count) {
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, image_view);
             return dev_state.LogError(vuids.storage_image_write_texel_count_08795, objlist, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") VkImageView is mapped to a OpImage format of %s which has %" PRIu32
-                            " components, but the OpImageWrite Texel operand only contains %" PRIu32 " components.",
-                            FormatHandle(set).c_str(), binding, index, string_VkFormat(image_view_format), format_component_count,
-                            texel_component_count);
+                                      "the descriptor %s VkImageView is mapped to a OpImage format of %s which has %" PRIu32
+                                      " components, but the OpImageWrite Texel operand only contains %" PRIu32 " components.",
+                                      DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(image_view_format),
+                                      format_component_count, texel_component_count);
         }
     }
 
@@ -931,13 +942,11 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     const vvl::TexelDescriptor &texel_descriptor) const {
     const VkBufferView buffer_view = texel_descriptor.GetBufferView();
     auto buffer_view_state = texel_descriptor.GetBufferViewState();
-    const auto binding = binding_info.first;
     if ((!buffer_view_state && !dev_state.enabled_features.nullDescriptor) || (buffer_view_state && buffer_view_state->Destroyed())) {
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                        ") is using bufferView %s that is invalid or has been destroyed.",
-                        FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str());
+                                  "the descriptor %s is using bufferView %s that is invalid or has been destroyed.",
+                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str());
     }
 
     if (buffer_view == VK_NULL_HANDLE) {
@@ -952,8 +961,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     if (buffer_state->Destroyed()) {
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32 ") is using buffer %s that has been destroyed.",
-                        FormatHandle(set).c_str(), binding, index, FormatHandle(buffer).c_str());
+                                  "the descriptor %s is using buffer %s that has been destroyed.",
+                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer).c_str());
     }
     const uint32_t format_bits = spirv::GetFormatType(buffer_view_format);
 
@@ -965,9 +974,8 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (!signed_override && !unsigned_override) {
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                      "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                      ") requires %s component type, but bound descriptor format is %s.",
-                                      FormatHandle(set).c_str(), binding, index,
+                                      "the descriptor %s requires %s component type, but bound descriptor format is %s.",
+                                      DescribeDescriptor(binding_info, index).c_str(),
                                       spirv::string_NumericType(variable->info.image_format_type),
                                       string_VkFormat(buffer_view_format));
         }
@@ -977,19 +985,19 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
     if (buffer_format_width_64 && variable->image_sampled_type_width != 64) {
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
-        return dev_state.LogError(
-            vuids.buffer_view_access_64_04472, objlist, loc,
-            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-            ") has a 64-bit component BufferView format (%s) but the OpTypeImage's Sampled Type has a width of %" PRIu32 ".",
-            FormatHandle(set).c_str(), binding, index, string_VkFormat(buffer_view_format), variable->image_sampled_type_width);
+        return dev_state.LogError(vuids.buffer_view_access_64_04472, objlist, loc,
+                                  "the descriptor %s has a 64-bit component BufferView format (%s) but the OpTypeImage's Sampled "
+                                  "Type has a width of %" PRIu32 ".",
+                                  DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(buffer_view_format),
+                                  variable->image_sampled_type_width);
     } else if (!buffer_format_width_64 && variable->image_sampled_type_width != 32) {
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
-        return dev_state.LogError(
-            vuids.buffer_view_access_32_04473, objlist, loc,
-            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-            ") has a 32-bit component BufferView format (%s) but the OpTypeImage's Sampled Type has a width of %" PRIu32 ".",
-            FormatHandle(set).c_str(), binding, index, string_VkFormat(buffer_view_format), variable->image_sampled_type_width);
+        return dev_state.LogError(vuids.buffer_view_access_32_04473, objlist, loc,
+                                  "the descripto %s has a 32-bit component BufferView format (%s) but the OpTypeImage's Sampled "
+                                  "Type has a width of %" PRIu32 ".",
+                                  DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(buffer_view_format),
+                                  variable->image_sampled_type_width);
     }
 
     const VkFormatFeatureFlags2 buffer_format_features = buffer_view_state->buffer_format_features;
@@ -999,13 +1007,12 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         !(buffer_format_features & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
         auto set = descriptor_set.Handle();
         const LogObjectList objlist(set, buffer_view);
-        return dev_state.LogError(vuids.bufferview_atomic_07888, objlist, loc,
-                                  "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                  ") has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
-                                  "(supported features: %s).",
-                                  FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
-                                  string_VkFormat(buffer_view_format),
-                                  string_VkFormatFeatureFlags2(buffer_format_features).c_str());
+        return dev_state.LogError(
+            vuids.bufferview_atomic_07888, objlist, loc,
+            "the descriptor %s has %s with format of %s which is missing VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT.\n"
+            "(supported features: %s).",
+            DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(), string_VkFormat(buffer_view_format),
+            string_VkFormatFeatureFlags2(buffer_format_features).c_str());
     }
 
     // When KHR_format_feature_flags2 is supported, the read/write without
@@ -1018,11 +1025,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_read_without_format_07030, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s with format of %s which is missing "
+                                          "the descriptor %s has %s with format of %s which is missing "
                                           "VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR.\n"
                                           "(supported features: %s).",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(),
                                           string_VkFormat(buffer_view_format),
                                           string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
@@ -1032,11 +1038,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                 auto set = descriptor_set.Handle();
                 const LogObjectList objlist(set, buffer_view);
                 return dev_state.LogError(vuids.storage_texel_buffer_write_without_format_07029, objlist, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") has %s with format of %s which is missing "
+                                          "the descriptor %s has %s with format of %s which is missing "
                                           "VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR.\n"
                                           "(supported features: %s).",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(buffer_view).c_str(),
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(buffer_view).c_str(),
                                           string_VkFormat(buffer_view_format),
                                           string_VkFormatFeatureFlags2(buffer_format_features).c_str());
             }
@@ -1061,11 +1066,10 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
             auto set = descriptor_set.Handle();
             const LogObjectList objlist(set, buffer_view);
             return dev_state.LogError(vuids.storage_texel_buffer_write_texel_count_04469, objlist, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") VkImageView is mapped to a OpImage format of %s which has %" PRIu32
-                            " components, but the OpImageWrite Texel operand only contains %" PRIu32 " components.",
-                            FormatHandle(set).c_str(), binding, index, string_VkFormat(buffer_view_format), format_component_count,
-                            texel_component_count);
+                                      "the descriptor %s VkImageView is mapped to a OpImage format of %s which has %" PRIu32
+                                      " components, but the OpImageWrite Texel operand only contains %" PRIu32 " components.",
+                                      DescribeDescriptor(binding_info, index).c_str(), string_VkFormat(buffer_view_format),
+                                      format_component_count, texel_component_count);
         }
     }
 
@@ -1076,25 +1080,23 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
                                     VkDescriptorType descriptor_type,
                                     const vvl::AccelerationStructureDescriptor &descriptor) const {
     // Verify that acceleration structures are valid
-    const auto binding = binding_info.first;
     if (descriptor.is_khr()) {
         auto acc = descriptor.GetAccelerationStructure();
         auto acc_node = descriptor.GetAccelerationStructureStateKHR();
         if (!acc_node || acc_node->Destroyed()) {
             if (acc != VK_NULL_HANDLE || !dev_state.enabled_features.nullDescriptor) {
                 auto set = descriptor_set.Handle();
-                return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") is using acceleration structure %s that is invalid or has been destroyed.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str());
+                return dev_state.LogError(
+                    vuids.descriptor_buffer_bit_set_08114, set, loc,
+                    "the descriptor %s is using acceleration structure %s that is invalid or has been destroyed.",
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str());
             }
         } else {
             for (const auto &mem_binding : acc_node->buffer_state->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") is using acceleration structure %s that references invalid memory %s.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
+                                          "the descriptor %s is using acceleration structure %s that references invalid memory %s.",
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str(),
                                           FormatHandle(mem_binding->Handle()).c_str());
             }
         }
@@ -1104,18 +1106,17 @@ bool vvl::DescriptorValidator::ValidateDescriptor(const DescriptorBindingInfo &b
         if (!acc_node || acc_node->Destroyed()) {
             if (acc != VK_NULL_HANDLE || !dev_state.enabled_features.nullDescriptor) {
                 auto set = descriptor_set.Handle();
-                return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                ") is using acceleration structure %s that is invalid or has been destroyed.",
-                                FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str());
+                return dev_state.LogError(
+                    vuids.descriptor_buffer_bit_set_08114, set, loc,
+                    "the descriptor %s is using acceleration structure %s that is invalid or has been destroyed.",
+                    DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str());
             }
         } else {
             for (const auto &mem_binding : acc_node->GetInvalidMemory()) {
                 auto set = descriptor_set.Handle();
                 return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                                          "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                                          ") is using acceleration structure %s that references invalid memory %s.",
-                                          FormatHandle(set).c_str(), binding, index, FormatHandle(acc).c_str(),
+                                          "the descriptor %s is using acceleration structure %s that references invalid memory %s.",
+                                          DescribeDescriptor(binding_info, index).c_str(), FormatHandle(acc).c_str(),
                                           FormatHandle(mem_binding->Handle()).c_str());
             }
         }
@@ -1133,18 +1134,16 @@ bool vvl::DescriptorValidator::ValidateSamplerDescriptor(const DescriptorBinding
     if (!sampler_state || sampler_state->Destroyed()) {
         auto set = descriptor_set.Handle();
         return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                        "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                        ") is using sampler %s that is invalid or has been destroyed.",
-                        FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(sampler).c_str());
+                                  "the descriptor %s is using sampler %s that is invalid or has been destroyed.",
+                                  DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler).c_str());
     } else {
         if (sampler_state->samplerConversion && !is_immutable) {
             auto set = descriptor_set.Handle();
             return dev_state.LogError(vuids.descriptor_buffer_bit_set_08114, set, loc,
-                            "the descriptor (%s, binding %" PRIu32 ", index %" PRIu32
-                            ") sampler (%s) contains a YCBCR conversion (%s), but the sampler is not an "
-                            "immutable sampler.",
-                            FormatHandle(set).c_str(), binding_info.first, index, FormatHandle(sampler).c_str(),
-                            FormatHandle(sampler_state->samplerConversion).c_str());
+                                      "the descriptor %s sampler (%s) contains a YCBCR conversion (%s), but the sampler is not an "
+                                      "immutable sampler.",
+                                      DescribeDescriptor(binding_info, index).c_str(), FormatHandle(sampler).c_str(),
+                                      FormatHandle(sampler_state->samplerConversion).c_str());
         }
     }
     return false;

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -35,6 +35,10 @@ class CommandBuffer;
 class Sampler;
 class DescriptorSet;
 
+// The reason there is a vector is because we can have a shader that looks like
+//   layout(set = 0, binding = 2) uniform sampler3D tex3d[];
+//   layout(set = 0, binding = 2) uniform sampler2D tex[];
+// And we need a DescriptorRequirement for each OpVariable
 using DescriptorBindingInfo = std::pair<uint32_t, std::vector<DescriptorRequirement>>;
 
 class DescriptorValidator {
@@ -75,6 +79,8 @@ class DescriptorValidator {
     // helper for the common parts of ImageSamplerDescriptor and SamplerDescriptor validation
     bool ValidateSamplerDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index, VkSampler sampler, bool is_immutable,
                                    const vvl::Sampler* sampler_state) const;
+
+    std::string DescribeDescriptor(const DescriptorBindingInfo& binding_info, uint32_t index) const;
 
     ValidationStateTracker& dev_state;
     vvl::CommandBuffer& cb_state;


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8190

When printing out the set/binding, we will now print out the SPIR-V debug name

error now looks like

> vkCmdDispatchIndirect():  the descriptor VkDescriptorSet 0xe88693000000000c[] [Set 0, Binding 0, Index 0, variable "SomeNameInGlsl"] is being used in dispatch but has never been updated via vkUpdateDescriptorSets() or a similar call