### PR TITLE
layers: Miscellaneous fixes

### DIFF
--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -824,7 +824,7 @@ bool CoreChecks::PreCallValidateGetCalibratedTimestampsKHR(VkDevice device, uint
                                                            const ErrorObject &error_obj) const {
     bool skip = false;
 
-    auto query_function = (error_obj.location.function == Func::vkGetPhysicalDeviceCalibrateableTimeDomainsKHR)
+    auto query_function = (error_obj.location.function == Func::vkGetCalibratedTimestampsKHR)
                               ? DispatchGetPhysicalDeviceCalibrateableTimeDomainsKHR
                               : DispatchGetPhysicalDeviceCalibrateableTimeDomainsEXT;
     uint32_t count = 0;

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -389,6 +389,19 @@ class Pipeline : public StateObject {
         return rt->sType;
     }
 
+    const void *GetCreateInfoPNext() const {
+        const auto *gfx = std::get_if<vku::safe_VkGraphicsPipelineCreateInfo>(&create_info);
+        if (gfx) {
+            return gfx->pNext;
+        }
+        const auto *cmp = std::get_if<vku::safe_VkComputePipelineCreateInfo>(&create_info);
+        if (cmp) {
+            return cmp->pNext;
+        }
+        const auto *rt = std::get_if<vku::safe_VkRayTracingPipelineCreateInfoCommon>(&create_info);
+        return rt->pNext;
+    }
+
     bool BlendConstantsEnabled() const { return fragment_output_state && fragment_output_state->blend_constants_enabled; }
 
     bool SampleLocationEnabled() const { return fragment_output_state && fragment_output_state->sample_location_enabled; }

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -31,6 +31,7 @@
 #include "chassis.h"
 #include "layer_options.h"
 #include "layer_chassis_dispatch.h"
+#include "state_tracker/descriptor_sets.h"
 #include "chassis/chassis_modification_state.h"
 
 thread_local WriteLockGuard* ValidationObject::record_guard{};

--- a/layers/vulkan/generated/layer_chassis_dispatch.cpp
+++ b/layers/vulkan/generated/layer_chassis_dispatch.cpp
@@ -334,7 +334,7 @@ void WrapPnextChainHandles(ValidationObject* layer_data, const void* pNext) {
     }
 }
 
-static bool NotDispatchableHandle(VkObjectType object_type) {
+[[maybe_unused]] static bool NotDispatchableHandle(VkObjectType object_type) {
     switch (object_type) {
         case VK_OBJECT_TYPE_INSTANCE:
         case VK_OBJECT_TYPE_PHYSICAL_DEVICE:

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -285,7 +285,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
         },
         'test_icd_helper.h' : {
             'generator' : TestIcdGenerator,
-            'genCombined': True,
+            'genCombined': False,
         },
     }
 
@@ -344,7 +344,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
                 cacheVkObjectData = pickle.load(file)
                 file.close()
 
-        if caching and cacheVkObjectData and 'regenerate' not in generators[target]:
+        if caching and cacheVkObjectData and ('regenerate' not in generators[target] or not generators[target]['regenerate']):
             # TODO - We shouldn't have to regenerate any files, need to investigate why we some scripts need it
             reg.gen.generateFromCache(cacheVkObjectData, reg.genOpts)
         else:

--- a/scripts/generators/base_generator.py
+++ b/scripts/generators/base_generator.py
@@ -36,7 +36,7 @@ vulkanConventions = VulkanConventions()
 
 # Helpers to keep things cleaner
 def splitIfGet(elem, name):
-    return elem.get(name).split(',') if elem.get(name) is not None else None
+    return elem.get(name).split(',') if elem.get(name) is not None and elem.get(name) != '' else None
 
 def textIfFind(elem, name):
     return elem.find(name).text if elem.find(name) is not None else None

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -231,7 +231,7 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             ''')
 
         out.append('''
-            static bool NotDispatchableHandle(VkObjectType object_type) {
+            [[maybe_unused]] static bool NotDispatchableHandle(VkObjectType object_type) {
                 switch(object_type) {
         ''')
         out.extend([f'case {handle.type}:\n' for handle in self.vk.handles.values() if handle.dispatchable])
@@ -528,7 +528,7 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
                         post_code += tmp_post
                         if process_pnext:
                             pre_code += f'WrapPnextChainHandles(layer_data, {prefix}{member.name}.pNext);\n'
-            elif member.type == 'VkObjectType':
+            elif member.type == 'VkObjectType' and member.name == 'objectType' and any(m.name == 'objectHandle' for m in members):
                 pre_code += '''
                     if (NotDispatchableHandle(objectType)) {
                         objectHandle = layer_data->Unwrap(objectHandle);

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -738,6 +738,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
             #include "chassis.h"
             #include "layer_options.h"
             #include "layer_chassis_dispatch.h"
+            #include "state_tracker/descriptor_sets.h"
             #include "chassis/chassis_modification_state.h"
 
             thread_local WriteLockGuard* ValidationObject::record_guard{};

--- a/tests/icd/CMakeLists.txt
+++ b/tests/icd/CMakeLists.txt
@@ -24,7 +24,6 @@ endif()
 # These variables enable downstream users to customize the CMake targets
 # based on the target API variant (e.g. Vulkan SC)
 set(ICD_NAME VVL_Test_ICD)
-set(GENERATED ${CMAKE_SOURCE_DIR}/layers/vulkan/generated)
 
 if(WIN32)
     add_definitions(-DVK_USE_PLATFORM_WIN32_KHR -DVK_USE_PLATFORM_WIN32_KHX -DWIN32_LEAN_AND_MEAN)
@@ -56,7 +55,7 @@ target_link_libraries(VVL_Test_ICD PRIVATE
 )
 
 target_include_directories(VVL_Test_ICD PRIVATE
-    ${GENERATED}
+    ${CMAKE_SOURCE_DIR}/layers/${API_TYPE}/generated
     .
 )
 
@@ -126,7 +125,7 @@ if (UNIX)
     set(JSON_LIBRARY_PATH "lib${ICD_NAME}.so")
 
     configure_file(${INPUT_FILE} ${UNIX_INTERMEDIATE_FILE} @ONLY)
-    install(FILES ${UNIX_INTERMEDIATE_FILE} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/vulkan/icd.d RENAME ${OUTPUT_FILE_FINAL_NAME})
+    install(FILES ${UNIX_INTERMEDIATE_FILE} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/${API_TYPE}/icd.d RENAME ${OUTPUT_FILE_FINAL_NAME})
 elseif (WIN32)
     install(FILES ${INTERMEDIATE_FILE} DESTINATION ${LAYER_INSTALL_DIR} RENAME ${OUTPUT_FILE_FINAL_NAME})
 endif()

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -435,14 +435,14 @@ static VKAPI_ATTR void VKAPI_CALL GetPhysicalDeviceQueueFamilyProperties(VkPhysi
                                                                          uint32_t* pQueueFamilyPropertyCount,
                                                                          VkQueueFamilyProperties* pQueueFamilyProperties) {
     if (pQueueFamilyProperties) {
-        std::vector<VkQueueFamilyProperties2KHR> props2(*pQueueFamilyPropertyCount,
-                                                        {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2_KHR, nullptr, {}});
-        GetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, props2.data());
+        std::vector<VkQueueFamilyProperties2> props2(*pQueueFamilyPropertyCount,
+                                                     {VK_STRUCTURE_TYPE_QUEUE_FAMILY_PROPERTIES_2, nullptr, {}});
+        GetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, props2.data());
         for (uint32_t i = 0; i < *pQueueFamilyPropertyCount; ++i) {
             pQueueFamilyProperties[i] = props2[i].queueFamilyProperties;
         }
     } else {
-        GetPhysicalDeviceQueueFamilyProperties2KHR(physicalDevice, pQueueFamilyPropertyCount, nullptr);
+        GetPhysicalDeviceQueueFamilyProperties2(physicalDevice, pQueueFamilyPropertyCount, nullptr);
     }
 }
 

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -1093,6 +1093,7 @@ TEST_F(NegativeImagelessFramebuffer, AttachmentImageFormat) {
 TEST_F(NegativeImagelessFramebuffer, MissingInheritanceRenderingInfo) {
     TEST_DESCRIPTION("Begin cmd buffer with imageless framebuffer and missing VkCommandBufferInheritanceRenderingInfo structure");
 
+    AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_IMAGELESS_FRAMEBUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::imagelessFramebuffer);
     RETURN_IF_SKIP(Init());

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -80,18 +80,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
                OpFunctionEnd
               )";
 
-    OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-                                     });
-
-    CreateComputePipelineHelper cs_pipeline(*this);
-    cs_pipeline.cs_ =
-        std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
-    cs_pipeline.LateBindPipelineInfo();
-    cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
     m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740");
-    cs_pipeline.CreateComputePipeline(false);  // need false to prevent late binding
+    VkShaderObj const cs(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
 
@@ -151,18 +141,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
                   OpFunctionEnd
                   )";
 
-    OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-                                     });
-
-    CreateComputePipelineHelper cs_pipeline(*this);
-    cs_pipeline.cs_ =
-        std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
-    cs_pipeline.LateBindPipelineInfo();
-    cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
     m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740");
-    cs_pipeline.CreateComputePipeline(false);  // need false to prevent late binding
+    VkShaderObj const cs(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
 
@@ -518,18 +498,8 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
                OpFunctionEnd
               )";
 
-    OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-                                     });
-
-    CreateComputePipelineHelper cs_pipeline(*this);
-    cs_pipeline.cs_ =
-        std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
-    cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
-    cs_pipeline.LateBindPipelineInfo();
-    cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-apiVersion-07955");
-    cs_pipeline.CreateComputePipeline(false);  // need false to prevent late binding
+    VkShaderObj const cs(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
 
@@ -583,18 +553,8 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
                   OpFunctionEnd
                   )";
 
-    OneOffDescriptorSet ds(m_device, {
-                                         {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_COMPUTE_BIT, nullptr},
-                                     });
-
-    CreateComputePipelineHelper cs_pipeline(*this);
-    cs_pipeline.cs_ =
-        std::make_unique<VkShaderObj>(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-    cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
-    cs_pipeline.LateBindPipelineInfo();
-    cs_pipeline.cp_ci_.stage.stage = VK_SHADER_STAGE_COMPUTE_BIT;  // override with wrong value
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-apiVersion-07954");
-    cs_pipeline.CreateComputePipeline(false);  // need false to prevent late binding
+    VkShaderObj const cs(this, csSource, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -1171,46 +1171,8 @@ TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
                OpFunctionEnd
     )";
 
-    VkShaderObj fs(this, fs_source.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
-
-    VkDescriptorSetLayoutBinding dslb = {0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-    const vkt::DescriptorSetLayout dsl(*m_device, {dslb});
-    const vkt::PipelineLayout pl(*m_device, {&dsl});
-
-    VkAttachmentDescription descs[2] = {
-        {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
-         VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-         VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL},
-        {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
-         VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE, VK_IMAGE_LAYOUT_GENERAL, VK_IMAGE_LAYOUT_GENERAL},
-    };
-    VkAttachmentReference color = {
-        0,
-        VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL,
-    };
-    VkAttachmentReference input = {
-        1,
-        VK_IMAGE_LAYOUT_GENERAL,
-    };
-
-    VkSubpassDescription sd = {0, VK_PIPELINE_BIND_POINT_GRAPHICS, 1, &input, 1, &color, nullptr, nullptr, 0, nullptr};
-
-    VkRenderPassCreateInfo rpci = vku::InitStructHelper();
-    rpci.flags = 0;
-    rpci.attachmentCount = 2;
-    rpci.pAttachments = descs;
-    rpci.subpassCount = 1;
-    rpci.pSubpasses = &sd;
-    rpci.dependencyCount = 0;
-    vkt::RenderPass rp(*m_device, rpci);
-    ASSERT_TRUE(rp.initialized());
-
     m_errorMonitor->SetDesiredError("VUID-VkShaderModuleCreateInfo-pCode-08740");
-    CreatePipelineHelper pipe(*this);
-    pipe.shader_stages_[1] = fs.GetStageCreateInfo();
-    pipe.gp_ci_.layout = pl.handle();
-    pipe.gp_ci_.renderPass = rp.handle();
-    pipe.CreateGraphicsPipeline();
+    VkShaderObj fs(this, fs_source.c_str(), VK_SHADER_STAGE_FRAGMENT_BIT, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3872,18 +3872,11 @@ TEST_F(NegativeSyncVal, DestroyedUnusedDescriptors) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorBindingPartiallyBound);
+    AddRequiredFeature(vkt::Feature::descriptorBindingUpdateUnusedWhilePending);
 
     RETURN_IF_SKIP(InitSyncValFramework());
-
-    VkPhysicalDeviceDescriptorIndexingFeaturesEXT indexing_features = vku::InitStructHelper();
-    auto features2 = GetPhysicalDeviceFeatures2(indexing_features);
-    RETURN_IF_SKIP(InitState(nullptr, &features2));
-    if (!indexing_features.descriptorBindingPartiallyBound) {
-        GTEST_SKIP() << "Partially bound bindings not supported, skipping test\n";
-    }
-    if (!indexing_features.descriptorBindingUpdateUnusedWhilePending) {
-        GTEST_SKIP() << "Updating unused while pending is not supported, skipping test\n";
-    }
+    RETURN_IF_SKIP(InitState());
 
     InitRenderTarget();
 


### PR DESCRIPTION
This change contains various fixes, including fixes for the following problems:
- incorrect query entry point used by vkGetCalibratedTimestampsKHR validation
- incorrect generator script logic for the malfunctioning generator script caching
- incorrect handling of empty structextends lists
- incorrect assumptions about entry points with VkObjectType parameters
- API parameterization changes for the Test ICD
- incorrect test cases still expecting "stateless" SPIR-V validation at pipeline create call
- incorrect test case dependencies