### PR TITLE
layers: Ignore pipeline state with dynamic state

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -617,8 +617,18 @@ class CoreChecks : public ValidationStateTracker {
                                                            const vku::safe_VkSubpassDescription2* subpass_desc,
                                                            const Location& color_loc) const;
     bool IsColorBlendStateAttachmentCountIgnore(const vvl::Pipeline& pipeline) const;
+    bool ValidatePipelineColorBlendAdvancedStateCreateInfo(
+        const vvl::Pipeline& pipeline, const VkPipelineColorBlendAdvancedStateCreateInfoEXT& color_blend_advanced,
+        const Location& color_loc) const;
     bool ValidateGraphicsPipelineColorBlendState(const vvl::Pipeline& pipeline, const vku::safe_VkSubpassDescription2* subpass_desc,
                                                  const Location& create_info_loc) const;
+    bool ValidatePipelineRasterizationStateStreamCreateInfo(
+        const vvl::Pipeline& pipeline, const VkPipelineRasterizationStateStreamCreateInfoEXT& rasterization_state_stream_ci,
+        const Location& raster_loc) const;
+    bool ValidatePipelineRasterizationConservativeStateCreateInfo(
+        const vvl::Pipeline& pipeline,
+        const VkPipelineRasterizationConservativeStateCreateInfoEXT& rasterization_conservative_state_ci,
+        const Location& raster_loc) const;
     bool ValidateGraphicsPipelineRasterizationState(const vvl::Pipeline& pipeline, const Location& create_info_loc) const;
     bool ValidateGraphicsPipelineRenderPassRasterization(const vvl::Pipeline& pipeline, const vvl::RenderPass& rp_state,
                                                          const vku::safe_VkSubpassDescription2& subpass_desc,

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -882,9 +882,8 @@ TEST_F(NegativePipeline, ColorBlendInvalidLogicOp) {
 
 TEST_F(NegativePipeline, ColorBlendUnsupportedLogicOp) {
     TEST_DESCRIPTION("Attempt enabling VkPipelineColorBlendStateCreateInfo::logicOpEnable when logicOp feature is disabled.");
-
-    VkPhysicalDeviceFeatures features{};
-    RETURN_IF_SKIP(Init(&features));
+    AddDisabledFeature(vkt::Feature::logicOp);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     const auto set_shading_enable = [](CreatePipelineHelper &helper) { helper.cb_ci_.logicOpEnable = VK_TRUE; };

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -224,17 +224,9 @@ TEST_F(NegativePipelineTopology, PrimitiveTopologyListRestart) {
 
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-
-    VkPhysicalDevicePrimitiveTopologyListRestartFeaturesEXT ptl_restart_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(ptl_restart_features);
-
-    if (!ptl_restart_features.primitiveTopologyListRestart) {
-        GTEST_SKIP() << "primitive topology list restart feature is not available, skipping test";
-    }
-    ptl_restart_features.primitiveTopologyListRestart = false;
-    ptl_restart_features.primitiveTopologyPatchListRestart = false;
-    RETURN_IF_SKIP(InitState(nullptr, &ptl_restart_features));
+    AddDisabledFeature(vkt::Feature::primitiveTopologyListRestart);
+    AddDisabledFeature(vkt::Feature::primitiveTopologyPatchListRestart);
+    RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
     VkShaderObj vs(this, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -564,3 +564,24 @@ TEST_F(PositivePipelineTopology, PointSizeMaintenance5) {
     };
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
 }
+
+TEST_F(PositivePipelineTopology, PrimitiveTopologyListRestartDynamic) {
+    TEST_DESCRIPTION("Ignore invalid primitiveRestartEnable");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_EXT_PRIMITIVE_TOPOLOGY_LIST_RESTART_EXTENSION_NAME);
+    AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_2_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::extendedDynamicState2);
+    AddDisabledFeature(vkt::Feature::primitiveTopologyListRestart);
+    AddDisabledFeature(vkt::Feature::primitiveTopologyPatchListRestart);
+    RETURN_IF_SKIP(Init());
+    InitRenderTarget();
+
+    VkShaderObj vs(this, kVertexPointSizeGlsl, VK_SHADER_STAGE_VERTEX_BIT);
+
+    CreatePipelineHelper pipe(*this);
+    pipe.AddDynamicState(VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE);
+    pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
+    pipe.ia_ci_.primitiveRestartEnable = VK_TRUE;
+    pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
+    pipe.CreateGraphicsPipeline();
+}


### PR DESCRIPTION
There were a few places were we were checking the value of the pipeline state, but it should have been ignore because the corresponding `VK_DYNAMIC_STATE_*` was used