### PR TITLE
sync: Add basic stats support

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -300,6 +300,8 @@ vvl_sources = [
   "layers/sync/sync_op.h",
   "layers/sync/sync_renderpass.cpp",
   "layers/sync/sync_renderpass.h",
+  "layers/sync/sync_stats.cpp",
+  "layers/sync/sync_stats.h",
   "layers/sync/sync_submit.cpp",
   "layers/sync/sync_submit.h",
   "layers/sync/sync_utils.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -334,6 +334,8 @@ target_sources(vvl PRIVATE
     sync/sync_op.h
     sync/sync_renderpass.cpp
     sync/sync_renderpass.h
+    sync/sync_stats.cpp
+    sync/sync_stats.h
     sync/sync_submit.cpp
     sync/sync_submit.h
     sync/sync_utils.cpp

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -257,7 +257,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     // to use shared_from_this from the constructor.
     void SetSelfReference() { cbs_referenced_->push_back(cb_state_->shared_from_this()); }
 
-    ~CommandBufferAccessContext() override = default;
+    ~CommandBufferAccessContext() override;
     const CommandExecutionContext &GetExecutionContext() const { return *this; }
 
     void Destroy() {
@@ -354,6 +354,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     std::vector<vvl::CommandBuffer::LabelCommand> &GetProxyLabelCommands() { return proxy_label_commands_; }
 
   private:
+    uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
+
     // As this is passing around a shared pointer to record, move to avoid needless atomics.
     void RecordSyncOp(SyncOpPointer &&sync_op);
 
@@ -362,6 +364,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     void CheckCommandTagDebugCheckpoint();
 
+  private:
     // Note: since every CommandBufferAccessContext is encapsulated in its CommandBuffer object,
     // a reference count is not needed here.
     vvl::CommandBuffer *cb_state_;

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -1,0 +1,65 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "sync_stats.h"
+
+#if VVL_ENABLE_SYNCVAL_STATS != 0
+#include "sync_commandbuffer.h"
+#include "utils/vk_layer_utils.h"
+
+namespace syncval_stats {
+
+void Value32::Update(uint32_t new_value) { u32.store(new_value); }
+uint32_t Value32::Add(uint32_t n) { return u32.fetch_add(n); }
+uint32_t Value32::Sub(uint32_t n) { return u32.fetch_sub(n); }
+
+void ValueMax32::Update(uint32_t new_value) {
+    value.Update(new_value);
+    vvl::atomic_fetch_max(max_value.u32, new_value);
+}
+
+void ValueMax32::Add(uint32_t n) {
+    uint32_t new_value = value.Add(n);
+    vvl::atomic_fetch_max(max_value.u32, new_value);
+}
+
+void ValueMax32::Sub(uint32_t n) {
+    uint32_t new_value = value.Sub(n);
+    vvl::atomic_fetch_max(max_value.u32, new_value);
+}
+
+void Stats::AddHandleRecord(uint32_t count) { handle_record_counter.Add(count); }
+void Stats::RemoveHandleRecord(uint32_t count) { handle_record_counter.Sub(count); }
+
+std::string Stats::CreateReport() {
+    uint32_t handle_record = handle_record_counter.value.u32;
+    uint64_t handle_record_memory = handle_record * sizeof(HandleRecord);
+
+    uint32_t handle_record_max = handle_record_counter.max_value.u32;
+    uint64_t handle_record_max_memory = handle_record_max * sizeof(HandleRecord);
+
+    std::ostringstream str;
+    str << "HandleRecord:\n";
+    str << "\tcount = " << handle_record << "\n";
+    str << "\tmemory = " << handle_record_memory << " bytes\n";
+    str << "\tmax_count = " << handle_record_max << "\n";
+    str << "\tmax_memory = " << handle_record_max_memory << " bytes\n";
+    return str.str();
+}
+
+}  // namespace syncval_stats
+#endif  // VVL_ENABLE_SYNCVAL_STATS != 0

--- a/layers/sync/sync_stats.h
+++ b/layers/sync/sync_stats.h
@@ -1,0 +1,61 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <string>
+
+#define VVL_ENABLE_SYNCVAL_STATS 0
+
+#if VVL_ENABLE_SYNCVAL_STATS != 0
+#include <atomic>
+#endif
+
+namespace syncval_stats {
+#if VVL_ENABLE_SYNCVAL_STATS != 0
+
+struct Value32 {
+    std::atomic_uint32_t u32;
+    void Update(uint32_t new_value);
+    uint32_t Add(uint32_t n);
+    uint32_t Sub(uint32_t n);
+};
+
+struct ValueMax32 {
+    Value32 value;
+    Value32 max_value;
+    void Update(uint32_t new_value);
+    void Add(uint32_t n);
+    void Sub(uint32_t n);
+};
+
+struct Stats {
+    ValueMax32 handle_record_counter;
+    void AddHandleRecord(uint32_t count = 1);
+    void RemoveHandleRecord(uint32_t count = 1);
+
+    std::string CreateReport();
+};
+
+#else
+struct Stats {
+    void AddHandleRecord(uint32_t count = 1) {}
+    void RemoveHandleRecord(uint32_t count = 1) {}
+    std::string CreateReport() { return "SyncVal stats are disabled in current build configuration"; }
+};
+#endif  // VVL_ENABLE_SYNCVAL_STATS != 0
+}  // namespace syncval_stats

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -26,6 +26,7 @@
 #include "sync/sync_access_context.h"
 #include "sync/sync_renderpass.h"
 #include "sync/sync_commandbuffer.h"
+#include "sync/sync_stats.h"
 #include "sync/sync_submit.h"
 
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkImage, syncval_state::ImageState, vvl::Image)
@@ -56,6 +57,8 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
 
     using SignaledFences = vvl::unordered_map<VkFence, FenceSyncState>;
     SignaledFences waitable_fences_;
+
+    mutable syncval_stats::Stats stats;  // Stats update is thread safe
 
     uint32_t debug_command_number = vvl::kU32Max;
     uint32_t debug_reset_count = 1;

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -521,11 +521,21 @@ const typename T::value_type *DataOrNull(const T &container) {
     return nullptr;
 }
 
-
 // Workaround for static_assert(false) before C++ 23 arrives
 // https://en.cppreference.com/w/cpp/language/static_assert
 // https://cplusplus.github.io/CWG/issues/2518.html
 template <typename>
 inline constexpr bool dependent_false_v = false;
+
+// Until C++ 26 std::atomic<T>::fetch_max arrives
+// https://en.cppreference.com/w/cpp/atomic/atomic/fetch_max
+// https://www.open-std.org/jtc1/sc22/wg21/docs/papers/2024/p0493r5.pdf
+template <typename T>
+inline T atomic_fetch_max(std::atomic<T> &current_max, const T &value) noexcept {
+    T t = current_max.load();
+    while (!current_max.compare_exchange_weak(t, std::max(t, value)))
+        ;
+    return t;
+}
 
 }  // namespace vvl


### PR DESCRIPTION
Some basic scaffolding that's enough for the current task, but the plan is to evolve this further.

Stats are disabled by default (`VVL_ENABLE_SYNCVAL_STATS` in `sync_stats.h`)