### PR TITLE
sync: Report descriptor resources

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -300,6 +300,7 @@ vvl_sources = [
   "layers/sync/sync_op.h",
   "layers/sync/sync_renderpass.cpp",
   "layers/sync/sync_renderpass.h",
+  "layers/sync/sync_settings.h",
   "layers/sync/sync_stats.cpp",
   "layers/sync/sync_stats.h",
   "layers/sync/sync_submit.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -334,6 +334,7 @@ target_sources(vvl PRIVATE
     sync/sync_op.h
     sync/sync_renderpass.cpp
     sync/sync_renderpass.h
+    sync/sync_settings.h
     sync/sync_stats.cpp
     sync/sync_stats.h
     sync/sync_submit.cpp

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -743,6 +743,23 @@
                                             }
                                         ]
                                     }
+                                },
+                                {
+                                    "key": "sync_report_descriptor_resources",
+                                    "label": "Report descriptor resources",
+                                    "description": "Report resource handles (images, buffers, etc.) associated with descriptors. Might consume significant amount of memory for complex workloads.",
+                                    "type": "BOOL",
+                                    "default": false,
+                                    "status": "STABLE",
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            {
+                                                "key": "validate_sync",
+                                                "value": true
+                                            }
+                                        ]
+                                    }
                                 }
                             ]
                         },

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -23,6 +23,8 @@
 #include "gpu/core/gpu_settings.h"
 #include "error_message/logging.h"
 
+#include "sync/sync_settings.h"
+
 // Include new / delete overrides if using mimalloc. This needs to be include exactly once in a file that is
 // part of the VVL but not the layer utils library.
 #if defined(USE_MIMALLOC) && defined(_WIN64)
@@ -90,6 +92,10 @@ const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+
+// SyncVal
+// ---
+const char *VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES = "sync_report_descriptor_resources";
 
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
@@ -555,6 +561,12 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (gpuav_settings.debug_validate_instrumented_shaders || gpuav_settings.debug_dump_instrumented_shaders) {
         // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
         gpuav_settings.cache_instrumented_shaders = false;
+    }
+
+    SyncValSettings &syncval_settings = *settings_data->syncval_settings;
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES,
+                                syncval_settings.report_descriptor_resources);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -86,6 +86,7 @@ using CHECK_ENABLED = std::array<bool, kMaxEnableFlags>;
 
 struct GpuAVSettings;
 struct DebugPrintfSettings;
+struct SyncValSettings;
 struct MessageFormatSettings;
 struct ConfigAndEnvSettings {
     const char *layer_description;
@@ -98,6 +99,7 @@ struct ConfigAndEnvSettings {
     bool *fine_grained_locking;
     GpuAVSettings *gpuav_settings;
     DebugPrintfSettings *printf_settings;
+    SyncValSettings *syncval_settings;
 };
 
 static const vvl::unordered_map<std::string, VkValidationFeatureDisableEXT> VkValFeatureDisableLookup = {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -493,6 +493,9 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         } else {
                             current_context_->UpdateAccessState(*img_view_state, sync_index, SyncOrdering::kNonAttachment, tag);
                         }
+                        if (sync_state_->syncval_settings.report_descriptor_resources) {
+                            AddCommandHandle(tag, img_view_state->Handle());
+                        }
                         break;
                     }
                     case DescriptorClass::TexelBuffer: {
@@ -504,6 +507,9 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         const auto *buf_state = buf_view_state->buffer_state.get();
                         const ResourceAccessRange range = MakeRange(*buf_view_state);
                         current_context_->UpdateAccessState(*buf_state, sync_index, SyncOrdering::kNonAttachment, range, tag);
+                        if (sync_state_->syncval_settings.report_descriptor_resources) {
+                            AddCommandHandle(tag, buf_view_state->Handle());
+                        }
                         break;
                     }
                     case DescriptorClass::GeneralBuffer: {
@@ -523,6 +529,9 @@ void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindP
                         const auto *buf_state = buffer_descriptor->GetBufferState();
                         const ResourceAccessRange range = MakeRange(*buf_state, offset, buffer_descriptor->GetRange());
                         current_context_->UpdateAccessState(*buf_state, sync_index, SyncOrdering::kNonAttachment, range, tag);
+                        if (sync_state_->syncval_settings.report_descriptor_resources) {
+                            AddCommandHandle(tag, buf_state->Handle());
+                        }
                         break;
                     }
                     // TODO: INLINE_UNIFORM_BLOCK_EXT, ACCELERATION_STRUCTURE_KHR

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+struct SyncValSettings {
+    // Report resource handles (images, buffers, etc.) associated with descriptors.
+    // Might consume significant amount of memory for complex workloads.
+    bool report_descriptor_resources = false;
+};

--- a/layers/sync/sync_stats.h
+++ b/layers/sync/sync_stats.h
@@ -20,7 +20,9 @@
 #include <string>
 #include <cstdint>
 
+#ifndef VVL_ENABLE_SYNCVAL_STATS
 #define VVL_ENABLE_SYNCVAL_STATS 0
+#endif
 
 #if VVL_ENABLE_SYNCVAL_STATS != 0
 #include <atomic>
@@ -56,7 +58,7 @@ struct Stats {
 struct Stats {
     void AddHandleRecord(uint32_t count = 1) {}
     void RemoveHandleRecord(uint32_t count = 1) {}
-    std::string CreateReport() { return "SyncVal stats are disabled in current build configuration"; }
+    std::string CreateReport() { return "SyncVal stats are disabled in the current build configuration\n"; }
 };
 #endif  // VVL_ENABLE_SYNCVAL_STATS != 0
 }  // namespace syncval_stats

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -16,6 +16,7 @@
  */
 
 #include <algorithm>
+#include <iostream>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -24,6 +25,22 @@
 #include "sync/sync_image.h"
 #include "state_tracker/device_state.h"
 #include "state_tracker/buffer_state.h"
+
+SyncValidator ::~SyncValidator() {
+    // Instance level SyncValidator does not have much to say
+    const bool device_validation_object = (device != nullptr);
+    // Get environment variable. Specify non-zero number to enable
+    const auto show_stats_str = GetEnvironment("VK_SYNCVAL_SHOW_STATS");
+    const bool show_stats = !show_stats_str.empty() && std::stoul(show_stats_str) != 0;
+
+    if (device_validation_object && show_stats) {
+        const std::string report = stats.CreateReport();
+        // LogInfo at this point can print the message but then hangs in the mutex lock.
+        // Everything is being destroyed here can be the reason.
+        // LogInfo("SYNCVAL_STATS", LogObjectList(), Location(vvl::Func::Empty), "%s", report.c_str());
+        std::cout << report;
+    }
+}
 
 ResourceUsageRange SyncValidator::ReserveGlobalTagRange(size_t tag_count) const {
     ResourceUsageRange reserve;

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -44,6 +44,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     using Field = vvl::Field;
 
     SyncValidator() { container_type = LayerObjectTypeSyncValidation; }
+    ~SyncValidator();
 
     // Global tag range for submitted command buffers resource usage logs
     // Started the global tag count at 1 s.t. zero are invalid and ResourceUsageTag normalization can just zero them.

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -418,6 +418,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     bool lock_setting;
     GpuAVSettings local_gpuav_settings = {};
     DebugPrintfSettings local_printf_settings = {};
+    SyncValSettings local_syncval_settings = {};
     ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                       pCreateInfo,
                                                       local_enables,
@@ -427,7 +428,8 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
                                                       &debug_report->message_format_settings,
                                                       &lock_setting,
                                                       &local_gpuav_settings,
-                                                      &local_printf_settings};
+                                                      &local_printf_settings,
+                                                      &local_syncval_settings};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
     LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
@@ -488,6 +490,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     framework->fine_grained_locking = lock_setting;
     framework->gpuav_settings = local_gpuav_settings;
     framework->printf_settings = local_printf_settings;
+    framework->syncval_settings = local_syncval_settings;
 
     framework->instance = *pInstance;
     layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);
@@ -508,6 +511,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
         intercept->fine_grained_locking = framework->fine_grained_locking;
         intercept->gpuav_settings = framework->gpuav_settings;
         intercept->printf_settings = framework->printf_settings;
+        intercept->syncval_settings = framework->syncval_settings;
         intercept->instance = *pInstance;
     }
 
@@ -649,6 +653,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         object->fine_grained_locking = instance_interceptor->fine_grained_locking;
         object->gpuav_settings = instance_interceptor->gpuav_settings;
         object->printf_settings = instance_interceptor->printf_settings;
+        object->syncval_settings = instance_interceptor->syncval_settings;
         object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
         object->instance_extensions = instance_interceptor->instance_extensions;
         object->device_extensions = device_interceptor->device_extensions;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -54,6 +54,7 @@
 #include "vk_dispatch_table_helper.h"
 #include "vk_extension_helper.h"
 #include "gpu/core/gpu_settings.h"
+#include "sync/sync_settings.h"
 
 extern std::atomic<uint64_t> global_unique_id;
 
@@ -2227,6 +2228,7 @@ class ValidationObject {
     bool fine_grained_locking{true};
     GpuAVSettings gpuav_settings = {};
     DebugPrintfSettings printf_settings = {};
+    SyncValSettings syncval_settings = {};
 
     VkInstance instance = VK_NULL_HANDLE;
     VkPhysicalDevice physical_device = VK_NULL_HANDLE;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -317,6 +317,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
             #include "vk_dispatch_table_helper.h"
             #include "vk_extension_helper.h"
             #include "gpu/core/gpu_settings.h"
+            #include "sync/sync_settings.h"
 
             extern std::atomic<uint64_t> global_unique_id;
 
@@ -425,6 +426,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool fine_grained_locking{true};
                 GpuAVSettings gpuav_settings = {};
                 DebugPrintfSettings printf_settings = {};
+                SyncValSettings syncval_settings = {};
 
                 VkInstance instance = VK_NULL_HANDLE;
                 VkPhysicalDevice physical_device = VK_NULL_HANDLE;
@@ -1094,6 +1096,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool lock_setting;
                 GpuAVSettings local_gpuav_settings = {};
                 DebugPrintfSettings local_printf_settings = {};
+                SyncValSettings local_syncval_settings = {};
                 ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
                                                                 pCreateInfo,
                                                                 local_enables,
@@ -1103,7 +1106,8 @@ class LayerChassisOutputGenerator(BaseGenerator):
                                                                 &debug_report->message_format_settings,
                                                                 &lock_setting,
                                                                 &local_gpuav_settings,
-                                                                &local_printf_settings};
+                                                                &local_printf_settings,
+                                                                &local_syncval_settings};
                 ProcessConfigAndEnvSettings(&config_and_env_settings_data);
                 LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
@@ -1164,6 +1168,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 framework->fine_grained_locking = lock_setting;
                 framework->gpuav_settings = local_gpuav_settings;
                 framework->printf_settings = local_printf_settings;
+                framework->syncval_settings = local_syncval_settings;
 
                 framework->instance = *pInstance;
                 layer_init_instance_dispatch_table(*pInstance, &framework->instance_dispatch_table, fpGetInstanceProcAddr);
@@ -1184,6 +1189,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     intercept->fine_grained_locking = framework->fine_grained_locking;
                     intercept->gpuav_settings = framework->gpuav_settings;
                     intercept->printf_settings = framework->printf_settings;
+                    intercept->syncval_settings = framework->syncval_settings;
                     intercept->instance = *pInstance;
                 }
 
@@ -1324,6 +1330,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     object->fine_grained_locking = instance_interceptor->fine_grained_locking;
                     object->gpuav_settings = instance_interceptor->gpuav_settings;
                     object->printf_settings = instance_interceptor->printf_settings;
+                    object->syncval_settings = instance_interceptor->syncval_settings;
                     object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
                     object->instance_extensions = instance_interceptor->instance_extensions;
                     object->device_extensions = device_interceptor->device_extensions;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -268,7 +268,7 @@ class DebugPrintfTests : public VkLayerTest {
 
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework(bool disable_queue_submit_validation = false);
+    void InitSyncValFramework(bool disable_queue_submit_validation = false, bool report_descriptor_resources = false);
     void InitSyncVal();
     void InitTimelineSemaphore();
 


### PR DESCRIPTION
One more PR to track resource handles for submit time validation. This adds the resource handles referenced by the descriptors. New option `sync_report_descriptor_resources` controls this feature (disabled by default).

The previous PRs added handle reporting for handles specified directly through API commands, as in `vkCmdCopyBuffer(buffer_a, buffer_b)`. Those handles have fixed and small memory footprint and they are always collected.

Shader can reference a lot of resources and it can take significant amount of memory depending on the application. That's the reason configuration option is introduced. Some numbers for the required amount of memory for descriptor resource handles from the test sessions: CS2: 70 Mb, Doom eternal: 600 Mb.

The next PR will use the information about tracked handles to detect a specific resource that caused hazard during submit time validation.
