### PR TITLE
sync: Store more resource handles for reporting

### DIFF
--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -315,12 +315,12 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                                 VkCommandBuffer commandBuffer, const VkDeviceSize struct_size, const VkBuffer buffer,
                                 const VkDeviceSize offset, const uint32_t drawCount, const uint32_t stride,
                                 const Location &loc) const;
-    void RecordIndirectBuffer(AccessContext &context, ResourceUsageTag tag, const VkDeviceSize struct_size, const VkBuffer buffer,
-                              const VkDeviceSize offset, const uint32_t drawCount, uint32_t stride);
+    void RecordIndirectBuffer(CommandBufferAccessContext &cb_context, ResourceUsageTag tag, const VkDeviceSize struct_size,
+                              const VkBuffer buffer, const VkDeviceSize offset, const uint32_t drawCount, uint32_t stride);
 
     bool ValidateCountBuffer(const CommandBufferAccessContext &cb_context, const AccessContext &context,
                              VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset, const Location &loc) const;
-    void RecordCountBuffer(AccessContext &context, ResourceUsageTag tag, VkBuffer buffer, VkDeviceSize offset);
+    void RecordCountBuffer(CommandBufferAccessContext &cb_context, ResourceUsageTag tag, VkBuffer buffer, VkDeviceSize offset);
 
     bool PreCallValidateCmdDispatch(VkCommandBuffer commandBuffer, uint32_t x, uint32_t y, uint32_t z,
                                     const ErrorObject &error_obj) const override;


### PR DESCRIPTION
Adds handles of the resources that are specified directly in the API calls (not everything covered, mostly functions like copies, indirect actions, but not barriers).

The amount of memory used by the handles depends on the game. CS2 max usage: 1-2MB, doom capture: ~10 MB (found by new stats system). The previous refactoring released by a rough estimate 2x more memory than the above numbers.