### PR TITLE
tests: Move Test Class name to source file

### DIFF
--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -229,12 +229,6 @@ VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDevi
 template <>
 VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysicalDeviceProperties2 &props2);
 
-// TODO - Want to remove - don't add to any new tests
-class VkPositiveLayerTest : public VkLayerTest {
-  public:
-  protected:
-};
-
 class VkBestPracticesLayerTest : public VkLayerTest {
   public:
     void InitBestPracticesFramework(const char *ValidationChecksToEnable = "");
@@ -245,17 +239,6 @@ class VkBestPracticesLayerTest : public VkLayerTest {
     VkValidationFeaturesEXT features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1, enables_, 0, nullptr};
 };
 
-class VkAmdBestPracticesLayerTest : public VkBestPracticesLayerTest {};
-class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
-  public:
-    std::unique_ptr<vkt::Image> CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
-                                            VkImageUsageFlags attachment_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
-    VkRenderPass CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op = VK_ATTACHMENT_LOAD_OP_CLEAR,
-                                  VkAttachmentStoreOp store_op = VK_ATTACHMENT_STORE_OP_STORE);
-    VkFramebuffer CreateFramebuffer(const uint32_t width, const uint32_t height, VkImageView image_view, VkRenderPass renderpass);
-};
-class VkNvidiaBestPracticesLayerTest : public VkBestPracticesLayerTest {};
-
 class GpuAVTest : public virtual VkLayerTest {
   public:
     void InitGpuAvFramework(void *p_next = nullptr);
@@ -263,59 +246,25 @@ class GpuAVTest : public virtual VkLayerTest {
     VkValidationFeaturesEXT GetGpuAvValidationFeatures();
 };
 
-class NegativeGpuAV : public GpuAVTest {};
-class PositiveGpuAV : public GpuAVTest {};
-class PositiveGpuAVParameterized : public GpuAVTest,
-                                   public ::testing::WithParamInterface<std::tuple<std::vector<const char *>, uint32_t>> {};
-
 class GpuAVBufferDeviceAddressTest : public GpuAVTest {
   public:
     void InitGpuVUBufferDeviceAddress(void *p_next = nullptr);
-};
-class NegativeGpuAVBufferDeviceAddress : public GpuAVBufferDeviceAddressTest {};
-class PositiveGpuAVBufferDeviceAddress : public GpuAVBufferDeviceAddressTest {};
-
-class NegativeGpuAVShaderDebugInfo : public GpuAVBufferDeviceAddressTest {
-  public:
-    void BasicSingleStorageBufferComputeOOB(const char *shader, const char *error);
 };
 
 class GpuAVDescriptorIndexingTest : public GpuAVTest {
   public:
     void InitGpuVUDescriptorIndexing();
 };
-class NegativeGpuAVDescriptorIndexing : public GpuAVDescriptorIndexingTest {};
-class PositiveGpuAVDescriptorIndexing : public GpuAVDescriptorIndexingTest {};
-
-class GpuAVSpirvTest : public GpuAVTest {};
-class NegativeGpuAVSpirv : public GpuAVSpirvTest {};
-class PositiveGpuAVSpirv : public GpuAVSpirvTest {};
-
-class NegativeGpuAVIndirectBuffer : public GpuAVTest {};
-
-class GpuAVOOBTest : public GpuAVTest {};
-class NegativeGpuAVOOB : public GpuAVOOBTest {
-  public:
-    void ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSize binding_offset, VkDeviceSize binding_range,
-                              VkDescriptorType descriptor_type, const char *fragment_shader,
-                              std::vector<const char *> expected_errors, bool shader_objects = false);
-    void ComputeStorageBufferTest(const char *expected_error, const char *shader, VkDeviceSize buffer_size);
-};
-class PositiveGpuAVOOB : public GpuAVOOBTest {};
 
 class GpuAVRayQueryTest : public GpuAVTest {
   public:
     void InitGpuAVRayQuery();
 };
-class NegativeGpuAVRayQuery : public GpuAVRayQueryTest {};
-class PositiveGpuAVRayQuery : public GpuAVRayQueryTest {};
 
-class NegativeDebugPrintf : public VkLayerTest {
+class DebugPrintfTests : public VkLayerTest {
   public:
     void InitDebugPrintfFramework(void *p_next = nullptr);
 };
-
-class NegativeDebugPrintfShaderDebugInfo : public NegativeDebugPrintf {};
 
 class VkSyncValTest : public VkLayerTest {
   public:
@@ -331,92 +280,32 @@ class VkSyncValTest : public VkLayerTest {
     VkValidationFeaturesEXT features_ = {};
 };
 
-class AndroidHardwareBufferTest : public VkLayerTest {};
-class NegativeAndroidHardwareBuffer : public AndroidHardwareBufferTest {};
-class PositiveAndroidHardwareBuffer : public AndroidHardwareBufferTest {};
-
 class AndroidExternalResolveTest : public VkLayerTest {
   public:
     void InitBasicAndroidExternalResolve();
     bool nullColorAttachmentWithExternalFormatResolve;
 };
-class NegativeAndroidExternalResolve : public AndroidExternalResolveTest {};
-class PositiveAndroidExternalResolve : public AndroidExternalResolveTest {};
-
-class AtomicTest : public VkLayerTest {};
-class NegativeAtomic : public AtomicTest {};
-class PositiveAtomic : public AtomicTest {};
-
-class BufferTest : public VkLayerTest {};
-class NegativeBuffer : public BufferTest {};
-class PositiveBuffer : public BufferTest {};
-
-class CommandTest : public VkLayerTest {};
-class NegativeCommand : public CommandTest {};
-class PositiveCommand : public CommandTest {};
-
-class SecondaryCommandBufferTest : public VkLayerTest {};
-class NegativeSecondaryCommandBuffer : public SecondaryCommandBufferTest {};
-class PositiveSecondaryCommandBuffer : public SecondaryCommandBufferTest {};
-
-class CopyBufferImageTest : public VkLayerTest {};
-class NegativeCopyBufferImage : public CopyBufferImageTest {};
-class PositiveCopyBufferImage : public CopyBufferImageTest {};
-
-class DescriptorsTest : public VkLayerTest {};
-class NegativeDescriptors : public DescriptorsTest {};
-class PositiveDescriptors : public DescriptorsTest {};
-
-class PushDescriptorTest : public VkLayerTest {};
-class NegativePushDescriptor : public PushDescriptorTest {};
-class PositivePushDescriptor : public PushDescriptorTest {};
-
-class DebugExtensionsTest : public VkLayerTest {};
-class NegativeDebugExtensions : public DebugExtensionsTest {};
-class PositiveDebugExtensions : public DebugExtensionsTest {};
 
 class DescriptorBufferTest : public VkLayerTest {
   public:
     void InitBasicDescriptorBuffer(void *pNextFeatures = nullptr);
 };
-class NegativeDescriptorBuffer : public DescriptorBufferTest {};
-class PositiveDescriptorBuffer : public DescriptorBufferTest {};
 
 class DescriptorIndexingTest : public VkLayerTest {
   public:
     void ComputePipelineShaderTest(const char *shader, std::vector<VkDescriptorSetLayoutBinding> &bindings);
 };
-class NegativeDescriptorIndexing : public DescriptorIndexingTest {};
-class PositiveDescriptorIndexing : public DescriptorIndexingTest {};
-
-class NegativeDeviceQueue : public VkLayerTest {};
 
 class DynamicRenderingTest : public VkLayerTest {
   public:
     void InitBasicDynamicRendering();
     void InitBasicDynamicRenderingLocalRead();
 };
-class NegativeDynamicRendering : public DynamicRenderingTest {};
-class PositiveDynamicRendering : public DynamicRenderingTest {};
-
-class NegativeDynamicRenderingLocalRead : public DynamicRenderingTest {};
-class PositiveDynamicRenderingLocalRead : public DynamicRenderingTest {};
 
 class DynamicStateTest : public VkLayerTest {
   public:
     void InitBasicExtendedDynamicState();  // enables VK_EXT_extended_dynamic_state
 };
-class NegativeDynamicState : public DynamicStateTest {
-    // helper functions for tests in this file
-  public:
-    // VK_EXT_extended_dynamic_state - not calling vkCmdSet before draw
-    void ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid);
-    // VK_EXT_extended_dynamic_state3 - Create a pipeline with dynamic state, but the feature disabled
-    void ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char *vuid);
-    // VK_EXT_line_rasterization - Init with LineRasterization features off
-    void InitLineRasterizationFeatureDisabled();
-};
-class PositiveDynamicState : public DynamicStateTest {};
 
 class ExternalMemorySyncTest : public VkLayerTest {
   protected:
@@ -426,22 +315,11 @@ class ExternalMemorySyncTest : public VkLayerTest {
     using ExternalHandle = int;
 #endif
 };
-class NegativeExternalMemorySync : public ExternalMemorySyncTest {};
-class PositiveExternalMemorySync : public ExternalMemorySyncTest {};
-
-class FragmentShadingRateTest : public VkLayerTest {};
-class NegativeFragmentShadingRate : public FragmentShadingRateTest {};
-class PositiveFragmentShadingRate : public FragmentShadingRateTest {};
-
-class NegativeGeometryTessellation : public VkLayerTest {};
-class PositiveGeometryTessellation : public VkLayerTest {};
 
 class GraphicsLibraryTest : public VkLayerTest {
   public:
     void InitBasicGraphicsLibrary();
 };
-class NegativeGraphicsLibrary : public GraphicsLibraryTest {};
-class PositiveGraphicsLibrary : public GraphicsLibraryTest {};
 
 class HostImageCopyTest : public VkLayerTest {
   public:
@@ -459,72 +337,22 @@ class HostImageCopyTest : public VkLayerTest {
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     VkImageCreateInfo image_ci;
 };
-class NegativeHostImageCopy : public HostImageCopyTest {};
-class PositiveHostImageCopy : public HostImageCopyTest {};
 
 class ImageTest : public VkLayerTest {
   public:
     VkImageCreateInfo DefaultImageInfo();
 };
-class NegativeImage : public ImageTest {};
-class PositiveImage : public ImageTest {};
 
 class ImageDrmTest : public VkLayerTest {
   public:
     void InitBasicImageDrm();
     std::vector<uint64_t> GetFormatModifier(VkFormat format, VkFormatFeatureFlags2 features, uint32_t plane_count = 1);
 };
-class NegativeImageDrm : public ImageDrmTest {};
-class PositiveImageDrm : public ImageDrmTest {};
-
-class ImagelessFramebufferTest : public VkLayerTest {};
-class NegativeImagelessFramebuffer : public ImagelessFramebufferTest {};
-class PositiveImagelessFramebuffer : public ImagelessFramebufferTest {};
-
-class NegativeInstanceless : public VkLayerTest {};
-
-class PositiveInstance : public VkLayerTest {};
-
-class MemoryTest : public VkLayerTest {};
-class NegativeMemory : public MemoryTest {};
-class PositiveMemory : public MemoryTest {};
-
-class MeshTest : public VkLayerTest {};
-class NegativeMesh : public MeshTest {};
-class PositiveMesh : public MeshTest {};
-
-class NegativeMultiview : public VkLayerTest {};
-
-class ObjectLifetimeTest : public VkLayerTest {};
-class NegativeObjectLifetime : public ObjectLifetimeTest {};
-class PositiveObjectLifetime : public ObjectLifetimeTest {};
-
-class NegativePipelineAdvancedBlend : public VkLayerTest {};
-
-class PipelineLayoutTest : public VkLayerTest {};
-class NegativePipelineLayout : public PipelineLayoutTest {};
-class PositivePipelineLayout : public PipelineLayoutTest {};
-
-class PipelineTopologyTest : public VkLayerTest {};
-class NegativePipelineTopology : public PipelineTopologyTest {};
-class PositivePipelineTopology : public PipelineTopologyTest {};
-
-class PipelineTest : public VkLayerTest {};
-class NegativePipeline : public PipelineTest {};
-class PositivePipeline : public PipelineTest {};
-
-class NegativePortabilitySubset : public VkLayerTest {};
-
-class ProtectedMemoryTest : public VkLayerTest {};
-class NegativeProtectedMemory : public ProtectedMemoryTest {};
-class PositiveProtectedMemory : public ProtectedMemoryTest {};
 
 class QueryTest : public VkLayerTest {
   public:
     bool HasZeroTimestampValidBits();
 };
-class NegativeQuery : public QueryTest {};
-class PositiveQuery : public QueryTest {};
 
 class RayTracingTest : public virtual VkLayerTest {
   public:
@@ -533,91 +361,14 @@ class RayTracingTest : public virtual VkLayerTest {
     void NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2KHR *features2 = nullptr,
                                           VkValidationFeaturesEXT *enabled_features = nullptr);
 };
-class NegativeRayTracing : public RayTracingTest {};
-class PositiveRayTracing : public RayTracingTest {};
-
-class NegativeRayTracingNV : public RayTracingTest {
-  public:
-    void OOBRayTracingShadersTestBodyNV(bool gpu_assisted);
-};
-
-class RayTracingPipelineTest : public RayTracingTest {};
-class NegativeRayTracingPipeline : public RayTracingPipelineTest {};
-class PositiveRayTracingPipeline : public RayTracingPipelineTest {};
-class NegativeRayTracingPipelineNV : public NegativeRayTracingPipeline {};
-class PositiveRayTracingPipelineNV : public PositiveRayTracingPipeline {};
 
 class GpuAVRayTracingTest : public GpuAVTest, public RayTracingTest {};
-class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};
-class PositiveGpuAVRayTracing : public GpuAVRayTracingTest {};
-
-class RenderPassTest : public VkLayerTest {};
-class NegativeRenderPass : public RenderPassTest {};
-class PositiveRenderPass : public RenderPassTest {};
-
-class RobustnessTest : public VkLayerTest {};
-class NegativeRobustness : public RobustnessTest {};
-class PositiveRobustness : public RobustnessTest {};
-
-class SamplerTest : public VkLayerTest {};
-class NegativeSampler : public SamplerTest {};
-class PositiveSampler : public SamplerTest {};
-
-class ShaderComputeTest : public VkLayerTest {};
-class NegativeShaderCompute : public ShaderComputeTest {};
-class PositiveShaderCompute : public ShaderComputeTest {};
 
 class ShaderObjectTest : public virtual VkLayerTest {
   public:
     void InitBasicShaderObject();
     void InitBasicMeshShaderObject(APIVersion target_api_version);
 };
-class NegativeShaderObject : public ShaderObjectTest {};
-class PositiveShaderObject : public ShaderObjectTest {};
-
-class PositiveGpuAVShaderObject : public PositiveGpuAV {};
-
-class ShaderInterfaceTest : public VkLayerTest {};
-class NegativeShaderInterface : public ShaderInterfaceTest {};
-class PositiveShaderInterface : public ShaderInterfaceTest {};
-
-class ShaderImageAccessTest : public VkLayerTest {};
-class PositiveShaderImageAccess : public ShaderImageAccessTest {};
-class NegativeShaderImageAccess : public ShaderImageAccessTest {};
-
-class ShaderLimitsTest : public VkLayerTest {};
-class NegativeShaderLimits : public ShaderLimitsTest {};
-class PositiveShaderLimits : public ShaderLimitsTest {};
-
-class NegativeShaderMesh : public VkLayerTest {};
-
-class ShaderPushConstantsTest : public VkLayerTest {};
-class NegativeShaderPushConstants : public ShaderPushConstantsTest {};
-class PositiveShaderPushConstants : public ShaderPushConstantsTest {};
-
-class ShaderSpirvTest : public VkLayerTest {};
-class NegativeShaderSpirv : public ShaderSpirvTest {};
-class PositiveShaderSpirv : public ShaderSpirvTest {};
-
-class ShaderStorageImageTest : public VkLayerTest {};
-class NegativeShaderStorageImage : public ShaderStorageImageTest {};
-class PositiveShaderStorageImage : public ShaderStorageImageTest {};
-
-class ShaderStorageTexelTest : public VkLayerTest {};
-class NegativeShaderStorageTexel : public ShaderStorageTexelTest {};
-class PositiveShaderStorageTexel : public ShaderStorageTexelTest {};
-
-class SparseTest : public VkLayerTest {};
-class NegativeSparseImage : public SparseTest {};
-class PositiveSparseImage : public SparseTest {};
-class NegativeSparseBuffer : public SparseTest {};
-class PositiveSparseBuffer : public SparseTest {};
-
-class NegativeSubgroup : public VkLayerTest {};
-
-class SubpassTest : public VkLayerTest {};
-class NegativeSubpass : public SubpassTest {};
-class PositiveSubpass : public SubpassTest {};
 
 class SyncObjectTest : public VkLayerTest {
   protected:
@@ -627,23 +378,6 @@ class SyncObjectTest : public VkLayerTest {
     using ExternalHandle = int;
 #endif
 };
-class NegativeSyncObject : public SyncObjectTest {};
-class PositiveSyncObject : public SyncObjectTest {};
-
-class NegativeTransformFeedback : public VkLayerTest {
-  public:
-    void InitBasicTransformFeedback();
-};
-
-class ToolingTest : public VkLayerTest {};
-class NegativeTooling : public ToolingTest {};
-class PositiveTooling : public ToolingTest {};
-
-class VertexInputTest : public VkLayerTest {};
-class NegativeVertexInput : public VertexInputTest {};
-class PositiveVertexInput : public VertexInputTest {};
-
-class NegativeViewportInheritance : public VkLayerTest {};
 
 class WsiTest : public VkLayerTest {
   public:
@@ -662,17 +396,12 @@ class WsiTest : public VkLayerTest {
     void InitWaylandContext(WaylandContext& context);
     void ReleaseWaylandContext(WaylandContext& context);
 #endif
-
 };
-class NegativeWsi : public WsiTest {};
-class PositiveWsi : public WsiTest {};
 
 class YcbcrTest : public VkLayerTest {
   public:
     void InitBasicYcbcr(void *pNextFeatures = nullptr);
 };
-class NegativeYcbcr : public YcbcrTest {};
-class PositiveYcbcr : public YcbcrTest {};
 
 class CooperativeMatrixTest : public VkLayerTest {
   public:
@@ -680,21 +409,12 @@ class CooperativeMatrixTest : public VkLayerTest {
     bool HasValidProperty(VkScopeKHR scope, uint32_t m, uint32_t n, uint32_t k, VkComponentTypeKHR type);
     std::vector<VkCooperativeMatrixPropertiesKHR> coop_matrix_props;
 };
-class NegativeShaderCooperativeMatrix : public CooperativeMatrixTest {};
-class PositiveShaderCooperativeMatrix : public CooperativeMatrixTest {};
 
 class ParentTest : public VkLayerTest {
   public:
     ~ParentTest();
     vkt::Device *m_second_device = nullptr;
 };
-class NegativeParent : public ParentTest {};
-class PositiveParent : public ParentTest {};
-
-// Thread safety tests and other tests that implement non-trivial threading scenarios
-class ThreadingTest : public VkLayerTest {};
-class NegativeThreading : public ThreadingTest {};
-class PositiveThreading : public ThreadingTest {};
 
 template <typename T>
 bool IsValidVkStruct(const T &s) {

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -18,6 +18,7 @@
 // Tests for AMD-specific best practices
 const char *kEnableAMDValidation = "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_AMD";
 
+class VkAmdBestPracticesLayerTest : public VkBestPracticesLayerTest {};
 
 // this is a very long test (~10 minutes)
 // disabled for now

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -17,6 +17,8 @@
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 
+class NegativeAndroidExternalResolve : public AndroidExternalResolveTest {};
+
 TEST_F(NegativeAndroidExternalResolve, SubpassDescriptionSample) {
     TEST_DESCRIPTION("invalid samples for VkSubpassDescription");
     RETURN_IF_SKIP(InitBasicAndroidExternalResolve());

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -29,6 +29,8 @@ void AndroidExternalResolveTest::InitBasicAndroidExternalResolve() {
     nullColorAttachmentWithExternalFormatResolve = external_format_resolve_props.nullColorAttachmentWithExternalFormatResolve;
 }
 
+class PositiveAndroidExternalResolve : public AndroidExternalResolveTest {};
+
 TEST_F(PositiveAndroidExternalResolve, NoResolve) {
     TEST_DESCRIPTION("Make sure enabling the feature doesn't break normal usage of API.");
     RETURN_IF_SKIP(InitBasicAndroidExternalResolve());

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -17,6 +17,8 @@
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 
+class NegativeAndroidHardwareBuffer : public VkLayerTest {};
+
 TEST_F(NegativeAndroidHardwareBuffer, ImageCreate) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer image create info.");
 

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -17,6 +17,8 @@
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 
+class PositiveAndroidHardwareBuffer : public VkLayerTest {};
+
 TEST_F(PositiveAndroidHardwareBuffer, MemoryRequirements) {
     TEST_DESCRIPTION("Verify AndroidHardwareBuffer doesn't conflict with memory requirements.");
 

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -18,6 +18,15 @@
 
 const char* kEnableArmValidation = "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_ARM";
 
+class VkArmBestPracticesLayerTest : public VkBestPracticesLayerTest {
+  public:
+    std::unique_ptr<vkt::Image> CreateImage(VkFormat format, const uint32_t width, const uint32_t height,
+                                            VkImageUsageFlags attachment_usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
+    VkRenderPass CreateRenderPass(VkFormat format, VkAttachmentLoadOp load_op = VK_ATTACHMENT_LOAD_OP_CLEAR,
+                                  VkAttachmentStoreOp store_op = VK_ATTACHMENT_STORE_OP_STORE);
+    VkFramebuffer CreateFramebuffer(const uint32_t width, const uint32_t height, VkImageView image_view, VkRenderPass renderpass);
+};
+
 class VkConstantBufferObj : public vkt::Buffer {
   public:
     VkConstantBufferObj(vkt::Device* device, VkDeviceSize size, const void* data,

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeAtomic : public VkLayerTest {};
+
 TEST_F(NegativeAtomic, VertexStoresAndAtomicsFeatureDisable) {
     TEST_DESCRIPTION("Run shader with StoreOp or AtomicOp to verify if vertexPipelineStoresAndAtomics disable.");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveAtomic : public VkLayerTest {};
+
 TEST_F(PositiveAtomic, ImageInt64) {
     TEST_DESCRIPTION("Test VK_EXT_shader_image_atomic_int64.");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -19,6 +19,8 @@
 #include "../framework/descriptor_helper.h"
 #include "utils/vk_layer_utils.h"
 
+class NegativeBuffer : public VkLayerTest {};
+
 TEST_F(NegativeBuffer, UpdateBufferAlignment) {
     TEST_DESCRIPTION("Check alignment parameters for vkCmdUpdateBuffer");
     uint32_t updateData[] = {1, 2, 3, 4, 5, 6, 7, 8};

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveBuffer : public VkLayerTest {};
+
 TEST_F(PositiveBuffer, OwnershipTranfers) {
     TEST_DESCRIPTION("Valid buffer ownership transfers that shouldn't create errors");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -18,6 +18,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeCommand : public VkLayerTest {};
+
 TEST_F(NegativeCommand, CommandPoolConsistency) {
     TEST_DESCRIPTION("Allocate command buffers from one command pool and attempt to delete them from another.");
 

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -17,6 +17,8 @@
 #include "../framework/thread_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveCommand : public VkLayerTest {};
+
 TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
     TEST_DESCRIPTION("Use VK_KHR_draw_indirect_count in 1.1 before drawIndirectCount feature was added");
 

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -14,6 +14,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class NegativeCopyBufferImage : public VkLayerTest {};
+
 TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
     TEST_DESCRIPTION("Image to buffer and buffer to image tests");
 

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -14,6 +14,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class PositiveCopyBufferImage : public VkLayerTest {};
+
 TEST_F(PositiveCopyBufferImage, ImageRemainingLayersMaintenance5) {
     TEST_DESCRIPTION(
         "Test copying an image with VkImageSubresourceLayers.layerCount = VK_REMAINING_ARRAY_LAYERS using VK_KHR_maintenance5");

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -14,6 +14,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class NegativeDebugExtensions : public VkLayerTest {};
+
 TEST_F(NegativeDebugExtensions, DebugMarkerName) {
     TEST_DESCRIPTION("Ensure debug marker object names are printed in debug report output");
     AddRequiredExtensions(VK_EXT_DEBUG_REPORT_EXTENSION_NAME);

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -11,6 +11,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class PositiveDebugExtensions : public VkLayerTest {};
+
 TEST_F(PositiveDebugExtensions, SetDebugUtilsObjectBuffer) {
     TEST_DESCRIPTION("call vkSetDebugUtilsObjectNameEXT on a VkBuffer");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -16,7 +16,7 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
-void NegativeDebugPrintf::InitDebugPrintfFramework(void *p_next) {
+void DebugPrintfTests::InitDebugPrintfFramework(void *p_next) {
     VkValidationFeatureEnableEXT enables[] = {VK_VALIDATION_FEATURE_ENABLE_DEBUG_PRINTF_EXT};
     VkValidationFeatureDisableEXT disables[] = {
         VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
@@ -38,6 +38,8 @@ void NegativeDebugPrintf::InitDebugPrintfFramework(void *p_next) {
         GTEST_SKIP() << "Currently disabled for Portability";
     }
 }
+
+class NegativeDebugPrintf : public DebugPrintfTests {};
 
 TEST_F(NegativeDebugPrintf, BasicCompute) {
     RETURN_IF_SKIP(InitDebugPrintfFramework());

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -15,6 +15,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeDebugPrintfShaderDebugInfo : public DebugPrintfTests {};
+
 // These tests print out the verbose info to make sure that info is correct
 static const VkBool32 verbose_value = true;
 static const VkLayerSettingEXT layer_setting = {OBJECT_LAYER_NAME, "printf_verbose", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -18,6 +18,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
+class NegativeDescriptorBuffer : public DescriptorBufferTest {};
+
 TEST_F(NegativeDescriptorBuffer, SetLayout) {
     TEST_DESCRIPTION("Descriptor buffer set layout tests.");
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -26,6 +26,8 @@ void DescriptorBufferTest::InitBasicDescriptorBuffer(void* pNextFeatures) {
     RETURN_IF_SKIP(InitState(nullptr, &descriptor_buffer_features));
 }
 
+class PositiveDescriptorBuffer : public DescriptorBufferTest {};
+
 TEST_F(PositiveDescriptorBuffer, BasicUsage) {
     TEST_DESCRIPTION("Create VkBuffer with extension.");
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());

--- a/tests/unit/descriptor_indexing.cpp
+++ b/tests/unit/descriptor_indexing.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeDescriptorIndexing : public DescriptorIndexingTest {};
+
 TEST_F(NegativeDescriptorIndexing, UpdateAfterBind) {
     TEST_DESCRIPTION("Exercise errors for updating a descriptor set after it is bound.");
 

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -27,6 +27,8 @@ void DescriptorIndexingTest::ComputePipelineShaderTest(const char *shader, std::
     pipe.CreateComputePipeline();
 }
 
+class PositiveDescriptorIndexing : public DescriptorIndexingTest {};
+
 TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     TEST_DESCRIPTION("Ensure that no validation errors for invalid descriptors if binding is PARTIALLY_BOUND");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -19,6 +19,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeDescriptors : public VkLayerTest {};
+
 TEST_F(NegativeDescriptors, DescriptorPoolConsistency) {
     TEST_DESCRIPTION("Allocate descriptor sets from one DS pool and attempt to delete them from another.");
 

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -19,6 +19,8 @@
 #include "generated/vk_extension_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
+class PositiveDescriptors : public VkLayerTest {};
+
 TEST_F(PositiveDescriptors, CopyNonupdatedDescriptors) {
     TEST_DESCRIPTION("Copy non-updated descriptors");
     unsigned int i;

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -13,6 +13,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeDeviceQueue : public VkLayerTest {};
+
 TEST_F(NegativeDeviceQueue, FamilyIndex) {
     TEST_DESCRIPTION("Create device queue with invalid queue family index.");
 

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -18,6 +18,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeDynamicRendering : public DynamicRenderingTest {};
+
 TEST_F(NegativeDynamicRendering, CommandBufferInheritanceRenderingInfo) {
     TEST_DESCRIPTION("VkCommandBufferInheritanceRenderingInfoKHR Dynamic Rendering Tests.");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -18,6 +18,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeDynamicRenderingLocalRead : public DynamicRenderingTest {};
+
 TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLayout) {
     TEST_DESCRIPTION("Feature is disabled, but attachment descriptor and/or reference uses VK_IMAGE_LAYOUT_RENDERING_LOCAL_READ_KHR");
 

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -25,6 +25,8 @@ void DynamicRenderingTest::InitBasicDynamicRenderingLocalRead() {
     RETURN_IF_SKIP(Init());
 }
 
+class PositiveDynamicRenderingLocalRead : public DynamicRenderingTest {};
+
 TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
     TEST_DESCRIPTION("Most simple way to use dynamic rendering local read");
     AddRequiredExtensions(VK_KHR_SYNCHRONIZATION_2_EXTENSION_NAME);

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -23,6 +23,8 @@ void DynamicRenderingTest::InitBasicDynamicRendering() {
     RETURN_IF_SKIP(Init());
 }
 
+class PositiveDynamicRendering : public DynamicRenderingTest {};
+
 TEST_F(PositiveDynamicRendering, BasicUsage) {
     TEST_DESCRIPTION("Most simple way to use dynamic rendering");
     RETURN_IF_SKIP(InitBasicDynamicRendering());

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -17,6 +17,17 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeDynamicState : public DynamicStateTest {
+    // helper functions for tests in this file
+  public:
+    // VK_EXT_extended_dynamic_state - not calling vkCmdSet before draw
+    void ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid);
+    // VK_EXT_extended_dynamic_state3 - Create a pipeline with dynamic state, but the feature disabled
+    void ExtendedDynamicState3PipelineFeatureDisabled(VkDynamicState dynamic_state, const char *vuid);
+    // VK_EXT_line_rasterization - Init with LineRasterization features off
+    void InitLineRasterizationFeatureDisabled();
+};
+
 TEST_F(NegativeDynamicState, DepthBiasNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Depth Bias dynamic state is required but not correctly bound.");

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -22,6 +22,8 @@ void DynamicStateTest::InitBasicExtendedDynamicState() {
     RETURN_IF_SKIP(Init());
 }
 
+class PositiveDynamicState : public DynamicStateTest {};
+
 TEST_F(PositiveDynamicState, DiscardRectanglesVersion) {
     TEST_DESCRIPTION("check version of VK_EXT_discard_rectangles");
 

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -18,6 +18,8 @@
 #include "../framework/external_memory_sync.h"
 #include "utils/vk_layer_utils.h"
 
+class NegativeExternalMemorySync : public ExternalMemorySyncTest {};
+
 TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
     TEST_DESCRIPTION("Creating buffer with incompatible external memory handle types");
 

--- a/tests/unit/external_memory_sync_positive.cpp
+++ b/tests/unit/external_memory_sync_positive.cpp
@@ -16,6 +16,8 @@
 #include "utils/vk_layer_utils.h"
 #include "generated/enum_flag_bits.h"
 
+class PositiveExternalMemorySync : public ExternalMemorySyncTest {};
+
 TEST_F(PositiveExternalMemorySync, GetMemoryFdHandle) {
     TEST_DESCRIPTION("Get POXIS handle for memory allocation");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -17,6 +17,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeFragmentShadingRate : public VkLayerTest {};
+
 TEST_F(NegativeFragmentShadingRate, Values) {
     TEST_DESCRIPTION("Specify invalid fragment shading rate values");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -12,6 +12,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
 
+class PositiveFragmentShadingRate : public VkLayerTest {};
+
 TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     TEST_DESCRIPTION("Specify shading rate pipeline stage with attachmentFragmentShadingRate feature enabled");
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeGeometryTessellation : public VkLayerTest {};
+
 TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     TEST_DESCRIPTION(
         "Attempt to use a stageMask w/ geometry shader and tesselation shader bits enabled when those features are disabled on the "

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveGeometryTessellation : public VkLayerTest {};
+
 TEST_F(PositiveGeometryTessellation, PointSizeGeomShaderDontWriteMaintenance5) {
     TEST_DESCRIPTION(
         "Create a pipeline using TOPOLOGY_POINT_LIST, set PointSize vertex shader, but not in the final geometry stage, but have maintenance5.");

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeGpuAV : public GpuAVTest {};
+
 TEST_F(NegativeGpuAV, DestroyedPipelineLayout) {
     TEST_DESCRIPTION("Check if can catch pipeline layout not being bound");
     RETURN_IF_SKIP(InitGpuAvFramework());

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -17,6 +17,8 @@
 #include "../framework/gpu_av_helper.h"
 #include "../layers/containers/range_vector.h"
 
+class NegativeGpuAVBufferDeviceAddress : public GpuAVBufferDeviceAddressTest {};
+
 TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     TEST_DESCRIPTION("Read before the valid pointer - use Push Constants to set the value");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -26,6 +26,8 @@ void GpuAVBufferDeviceAddressTest::InitGpuVUBufferDeviceAddress(void *p_next) {
     RETURN_IF_SKIP(InitState());
 }
 
+class PositiveGpuAVBufferDeviceAddress : public GpuAVBufferDeviceAddressTest {};
+
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140) {
     TEST_DESCRIPTION("Makes sure that writing to a buffer that was created after command buffer record doesn't get OOB error");
     RETURN_IF_SKIP(InitGpuVUBufferDeviceAddress());

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -18,6 +18,8 @@
 
 #include "../layers/gpu/shaders/gpu_shaders_constants.h"
 
+class NegativeGpuAVDescriptorIndexing : public GpuAVDescriptorIndexingTest {};
+
 TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_ArrayOOBBuffer) {
     TEST_DESCRIPTION(
         "GPU validation: Verify detection of out-of-bounds descriptor array indexing and use of uninitialized descriptors.");

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -37,6 +37,8 @@ void GpuAVDescriptorIndexingTest::InitGpuVUDescriptorIndexing() {
     RETURN_IF_SKIP(InitState());
 }
 
+class PositiveGpuAVDescriptorIndexing : public GpuAVDescriptorIndexingTest {};
+
 TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
     TEST_DESCRIPTION("Basic indexing into a valid descriptor index");
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeGpuAVIndirectBuffer : public GpuAVTest {};
+
 TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     TEST_DESCRIPTION("GPU validation: Validate maxDrawIndirectCount limit");
     SetTargetApiVersion(VK_API_VERSION_1_3);

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -17,6 +17,14 @@
 #include "../framework/gpu_av_helper.h"
 #include "../layers/gpu/shaders/gpu_shaders_constants.h"
 
+class NegativeGpuAVOOB : public GpuAVTest {
+  public:
+    void ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSize binding_offset, VkDeviceSize binding_range,
+                              VkDescriptorType descriptor_type, const char *fragment_shader,
+                              std::vector<const char *> expected_errors, bool shader_objects = false);
+    void ComputeStorageBufferTest(const char *expected_error, const char *shader, VkDeviceSize buffer_size);
+};
+
 TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     TEST_DESCRIPTION("Check buffer oob validation when per pipeline robustness is enabled");
 

--- a/tests/unit/gpu_av_oob_positive.cpp
+++ b/tests/unit/gpu_av_oob_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class PositiveGpuAVOOB : public GpuAVTest {};
+
 TEST_F(PositiveGpuAVOOB, Basic) {
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -21,6 +21,8 @@
 #include "../framework/gpu_av_helper.h"
 #include "../../layers/gpu/shaders/gpu_shaders_constants.h"
 
+class PositiveGpuAV : public GpuAVTest {};
+
 static const std::array gpu_av_enables = {VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT,
                                           VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT};
 static const std::array gpu_av_disables = {VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT,
@@ -1198,6 +1200,9 @@ TEST_F(PositiveGpuAV, SwapchainImage) {
     ivci.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vkt::ImageView view(*m_device, ivci);
 }
+
+class PositiveGpuAVParameterized : public GpuAVTest,
+                                   public ::testing::WithParamInterface<std::tuple<std::vector<const char *>, uint32_t>> {};
 
 TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
     TEST_DESCRIPTION("Validate illegal firstInstance values");

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -22,6 +22,8 @@
 #include "../framework/ray_tracing_objects.h"
 #include "../../layers/gpu/shaders/gpu_shaders_constants.h"
 
+class NegativeGpuAVRayQuery : public GpuAVRayQueryTest {};
+
 TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     TEST_DESCRIPTION("Ray query with a negative value for Ray TMin");
     RETURN_IF_SKIP(InitGpuAVRayQuery());

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -32,6 +32,8 @@ void GpuAVRayQueryTest::InitGpuAVRayQuery() {
     RETURN_IF_SKIP(InitState());
 }
 
+class PositiveGpuAVRayQuery : public GpuAVRayQueryTest {};
+
 TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     TEST_DESCRIPTION("Ray query in a compute shader");
     RETURN_IF_SKIP(InitGpuAVRayQuery());

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -17,6 +17,8 @@
 #include "../framework/shader_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};
+
 TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
     TEST_DESCRIPTION("Invalid parameters used in vkCmdTraceRaysIndirectKHR");
 

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -17,6 +17,8 @@
 #include "../framework/shader_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class PositiveGpuAVRayTracing : public GpuAVRayTracingTest {};
+
 TEST_F(PositiveGpuAVRayTracing, BasicTraceRays) {
     TEST_DESCRIPTION(
         "Setup a ray tracing pipeline (ray generation, miss and closest hit shaders) and acceleration structure, and trace one "

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -15,6 +15,11 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeGpuAVShaderDebugInfo : public GpuAVBufferDeviceAddressTest {
+  public:
+    void BasicSingleStorageBufferComputeOOB(const char *shader, const char *error);
+};
+
 // shader must have a SSBO at (set = 0, binding = 0)
 void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char *shader, const char *error) {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/shader_object_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class PositiveGpuAVShaderObject : public GpuAVTest {};
+
 TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
     TEST_DESCRIPTION("GPU validation: Validate selection of which shaders get instrumented for GPU-AV");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -20,6 +20,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class NegativeGpuAVSpirv : public GpuAVTest {};
+
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462
 TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
     TEST_DESCRIPTION("Require injection in the Loop Header block that contains a Phi");

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -20,6 +20,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/gpu_av_helper.h"
 
+class PositiveGpuAVSpirv : public GpuAVTest {};
+
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7462
 TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     TEST_DESCRIPTION("Loop that has the Phi parent pointed to itself");

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class NegativeGraphicsLibrary : public GraphicsLibraryTest {};
+
 TEST_F(NegativeGraphicsLibrary, DSLs) {
     TEST_DESCRIPTION("Create a pipeline layout with invalid descriptor set layouts");
 

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -22,6 +22,8 @@ void GraphicsLibraryTest::InitBasicGraphicsLibrary() {
     RETURN_IF_SKIP(Init());
 }
 
+class PositiveGraphicsLibrary : public GraphicsLibraryTest {};
+
 TEST_F(PositiveGraphicsLibrary, VertexInput) {
     TEST_DESCRIPTION("Create a vertex input graphics library");
 

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -15,6 +15,8 @@
 #include "utils/vk_layer_utils.h"
 #include "generated/enum_flag_bits.h"
 
+class NegativeHostImageCopy : public HostImageCopyTest {};
+
 TEST_F(NegativeHostImageCopy, ImageLayout) {
     TEST_DESCRIPTION("Bad Image Layout");
     image_ci = vkt::Image::ImageCreateInfo2D(

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -65,6 +65,8 @@ void HostImageCopyTest::InitHostImageCopyTest(const VkImageCreateInfo &create_in
     }
 }
 
+class PositiveHostImageCopy : public HostImageCopyTest {};
+
 TEST_F(PositiveHostImageCopy, BasicUsage) {
     TEST_DESCRIPTION("Use VK_EXT_host_image_copy to copy to and from host memory");
     image_ci = vkt::Image::ImageCreateInfo2D(

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -19,6 +19,8 @@
 #include "../framework/descriptor_helper.h"
 #include "utils/vk_layer_utils.h"
 
+class NegativeImage : public ImageTest {};
+
 TEST_F(NegativeImage, UsageBits) {
     TEST_DESCRIPTION(
         "Specify wrong usage for image then create conflicting view of image Initialize buffer with wrong usage then perform copy "

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -13,6 +13,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class NegativeImageDrm : public ImageDrmTest {};
+
 TEST_F(NegativeImageDrm, Basic) {
     RETURN_IF_SKIP(InitBasicImageDrm());
 

--- a/tests/unit/image_drm_positive.cpp
+++ b/tests/unit/image_drm_positive.cpp
@@ -43,6 +43,8 @@ std::vector<uint64_t> ImageDrmTest::GetFormatModifier(VkFormat format, VkFormatF
     return mods;
 }
 
+class PositiveImageDrm : public ImageDrmTest {};
+
 TEST_F(PositiveImageDrm, Basic) {
     // See https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/2610
     TEST_DESCRIPTION("Create image and imageView using VK_EXT_image_drm_format_modifier");

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -37,6 +37,8 @@ VkImageCreateInfo ImageTest::DefaultImageInfo() {
     return ci;
 }
 
+class PositiveImage : public ImageTest {};
+
 TEST_F(PositiveImage, OwnershipTranfersImage) {
     TEST_DESCRIPTION("Valid image ownership transfers that shouldn't create errors");
     RETURN_IF_SKIP(Init());
@@ -1191,7 +1193,7 @@ TEST_F(PositiveImage, RemainingMipLevels2DViewOf3D) {
     vkt::ImageView view = image.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, VK_REMAINING_MIP_LEVELS, 0, 1);
 }
 
-TEST_F(NegativeImage, RemainingMipLevelsBlockTexelView) {
+TEST_F(PositiveImage, RemainingMipLevelsBlockTexelView) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkImageCreateInfo image_create_info = vku::InitStructHelper();

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeImagelessFramebuffer : public VkLayerTest {};
+
 TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
     TEST_DESCRIPTION(
         "Begin a renderPass where the image views specified do not match the parameters used to create the framebuffer and render "

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -12,6 +12,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
 
+class PositiveImagelessFramebuffer : public VkLayerTest {};
+
 TEST_F(PositiveImagelessFramebuffer, BasicUsage) {
     TEST_DESCRIPTION("Create an imageless framebuffer");
 

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveInstance : public VkLayerTest {};
+
 TEST_F(PositiveInstance, TwoInstances) {
     TEST_DESCRIPTION("Create two instances before destroy");
 

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -35,6 +35,8 @@
 
 static VkInstance dummy_instance;
 
+class NegativeInstanceless : public VkLayerTest {};
+
 TEST_F(NegativeInstanceless, InstanceExtensionDependencies) {
     TEST_DESCRIPTION("Test enabling instance extension without dependencies met.");
 

--- a/tests/unit/layer_utils_positive.cpp
+++ b/tests/unit/layer_utils_positive.cpp
@@ -1,7 +1,7 @@
 
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
 #include "generated/vk_extension_helper.h"
 #include "utils/vk_layer_utils.h"
 
-class PositiveLayerUtils : public VkPositiveLayerTest {};
+class PositiveLayerUtils : public VkLayerTest {};
 
 // These test check utils in the layer without needing to create a full Vulkan instance
 

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -20,6 +20,8 @@
 #include <sys/mman.h>
 #endif
 
+class NegativeMemory : public VkLayerTest {};
+
 TEST_F(NegativeMemory, MapMemory) {
     TEST_DESCRIPTION("Attempt to map memory in a number of incorrect ways");
     bool pass;

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -17,6 +17,8 @@
 #include <sys/mman.h>
 #endif
 
+class PositiveMemory : public VkLayerTest {};
+
 TEST_F(PositiveMemory, MapMemory2) {
     TEST_DESCRIPTION("Validate vkMapMemory2 and vkUnmapMemory2");
 

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeMesh : public VkLayerTest {};
+
 TEST_F(NegativeMesh, BasicUsage) {
     TEST_DESCRIPTION("Test VK_EXT_mesh_shader.");
 

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveMesh : public VkLayerTest {};
+
 TEST_F(PositiveMesh, BasicUsage) {
     TEST_DESCRIPTION("Test basic VK_EXT_mesh_shader.");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -19,6 +19,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeMultiview : public VkLayerTest {};
+
 TEST_F(NegativeMultiview, MaxInstanceIndex) {
     TEST_DESCRIPTION("Verify if instance index in CmdDraw is greater than maxMultiviewInstanceIndex.");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -24,6 +24,8 @@ const char *kEnableNVIDIAValidation = "VALIDATION_CHECK_ENABLE_VENDOR_SPECIFIC_N
 
 static constexpr float defaultQueuePriority = 0.0f;
 
+class VkNvidiaBestPracticesLayerTest : public VkBestPracticesLayerTest {};
+
 TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
     AddRequiredExtensions(VK_EXT_PAGEABLE_DEVICE_LOCAL_MEMORY_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -20,6 +20,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/external_memory_sync.h"
 
+class NegativeObjectLifetime : public VkLayerTest {};
+
 TEST_F(NegativeObjectLifetime, CmdBufferBufferDestroyed) {
     TEST_DESCRIPTION("Attempt to draw with a command buffer that is invalid due to a buffer dependency being destroyed.");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/object_lifetime_positive.cpp
+++ b/tests/unit/object_lifetime_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 
+class PositiveObjectLifetime : public VkLayerTest {};
+
 TEST_F(PositiveObjectLifetime, DestroyFreeNullHandles) {
     VkResult err;
 

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -16,6 +16,8 @@
 
 #include <cstdlib>
 
+class VkPositiveLayerTest : public VkLayerTest {};
+
 TEST_F(VkPositiveLayerTest, StatelessValidationDisable) {
     TEST_DESCRIPTION("Specify a non-zero value for a reserved parameter with stateless validation disabled");
 

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -43,6 +43,8 @@ struct Surface {
 };
 }  // namespace
 
+class NegativeParent : public ParentTest {};
+
 TEST_F(NegativeParent, FillBuffer) {
     TEST_DESCRIPTION("Test VUID-*-commonparent checks not sharing the same Device");
 

--- a/tests/unit/parent_positive.cpp
+++ b/tests/unit/parent_positive.cpp
@@ -18,6 +18,8 @@ ParentTest::~ParentTest() {
     }
 }
 
+class PositiveParent : public ParentTest {};
+
 TEST_F(PositiveParent, ImagelessFramebuffer) {
     TEST_DESCRIPTION("pAttachments is ignored even for common parent");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -19,6 +19,8 @@
 #include "../framework/render_pass_helper.h"
 #include "../framework/shader_helper.h"
 
+class NegativePipeline : public VkLayerTest {};
+
 TEST_F(NegativePipeline, NotBound) {
     TEST_DESCRIPTION("Pass in an invalid pipeline object handle into a Vulkan API call.");
 

--- a/tests/unit/pipeline_advanced_blend.cpp
+++ b/tests/unit/pipeline_advanced_blend.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativePipelineAdvancedBlend : public VkLayerTest {};
+
 TEST_F(NegativePipelineAdvancedBlend, BlendOps) {
     TEST_DESCRIPTION("Advanced blending with invalid VkBlendOps");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativePipelineLayout : public VkLayerTest {};
+
 TEST_F(NegativePipelineLayout, ExceedsSetLimit) {
     TEST_DESCRIPTION("Attempt to create a pipeline layout using more than the physical limit of SetLayouts.");
 

--- a/tests/unit/pipeline_layout_positive.cpp
+++ b/tests/unit/pipeline_layout_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class PositivePipelineLayout : public VkLayerTest {};
+
 TEST_F(PositivePipelineLayout, DescriptorTypeMismatchNonCombinedImageSampler) {
     TEST_DESCRIPTION("HLSL will sometimes produce a SAMPLED_IMAGE / SAMPLER on the same slot that is same as COMBINED_IMAGE_SAMPLER");
 

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -17,6 +17,8 @@
 #include "../framework/render_pass_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositivePipeline : public VkLayerTest {};
+
 TEST_F(PositivePipeline, ComplexTypes) {
     TEST_DESCRIPTION("Smoke test for complex types across VS/FS boundary");
     AddRequiredFeature(vkt::Feature::tessellationShader);

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativePipelineTopology : public VkLayerTest {};
+
 TEST_F(NegativePipelineTopology, PolygonMode) {
     TEST_DESCRIPTION("Attempt to use invalid polygon fill modes.");
     // The sacrificial device object

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositivePipelineTopology : public VkLayerTest {};
+
 TEST_F(PositivePipelineTopology, PointSizeWriteInFunction) {
     TEST_DESCRIPTION("Create a pipeline using TOPOLOGY_POINT_LIST and write PointSize in vertex shader function.");
 

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativePortabilitySubset : public VkLayerTest {};
+
 TEST_F(NegativePortabilitySubset, Device) {
     TEST_DESCRIPTION("Portability: CreateDevice called and VK_KHR_portability_subset not enabled");
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -17,6 +17,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeProtectedMemory : public VkLayerTest {};
+
 TEST_F(NegativeProtectedMemory, Queue) {
     TEST_DESCRIPTION("Try creating queue without VK_QUEUE_PROTECTED_BIT capability");
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -15,6 +15,8 @@
 #include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
+class PositiveProtectedMemory : public VkLayerTest {};
+
 TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
     TEST_DESCRIPTION("Test creating 2 queues, 1 protected, and getting both with vkGetDeviceQueue2");
     all_queue_count_ = true;

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -18,6 +18,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativePushDescriptor : public VkLayerTest {};
+
 TEST_F(NegativePushDescriptor, DSBufferInfo) {
     TEST_DESCRIPTION(
         "Attempt to update buffer descriptor set that has incorrect parameters in VkDescriptorBufferInfo struct. This includes:\n"

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class PositivePushDescriptor : public VkLayerTest {};
+
 TEST_F(PositivePushDescriptor, NullDstSet) {
     TEST_DESCRIPTION("Use null dstSet in CmdPushDescriptorSetKHR");
 

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -17,6 +17,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeQuery : public QueryTest {};
+
 TEST_F(NegativeQuery, PerformanceCreation) {
     TEST_DESCRIPTION("Create performance query without support");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -23,6 +23,8 @@ bool QueryTest::HasZeroTimestampValidBits() {
     return (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0);
 }
 
+class PositiveQuery : public QueryTest {};
+
 TEST_F(PositiveQuery, OutsideRenderPass) {
     AddRequiredFeature(vkt::Feature::pipelineStatisticsQuery);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -41,6 +41,8 @@ constexpr T binom(T n, T k) {
     return numerator / denominator;
 }
 
+class NegativeRayTracing : public RayTracingTest {};
+
 TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     TEST_DESCRIPTION("Test barrier with access ACCELERATION_STRUCTURE bit.");
 

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -33,6 +33,11 @@ void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2K
     }
 }
 
+class NegativeRayTracingNV : public RayTracingTest {
+  public:
+    void OOBRayTracingShadersTestBodyNV(bool gpu_assisted);
+};
+
 void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
+class NegativeRayTracingPipeline : public RayTracingTest {};
+
 TEST_F(NegativeRayTracingPipeline, BasicUsage) {
     TEST_DESCRIPTION("Validate CreateInfo parameters during ray-tracing pipeline creation");
 

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -16,6 +16,8 @@
 #include "../framework/ray_tracing_helper_nv.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeRayTracingPipelineNV : public RayTracingTest {};
+
 TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
     TEST_DESCRIPTION("Validate vkCreateRayTracingPipelinesNV and CreateInfo parameters during ray-tracing pipeline creation");
     AddRequiredExtensions(VK_EXT_PIPELINE_CREATION_CACHE_CONTROL_EXTENSION_NAME);

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
+class PositiveRayTracingPipeline : public RayTracingTest {};
+
 TEST_F(PositiveRayTracingPipeline, ShaderGroupsKHR) {
     TEST_DESCRIPTION("Test that no warning is produced when a library is referenced in the raytracing shader groups.");
 

--- a/tests/unit/ray_tracing_pipeline_positive_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive_nv.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_helper_nv.h"
 #include "../framework/pipeline_helper.h"
+
+class PositiveRayTracingPipelineNV : public RayTracingTest {};
 
 TEST_F(PositiveRayTracingPipelineNV, BasicUsage) {
     TEST_DESCRIPTION("Test VK_NV_ray_tracing.");

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -33,6 +33,8 @@ void RayTracingTest::InitFrameworkForRayTracingTest(VkValidationFeaturesEXT* ena
     RETURN_IF_SKIP(InitFramework(enabled_features));
 }
 
+class PositiveRayTracing : public RayTracingTest {};
+
 TEST_F(PositiveRayTracing, GetAccelerationStructureBuildSizes) {
     TEST_DESCRIPTION("Test enabled features for GetAccelerationStructureBuildSizes");
 

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -19,6 +19,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeRenderPass : public VkLayerTest {};
+
 TEST_F(NegativeRenderPass, AttachmentIndexOutOfRange) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class PositiveRenderPass : public VkLayerTest {};
+
 TEST_F(PositiveRenderPass, AttachmentUsedTwiceOK) {
     TEST_DESCRIPTION("Attachment is used simultaneously as color and input, with the same layout. This is OK.");
 

--- a/tests/unit/robustness.cpp
+++ b/tests/unit/robustness.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeRobustness : public VkLayerTest {};
+
 TEST_F(NegativeRobustness, PipelineRobustnessDisabled) {
     TEST_DESCRIPTION("Create a pipeline using VK_EXT_pipeline_robustness but with pipelineRobustness == VK_FALSE");
 

--- a/tests/unit/robustness_positive.cpp
+++ b/tests/unit/robustness_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/descriptor_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveRobustness : public VkLayerTest {};
+
 TEST_F(PositiveRobustness, WriteDescriptorSetAccelerationStructureNVNullDescriptor) {
     TEST_DESCRIPTION("Validate using NV acceleration structure descriptor writing with null descriptor.");
 

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -18,6 +18,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativeSampler : public VkLayerTest {};
+
 TEST_F(NegativeSampler, MirrorClampToEdgeNotEnabled) {
     TEST_DESCRIPTION("Validation should catch using CLAMP_TO_EDGE addressing mode if the extension is not enabled.");
 

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -1,8 +1,8 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (c) 2015-2023 Google, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (c) 2015-2024 Google, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,6 +13,8 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
+
+class PositiveSampler : public VkLayerTest {};
 
 TEST_F(PositiveSampler, SamplerMirrorClampToEdgeWithoutFeature) {
     TEST_DESCRIPTION("Use VK_KHR_sampler_mirror_clamp_to_edge in 1.1 before samplerMirrorClampToEdge feature was added");

--- a/tests/unit/secondary_command_buffer.cpp
+++ b/tests/unit/secondary_command_buffer.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeSecondaryCommandBuffer : public VkLayerTest {};
+
 TEST_F(NegativeSecondaryCommandBuffer, AsPrimary) {
     TEST_DESCRIPTION("Create a secondary command buffer and pass it to QueueSubmit.");
     m_errorMonitor->SetDesiredError("VUID-VkSubmitInfo-pCommandBuffers-00075");

--- a/tests/unit/secondary_command_buffer_positive.cpp
+++ b/tests/unit/secondary_command_buffer_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/render_pass_helper.h"
 
+class PositiveSecondaryCommandBuffer : public VkLayerTest {};
+
 TEST_F(PositiveSecondaryCommandBuffer, Barrier) {
     TEST_DESCRIPTION("Add a pipeline barrier in a secondary command buffer");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeShaderCompute : public VkLayerTest {};
+
 TEST_F(NegativeShaderCompute, SharedMemoryOverLimit) {
     TEST_DESCRIPTION("Validate compute shader shared memory does not exceed maxComputeSharedMemorySize");
 

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveShaderCompute : public VkLayerTest {};
+
 TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSize) {
     // "If an object is decorated with the WorkgroupSize decoration, this takes precedence over any LocalSize or LocalSizeId
     // execution mode."

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeShaderCooperativeMatrix : public CooperativeMatrixTest {};
+
 TEST_F(NegativeShaderCooperativeMatrix, SpecInfo) {
     TEST_DESCRIPTION("Test VK_KHR_cooperative_matrix.");
 

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -82,6 +82,8 @@ bool CooperativeMatrixTest::HasValidProperty(VkScopeKHR scope, uint32_t m, uint3
     return found_a && found_b && found_c && found_r;
 }
 
+class PositiveShaderCooperativeMatrix : public CooperativeMatrixTest {};
+
 TEST_F(PositiveShaderCooperativeMatrix, CooperativeMatrixNV) {
     TEST_DESCRIPTION("Test VK_NV_cooperative_matrix.");
 

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -12,6 +12,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeShaderImageAccess : public VkLayerTest {};
+
 TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     TEST_DESCRIPTION("Use Component Format mismatch to test image access edge cases");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -12,6 +12,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveShaderImageAccess : public VkLayerTest {};
+
 TEST_F(PositiveShaderImageAccess, FunctionParameterToVariable) {
     TEST_DESCRIPTION("Test getting a ImageAccess from a OpFunctionParameter to a OpVariable");
 

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeShaderInterface : public VkLayerTest {};
+
 TEST_F(NegativeShaderInterface, MaxVertexComponentsWithBuiltins) {
     TEST_DESCRIPTION("Test if the max componenets checks are being checked from OpMemberDecorate built-ins");
 
@@ -1316,7 +1318,7 @@ TEST_F(NegativeShaderInterface, AlphaToCoverageOutputLocation0) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkGraphicsPipelineCreateInfo-alphaToCoverageEnable-08891");
 }
 
-TEST_F(PositiveShaderInterface, AlphaToCoverageOutputIndex1) {
+TEST_F(NegativeShaderInterface, AlphaToCoverageOutputIndex1) {
     TEST_DESCRIPTION("DualSource blend has two outputs at location zero, so Index 0 is the one that's required");
     AddRequiredFeature(vkt::Feature::dualSrcBlend);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class PositiveShaderInterface : public VkLayerTest {};
+
 TEST_F(PositiveShaderInterface, InputAndOutputComponents) {
     TEST_DESCRIPTION("Test shader layout in and out with different components.");
 

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativeShaderLimits : public VkLayerTest {};
+
 TEST_F(NegativeShaderLimits, MaxSampleMaskWordsInput) {
     TEST_DESCRIPTION("Test limit of maxSampleMaskWords.");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveShaderLimits : public VkLayerTest {};
+
 TEST_F(PositiveShaderLimits, MaxSampleMaskWords) {
     TEST_DESCRIPTION("Test limit of maxSampleMaskWords.");
 

--- a/tests/unit/shader_mesh.cpp
+++ b/tests/unit/shader_mesh.cpp
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,6 +11,8 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+
+class NegativeShaderMesh : public VkLayerTest {};
 
 TEST_F(NegativeShaderMesh, SharedMemoryOverLimit) {
     TEST_DESCRIPTION("Validate mesh shader shared memory does not exceed maxMeshSharedMemorySize");

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -14,6 +14,8 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeShaderObject : public ShaderObjectTest {};
+
 TEST_F(NegativeShaderObject, SpirvCodeSize) {
     TEST_DESCRIPTION("Create shader with invalid spirv code size.");
 

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -38,6 +38,8 @@ void ShaderObjectTest::InitBasicMeshShaderObject(APIVersion target_api_version) 
     RETURN_IF_SKIP(Init());
 }
 
+class PositiveShaderObject : public ShaderObjectTest {};
+
 TEST_F(PositiveShaderObject, CreateAndDestroyShaderObject) {
     TEST_DESCRIPTION("Create and destroy shader object.");
 

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -15,6 +15,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeShaderPushConstants : public VkLayerTest {};
+
 TEST_F(NegativeShaderPushConstants, NotDeclared) {
     TEST_DESCRIPTION(
         "Create a graphics pipeline in which a push constant range containing a push constant block member is not declared in the "

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveShaderPushConstants : public VkLayerTest {};
+
 TEST_F(PositiveShaderPushConstants, OverlappingPushConstantRange) {
     TEST_DESCRIPTION("Test overlapping push-constant ranges.");
 

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -22,6 +22,8 @@ struct icd_spv_header {
     uint32_t gen_magic = 0;  // Generator's magic number
 };
 
+class NegativeShaderSpirv : public VkLayerTest {};
+
 TEST_F(NegativeShaderSpirv, CodeSize) {
     TEST_DESCRIPTION("Test that errors are produced for a spirv modules with invalid code sizes");
 

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveShaderSpirv : public VkLayerTest {};
+
 TEST_F(PositiveShaderSpirv, NonSemanticInfo) {
     // This is a positive test, no errors expected
     // Verifies the ability to use non-semantic extended instruction sets when the extension is enabled
@@ -603,7 +605,7 @@ TEST_F(PositiveShaderSpirv, Spirv16Vulkan13) {
     VkShaderObj vs(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_3);
 }
 
-TEST_F(PositiveShaderInterface, OpTypeArraySpecConstant) {
+TEST_F(PositiveShaderSpirv, OpTypeArraySpecConstant) {
     TEST_DESCRIPTION("Make sure spec constants for a OpTypeArray doesn't assert");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativeShaderStorageImage : public VkLayerTest {};
+
 TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     TEST_DESCRIPTION("Create a shader reading a storage image without an image format");
 

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class PositiveShaderStorageImage : public VkLayerTest {};
+
 TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
     TEST_DESCRIPTION("Test writing to image with less components.");
 

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -16,6 +16,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class NegativeShaderStorageTexel : public VkLayerTest {};
+
 TEST_F(NegativeShaderStorageTexel, WriteLessComponent) {
     TEST_DESCRIPTION("Test writing to texel buffer with less components.");
 

--- a/tests/unit/shader_storage_texel_positive.cpp
+++ b/tests/unit/shader_storage_texel_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class PositiveShaderStorageTexel : public VkLayerTest {};
+
 TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
     TEST_DESCRIPTION("Test writing to image with less components.");
 

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -16,6 +16,8 @@
 #include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
+class NegativeSparseBuffer : public VkLayerTest {};
+
 TEST_F(NegativeSparseBuffer, QueueBindSparseMemoryBindSize) {
     TEST_DESCRIPTION("Test QueueBindSparse with invalid sparse memory bind size");
     AddRequiredFeature(vkt::Feature::sparseBinding);

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -13,6 +13,8 @@
 
 #include "../framework/layer_validation_tests.h"
 
+class PositiveSparseBuffer : public VkLayerTest {};
+
 TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     TEST_DESCRIPTION("Test correct non overlapping sparse buffers' copy");
     AddRequiredFeature(vkt::Feature::sparseBinding);

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -18,6 +18,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 
+class NegativeSparseImage : public VkLayerTest {};
+
 TEST_F(NegativeSparseImage, BindingImageBufferCreate) {
     TEST_DESCRIPTION("Create buffer/image with sparse attributes but without the sparse_binding bit set");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -15,6 +15,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 
+class PositiveSparseImage : public VkLayerTest {};
+
 TEST_F(PositiveSparseImage, MultipleBinds) {
     TEST_DESCRIPTION("Bind 2 memory ranges to one image using vkQueueBindSparse, destroy the image and then free the memory");
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeSubgroup : public VkLayerTest {};
+
 TEST_F(NegativeSubgroup, Properties) {
     TEST_DESCRIPTION(
         "Test shader validation support for subgroup VkPhysicalDeviceSubgroupProperties such as supportedStages, and "

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -18,6 +18,8 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeSubpass : public VkLayerTest {};
+
 TEST_F(NegativeSubpass, NonGraphicsPipeline) {
     TEST_DESCRIPTION("Create a subpass with the compute pipeline bind point");
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -18,6 +18,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class PositiveSubpass : public VkLayerTest {};
+
 TEST_F(PositiveSubpass, SubpassImageBarrier) {
     TEST_DESCRIPTION("Subpass with image barrier (self-dependency)");
     SetTargetApiVersion(VK_API_VERSION_1_3);

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -18,6 +18,8 @@
 #include "../framework/barrier_queue_family.h"
 #include "../framework/render_pass_helper.h"
 
+class NegativeSyncObject : public SyncObjectTest {};
+
 TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     TEST_DESCRIPTION("Add a pipeline barrier within a subpass that has conflicting state");
     RETURN_IF_SKIP(Init());

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -21,6 +21,8 @@
 #include <poll.h>
 #endif
 
+class PositiveSyncObject : public SyncObjectTest {};
+
 TEST_F(PositiveSyncObject, Sync2OwnershipTranfersImage) {
     TEST_DESCRIPTION("Valid image ownership transfers that shouldn't create errors");
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -17,6 +17,8 @@
 #include "../framework/thread_helper.h"
 
 #if GTEST_IS_THREADSAFE
+class NegativeThreading : public VkLayerTest {};
+
 TEST_F(NegativeThreading, CommandBufferCollision) {
     m_errorMonitor->SetDesiredError("THREADING ERROR");
     m_errorMonitor->SetAllowedFailureMsg("THREADING ERROR");  // Ignore any extra threading errors found beyond the first one

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -17,6 +17,8 @@
 #include "../framework/thread_helper.h"
 
 #if GTEST_IS_THREADSAFE
+class PositiveThreading : public VkLayerTest {};
+
 TEST_F(PositiveThreading, DisplayObjects) {
     TEST_DESCRIPTION("Create and use VkDisplayKHR objects with GetPhysicalDeviceDisplayPropertiesKHR in thread-safety.");
 

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
+class NegativeTooling : public VkLayerTest {};
+
 TEST_F(NegativeTooling, PrivateDataFeature) {
     TEST_DESCRIPTION("Test privateData feature not being enabled.");
     AddRequiredExtensions(VK_EXT_PRIVATE_DATA_EXTENSION_NAME);

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -14,6 +14,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveTooling : public VkLayerTest {};
+
 TEST_F(PositiveTooling, InfoExt) {
     TEST_DESCRIPTION("Basic usage calling Tooling Extension and verify layer results.");
     AddRequiredExtensions(VK_EXT_TOOLING_INFO_EXTENSION_NAME);

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -51,6 +51,11 @@ static const char *kXfbVsSource = R"asm(
                OpFunctionEnd
         )asm";
 
+class NegativeTransformFeedback : public VkLayerTest {
+  public:
+    void InitBasicTransformFeedback();
+};
+
 void NegativeTransformFeedback::InitBasicTransformFeedback() {
     AddRequiredExtensions(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::transformFeedback);

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -16,6 +16,8 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 
+class NegativeVertexInput : public VkLayerTest {};
+
 TEST_F(NegativeVertexInput, AttributeFormat) {
     TEST_DESCRIPTION("Test that pipeline validation catches invalid vertex attribute formats");
 

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -16,6 +16,8 @@
 #include "../framework/render_pass_helper.h"
 #include "generated/vk_extension_helper.h"
 
+class PositiveVertexInput : public VkLayerTest {};
+
 TEST_F(PositiveVertexInput, AttributeMatrixType) {
     TEST_DESCRIPTION("Test that pipeline validation accepts matrices passed as vertex attributes");
 

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -399,6 +399,8 @@ class ViewportInheritanceTestData {
     }
 };
 
+class NegativeViewportInheritance : public VkLayerTest {};
+
 TEST_F(NegativeViewportInheritance, BasicUsage) {
 #if defined(VVL_ENABLE_TSAN)
     GTEST_SKIP() << "https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/5965";

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -19,6 +19,8 @@
 #include "wayland-client.h"
 #endif
 
+class NegativeWsi : public WsiTest {};
+
 TEST_F(NegativeWsi, GetPhysicalDeviceDisplayPropertiesNull) {
     TEST_DESCRIPTION("Call vkGetPhysicalDeviceDisplayPropertiesKHR with null pointer");
     AddRequiredExtensions(VK_KHR_DISPLAY_EXTENSION_NAME);
@@ -3218,7 +3220,7 @@ TEST_F(NegativeWsi, PresentRegionsKHR) {
     }
 }
 
-TEST_F(PositiveWsi, UseDestroyedSwapchain) {
+TEST_F(NegativeWsi, UseDestroyedSwapchain) {
     TEST_DESCRIPTION("Draw to images of a destroyed swapchain");
     AddSurfaceExtension();
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -104,6 +104,8 @@ void WsiTest::ReleaseWaylandContext(WaylandContext &context) {
 }
 #endif  // VK_USE_PLATFORM_WAYLAND_KHR
 
+class PositiveWsi : public WsiTest {};
+
 TEST_F(PositiveWsi, CreateWaylandSurface) {
     TEST_DESCRIPTION("Test creating wayland surface");
 

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -19,6 +19,8 @@
 #include "../framework/pipeline_helper.h"
 #include "utils/vk_layer_utils.h"
 
+class NegativeYcbcr : public YcbcrTest {};
+
 TEST_F(NegativeYcbcr, Sampler) {
     TEST_DESCRIPTION("Verify YCbCr sampler creation.");
 

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -33,6 +33,8 @@ void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 }
 
+class PositiveYcbcr : public YcbcrTest {};
+
 TEST_F(PositiveYcbcr, PlaneAspectNone) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());


### PR DESCRIPTION
We had a LOT of classes defined in `layer_validation_tests.h` and this moves them to the source file

This actually caught a few tests that had the wrong test class name as well