### PR TITLE
layers: Add Dispatch helpers for GPDP2 calls

### DIFF
--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -136,7 +136,7 @@ bool BestPractices::PreCallValidateCreateRenderPass(VkDevice device, const VkRen
                         const VkFormat format = pCreateInfo->pAttachments[attachment].format;
                         VkSubpassResolvePerformanceQueryEXT performance_query = vku::InitStructHelper();
                         VkFormatProperties2 format_properties2 = vku::InitStructHelper(&performance_query);
-                        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &format_properties2);
+                        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &format_properties2);
                         if (performance_query.optimal == VK_FALSE) {
                             skip |= LogPerformanceWarning(
                                 "BestPractices-vkCreateRenderPass-SubpassResolve-NonOptimalFormat", device,

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -239,7 +239,7 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
             VkExternalImageFormatProperties ext_img_fmt_props = vku::InitStructHelper();
             VkImageFormatProperties2 ifp2 = vku::InitStructHelper(&ext_img_fmt_props);
 
-            VkResult fmt_lookup_result = DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &pdifi2, &ifp2);
+            VkResult fmt_lookup_result = DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &pdifi2, &ifp2);
 
             if ((VK_SUCCESS != fmt_lookup_result) || (0 == (ext_img_fmt_props.externalMemoryProperties.externalMemoryFeatures &
                                                             VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT))) {

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2916,7 +2916,8 @@ bool CoreChecks::ValidateGetDescriptorDataSize(const VkDescriptorGetInfoEXT &des
                 image_format_info.flags = image_info.flags;
                 VkSamplerYcbcrConversionImageFormatProperties sampler_ycbcr_image_format_info = vku::InitStructHelper();
                 VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&sampler_ycbcr_image_format_info);
-                DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
+                DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &image_format_info,
+                                                                      &image_format_properties);
                 size *= static_cast<size_t>(sampler_ycbcr_image_format_info.combinedImageSamplerDescriptorCount);
                 if (size != data_size) {
                     skip |= LogError("VUID-vkGetDescriptorEXT-descriptorType-09469", device, descriptor_info_loc.dot(Field::type),

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -102,7 +102,7 @@ bool CoreChecks::GetPhysicalDeviceImageFormatProperties(vvl::Image &image_state,
         image_format_info.flags = image_create_info.flags;
         VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
         image_properties_result =
-            DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
+            DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &image_format_info, &image_format_properties);
         image_state.image_format_properties = image_format_properties.imageFormatProperties;
     }
     if (image_properties_result != VK_SUCCESS) {
@@ -646,7 +646,7 @@ VkFormatProperties3KHR CoreChecks::GetPDFormatProperties(const VkFormat format) 
     VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
     if (has_format_feature2) {
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
         fmt_props_3.linearTilingFeatures |= fmt_props_2.formatProperties.linearTilingFeatures;
         fmt_props_3.optimalTilingFeatures |= fmt_props_2.formatProperties.optimalTilingFeatures;
         fmt_props_3.bufferFeatures |= fmt_props_2.formatProperties.bufferFeatures;

--- a/layers/core_checks/cc_device_memory.cpp
+++ b/layers/core_checks/cc_device_memory.cpp
@@ -380,14 +380,9 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExter
     VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
     VkImageFormatProperties2 properties = vku::InitStructHelper(&external_properties);
     if (image.create_info.tiling != VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT) {
-        if (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) {
-            if (DispatchGetPhysicalDeviceImageFormatProperties2KHR(physical_device, &info, &properties) != VK_SUCCESS) {
-                return false;
-            }
-        } else {
-            if (DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &info, &properties) != VK_SUCCESS) {
-                return false;
-            }
+        // Can't get into function with using external memory extensions which require GPDP2
+        if (DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &info, &properties) != VK_SUCCESS) {
+            return false;
         }
     } else {
         VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
@@ -401,7 +396,7 @@ bool CoreChecks::HasExternalMemoryImportSupport(const vvl::Image &image, VkExter
             return false;
         }
         drm_format_modifier.drmFormatModifier = drm_format_properties.drmFormatModifier;
-        if (DispatchGetPhysicalDeviceImageFormatProperties2KHR(physical_device, &info, &properties) != VK_SUCCESS) {
+        if (DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &info, &properties) != VK_SUCCESS) {
             return false;
         }
     }
@@ -1747,7 +1742,7 @@ bool CoreChecks::ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindIma
                             }
                         }
                         auto result =
-                            DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_info, &image_properties);
+                            DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &image_info, &image_properties);
                         if (result != VK_SUCCESS) {
                             export_supported = false;
                             const LogObjectList objlist(bind_info.image, bind_info.memory);

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -231,7 +231,7 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     if (gpuav_settings.validate_descriptors) {
         VkPhysicalDeviceDescriptorIndexingProperties desc_indexing_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&desc_indexing_props);
-        DispatchGetPhysicalDeviceProperties2(physical_device, &props2);
+        DispatchGetPhysicalDeviceProperties2Helper(physical_device, &props2);
 
         uint32_t num_descs = desc_indexing_props.maxUpdateAfterBindDescriptorsInAllPools;
         if (num_descs == 0 || num_descs > glsl::kDebugInputBindlessMaxDescriptors) {

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -143,9 +143,10 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetExternalFormatFeaturesANDROI
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR
 
-VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device, bool has_format_feature2, bool has_drm_modifiers,
-                                                VkDevice device, VkImage image, VkFormat format, VkImageTiling tiling) {
-    VkFormatFeatureFlags2KHR format_features = 0;
+VkFormatFeatureFlags2 ValidationStateTracker::GetImageFormatFeatures(VkPhysicalDevice physical_device, bool has_format_feature2,
+                                                                     bool has_drm_modifiers, VkDevice device, VkImage image,
+                                                                     VkFormat format, VkImageTiling tiling) {
+    VkFormatFeatureFlags2 format_features = 0;
 
     // Add feature support according to Image Format Features (vkspec.html#resources-image-format-features)
     // if format is AHB external format then the features are already set
@@ -154,7 +155,7 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
         auto fmt_props_3 = vku::InitStruct<VkFormatProperties3KHR>(has_drm_modifiers ? &fmt_drm_props : nullptr);
         VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
         fmt_props_3.linearTilingFeatures |= fmt_props_2.formatProperties.linearTilingFeatures;
         fmt_props_3.optimalTilingFeatures |= fmt_props_2.formatProperties.optimalTilingFeatures;
@@ -171,7 +172,7 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
             fmt_drm_props.pDrmFormatModifierProperties = &drm_mod_props[0];
 
             // Second query to have all the modifiers filled
-            DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
             // Look for the image modifier in the list
             for (uint32_t i = 0; i < fmt_drm_props.drmFormatModifierCount; i++) {
@@ -191,11 +192,11 @@ VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device
         VkFormatProperties2 format_properties_2 = vku::InitStructHelper();
         VkDrmFormatModifierPropertiesListEXT drm_properties_list = vku::InitStructHelper();
         format_properties_2.pNext = (void *)&drm_properties_list;
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &format_properties_2);
+        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &format_properties_2);
         std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
         drm_properties.resize(drm_properties_list.drmFormatModifierCount);
         drm_properties_list.pDrmFormatModifierProperties = &drm_properties[0];
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &format_properties_2);
+        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &format_properties_2);
 
         for (uint32_t i = 0; i < drm_properties_list.drmFormatModifierCount; i++) {
             if (drm_properties_list.pDrmFormatModifierProperties[i].drmFormatModifier == drm_format_properties.drmFormatModifier) {
@@ -423,7 +424,7 @@ void ValidationStateTracker::PostCallRecordCreateBufferView(VkDevice device, con
     if (has_format_feature2) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
-        DispatchGetPhysicalDeviceFormatProperties2(physical_device, pCreateInfo->format, &fmt_props_2);
+        DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, pCreateInfo->format, &fmt_props_2);
         buffer_features = fmt_props_3.bufferFeatures | fmt_props_2.formatProperties.bufferFeatures;
     } else {
         VkFormatProperties format_properties;
@@ -472,7 +473,7 @@ void ValidationStateTracker::PostCallRecordCreateImageView(VkDevice device, cons
 
         VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&filter_cubic_props);
 
-        DispatchGetPhysicalDeviceImageFormatProperties2(physical_device, &image_format_info, &image_format_properties);
+        DispatchGetPhysicalDeviceImageFormatProperties2Helper(physical_device, &image_format_info, &image_format_properties);
     }
 
     Add(CreateImageViewState(image_state, *pView, pCreateInfo, format_features, filter_cubic_props));
@@ -633,7 +634,7 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetPotentialFormatFeatures(VkFo
                 IsExtEnabled(device_extensions.vk_ext_image_drm_format_modifier) ? &fmt_drm_props : nullptr);
             VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_props_3);
 
-            DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+            DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
             format_features |= fmt_props_2.formatProperties.linearTilingFeatures;
             format_features |= fmt_props_2.formatProperties.optimalTilingFeatures;
@@ -645,7 +646,7 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetPotentialFormatFeatures(VkFo
                 std::vector<VkDrmFormatModifierProperties2EXT> drm_properties;
                 drm_properties.resize(fmt_drm_props.drmFormatModifierCount);
                 fmt_drm_props.pDrmFormatModifierProperties = drm_properties.data();
-                DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+                DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
                 for (uint32_t i = 0; i < fmt_drm_props.drmFormatModifierCount; i++) {
                     format_features |= fmt_drm_props.pDrmFormatModifierProperties[i].drmFormatModifierTilingFeatures;
@@ -661,12 +662,12 @@ VkFormatFeatureFlags2KHR ValidationStateTracker::GetPotentialFormatFeatures(VkFo
                 VkDrmFormatModifierPropertiesListEXT fmt_drm_props = vku::InitStructHelper();
                 VkFormatProperties2 fmt_props_2 = vku::InitStructHelper(&fmt_drm_props);
 
-                DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+                DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
                 std::vector<VkDrmFormatModifierPropertiesEXT> drm_properties;
                 drm_properties.resize(fmt_drm_props.drmFormatModifierCount);
                 fmt_drm_props.pDrmFormatModifierProperties = drm_properties.data();
-                DispatchGetPhysicalDeviceFormatProperties2(physical_device, format, &fmt_props_2);
+                DispatchGetPhysicalDeviceFormatProperties2Helper(physical_device, format, &fmt_props_2);
 
                 for (uint32_t i = 0; i < fmt_drm_props.drmFormatModifierCount; i++) {
                     format_features |= fmt_drm_props.pDrmFormatModifierProperties[i].drmFormatModifierTilingFeatures;
@@ -1052,7 +1053,7 @@ void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateI
     }
 
     // Query queue family extension properties
-    {
+    if (IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) {
         uint32_t queue_family_count = (uint32_t)physical_device_state->queue_family_properties.size();
         auto &ext_props = queue_family_ext_props;
         ext_props.resize(queue_family_count);
@@ -1067,11 +1068,7 @@ void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateI
             }
         }
 
-        if (api_version >= VK_API_VERSION_1_1) {
-            DispatchGetPhysicalDeviceQueueFamilyProperties2(physical_device, &queue_family_count, props.data());
-        } else if (IsExtEnabled(instance_extensions.vk_khr_get_physical_device_properties2)) {
-            DispatchGetPhysicalDeviceQueueFamilyProperties2KHR(physical_device, &queue_family_count, props.data());
-        }
+        DispatchGetPhysicalDeviceQueueFamilyProperties2Helper(physical_device, &queue_family_count, props.data());
     }
 }
 

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -1671,13 +1671,8 @@ class ValidationStateTracker : public ValidationObject {
             if constexpr (init) {
                 *ext_prop = vku::InitStructHelper();
             }
-            if (api_version < VK_API_VERSION_1_1) {
-                VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
-                DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
-            } else {
-                VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
-                DispatchGetPhysicalDeviceProperties2(gpu, &prop2);
-            }
+            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
+            DispatchGetPhysicalDeviceProperties2Helper(gpu, &prop2);
         }
     }
 
@@ -1685,14 +1680,13 @@ class ValidationStateTracker : public ValidationObject {
     void GetPhysicalDeviceExtProperties(VkPhysicalDevice gpu, ExtProp* ext_prop) {
         assert(ext_prop);
         *ext_prop = vku::InitStructHelper();
-        if (api_version < VK_API_VERSION_1_1) {
-            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
-            DispatchGetPhysicalDeviceProperties2KHR(gpu, &prop2);
-        } else {
-            VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
-            DispatchGetPhysicalDeviceProperties2(gpu, &prop2);
-        }
+        VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(ext_prop);
+        DispatchGetPhysicalDeviceProperties2Helper(gpu, &prop2);
     }
+
+    VkFormatFeatureFlags2KHR GetImageFormatFeatures(VkPhysicalDevice physical_device, bool has_format_feature2,
+                                                    bool has_drm_modifiers, VkDevice device, VkImage image, VkFormat format,
+                                                    VkImageTiling tiling);
 
     inline std::shared_ptr<vvl::ShaderModule> GetShaderModuleStateFromIdentifier(const VkShaderModuleIdentifierEXT& ident) {
         ReadLockGuard guard(shader_identifier_map_lock_);

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -304,15 +304,6 @@ void StatelessValidation::PreCallRecordDestroyInstance(VkInstance instance, cons
     }
 }
 
-void StatelessValidation::GetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice,
-                                                       VkPhysicalDeviceProperties2 &pProperties) const {
-    if (api_version >= VK_API_VERSION_1_1) {
-        DispatchGetPhysicalDeviceProperties2(physicalDevice, &pProperties);
-    } else if (IsExtEnabled(device_extensions.vk_khr_get_physical_device_properties2)) {
-        DispatchGetPhysicalDeviceProperties2KHR(physicalDevice, &pProperties);
-    }
-}
-
 void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                                      const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
                                                      const RecordObject &record_obj) {
@@ -332,7 +323,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed shading rate image limits
         VkPhysicalDeviceShadingRateImagePropertiesNV shading_rate_image_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&shading_rate_image_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.shading_rate_image_props = shading_rate_image_props;
     }
 
@@ -340,7 +331,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed mesh shader limits
         VkPhysicalDeviceMeshShaderPropertiesNV mesh_shader_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&mesh_shader_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.mesh_shader_props_nv = mesh_shader_props;
     }
 
@@ -348,7 +339,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed mesh shader EXT limits
         VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_props_ext = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&mesh_shader_props_ext);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.mesh_shader_props_ext = mesh_shader_props_ext;
     }
 
@@ -356,7 +347,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed ray tracing limits
         VkPhysicalDeviceRayTracingPropertiesNV ray_tracing_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&ray_tracing_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.ray_tracing_props_nv = ray_tracing_props;
     }
 
@@ -364,7 +355,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed ray tracing limits
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&ray_tracing_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.ray_tracing_props_khr = ray_tracing_props;
     }
 
@@ -372,7 +363,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed ray tracing acc structure limits
         VkPhysicalDeviceAccelerationStructurePropertiesKHR acc_structure_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&acc_structure_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.acc_structure_props = acc_structure_props;
     }
 
@@ -380,7 +371,7 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed transform feedback limits
         VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&transform_feedback_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.transform_feedback_props = transform_feedback_props;
     }
 
@@ -388,13 +379,13 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed vertex attribute divisor limits
         VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR vertex_attribute_divisor_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&vertex_attribute_divisor_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.vertex_attribute_divisor_props = vertex_attribute_divisor_props;
     } else if (IsExtEnabled(device_extensions.vk_ext_vertex_attribute_divisor)) {
         // Get the needed vertex attribute divisor limits
         VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_attribute_divisor_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&vertex_attribute_divisor_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.vertex_attribute_divisor_props = vku::InitStructHelper();
         phys_dev_ext_props.vertex_attribute_divisor_props.maxVertexAttribDivisor =
             vertex_attribute_divisor_props.maxVertexAttribDivisor;
@@ -404,35 +395,35 @@ void StatelessValidation::PostCallRecordCreateDevice(VkPhysicalDevice physicalDe
         // Get the needed maintenance4 properties
         VkPhysicalDeviceMaintenance4PropertiesKHR maintance4_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&maintance4_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.maintenance4_props = maintance4_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_fragment_shading_rate)) {
         VkPhysicalDeviceFragmentShadingRatePropertiesKHR fragment_shading_rate_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&fragment_shading_rate_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.fragment_shading_rate_props = fragment_shading_rate_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_khr_depth_stencil_resolve)) {
         VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&depth_stencil_resolve_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.depth_stencil_resolve_props = depth_stencil_resolve_props;
     }
 
     if (IsExtEnabled(device_extensions.vk_ext_external_memory_host)) {
         VkPhysicalDeviceExternalMemoryHostPropertiesEXT external_memory_host_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&external_memory_host_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.external_memory_host_props = external_memory_host_props;
     }
 
      if (IsExtEnabled(device_extensions.vk_arm_render_pass_striped)) {
         VkPhysicalDeviceRenderPassStripedPropertiesARM renderpass_striped_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 prop2 = vku::InitStructHelper(&renderpass_striped_props);
-        GetPhysicalDeviceProperties2(physicalDevice, prop2);
+        DispatchGetPhysicalDeviceProperties2Helper(physicalDevice, &prop2);
         phys_dev_ext_props.renderpass_striped_props = renderpass_striped_props;
     }
 
@@ -817,7 +808,7 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
                         image_drm_format->queueFamilyIndexCount);
                 } else {
                     uint32_t queue_family_property_count = 0;
-                    DispatchGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, &queue_family_property_count, nullptr);
+                    DispatchGetPhysicalDeviceQueueFamilyProperties2Helper(physicalDevice, &queue_family_property_count, nullptr);
                     vvl::unordered_set<uint32_t> queue_family_indices_set;
                     for (uint32_t i = 0; i < image_drm_format->queueFamilyIndexCount; i++) {
                         const uint32_t queue_index = image_drm_format->pQueueFamilyIndices[i];

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -514,7 +514,6 @@ class StatelessValidation : public ValidationObject {
                                             const RecordObject &record_obj) override;
     void PostCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks *pAllocator,
                                          const RecordObject &record_obj) override;
-    void GetPhysicalDeviceProperties2(VkPhysicalDevice physicalDevice, VkPhysicalDeviceProperties2 &pProperties) const;
     void PostCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                     const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
                                     const RecordObject &record_obj) override;

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -143,6 +143,72 @@ static void InitDeviceObjectDispatch(ValidationObject* instance_interceptor, Val
     }
 }
 
+void ValidationObject::DispatchGetPhysicalDeviceFeatures2Helper(VkPhysicalDevice physicalDevice,
+                                                                VkPhysicalDeviceFeatures2* pFeatures) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceFeatures2(physicalDevice, pFeatures);
+    } else {
+        return DispatchGetPhysicalDeviceFeatures2KHR(physicalDevice, pFeatures);
+    }
+}
+
+void ValidationObject::DispatchGetPhysicalDeviceProperties2Helper(VkPhysicalDevice physicalDevice,
+                                                                  VkPhysicalDeviceProperties2* pProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceProperties2(physicalDevice, pProperties);
+    } else {
+        return DispatchGetPhysicalDeviceProperties2KHR(physicalDevice, pProperties);
+    }
+}
+
+void ValidationObject::DispatchGetPhysicalDeviceFormatProperties2Helper(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                                        VkFormatProperties2* pFormatProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceFormatProperties2(physicalDevice, format, pFormatProperties);
+    } else {
+        return DispatchGetPhysicalDeviceFormatProperties2KHR(physicalDevice, format, pFormatProperties);
+    }
+}
+
+VkResult ValidationObject::DispatchGetPhysicalDeviceImageFormatProperties2Helper(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+    VkImageFormatProperties2* pImageFormatProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceImageFormatProperties2(physicalDevice, pImageFormatInfo, pImageFormatProperties);
+    } else {
+        return DispatchGetPhysicalDeviceImageFormatProperties2KHR(physicalDevice, pImageFormatInfo, pImageFormatProperties);
+    }
+}
+
+void ValidationObject::DispatchGetPhysicalDeviceQueueFamilyProperties2Helper(
+    VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount, VkQueueFamilyProperties2* pQueueFamilyProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, pQueueFamilyProperties);
+    } else {
+        return DispatchGetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount,
+                                                                  pQueueFamilyProperties);
+    }
+}
+
+void ValidationObject::DispatchGetPhysicalDeviceMemoryProperties2Helper(
+    VkPhysicalDevice physicalDevice, VkPhysicalDeviceMemoryProperties2* pMemoryProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceMemoryProperties2(physicalDevice, pMemoryProperties);
+    } else {
+        return DispatchGetPhysicalDeviceMemoryProperties2KHR(physicalDevice, pMemoryProperties);
+    }
+}
+
+void ValidationObject::DispatchGetPhysicalDeviceSparseImageFormatProperties2Helper(
+    VkPhysicalDevice physicalDevice, const VkPhysicalDeviceSparseImageFormatInfo2* pFormatInfo, uint32_t* pPropertyCount,
+    VkSparseImageFormatProperties2* pProperties) const {
+    if (api_version >= VK_API_VERSION_1_1) {
+        return DispatchGetPhysicalDeviceSparseImageFormatProperties2(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
+    } else {
+        return DispatchGetPhysicalDeviceSparseImageFormatProperties2KHR(physicalDevice, pFormatInfo, pPropertyCount, pProperties);
+    }
+}
+
 // Global list of sType,size identifiers
 std::vector<std::pair<uint32_t, uint32_t>> custom_stype_info{};
 

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2423,6 +2423,23 @@ class ValidationObject {
         display_id_reverse_mapping.insert_or_assign(handle, unique_id);
         return (VkDisplayKHR)unique_id;
     }
+    // We make many internal dispatch calls to VK_KHR_get_physical_device_properties2 functions which can depend on the API version
+    void DispatchGetPhysicalDeviceFeatures2Helper(VkPhysicalDevice physicalDevice, VkPhysicalDeviceFeatures2* pFeatures) const;
+    void DispatchGetPhysicalDeviceProperties2Helper(VkPhysicalDevice physicalDevice,
+                                                    VkPhysicalDeviceProperties2* pProperties) const;
+    void DispatchGetPhysicalDeviceFormatProperties2Helper(VkPhysicalDevice physicalDevice, VkFormat format,
+                                                          VkFormatProperties2* pFormatProperties) const;
+    VkResult DispatchGetPhysicalDeviceImageFormatProperties2Helper(VkPhysicalDevice physicalDevice,
+                                                                   const VkPhysicalDeviceImageFormatInfo2* pImageFormatInfo,
+                                                                   VkImageFormatProperties2* pImageFormatProperties) const;
+    void DispatchGetPhysicalDeviceQueueFamilyProperties2Helper(VkPhysicalDevice physicalDevice, uint32_t* pQueueFamilyPropertyCount,
+                                                               VkQueueFamilyProperties2* pQueueFamilyProperties) const;
+    void DispatchGetPhysicalDeviceMemoryProperties2Helper(VkPhysicalDevice physicalDevice,
+                                                          VkPhysicalDeviceMemoryProperties2* pMemoryProperties) const;
+    void DispatchGetPhysicalDeviceSparseImageFormatProperties2Helper(VkPhysicalDevice physicalDevice,
+                                                                     const VkPhysicalDeviceSparseImageFormatInfo2* pFormatInfo,
+                                                                     uint32_t* pPropertyCount,
+                                                                     VkSparseImageFormatProperties2* pProperties) const;
 
     // clang-format off
         // Pre/post hook point declarations


### PR DESCRIPTION
We make a lot of internal calls to `VK_KHR_get_physical_device_properties2` functions, but we need to make sure to use the `DispatchGetPhysicalDeviceFormatProperties2` vs `DispatchGetPhysicalDeviceFormatProperties2KHR` depending if still using Vulkan 1.0 or not

This adds a DispatchGetPhysicalDevice*2Helper` for all those calls and substitutes them everywhere