### PR TITLE
sync: Detect hazardous buffer resource

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -180,10 +180,10 @@ void AccessContext::ResolvePreviousAccesses() {
 }
 
 void AccessContext::UpdateAccessState(const vvl::Buffer &buffer, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                                      const ResourceAccessRange &range, const ResourceUsageTag tag) {
+                                      const ResourceAccessRange &range, ResourceUsageTagEx tag_ex) {
     if (!SimpleBinding(buffer)) return;
     const auto base_address = ResourceBaseAddress(buffer);
-    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag);
+    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag_ex);
     UpdateMemoryAccessRangeState(access_state_map_, action, range + base_address);
 }
 
@@ -235,7 +235,7 @@ void AccessContext::UpdateAccessState(const vvl::VideoSession &vs_state, const v
 
 void AccessContext::UpdateAccessState(ImageRangeGen &range_gen, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                                       ResourceUsageTag tag) {
-    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, tag);
+    UpdateMemoryAccessStateFunctor action(*this, current_usage, ordering_rule, ResourceUsageTagEx{tag});
     UpdateMemoryAccessState(action, range_gen);
 }
 
@@ -523,7 +523,7 @@ ResourceAccessRangeMap::iterator AccessContext::UpdateMemoryAccessStateFunctor::
 }
 void AccessContext::UpdateMemoryAccessStateFunctor::operator()(const ResourceAccessRangeMap::iterator &pos) const {
     auto &access_state = pos->second;
-    access_state.Update(usage_info, ordering_rule, tag);
+    access_state.Update(usage_info, ordering_rule, tag_ex);
 }
 
 // This is called with the *recorded* command buffers access context, with the *active* access context pass in, againsts which

--- a/layers/sync/sync_access_context.h
+++ b/layers/sync/sync_access_context.h
@@ -309,7 +309,7 @@ class AccessContext {
                             const ResourceAccessState *infill_state = nullptr, bool recur_to_infill = false);
 
     void UpdateAccessState(const vvl::Buffer &buffer, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
-                           const ResourceAccessRange &range, ResourceUsageTag tag);
+                           const ResourceAccessRange &range, ResourceUsageTagEx tag_ex);
     void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
                            const VkImageSubresourceRange &subresource_range, const ResourceUsageTag &tag);
     void UpdateAccessState(const ImageState &image, SyncStageAccessIndex current_usage, SyncOrdering ordering_rule,
@@ -397,12 +397,12 @@ class AccessContext {
         Iterator Infill(ResourceAccessRangeMap *accesses, const Iterator &pos, const ResourceAccessRange &range) const;
         void operator()(const Iterator &pos) const;
         UpdateMemoryAccessStateFunctor(const AccessContext &context_, SyncStageAccessIndex usage_, SyncOrdering ordering_rule_,
-                                       ResourceUsageTag tag_)
-            : context(context_), usage_info(SyncStageAccess::UsageInfo(usage_)), ordering_rule(ordering_rule_), tag(tag_) {}
+                                       ResourceUsageTagEx tag_ex)
+            : context(context_), usage_info(SyncStageAccess::UsageInfo(usage_)), ordering_rule(ordering_rule_), tag_ex(tag_ex) {}
         const AccessContext &context;
         const SyncStageAccessInfoType &usage_info;
         const SyncOrdering ordering_rule;
-        const ResourceUsageTag tag;
+        const ResourceUsageTagEx tag_ex;
     };
 
     // Follow the context previous to access the access state, supporting "lazy" import into the context. Not intended for

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -139,16 +139,21 @@ struct DebugNameProvider;
 struct ResourceUsageRecord : public ResourceCmdUsageRecord {
     struct FormatterState {
         FormatterState(const SyncValidator &sync_state_, const ResourceUsageRecord &record_, const vvl::CommandBuffer *cb_state_,
-                       const DebugNameProvider *debug_name_provider_)
-            : sync_state(sync_state_), record(record_), ex_cb_state(cb_state_), debug_name_provider(debug_name_provider_) {}
+                       const DebugNameProvider *debug_name_provider_, uint32_t handle_index)
+            : sync_state(sync_state_),
+              record(record_),
+              ex_cb_state(cb_state_),
+              debug_name_provider(debug_name_provider_),
+              handle_index(handle_index) {}
         const SyncValidator &sync_state;
         const ResourceUsageRecord &record;
         const vvl::CommandBuffer *ex_cb_state;
         const DebugNameProvider *debug_name_provider;
+        uint32_t handle_index;
     };
     FormatterState Formatter(const SyncValidator &sync_state, const vvl::CommandBuffer *ex_cb_state,
-                             const DebugNameProvider *debug_name_provider) const {
-        return FormatterState(sync_state, *this, ex_cb_state, debug_name_provider);
+                             const DebugNameProvider *debug_name_provider, uint32_t handle_index) const {
+        return FormatterState(sync_state, *this, ex_cb_state, debug_name_provider, handle_index);
     }
 
     AlternateResourceUsage alt_usage;
@@ -265,7 +270,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
 
     void Reset();
 
-    std::string FormatUsage(ResourceUsageTag tag) const override;
+    std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
     std::string FormatUsage(const char *usage_string,
                             const ResourceFirstAccess &access) const;  //  Only command buffers have "first usage"
     AccessContext *GetCurrentAccessContext() override { return current_context_; }
@@ -319,7 +324,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
                                     ResourceUsageRecord::SubcommandType subcommand = ResourceUsageRecord::SubcommandType::kNone);
     ResourceUsageTag NextSubcommandTag(vvl::Func command, ResourceUsageRecord::SubcommandType subcommand);
 
-    void AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle, uint32_t index = vvl::kNoIndex32);
+    ResourceUsageTagEx AddCommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle,
+                                        uint32_t index = vvl::kNoIndex32);
 
     // Default subcommand behavior is that it references the same handles as the main command.
     // The following method allows to set subcommand handles independently of the main command.

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -53,6 +53,12 @@ using ResourceUsageRange = sparse_container::range<ResourceUsageTag>;
 using ResourceAddress = VkDeviceSize;
 using ResourceAccessRange = sparse_container::range<ResourceAddress>;
 
+// Usage tag extended with resource handle information
+struct ResourceUsageTagEx {
+    ResourceUsageTag tag = kInvalidTag;
+    uint32_t handle_index = vvl::kNoIndex32;
+};
+
 template <typename T>
 ResourceAccessRange MakeRange(const T &has_offset_and_size) {
     return ResourceAccessRange(has_offset_and_size.offset, (has_offset_and_size.offset + has_offset_and_size.size));
@@ -80,7 +86,7 @@ class SyncValidationInfo {
         return *sync_state_;
     }
     std::string FormatHazard(const HazardResult& hazard) const;
-    virtual std::string FormatUsage(ResourceUsageTag tag) const = 0;
+    virtual std::string FormatUsage(ResourceUsageTagEx tag_ex) const = 0;
 
   protected:
     const SyncValidator* sync_state_;

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -447,9 +447,9 @@ std::vector<QueueBatchContext::CommandBufferInfo> QueueBatchContext::GetCommandB
 }
 
 // Look up the usage informaiton from the local or global logger
-std::string QueueBatchContext::FormatUsage(ResourceUsageTag tag) const {
+std::string QueueBatchContext::FormatUsage(ResourceUsageTagEx tag_ex) const {
     std::stringstream out;
-    BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag);
+    BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag_ex.tag);
     if (access.IsValid()) {
         const BatchAccessLog::BatchRecord& batch = *access.batch;
         const ResourceUsageRecord& record = *access.record;
@@ -461,7 +461,7 @@ std::string QueueBatchContext::FormatUsage(ResourceUsageTag tag) const {
         out << ", batch_tag: " << batch.base_tag;
 
         // Commandbuffer Usages Information
-        out << ", " << record.Formatter(*sync_state_, nullptr, access.debug_name_provider);
+        out << ", " << record.Formatter(*sync_state_, nullptr, access.debug_name_provider, tag_ex.handle_index);
     }
     return out.str();
 }

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -449,7 +449,7 @@ std::vector<QueueBatchContext::CommandBufferInfo> QueueBatchContext::GetCommandB
 // Look up the usage informaiton from the local or global logger
 std::string QueueBatchContext::FormatUsage(ResourceUsageTag tag) const {
     std::stringstream out;
-    BatchAccessLog::AccessRecord access = batch_log_[tag];
+    BatchAccessLog::AccessRecord access = batch_log_.GetAccessRecord(tag);
     if (access.IsValid()) {
         const BatchAccessLog::BatchRecord& batch = *access.batch;
         const ResourceUsageRecord& record = *access.record;
@@ -692,10 +692,10 @@ void BatchAccessLog::Trim(const ResourceUsageTagSet& used_tags) {
     }
 }
 
-BatchAccessLog::AccessRecord BatchAccessLog::operator[](ResourceUsageTag tag) const {
+BatchAccessLog::AccessRecord BatchAccessLog::GetAccessRecord(ResourceUsageTag tag) const {
     auto found_log = log_map_.find(tag);
     if (found_log != log_map_.cend()) {
-        return found_log->second[tag];
+        return found_log->second.GetAccessRecord(tag);
     }
     // tag not found
     assert(false);
@@ -708,7 +708,7 @@ std::string BatchAccessLog::CBSubmitLog::GetDebugRegionName(const ResourceUsageR
     return vvl::CommandBuffer::GetDebugRegionName(label_commands, record.label_command_index, initial_label_stack_);
 }
 
-BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::operator[](ResourceUsageTag tag) const {
+BatchAccessLog::AccessRecord BatchAccessLog::CBSubmitLog::GetAccessRecord(ResourceUsageTag tag) const {
     assert(tag >= batch_.base_tag);
     const size_t index = tag - batch_.base_tag;
     assert(log_);

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -231,7 +231,7 @@ class QueueBatchContext : public CommandExecutionContext, public std::enable_sha
     QueueBatchContext() = delete;
     void Trim();
 
-    std::string FormatUsage(ResourceUsageTag tag) const override;
+    std::string FormatUsage(ResourceUsageTagEx tag_ex) const override;
     AccessContext *GetCurrentAccessContext() override { return current_access_context_; }
     const AccessContext *GetCurrentAccessContext() const override { return current_access_context_; }
     SyncEventsContext *GetCurrentEventsContext() override { return &events_context_; }

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -149,7 +149,7 @@ class BatchAccessLog {
         CBSubmitLog(const BatchRecord &batch, const CommandBufferAccessContext &cb,
                     const std::vector<std::string> &initial_label_stack);
         size_t Size() const { return log_->size(); }
-        AccessRecord operator[](ResourceUsageTag tag) const;
+        AccessRecord GetAccessRecord(ResourceUsageTag tag) const;
 
         // DebugNameProvider
         std::string GetDebugRegionName(const ResourceUsageRecord &record) const override;
@@ -180,7 +180,7 @@ class BatchAccessLog {
 
     void Trim(const ResourceUsageTagSet &used);
     // AccessRecord lookup is based on global tags
-    AccessRecord operator[](ResourceUsageTag tag) const;
+    AccessRecord GetAccessRecord(ResourceUsageTag tag) const;
     BatchAccessLog() {}
 
   private:


### PR DESCRIPTION
This adds the support to detect a hazardous buffer resource during queue submit validation. A similar functionality for images (and other resources) will be added later.

`ResourceUsageTagEx` is a new structure that extends tag id with resource handle information.

`vkQueueSubmit` error message adds a resource field in the end:
> [ SYNC-HAZARD-WRITE-AFTER-WRITE ] Object 0: handle = 0x2cf6ffd67d0, type = VK_OBJECT_TYPE_QUEUE; | MessageID = 0x5c0ec5d6 | vkQueueSubmit():  Hazard WRITE_AFTER_WRITE for entry 0, VkCommandBuffer 0x2cf7ea5bb60[], Submitted access info (submitted_usage: SYNC_COMPUTE_SHADER_SHADER_STORAGE_WRITE, command: vkCmdDispatch, seq_no: 1, reset_no: 1, resource: VkBuffer 0xead9370000000008[BufferB]). Access info (prior_usage: SYNC_COPY_TRANSFER_WRITE, write_barriers: 0, queue: VkQueue 0x2cf6ffd67d0[], submit: 0, batch: 0, batch_tag: 1, command: vkCmdCopyBuffer, command_buffer: VkCommandBuffer 0x2cf7ea43a60[], seq_no: 1, reset_no: 1, **resource: VkBuffer 0xead9370000000008[BufferB]**)

Addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8139
