### PR TITLE
sync: Make QueueId deterministic

### DIFF
--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -255,7 +255,7 @@ void BestPractices::ValidateImageInQueueArmImg(Func command, const bp_state::Ima
 
 void BestPractices::ValidateImageInQueue(const vvl::Queue& qs, const vvl::CommandBuffer& cbs, Func command, bp_state::Image& state,
                                          IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level) {
-    auto queue_family = qs.queueFamilyIndex;
+    auto queue_family = qs.queue_family_index;
     auto last_usage = state.UpdateUsage(array_layer, mip_level, usage, queue_family);
 
     // Concurrent sharing usage of image with exclusive sharing mode

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -506,7 +506,8 @@ bool BestPractices::PreCallValidateQueueBindSparse(VkQueue queue, uint32_t bindI
 
     if (VendorCheckEnabled(kBPVendorNVIDIA)) {
         auto queue_state = Get<vvl::Queue>(queue);
-        if (queue_state && queue_state->queueFamilyProperties.queueFlags != (VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)) {
+        if (queue_state &&
+            queue_state->queue_family_properties.queueFlags != (VK_QUEUE_TRANSFER_BIT | VK_QUEUE_SPARSE_BINDING_BIT)) {
             skip |= LogPerformanceWarning("BestPractices-NVIDIA-QueueBindSparse-NotAsync", queue, error_obj.location,
                                           "issued on queue %s. All binds should happen on an asynchronous copy "
                                           "queue to hide the OS scheduling and submit costs.",

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -471,7 +471,7 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
                                                                               const vvl::CommandBuffer& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {
                 // Update queue family index without changing usage, signifying a correct queue family transfer
-                image->UpdateUsage(layer, level, image->GetUsageType(layer, level), qs.queueFamilyIndex);
+                image->UpdateUsage(layer, level, image->GetUsageType(layer, level), qs.queue_family_index);
             });
             return false;
         });

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -2112,7 +2112,7 @@ class ValidatorState {
     // application input.
     static bool ValidateAtQueueSubmit(const vvl::Queue *queue_state, const ValidationStateTracker &device_data, uint32_t src_family,
                                       uint32_t dst_family, const ValidatorState &val) {
-        uint32_t queue_family = queue_state->queueFamilyIndex;
+        uint32_t queue_family = queue_state->queue_family_index;
         if ((src_family != queue_family) && (dst_family != queue_family)) {
             const char *src_annotation = val.GetFamilyAnnotation(src_family);
             const char *dst_annotation = val.GetFamilyAnnotation(dst_family);

--- a/layers/gpu/core/gpu_state_tracker.cpp
+++ b/layers/gpu/core/gpu_state_tracker.cpp
@@ -51,7 +51,7 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
         VkResult result = VK_SUCCESS;
 
         VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
-        pool_create_info.queueFamilyIndex = queueFamilyIndex;
+        pool_create_info.queueFamilyIndex = queue_family_index;
         result = DispatchCreateCommandPool(shader_instrumentor_.device, &pool_create_info, nullptr, &barrier_command_pool_);
         if (result != VK_SUCCESS) {
             shader_instrumentor_.InternalError(vvl::Queue::VkHandle(), loc, "Unable to create command pool for barrier CB.");

--- a/layers/gpu/core/gpu_state_tracker.cpp
+++ b/layers/gpu/core/gpu_state_tracker.cpp
@@ -24,9 +24,10 @@ CommandBuffer::CommandBuffer(gpu::GpuShaderInstrumentor &shader_instrumentor, Vk
                              const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool)
     : vvl::CommandBuffer(shader_instrumentor, handle, pCreateInfo, pool) {}
 
-Queue::Queue(gpu::GpuShaderInstrumentor &shader_instrumentor, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
-             const VkQueueFamilyProperties &queueFamilyProperties)
-    : vvl::Queue(shader_instrumentor, q, index, flags, queueFamilyProperties), shader_instrumentor_(shader_instrumentor) {}
+Queue::Queue(gpu::GpuShaderInstrumentor &shader_instrumentor, VkQueue q, uint32_t family_index, uint32_t queue_index,
+             VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties)
+    : vvl::Queue(shader_instrumentor, q, family_index, queue_index, flags, queueFamilyProperties),
+      shader_instrumentor_(shader_instrumentor) {}
 
 Queue::~Queue() {
     if (barrier_command_buffer_) {

--- a/layers/gpu/core/gpu_state_tracker.h
+++ b/layers/gpu/core/gpu_state_tracker.h
@@ -26,8 +26,8 @@ namespace gpu_tracker {
 
 class Queue : public vvl::Queue {
   public:
-    Queue(gpu::GpuShaderInstrumentor &shader_instrumentor_, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
-          const VkQueueFamilyProperties &queueFamilyProperties);
+    Queue(gpu::GpuShaderInstrumentor &shader_instrumentor_, VkQueue q, uint32_t family_index, uint32_t queue_index,
+          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties);
     virtual ~Queue();
 
   protected:

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -83,7 +83,7 @@ class Validator : public gpu::GpuShaderInstrumentor {
     std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet, vvl::DescriptorPool*,
                                                             const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
                                                             uint32_t variable_count) final;
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
+    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
                                             const VkQueueFamilyProperties& queueFamilyProperties) final;
 
     void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -70,9 +70,11 @@ std::shared_ptr<vvl::CommandBuffer> Validator::CreateCmdBufferState(VkCommandBuf
     return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(*this, handle, pCreateInfo, pool));
 }
 
-std::shared_ptr<vvl::Queue> Validator::CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
+std::shared_ptr<vvl::Queue> Validator::CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index,
+                                                   VkDeviceQueueCreateFlags flags,
                                                    const VkQueueFamilyProperties &queueFamilyProperties) {
-    return std::static_pointer_cast<vvl::Queue>(std::make_shared<Queue>(*this, q, index, flags, queueFamilyProperties));
+    return std::static_pointer_cast<vvl::Queue>(
+        std::make_shared<Queue>(*this, q, family_index, queue_index, flags, queueFamilyProperties));
 }
 
 void Validator::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -180,10 +180,11 @@ WriteLockGuard GpuShaderInstrumentor::WriteLock() {
     }
 }
 
-std::shared_ptr<vvl::Queue> GpuShaderInstrumentor::CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
+std::shared_ptr<vvl::Queue> GpuShaderInstrumentor::CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index,
+                                                               VkDeviceQueueCreateFlags flags,
                                                                const VkQueueFamilyProperties &queueFamilyProperties) {
     return std::static_pointer_cast<vvl::Queue>(
-        std::make_shared<gpu_tracker::Queue>(*this, q, index, flags, queueFamilyProperties));
+        std::make_shared<gpu_tracker::Queue>(*this, q, family_index, queue_index, flags, queueFamilyProperties));
 }
 
 // These are the common things required for anything that deals with shader instrumentation

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -166,7 +166,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                          VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const;
 
   protected:
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags,
+    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
                                             const VkQueueFamilyProperties &queueFamilyProperties) override;
 
     template <typename CreateInfo, typename SafeCreateInfo, typename ChassisState>

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -536,8 +536,9 @@ void CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
     }
 }
 
-Queue::Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp)
-    : gpu_tracker::Queue(state, q, index, flags, qfp) {}
+Queue::Queue(Validator &state, VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+             const VkQueueFamilyProperties &qfp)
+    : gpu_tracker::Queue(state, q, family_index, queue_index, flags, qfp) {}
 
 vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
     return gpu_tracker::Queue::PreSubmit(std::move(submissions));

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -157,7 +157,8 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
 
 class Queue : public gpu_tracker::Queue {
   public:
-    Queue(Validator &state, VkQueue q, uint32_t index, VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &qfp);
+    Queue(Validator &state, VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+          const VkQueueFamilyProperties &qfp);
 
   protected:
     vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -85,10 +85,11 @@ struct PreSubmitResult {
 
 class Queue: public StateObject {
   public:
-    Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t index, VkDeviceQueueCreateFlags flags,
-          const VkQueueFamilyProperties &queueFamilyProperties)
+    Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index,
+          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties)
         : StateObject(handle, kVulkanObjectTypeQueue),
-          queueFamilyIndex(index),
+          queueFamilyIndex(family_index),
+          queue_index(queue_index),
           flags(flags),
           queueFamilyProperties(queueFamilyProperties),
           dev_data_(dev_data) {}
@@ -114,7 +115,12 @@ class Queue: public StateObject {
     // Helper that combines Notify and Wait
     void NotifyAndWait(const Location &loc, uint64_t until_seq = kU64Max);
 
+    // Queue family index. As queueFamilyIndex parameter in vkGetDeviceQueue.
     const uint32_t queueFamilyIndex;
+
+    // Index of the queue within a queue family. As queueIndex parameter in vkGetDeviceQueue.
+    const uint32_t queue_index;
+
     const VkDeviceQueueCreateFlags flags;
     const VkQueueFamilyProperties queueFamilyProperties;
 

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -83,15 +83,15 @@ struct PreSubmitResult {
     uint64_t submission_with_external_fence_seq = 0;
 };
 
-class Queue: public StateObject {
+class Queue : public StateObject {
   public:
     Queue(ValidationStateTracker &dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index,
           VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties)
         : StateObject(handle, kVulkanObjectTypeQueue),
-          queueFamilyIndex(family_index),
+          queue_family_index(family_index),
           queue_index(queue_index),
-          flags(flags),
-          queueFamilyProperties(queueFamilyProperties),
+          create_flags(flags),
+          queue_family_properties(queueFamilyProperties),
           dev_data_(dev_data) {}
 
     ~Queue() { Destroy(); }
@@ -115,14 +115,15 @@ class Queue: public StateObject {
     // Helper that combines Notify and Wait
     void NotifyAndWait(const Location &loc, uint64_t until_seq = kU64Max);
 
+  public:
     // Queue family index. As queueFamilyIndex parameter in vkGetDeviceQueue.
-    const uint32_t queueFamilyIndex;
+    const uint32_t queue_family_index;
 
     // Index of the queue within a queue family. As queueIndex parameter in vkGetDeviceQueue.
     const uint32_t queue_index;
 
-    const VkDeviceQueueCreateFlags flags;
-    const VkQueueFamilyProperties queueFamilyProperties;
+    const VkDeviceQueueCreateFlags create_flags;
+    const VkQueueFamilyProperties queue_family_properties;
 
     // Track command buffer label stack accross all command buffers submitted to this queue.
     // Access to this variable relies on external queue synchronization.
@@ -135,6 +136,7 @@ class Queue: public StateObject {
     // Stop per-queue label tracking after the first label mismatch error.
     // Access to this variable relies on external queue synchronization.
     bool found_unbalanced_cmdbuf_label = false;
+
   protected:
     // called from the various PostCallRecordQueueSubmit() methods
     virtual void PostSubmit(QueueSubmission &submission) {}
@@ -160,4 +162,4 @@ class Queue: public StateObject {
     // condition to wake up the queue's thread
     std::condition_variable cond_;
 };
-} // namespace vvl
+}  // namespace vvl

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -313,14 +313,6 @@ class ValidationStateTracker : public ValidationObject {
         }
     }
 
-    template <typename State, typename Fn>
-    void ForEachShared(Fn&& fn) {
-        auto& map = GetStateMap<State>();
-        for (const auto& entry : map.snapshot()) {
-            fn(entry.second);
-        }
-    }
-
     template <typename State>
     void ForEach(std::function<void(const State& s)> fn) const {
         const auto& map = GetStateMap<State>();

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -478,7 +478,8 @@ class ValidationStateTracker : public ValidationObject {
                                                             VkVideoSessionMemoryRequirementsKHR* pMemoryRequirements,
                                                             const RecordObject& record_obj) override;
 
-    virtual std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t queue_family_index, VkDeviceQueueCreateFlags flags,
+    virtual std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t queue_family_index, uint32_t queue_index,
+                                                    VkDeviceQueueCreateFlags flags,
                                                     const VkQueueFamilyProperties& queueFamilyProperties);
 
     void PostCallRecordGetDeviceQueue(VkDevice device, uint32_t queueFamilyIndex, uint32_t queueIndex, VkQueue* pQueue,
@@ -1471,7 +1472,8 @@ class ValidationStateTracker : public ValidationObject {
     void RecordEnumeratePhysicalDeviceQueueFamilyPerformanceQueryCounters(VkPhysicalDevice physicalDevice,
                                                                           uint32_t queueFamilyIndex, uint32_t* pCounterCount,
                                                                           VkPerformanceCounterKHR* pCounters);
-    void RecordGetDeviceQueueState(uint32_t queue_family_index, VkDeviceQueueCreateFlags flags, VkQueue queue);
+    void RecordGetDeviceQueueState(uint32_t queue_family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+                                   VkQueue queue);
     void RecordGetExternalFenceState(VkFence fence, VkExternalFenceHandleTypeFlagBits handle_type, const Location& loc);
     void RecordGetImageMemoryRequirementsState(VkImage image, const VkImageMemoryRequirementsInfo2* pInfo);
     void RecordImportSemaphoreState(VkSemaphore semaphore, VkExternalSemaphoreHandleTypeFlagBits handle_type,

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -305,7 +305,7 @@ class QueueSyncState {
     QueueBatchContext::Ptr LastBatch() { return last_batch_; }
     void UpdateLastBatch();
     const vvl::Queue *GetQueueState() const { return queue_state_.get(); }
-    VkQueueFlags GetQueueFlags() const { return queue_state_->queueFamilyProperties.queueFlags; }
+    VkQueueFlags GetQueueFlags() const { return queue_state_->queue_family_properties.queueFlags; }
     QueueId GetQueueId() const { return id_; }
 
     // Method is const but updates mutable sumbit_index atomically.

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -611,8 +611,8 @@ void SyncValidator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, cons
         std::vector<std::shared_ptr<vvl::Queue>> queues;
         ForEachShared<vvl::Queue>([&queues](const std::shared_ptr<vvl::Queue> &queue) { queues.emplace_back(queue); });
         std::sort(queues.begin(), queues.end(), [](const auto &q1, const auto &q2) {
-            return (q1->queueFamilyIndex < q2->queueFamilyIndex) ||
-                   (q1->queueFamilyIndex == q2->queueFamilyIndex && q1->queue_index < q2->queue_index);
+            return (q1->queue_family_index < q2->queue_family_index) ||
+                   (q1->queue_family_index == q2->queue_family_index && q1->queue_index < q2->queue_index);
         });
         return queues;
     };


### PR DESCRIPTION
This allows syncval to have deterministic `QueueId` between runs that simplifies debugging. It can be frustrating when during long debug session you learn how QueueId numbers map to specific queues and on the next run the mapping changes.

`vvl::Queue` adds `queue_index` field that is the index of the queue within a queue family.