### PR TITLE
sync: Fix HandleRecord increased memory usage

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -743,23 +743,6 @@
                                             }
                                         ]
                                     }
-                                },
-                                {
-                                    "key": "sync_report_descriptor_resources",
-                                    "label": "Report descriptor resources",
-                                    "description": "Report resource handles (images, buffers, etc.) associated with descriptors. Might consume significant amount of memory for complex workloads.",
-                                    "type": "BOOL",
-                                    "default": false,
-                                    "status": "STABLE",
-                                    "dependence": {
-                                        "mode": "ALL",
-                                        "settings": [
-                                            {
-                                                "key": "validate_sync",
-                                                "value": true
-                                            }
-                                        ]
-                                    }
                                 }
                             ]
                         },

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -93,10 +93,6 @@ const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
 
-// SyncVal
-// ---
-const char *VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES = "sync_report_descriptor_resources";
-
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 
@@ -561,12 +557,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (gpuav_settings.debug_validate_instrumented_shaders || gpuav_settings.debug_dump_instrumented_shaders) {
         // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
         gpuav_settings.cache_instrumented_shaders = false;
-    }
-
-    SyncValSettings &syncval_settings = *settings_data->syncval_settings;
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_REPORT_DESCRIPTOR_RESOURCES,
-                                syncval_settings.report_descriptor_resources);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -244,20 +244,17 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
         SyncOpEntry(const SyncOpEntry &other) = default;
     };
 
-    CommandBufferAccessContext(const SyncValidator *sync_validator = nullptr);
-    CommandBufferAccessContext(SyncValidator &sync_validator, vvl::CommandBuffer *cb_state)
-        : CommandBufferAccessContext(&sync_validator) {
-        cb_state_ = cb_state;
-    }
+    CommandBufferAccessContext(SyncValidator &sync_validator, vvl::CommandBuffer *cb_state);
 
     struct AsProxyContext {};
     CommandBufferAccessContext(const CommandBufferAccessContext &real_context, AsProxyContext dummy);
+
+    ~CommandBufferAccessContext() override;
 
     // NOTE: because this class is encapsulated in syncval_state::CommandBuffer, it isn't safe
     // to use shared_from_this from the constructor.
     void SetSelfReference() { cbs_referenced_->push_back(cb_state_->shared_from_this()); }
 
-    ~CommandBufferAccessContext() override;
     const CommandExecutionContext &GetExecutionContext() const { return *this; }
 
     void Destroy() {
@@ -354,6 +351,8 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     std::vector<vvl::CommandBuffer::LabelCommand> &GetProxyLabelCommands() { return proxy_label_commands_; }
 
   private:
+    CommandBufferAccessContext(const SyncValidator &sync_validator);
+
     uint32_t AddHandle(const VulkanTypedHandle &typed_handle, uint32_t index);
 
     // As this is passing around a shared pointer to record, move to avoid needless atomics.

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -17,8 +17,4 @@
 
 #pragma once
 
-struct SyncValSettings {
-    // Report resource handles (images, buffers, etc.) associated with descriptors.
-    // Might consume significant amount of memory for complex workloads.
-    bool report_descriptor_resources = false;
-};
+struct SyncValSettings {};

--- a/layers/sync/sync_stats.h
+++ b/layers/sync/sync_stats.h
@@ -47,10 +47,18 @@ struct ValueMax32 {
 };
 
 struct Stats {
+    ~Stats();
+    bool report_on_destruction = false;
+
+    ValueMax32 command_buffer_context_counter;
+    void AddCommandBufferContext();
+    void RemoveCommandBufferContext();
+
     ValueMax32 handle_record_counter;
     void AddHandleRecord(uint32_t count = 1);
     void RemoveHandleRecord(uint32_t count = 1);
 
+    void ReportOnDestruction();
     std::string CreateReport();
 };
 
@@ -58,6 +66,9 @@ struct Stats {
 struct Stats {
     void AddHandleRecord(uint32_t count = 1) {}
     void RemoveHandleRecord(uint32_t count = 1) {}
+    void AddCommandBufferContext() {}
+    void RemoveCommandBufferContext() {}
+    void ReportOnDestruction() {}
     std::string CreateReport() { return "SyncVal stats are disabled in the current build configuration\n"; }
 };
 #endif  // VVL_ENABLE_SYNCVAL_STATS != 0

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -27,7 +27,7 @@
 #include "state_tracker/buffer_state.h"
 #include "utils/convert_utils.h"
 
-SyncValidator ::~SyncValidator() {
+SyncValidator::~SyncValidator() {
     // Instance level SyncValidator does not have much to say
     const bool device_validation_object = (device != nullptr);
     // Get environment variable. Specify non-zero number to enable
@@ -35,11 +35,7 @@ SyncValidator ::~SyncValidator() {
     const bool show_stats = !show_stats_str.empty() && std::stoul(show_stats_str) != 0;
 
     if (device_validation_object && show_stats) {
-        const std::string report = stats.CreateReport();
-        // LogInfo at this point can print the message but then hangs in the mutex lock.
-        // Everything is being destroyed here can be the reason.
-        // LogInfo("SYNCVAL_STATS", LogObjectList(), Location(vvl::Func::Empty), "%s", report.c_str());
-        std::cout << report;
+        stats.ReportOnDestruction();
     }
 }
 

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -46,6 +46,11 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     SyncValidator() { container_type = LayerObjectTypeSyncValidation; }
     ~SyncValidator();
 
+    // Stats object must be the first member of this class:
+    // - it is the first to be constructed: can observe all subsequent syncval stats events
+    // - it is the last to be destroyed: ensures there are no unreported syncval stats events.
+    mutable syncval_stats::Stats stats;  // Stats object is thread safe
+
     // Global tag range for submitted command buffers resource usage logs
     // Started the global tag count at 1 s.t. zero are invalid and ResourceUsageTag normalization can just zero them.
     mutable std::atomic<ResourceUsageTag> tag_limit_{1};  // This is reserved in Validation phase, thus mutable and atomic
@@ -58,8 +63,6 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
 
     using SignaledFences = vvl::unordered_map<VkFence, FenceSyncState>;
     SignaledFences waitable_fences_;
-
-    mutable syncval_stats::Stats stats;  // Stats update is thread safe
 
     uint32_t debug_command_number = vvl::kU32Max;
     uint32_t debug_reset_count = 1;

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -268,7 +268,7 @@ class DebugPrintfTests : public VkLayerTest {
 
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework(bool disable_queue_submit_validation = false, bool report_descriptor_resources = false);
+    void InitSyncValFramework(bool disable_queue_submit_validation = false);
     void InitSyncVal();
     void InitTimelineSemaphore();
 

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -6255,8 +6255,7 @@ TEST_F(NegativeSyncVal, DebugResourceName) {
 TEST_F(NegativeSyncVal, DebugDescriptorBufferName) {
     TEST_DESCRIPTION("Test that the name of the buffer used by the shader appears in the error message");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitSyncValFramework(false, true));
-    RETURN_IF_SKIP(InitState());
+    RETURN_IF_SKIP(InitSyncVal());
 
     vkt::Buffer buffer_a(*m_device, 128, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT);
     buffer_a.SetName("BufferA");

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -21,7 +21,7 @@
 class PositiveSyncVal : public VkSyncValTest {};
 
 // TODO: refactor this and use p_next as in gpuav instead of passing parameters about all possible options.
-void VkSyncValTest::InitSyncValFramework(bool disable_queue_submit_validation, bool enable_descriptor_resources_reporting) {
+void VkSyncValTest::InitSyncValFramework(bool disable_queue_submit_validation) {
     // Enable synchronization validation
     features_ = {VK_STRUCTURE_TYPE_VALIDATION_FEATURES_EXT, nullptr, 1u, enables_, 4, disables_};
 
@@ -37,11 +37,6 @@ void VkSyncValTest::InitSyncValFramework(bool disable_queue_submit_validation, b
     if (disable_queue_submit_validation) {
         settings[setting_count++] = {OBJECT_LAYER_NAME, "disables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1,
                                      kDisableQueuSubmitSyncValidation};
-    }
-    static const VkBool32 report_descriptor_resources = true;
-    if (enable_descriptor_resources_reporting) {
-        settings[setting_count++] = {OBJECT_LAYER_NAME, "sync_report_descriptor_resources", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
-                                     &report_descriptor_resources};
     }
 
     // The pNext of syncval_setting is modified by InitFramework that's why it can't


### PR DESCRIPTION
I forgot to clean up handles in `CommandBufferAccessContext::Reset`.
With this fix the memory consumption by HandleRecord objects in doom capture is ~7MB (previously ~700MB).

There is an opportunity to de-duplicate groups of handles which might reduce `HandleRecord` memory usage to < 1MB range for complex workloads. That's a backup plan if we need to get rid of few more MBs.

Also improvements to syncval stats system.