### PR TITLE
layers: Reorganize renderpass framebuffer checks

### DIFF
--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -565,15 +565,12 @@ bool CoreChecks::ValidateCmdBeginRenderPass(VkCommandBuffer commandBuffer, const
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
     if (device_group_begin_info) {
         const LogObjectList objlist(commandBuffer, pRenderPassBegin->renderPass);
-        skip |=
-            ValidateDeviceMaskToPhysicalDeviceCount(device_group_begin_info->deviceMask, objlist,
-                                                    rp_begin_loc.pNext(Struct::VkDeviceGroupRenderPassBeginInfo, Field::deviceMask),
-                                                    "VUID-VkDeviceGroupRenderPassBeginInfo-deviceMask-00905");
-        skip |= ValidateDeviceMaskToZero(device_group_begin_info->deviceMask, objlist,
-                                         rp_begin_loc.pNext(Struct::VkDeviceGroupRenderPassBeginInfo, Field::deviceMask),
+        const Location device_mask_loc = rp_begin_loc.pNext(Struct::VkDeviceGroupRenderPassBeginInfo, Field::deviceMask);
+        skip |= ValidateDeviceMaskToPhysicalDeviceCount(device_group_begin_info->deviceMask, objlist, device_mask_loc,
+                                                        "VUID-VkDeviceGroupRenderPassBeginInfo-deviceMask-00905");
+        skip |= ValidateDeviceMaskToZero(device_group_begin_info->deviceMask, objlist, device_mask_loc,
                                          "VUID-VkDeviceGroupRenderPassBeginInfo-deviceMask-00906");
-        skip |= ValidateDeviceMaskToCommandBuffer(cb_state, device_group_begin_info->deviceMask, objlist,
-                                                  rp_begin_loc.pNext(Struct::VkDeviceGroupRenderPassBeginInfo, Field::deviceMask),
+        skip |= ValidateDeviceMaskToCommandBuffer(cb_state, device_group_begin_info->deviceMask, objlist, device_mask_loc,
                                                   "VUID-VkDeviceGroupRenderPassBeginInfo-deviceMask-00907");
 
         if (device_group_begin_info->deviceRenderAreaCount != 0 &&
@@ -3513,23 +3510,7 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     bool skip = false;
     skip |= ValidateCmd(*cb_state, error_obj.location);
 
-    if (!enabled_features.dynamicRendering) {
-        skip |= LogError("VUID-vkCmdBeginRendering-dynamicRendering-06446", commandBuffer, error_obj.location,
-                         "dynamicRendering is not enabled.");
-    }
-
     const Location rendering_info_loc = error_obj.location.dot(Field::pRenderingInfo);
-    if ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_INLINE_BIT_EXT) != 0 && !enabled_features.nestedCommandBuffer &&
-        !enabled_features.maintenance7) {
-        skip |= LogError("VUID-VkRenderingInfo-flags-10012", commandBuffer, rendering_info_loc.dot(Field::flags),
-                         "are %s, but nestedCommandBuffer and maintenance7 feature were not enabled.",
-                         string_VkRenderingFlags(pRenderingInfo->flags).c_str());
-    }
-    if (pRenderingInfo->layerCount > phys_dev_props.limits.maxFramebufferLayers) {
-        skip |= LogError("VUID-VkRenderingInfo-layerCount-07817", commandBuffer, rendering_info_loc.dot(Field::layerCount),
-                         "(%" PRIu32 ") is greater than maxFramebufferLayers (%" PRIu32 ").", pRenderingInfo->layerCount,
-                         phys_dev_props.limits.maxFramebufferLayers);
-    }
 
     if (cb_state->IsSeconary() && ((pRenderingInfo->flags & VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR) != 0) &&
         !enabled_features.nestedCommandBuffer) {
@@ -3598,11 +3579,6 @@ bool CoreChecks::PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer,
     skip |= ValidateBeginRenderingFragmentShadingRate(commandBuffer, *pRenderingInfo, rendering_info_loc);
     skip |= ValidateBeginRenderingDeviceGroup(commandBuffer, *pRenderingInfo, rendering_info_loc);
     skip |= ValidateBeginRenderingMultisampledRenderToSingleSampled(commandBuffer, *pRenderingInfo, rendering_info_loc);
-
-    if ((enabled_features.multiview == VK_FALSE) && (pRenderingInfo->viewMask != 0)) {
-        skip |= LogError("VUID-VkRenderingInfo-multiview-06127", commandBuffer, rendering_info_loc.dot(Field::viewMask),
-                         "%" PRId32 " but the multiview feature is not enabled.", pRenderingInfo->viewMask);
-    }
 
     const auto *device_group_begin_info = vku::FindStructInPNextChain<VkDeviceGroupRenderPassBeginInfo>(pRenderingInfo->pNext);
     const bool non_zero_device_render_area = device_group_begin_info && device_group_begin_info->deviceRenderAreaCount != 0;
@@ -4146,7 +4122,7 @@ void CoreChecks::PostCallRecordCmdNextSubpass2(VkCommandBuffer commandBuffer, co
     RecordCmdNextSubpassLayouts(commandBuffer, pSubpassBeginInfo->contents);
 }
 
-bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attachments, const VkFramebufferCreateInfo *fbci,
+bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attachments, const VkFramebufferCreateInfo &fbci,
                             VkImageUsageFlagBits usage_flag, const char *vuid, const Location &create_info_loc) const {
     bool skip = false;
 
@@ -4156,11 +4132,11 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
     for (uint32_t attach = 0; attach < count; attach++) {
         const uint32_t fb_attachment = attachments[attach].attachment;
         // Attachment counts are verified elsewhere, but prevent an invalid access
-        if (fb_attachment == VK_ATTACHMENT_UNUSED || fb_attachment >= fbci->attachmentCount) {
+        if (fb_attachment == VK_ATTACHMENT_UNUSED || fb_attachment >= fbci.attachmentCount) {
             continue;
         }
-        if ((fbci->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
-            const VkImageView *image_view = &fbci->pAttachments[fb_attachment];
+        if ((fbci.flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
+            const VkImageView *image_view = &fbci.pAttachments[fb_attachment];
             if (auto view_state = Get<vvl::ImageView>(*image_view)) {
                 const auto &ici = view_state->image_state->create_info;
                 auto creation_usage = ici.usage;
@@ -4175,7 +4151,8 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
                 }
             }
         } else {
-            const VkFramebufferAttachmentsCreateInfo *fbaci = vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(fbci->pNext);
+            const VkFramebufferAttachmentsCreateInfo *fbaci =
+                vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(fbci.pNext);
             if (fbaci != nullptr && fbaci->pAttachmentImageInfos != nullptr && fbaci->attachmentImageInfoCount > fb_attachment) {
                 uint32_t image_usage = fbaci->pAttachmentImageInfos[fb_attachment].usage;
                 if ((image_usage & usage_flag) == 0) {
@@ -4190,21 +4167,21 @@ bool CoreChecks::MatchUsage(uint32_t count, const VkAttachmentReference2 *attach
 }
 
 bool CoreChecks::MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, const VkAttachmentReference2 *attachments,
-                                                                const VkFramebufferCreateInfo *fbci,
-                                                                const VkRenderPassCreateInfo2 *rpci, uint32_t subpass,
+                                                                const VkFramebufferCreateInfo &fbci,
+                                                                const VkRenderPassCreateInfo2 &rpci, uint32_t subpass,
                                                                 VkSampleCountFlagBits sample_count,
                                                                 const Location &create_info_loc) const {
     bool skip = false;
 
     for (uint32_t attach = 0; attach < count; attach++) {
         const uint32_t fb_attachment = attachments[attach].attachment;
-        if (fb_attachment == VK_ATTACHMENT_UNUSED || fb_attachment >= fbci->attachmentCount) {
+        if (fb_attachment == VK_ATTACHMENT_UNUSED || fb_attachment >= fbci.attachmentCount) {
             continue;
         }
 
-        const auto renderpass_samples = rpci->pAttachments[fb_attachment].samples;
+        const auto renderpass_samples = rpci.pAttachments[fb_attachment].samples;
         if (renderpass_samples == VK_SAMPLE_COUNT_1_BIT) {
-            const VkImageView *image_view = &fbci->pAttachments[fb_attachment];
+            const VkImageView *image_view = &fbci.pAttachments[fb_attachment];
             auto view_state = Get<vvl::ImageView>(*image_view);
             ASSERT_AND_CONTINUE(view_state);
             auto image_state = view_state->image_state;
@@ -4251,56 +4228,11 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
     bool skip = false;
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     const Location create_info_loc = error_obj.location.dot(Field::pCreateInfo);
-    const auto *framebuffer_attachments_create_info = vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(pCreateInfo->pNext);
-    if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) != 0) {
-        if (!enabled_features.imagelessFramebuffer) {
-            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03189", device, create_info_loc.dot(Field::flags),
-                             "includes VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, but the imagelessFramebuffer feature is not enabled.");
-        }
-
-        if (framebuffer_attachments_create_info == nullptr) {
-            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03190", device, create_info_loc.dot(Field::flags),
-                             "includes VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT, but no instance of VkFramebufferAttachmentsCreateInfo "
-                             "is present in the pNext chain.");
-        } else {
-            if (framebuffer_attachments_create_info->attachmentImageInfoCount != 0 &&
-                framebuffer_attachments_create_info->attachmentImageInfoCount != pCreateInfo->attachmentCount) {
-                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03191", device,
-                                 create_info_loc.pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::attachmentImageInfoCount),
-                                 "is %" PRIu32 " which is not equal to pCreateInfo->attachmentCount (%" PRIu32 ").",
-                                 framebuffer_attachments_create_info->attachmentImageInfoCount, pCreateInfo->attachmentCount);
-            }
-        }
-    }
-    // Verify FB dimensions are within physical device limits
-    if (pCreateInfo->width > phys_dev_props.limits.maxFramebufferWidth) {
-        skip |= LogError("VUID-VkFramebufferCreateInfo-width-00886", device, create_info_loc.dot(Field::width),
-                         "(%" PRIu32 ") exceeds physical device limits (%" PRIu32 ").", pCreateInfo->width,
-                         phys_dev_props.limits.maxFramebufferWidth);
-    }
-    if (pCreateInfo->height > phys_dev_props.limits.maxFramebufferHeight) {
-        skip |= LogError("VUID-VkFramebufferCreateInfo-height-00888", device, create_info_loc.dot(Field::height),
-                         "(%" PRIu32 ") exceeds physical device limits (%" PRIu32 ").", pCreateInfo->height,
-                         phys_dev_props.limits.maxFramebufferHeight);
-    }
-    if (pCreateInfo->layers > phys_dev_props.limits.maxFramebufferLayers) {
-        skip |= LogError("VUID-VkFramebufferCreateInfo-layers-00890", device, create_info_loc.dot(Field::layers),
-                         "(%" PRIu32 ") exceeds physical device limits (%" PRIu32 ").", pCreateInfo->layers,
-                         phys_dev_props.limits.maxFramebufferLayers);
-    }
 
     auto rp_state = Get<vvl::RenderPass>(pCreateInfo->renderPass);
     ASSERT_AND_RETURN_SKIP(rp_state);
 
     const VkRenderPassCreateInfo2 *rpci = rp_state->create_info.ptr();
-
-    bool b_has_non_zero_view_masks = false;
-    for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
-        if (rpci->pSubpasses[i].viewMask != 0) {
-            b_has_non_zero_view_masks = true;
-            break;
-        }
-    }
 
     if (rpci->attachmentCount != pCreateInfo->attachmentCount) {
         skip |= LogError("VUID-VkFramebufferCreateInfo-attachmentCount-00876", pCreateInfo->renderPass,
@@ -4310,6 +4242,8 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
         return skip;  // nothing else to validate
     }
 
+    const auto *framebuffer_attachments_create_info =
+        vku::FindStructInPNextChain<VkFramebufferAttachmentsCreateInfo>(pCreateInfo->pNext);
     if (framebuffer_attachments_create_info) {
         for (const auto [i, attachment_image_info] :
              vvl::enumerate(framebuffer_attachments_create_info->pAttachmentImageInfos,
@@ -4333,400 +4267,421 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
 
     // attachmentCounts match, so make sure corresponding attachment details line up
     if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
-        const VkImageView *image_views = pCreateInfo->pAttachments;
-        for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
-            const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
-            auto view_state = Get<vvl::ImageView>(image_views[i]);
-            ASSERT_AND_CONTINUE(view_state);
-            auto &ivci = view_state->create_info;
-            auto &subresource_range = view_state->normalized_subresource_range;
-            if (ivci.format != rpci->pAttachments[i].format) {
-                LogObjectList objlist(pCreateInfo->renderPass, image_views[i]);
-                skip |=
-                    LogError("VUID-VkFramebufferCreateInfo-pAttachments-00880", objlist, attachment_loc,
+        skip |= ValidateFrameBufferSubpasses(*pCreateInfo, create_info_loc, *rpci);
+        skip |= ValidateFrameBufferAttachments(*pCreateInfo, create_info_loc, *rp_state, *rpci);
+    } else if (framebuffer_attachments_create_info) {
+        skip |= ValidateFrameBufferAttachmentsImageless(*pCreateInfo, create_info_loc, *rpci, *framebuffer_attachments_create_info);
+    }
+
+    if (rp_state->has_multiview_enabled && pCreateInfo->layers != 1) {
+        skip |=
+            LogError("VUID-VkFramebufferCreateInfo-renderPass-02531", pCreateInfo->renderPass, create_info_loc.dot(Field::layers),
+                     "is %" PRIu32 " but renderPass (%s) was specified with non-zero view masks.", pCreateInfo->layers,
+                     FormatHandle(pCreateInfo->renderPass).c_str());
+    }
+
+    return skip;
+}
+
+bool CoreChecks::ValidateFrameBufferAttachments(const VkFramebufferCreateInfo &create_info, const Location &create_info_loc,
+                                                const vvl::RenderPass &rp_state, const VkRenderPassCreateInfo2 &rpci) const {
+    bool skip = false;
+
+    const VkImageView *image_views = create_info.pAttachments;
+    for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
+        const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
+        auto view_state = Get<vvl::ImageView>(image_views[i]);
+        ASSERT_AND_CONTINUE(view_state);
+        auto &ivci = view_state->create_info;
+        auto &subresource_range = view_state->normalized_subresource_range;
+        if (ivci.format != rpci.pAttachments[i].format) {
+            LogObjectList objlist(create_info.renderPass, image_views[i]);
+            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00880", objlist, attachment_loc,
                              "has format of %s that does not match the format of %s used by the corresponding attachment for %s.",
-                             string_VkFormat(ivci.format), string_VkFormat(rpci->pAttachments[i].format),
-                             FormatHandle(pCreateInfo->renderPass).c_str());
-            } else if (ivci.format == VK_FORMAT_UNDEFINED) {
-                // both have external foramts
-                const uint64_t attachment_external_format = GetExternalFormat(rpci->pAttachments[i].pNext);
-                if (view_state->image_state->ahb_format != attachment_external_format) {
-                    LogObjectList objlist(pCreateInfo->renderPass, image_views[i]);
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-09350", objlist, attachment_loc,
-                                     "has externalFormat %" PRIu64 " that does not match the externalFormat of %" PRIu64
-                                     " used by the corresponding attachment for %s.",
-                                     view_state->image_state->ahb_format, attachment_external_format,
-                                     FormatHandle(pCreateInfo->renderPass).c_str());
-                }
+                             string_VkFormat(ivci.format), string_VkFormat(rpci.pAttachments[i].format),
+                             FormatHandle(create_info.renderPass).c_str());
+        } else if (ivci.format == VK_FORMAT_UNDEFINED) {
+            // both have external foramts
+            const uint64_t attachment_external_format = GetExternalFormat(rpci.pAttachments[i].pNext);
+            if (view_state->image_state->ahb_format != attachment_external_format) {
+                LogObjectList objlist(create_info.renderPass, image_views[i]);
+                skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-09350", objlist, attachment_loc,
+                                 "has externalFormat %" PRIu64 " that does not match the externalFormat of %" PRIu64
+                                 " used by the corresponding attachment for %s.",
+                                 view_state->image_state->ahb_format, attachment_external_format,
+                                 FormatHandle(create_info.renderPass).c_str());
             }
+        }
 
-            const auto &ici = view_state->image_state->create_info;
-            if (ici.samples != rpci->pAttachments[i].samples) {
-                LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                skip |=
-                    LogError("VUID-VkFramebufferCreateInfo-pAttachments-00881", objlist, attachment_loc,
+        const auto &ici = view_state->image_state->create_info;
+        if (ici.samples != rpci.pAttachments[i].samples) {
+            LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00881", objlist, attachment_loc,
                              "has %s samples that do not match the %s samples used by the corresponding attachment for %s.",
-                             string_VkSampleCountFlagBits(ici.samples), string_VkSampleCountFlagBits(rpci->pAttachments[i].samples),
-                             FormatHandle(pCreateInfo->renderPass).c_str());
-            }
+                             string_VkSampleCountFlagBits(ici.samples), string_VkSampleCountFlagBits(rpci.pAttachments[i].samples),
+                             FormatHandle(create_info.renderPass).c_str());
+        }
 
-            // Verify that image memory is valid
-            if (auto image_data = Get<vvl::Image>(ivci.image)) {
-                // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5598
-                skip |= ValidateMemoryIsBoundToImage(LogObjectList(ivci.image), *image_data, attachment_loc,
-                                                     "UNASSIGNED-VkFramebufferCreateInfo-BoundResourceFreedMemoryAccess");
-            }
+        // Verify that image memory is valid
+        if (auto image_data = Get<vvl::Image>(ivci.image)) {
+            // VU being worked on https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/5598
+            skip |= ValidateMemoryIsBoundToImage(LogObjectList(ivci.image), *image_data, attachment_loc,
+                                                 "UNASSIGNED-VkFramebufferCreateInfo-BoundResourceFreedMemoryAccess");
+        }
 
-            // Verify that view only has a single mip level
-            if (subresource_range.levelCount != 1) {
-                LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00883", objlist, attachment_loc,
-                                 "has mip levelCount of %" PRIu32
-                                 " but only a single mip level (levelCount ==  1) is allowed when creating a Framebuffer.",
-                                 subresource_range.levelCount);
-            }
-            const uint32_t mip_level = subresource_range.baseMipLevel;
-            uint32_t mip_width = std::max(1u, ici.extent.width >> mip_level);
-            uint32_t mip_height = std::max(1u, ici.extent.height >> mip_level);
-            bool used_as_input_color_resolve_depth_stencil_attachment = false;
-            bool used_as_fragment_shading_rate_attachment = false;
-            bool fsr_non_zero_viewmasks = false;
+        // Verify that view only has a single mip level
+        if (subresource_range.levelCount != 1) {
+            LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00883", objlist, attachment_loc,
+                             "has mip levelCount of %" PRIu32
+                             " but only a single mip level (levelCount ==  1) is allowed when creating a Framebuffer.",
+                             subresource_range.levelCount);
+        }
+        const uint32_t mip_level = subresource_range.baseMipLevel;
+        uint32_t mip_width = std::max(1u, ici.extent.width >> mip_level);
+        uint32_t mip_height = std::max(1u, ici.extent.height >> mip_level);
+        bool used_as_input_color_resolve_depth_stencil_attachment = false;
+        bool used_as_fragment_shading_rate_attachment = false;
+        bool fsr_non_zero_viewmasks = false;
 
-            for (uint32_t j = 0; j < rpci->subpassCount; ++j) {
-                const VkSubpassDescription2 &subpass = rpci->pSubpasses[j];
+        for (uint32_t j = 0; j < rpci.subpassCount; ++j) {
+            const VkSubpassDescription2 &subpass = rpci.pSubpasses[j];
 
-                int highest_view_bit = MostSignificantBit(subpass.viewMask);
+            int highest_view_bit = MostSignificantBit(subpass.viewMask);
 
-                for (uint32_t k = 0; k < rpci->pSubpasses[j].inputAttachmentCount; ++k) {
-                    if (subpass.pInputAttachments[k].attachment == i) {
-                        used_as_input_color_resolve_depth_stencil_attachment = true;
-                        break;
-                    }
-                }
-
-                for (uint32_t k = 0; k < rpci->pSubpasses[j].colorAttachmentCount; ++k) {
-                    if (subpass.pColorAttachments[k].attachment == i ||
-                        (subpass.pResolveAttachments && subpass.pResolveAttachments[k].attachment == i)) {
-                        used_as_input_color_resolve_depth_stencil_attachment = true;
-                        break;
-                    }
-                }
-
-                if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment == i) {
+            for (uint32_t k = 0; k < rpci.pSubpasses[j].inputAttachmentCount; ++k) {
+                if (subpass.pInputAttachments[k].attachment == i) {
                     used_as_input_color_resolve_depth_stencil_attachment = true;
-                }
-
-                if (used_as_input_color_resolve_depth_stencil_attachment) {
-                    if (static_cast<int32_t>(subresource_range.layerCount) <= highest_view_bit) {
-                        LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-04536", objlist, attachment_loc,
-                                         "has a layer count (%" PRIu32
-                                         ") less than or equal to the highest bit in the view mask (%i) of subpass %" PRIu32 ".",
-                                         subresource_range.layerCount, highest_view_bit, j);
-                    }
-                }
-
-                if (enabled_features.attachmentFragmentShadingRate) {
-                    const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
-                    if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment &&
-                        fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
-                        used_as_fragment_shading_rate_attachment = true;
-                        const bool validate_render_area =
-                            !enabled_features.maintenance7 ||
-                            !phys_dev_ext_props.maintenance7_props.robustFragmentShadingRateAttachmentAccess;
-                        if (validate_render_area &&
-                            (mip_width * fsr_attachment->shadingRateAttachmentTexelSize.width) < pCreateInfo->width) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04539", objlist, attachment_loc,
-                                             "mip level %" PRIu32
-                                             " is used as a "
-                                             "fragment shading rate attachment in subpass %" PRIu32
-                                             ", but the product of its "
-                                             "width (%" PRIu32
-                                             ") and the "
-                                             "specified shading rate texel width (%" PRIu32
-                                             ") are smaller than the "
-                                             "corresponding framebuffer width (%" PRIu32 ").",
-                                             subresource_range.baseMipLevel, j, mip_width,
-                                             fsr_attachment->shadingRateAttachmentTexelSize.width, pCreateInfo->width);
-                        }
-                        if (validate_render_area &&
-                            (mip_height * fsr_attachment->shadingRateAttachmentTexelSize.height) < pCreateInfo->height) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04540", objlist, attachment_loc,
-                                             "mip level %" PRIu32
-                                             " is used as a "
-                                             "fragment shading rate attachment in subpass %" PRIu32
-                                             ", but the product of its "
-                                             "height (%" PRIu32
-                                             ") and the "
-                                             "specified shading rate texel height (%" PRIu32
-                                             ") are smaller than the corresponding "
-                                             "framebuffer height (%" PRIu32 ").",
-                                             subresource_range.baseMipLevel, j, mip_height,
-                                             fsr_attachment->shadingRateAttachmentTexelSize.height, pCreateInfo->height);
-                        }
-                        if (highest_view_bit >= 0) {
-                            fsr_non_zero_viewmasks = true;
-                        }
-                        if (static_cast<int32_t>(subresource_range.layerCount) <= highest_view_bit &&
-                            subresource_range.layerCount != 1) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |=
-                                LogError("VUID-VkFramebufferCreateInfo-flags-04537", objlist, attachment_loc,
-                                         "has a layer count (%" PRIu32
-                                         ") less than or equal to the highest bit in the view mask (%i) of subpass %" PRIu32 ".",
-                                         subresource_range.layerCount, highest_view_bit, j);
-                        }
-                    }
-                }
-
-                if (enabled_features.fragmentDensityMap && api_version >= VK_API_VERSION_1_1) {
-                    const auto *fdm_attachment =
-                        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
-
-                    if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
-                        int32_t layer_count = view_state->normalized_subresource_range.layerCount;
-                        if (b_has_non_zero_view_masks && layer_count != 1 && layer_count <= highest_view_bit) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
-                                             "has a layer count (%" PRId32
-                                             ") different than 1 or lower than the most significant bit in viewMask (%i"
-                                             ") but renderPass (%s) was specified with non-zero view masks.",
-                                             layer_count, highest_view_bit, FormatHandle(pCreateInfo->renderPass).c_str());
-                        }
-
-                        if (!b_has_non_zero_view_masks && layer_count != 1) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
-                                             "has a layer count (%" PRIu32
-                                             ") not equal to 1 but renderPass (%s) was not specified with non-zero view masks.",
-                                             layer_count, FormatHandle(pCreateInfo->renderPass).c_str());
-                        }
-                    }
-                }
-
-                if (enabled_features.externalFormatResolve && !android_external_format_resolve_null_color_attachment_prop &&
-                    subpass.pResolveAttachments && subpass.pResolveAttachments[0].attachment == i && subpass.pColorAttachments) {
-                    const uint64_t attachment_external_format =
-                        GetExternalFormat(rpci->pAttachments[subpass.pResolveAttachments[0].attachment].pNext);
-                    auto it = ahb_ext_resolve_formats_map.find(attachment_external_format);
-                    if (it != ahb_ext_resolve_formats_map.end()) {
-                        VkFormat color_format = rpci->pAttachments[subpass.pColorAttachments[0].attachment].format;
-                        if (it->second != color_format) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i]);
-                            skip |= LogError(
-                                "VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349", objlist,
-                                attachment_loc,
-                                "subpass[%" PRIu32 "].pResolveAttachments[0].attachment %" PRIu32 " has externalFormat %" PRIu64
-                                " which corresponds to needing a color attachment format of %s, but the format is %s.",
-                                j, i, attachment_external_format, string_VkFormat(it->second), string_VkFormat(color_format));
-                        }
-                    }
+                    break;
                 }
             }
 
-            if (enabled_features.fragmentDensityMap) {
-                const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
-                if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
-                    if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
-                        uint32_t ceiling_width = vvl::GetQuotientCeil(
-                            pCreateInfo->width, phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width);
-                        if (mip_width < ceiling_width) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02555", objlist, attachment_loc,
-                                             "mip level %" PRIu32
-                                             " has width "
-                                             "smaller than the corresponding the ceiling of framebuffer width / "
-                                             "maxFragmentDensityTexelSize.width "
-                                             "Here are the respective dimensions for attachment #%" PRIu32
-                                             ", the ceiling value:\n "
-                                             "attachment #%" PRIu32
-                                             ", framebuffer:\n"
-                                             "width: %" PRIu32 ", the ceiling value: %" PRIu32 "\n",
-                                             subresource_range.baseMipLevel, i, i, mip_width, ceiling_width);
-                        }
-                        uint32_t ceiling_height = vvl::GetQuotientCeil(
-                            pCreateInfo->height, phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height);
-                        if (mip_height < ceiling_height) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02556", objlist, attachment_loc,
-                                             "mip level %" PRIu32
-                                             " has height smaller than the corresponding the ceiling of framebuffer height / "
-                                             "maxFragmentDensityTexelSize.height "
-                                             "Here are the respective dimensions for attachment #%" PRIu32
-                                             ", the ceiling value:\n "
-                                             "attachment #%" PRIu32
-                                             ", framebuffer:\n"
-                                             "height: %" PRIu32 ", the ceiling value: %" PRIu32 "\n",
-                                             subresource_range.baseMipLevel, i, i, mip_height, ceiling_height);
-                        }
-                        if (view_state->normalized_subresource_range.layerCount != 1 &&
-                            !IsExtEnabled(device_extensions.vk_khr_multiview)) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
-                                             "is referenced by "
-                                             "VkRenderPassFragmentDensityMapCreateInfoEXT::fragmentDensityMapAttachment in "
-                                             "the pNext chain, but it was create with subresourceRange.layerCount (%" PRIu32
-                                             ") different from 1.",
-                                             view_state->normalized_subresource_range.layerCount);
-                        }
-                        if ((ici.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) != 0) {
-                            LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02552", objlist, attachment_loc,
-                                             "must not be created with flag value VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT if it is "
-                                             "used as a fragment density map");
-                        }
-                    } else if (!enabled_features.fragmentDensityMapNonSubsampledImages &&
-                               (ici.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) == 0) {
-                        LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02553", objlist, attachment_loc,
-                                         "is not created with flag value "
-                                         "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT and "
-                                         "fragmentDensityMapNonSubsampledImages is not enabled");
-                    }
+            for (uint32_t k = 0; k < rpci.pSubpasses[j].colorAttachmentCount; ++k) {
+                if (subpass.pColorAttachments[k].attachment == i ||
+                    (subpass.pResolveAttachments && subpass.pResolveAttachments[k].attachment == i)) {
+                    used_as_input_color_resolve_depth_stencil_attachment = true;
+                    break;
                 }
+            }
+
+            if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment == i) {
+                used_as_input_color_resolve_depth_stencil_attachment = true;
             }
 
             if (used_as_input_color_resolve_depth_stencil_attachment) {
-                if (mip_width < pCreateInfo->width) {
-                    LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04533", objlist, attachment_loc,
-                                     "mip level %" PRIu32 " has width (%" PRIu32
-                                     ") smaller than the corresponding framebuffer width (%" PRIu32 ").",
-                                     mip_level, mip_width, pCreateInfo->width);
-                }
-                if (mip_height < pCreateInfo->height) {
-                    LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04534", objlist, attachment_loc,
-                                     "mip level %" PRIu32 " has height (%" PRIu32
-                                     ") smaller than the corresponding framebuffer height (%" PRIu32 ").",
-                                     mip_level, mip_height, pCreateInfo->height);
-                }
-                uint32_t layerCount = view_state->GetAttachmentLayerCount();
-                if (layerCount < pCreateInfo->layers) {
-                    LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04535", objlist, attachment_loc,
+                if (static_cast<int32_t>(subresource_range.layerCount) <= highest_view_bit) {
+                    LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                    skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-04536", objlist, attachment_loc,
                                      "has a layer count (%" PRIu32
-                                     ") smaller than the corresponding framebuffer layer count (%" PRIu32 ").",
-                                     layerCount, pCreateInfo->layers);
+                                     ") less than or equal to the highest bit in the view mask (%i) of subpass %" PRIu32 ".",
+                                     subresource_range.layerCount, highest_view_bit, j);
                 }
             }
 
-            if (used_as_fragment_shading_rate_attachment && !fsr_non_zero_viewmasks) {
-                if (subresource_range.layerCount != 1 && subresource_range.layerCount < pCreateInfo->layers) {
-                    LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04538", objlist, attachment_loc,
-                                     "has a layer count (%" PRIu32
-                                     ") "
-                                     "smaller than the corresponding framebuffer layer count (%" PRIu32 ").",
-                                     subresource_range.layerCount, pCreateInfo->layers);
-                }
-            }
-
-            if (IsIdentitySwizzle(ivci.components) == false) {
-                LogObjectList objlist(pCreateInfo->renderPass, image_views[i]);
-                skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00884", objlist, attachment_loc,
-                                 "has non-identy swizzle. All "
-                                 "framebuffer attachments must have been created with the identity swizzle. Here are the actual "
-                                 "swizzle values:\n"
-                                 "r swizzle = %s\n"
-                                 "g swizzle = %s\n"
-                                 "b swizzle = %s\n"
-                                 "a swizzle = %s\n",
-                                 string_VkComponentSwizzle(ivci.components.r), string_VkComponentSwizzle(ivci.components.g),
-                                 string_VkComponentSwizzle(ivci.components.b), string_VkComponentSwizzle(ivci.components.a));
-            }
-            if ((ivci.viewType == VK_IMAGE_VIEW_TYPE_2D) || (ivci.viewType == VK_IMAGE_VIEW_TYPE_2D)) {
-                auto image_state = Get<vvl::Image>(ivci.image);
-                if (image_state && image_state->create_info.imageType == VK_IMAGE_TYPE_3D) {
-                    if (vkuFormatIsDepthOrStencil(ivci.format)) {
-                        LogObjectList objlist(pCreateInfo->renderPass, image_views[i], ivci.image);
-                        skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00891", objlist, attachment_loc,
-                                         "has an image view type of %s which was taken from image %s of type "
-                                         "VK_IMAGE_TYPE_3D, but the image view format is a "
-                                         "depth/stencil format %s.",
-                                         string_VkImageViewType(ivci.viewType), FormatHandle(ivci.image).c_str(),
-                                         string_VkFormat(ivci.format));
+            if (enabled_features.attachmentFragmentShadingRate) {
+                const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
+                if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment &&
+                    fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
+                    used_as_fragment_shading_rate_attachment = true;
+                    const bool validate_render_area =
+                        !enabled_features.maintenance7 ||
+                        !phys_dev_ext_props.maintenance7_props.robustFragmentShadingRateAttachmentAccess;
+                    if (validate_render_area &&
+                        (mip_width * fsr_attachment->shadingRateAttachmentTexelSize.width) < create_info.width) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04539", objlist, attachment_loc,
+                                         "mip level %" PRIu32
+                                         " is used as a "
+                                         "fragment shading rate attachment in subpass %" PRIu32
+                                         ", but the product of its "
+                                         "width (%" PRIu32
+                                         ") and the "
+                                         "specified shading rate texel width (%" PRIu32
+                                         ") are smaller than the "
+                                         "corresponding framebuffer width (%" PRIu32 ").",
+                                         subresource_range.baseMipLevel, j, mip_width,
+                                         fsr_attachment->shadingRateAttachmentTexelSize.width, create_info.width);
+                    }
+                    if (validate_render_area &&
+                        (mip_height * fsr_attachment->shadingRateAttachmentTexelSize.height) < create_info.height) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04540", objlist, attachment_loc,
+                                         "mip level %" PRIu32
+                                         " is used as a "
+                                         "fragment shading rate attachment in subpass %" PRIu32
+                                         ", but the product of its "
+                                         "height (%" PRIu32
+                                         ") and the "
+                                         "specified shading rate texel height (%" PRIu32
+                                         ") are smaller than the corresponding "
+                                         "framebuffer height (%" PRIu32 ").",
+                                         subresource_range.baseMipLevel, j, mip_height,
+                                         fsr_attachment->shadingRateAttachmentTexelSize.height, create_info.height);
+                    }
+                    if (highest_view_bit >= 0) {
+                        fsr_non_zero_viewmasks = true;
+                    }
+                    if (static_cast<int32_t>(subresource_range.layerCount) <= highest_view_bit &&
+                        subresource_range.layerCount != 1) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04537", objlist, attachment_loc,
+                                         "has a layer count (%" PRIu32
+                                         ") less than or equal to the highest bit in the view mask (%i) of subpass %" PRIu32 ".",
+                                         subresource_range.layerCount, highest_view_bit, j);
                     }
                 }
             }
-            if (ivci.viewType == VK_IMAGE_VIEW_TYPE_3D) {
-                LogObjectList objlist(pCreateInfo->renderPass, image_views[i]);
-                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04113", objlist, attachment_loc,
-                                 "has an image view type of VK_IMAGE_VIEW_TYPE_3D.");
+
+            if (enabled_features.fragmentDensityMap && api_version >= VK_API_VERSION_1_1) {
+                const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
+
+                if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
+                    int32_t layer_count = view_state->normalized_subresource_range.layerCount;
+                    if (rp_state.has_multiview_enabled && layer_count != 1 && layer_count <= highest_view_bit) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
+                                         "has a layer count (%" PRId32
+                                         ") different than 1 or lower than the most significant bit in viewMask (%i"
+                                         ") but renderPass (%s) was specified with non-zero view masks.",
+                                         layer_count, highest_view_bit, FormatHandle(create_info.renderPass).c_str());
+                    }
+
+                    if (!rp_state.has_multiview_enabled && layer_count != 1) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
+                                         "has a layer count (%" PRIu32
+                                         ") not equal to 1 but renderPass (%s) was not specified with non-zero view masks.",
+                                         layer_count, FormatHandle(create_info.renderPass).c_str());
+                    }
+                }
+            }
+
+            if (enabled_features.externalFormatResolve && !android_external_format_resolve_null_color_attachment_prop &&
+                subpass.pResolveAttachments && subpass.pResolveAttachments[0].attachment == i && subpass.pColorAttachments) {
+                const uint64_t attachment_external_format =
+                    GetExternalFormat(rpci.pAttachments[subpass.pResolveAttachments[0].attachment].pNext);
+                auto it = ahb_ext_resolve_formats_map.find(attachment_external_format);
+                if (it != ahb_ext_resolve_formats_map.end()) {
+                    VkFormat color_format = rpci.pAttachments[subpass.pColorAttachments[0].attachment].format;
+                    if (it->second != color_format) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i]);
+                        skip |= LogError(
+                            "VUID-VkFramebufferCreateInfo-nullColorAttachmentWithExternalFormatResolve-09349", objlist,
+                            attachment_loc,
+                            "subpass[%" PRIu32 "].pResolveAttachments[0].attachment %" PRIu32 " has externalFormat %" PRIu64
+                            " which corresponds to needing a color attachment format of %s, but the format is %s.",
+                            j, i, attachment_external_format, string_VkFormat(it->second), string_VkFormat(color_format));
+                    }
+                }
             }
         }
-    } else if (framebuffer_attachments_create_info) {
-        // VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT is set
-        for (uint32_t i = 0; i < pCreateInfo->attachmentCount; ++i) {
-            const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
-            auto &aii = framebuffer_attachments_create_info->pAttachmentImageInfos[i];
-            bool format_found = false;
-            for (uint32_t j = 0; j < aii.viewFormatCount; ++j) {
-                if (aii.pViewFormats[j] == rpci->pAttachments[i].format) {
-                    format_found = true;
+
+        if (enabled_features.fragmentDensityMap) {
+            const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
+            if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment != VK_ATTACHMENT_UNUSED) {
+                if (fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
+                    uint32_t ceiling_width = vvl::GetQuotientCeil(
+                        create_info.width, phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.width);
+                    if (mip_width < ceiling_width) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02555", objlist, attachment_loc,
+                                         "mip level %" PRIu32
+                                         " has width "
+                                         "smaller than the corresponding the ceiling of framebuffer width / "
+                                         "maxFragmentDensityTexelSize.width "
+                                         "Here are the respective dimensions for attachment #%" PRIu32
+                                         ", the ceiling value:\n "
+                                         "attachment #%" PRIu32
+                                         ", framebuffer:\n"
+                                         "width: %" PRIu32 ", the ceiling value: %" PRIu32 "\n",
+                                         subresource_range.baseMipLevel, i, i, mip_width, ceiling_width);
+                    }
+                    uint32_t ceiling_height = vvl::GetQuotientCeil(
+                        create_info.height, phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize.height);
+                    if (mip_height < ceiling_height) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02556", objlist, attachment_loc,
+                                         "mip level %" PRIu32
+                                         " has height smaller than the corresponding the ceiling of framebuffer height / "
+                                         "maxFragmentDensityTexelSize.height "
+                                         "Here are the respective dimensions for attachment #%" PRIu32
+                                         ", the ceiling value:\n "
+                                         "attachment #%" PRIu32
+                                         ", framebuffer:\n"
+                                         "height: %" PRIu32 ", the ceiling value: %" PRIu32 "\n",
+                                         subresource_range.baseMipLevel, i, i, mip_height, ceiling_height);
+                    }
+                    if (view_state->normalized_subresource_range.layerCount != 1 &&
+                        !IsExtEnabled(device_extensions.vk_khr_multiview)) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02746", objlist, attachment_loc,
+                                         "is referenced by "
+                                         "VkRenderPassFragmentDensityMapCreateInfoEXT::fragmentDensityMapAttachment in "
+                                         "the pNext chain, but it was create with subresourceRange.layerCount (%" PRIu32
+                                         ") different from 1.",
+                                         view_state->normalized_subresource_range.layerCount);
+                    }
+                    if ((ici.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) != 0) {
+                        LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-02552", objlist, attachment_loc,
+                                            "must not be created with flag value VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT if it is "
+                                            "used as a fragment density map");
+                    }
+                } else if (!enabled_features.fragmentDensityMapNonSubsampledImages &&
+                           (ici.flags & VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT) == 0) {
+                    LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                    skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-02553", objlist, attachment_loc,
+                                     "is not created with flag value "
+                                     "VK_IMAGE_CREATE_SUBSAMPLED_BIT_EXT and "
+                                     "fragmentDensityMapNonSubsampledImages is not enabled");
                 }
             }
-            if (!format_found) {
-                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03205", pCreateInfo->renderPass,
-                                 create_info_loc.pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, i)
-                                     .dot(Field::pViewFormats),
-                                 "does not include format %s used by the corresponding attachment for renderPass (%s).",
-                                 string_VkFormat(rpci->pAttachments[i].format), FormatHandle(pCreateInfo->renderPass).c_str());
+        }
+
+        if (used_as_input_color_resolve_depth_stencil_attachment) {
+            if (mip_width < create_info.width) {
+                LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04533", objlist, attachment_loc,
+                                 "mip level %" PRIu32 " has width (%" PRIu32
+                                 ") smaller than the corresponding framebuffer width (%" PRIu32 ").",
+                                 mip_level, mip_width, create_info.width);
             }
+            if (mip_height < create_info.height) {
+                LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04534", objlist, attachment_loc,
+                                 "mip level %" PRIu32 " has height (%" PRIu32
+                                 ") smaller than the corresponding framebuffer height (%" PRIu32 ").",
+                                 mip_level, mip_height, create_info.height);
+            }
+            uint32_t layerCount = view_state->GetAttachmentLayerCount();
+            if (layerCount < create_info.layers) {
+                LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04535", objlist, attachment_loc,
+                                 "has a layer count (%" PRIu32 ") smaller than the corresponding framebuffer layer count (%" PRIu32
+                                 ").",
+                                 layerCount, create_info.layers);
+            }
+        }
 
-            bool used_as_input_color_resolve_depth_stencil_attachment = false;
-            bool used_as_fragment_shading_rate_attachment = false;
-            bool fsr_non_zero_viewmasks = false;
+        if (used_as_fragment_shading_rate_attachment && !fsr_non_zero_viewmasks) {
+            if (subresource_range.layerCount != 1 && subresource_range.layerCount < create_info.layers) {
+                LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04538", objlist, attachment_loc,
+                                 "has a layer count (%" PRIu32
+                                 ") "
+                                 "smaller than the corresponding framebuffer layer count (%" PRIu32 ").",
+                                 subresource_range.layerCount, create_info.layers);
+            }
+        }
 
-            for (uint32_t j = 0; j < rpci->subpassCount; ++j) {
-                const VkSubpassDescription2 &subpass = rpci->pSubpasses[j];
-
-                int highest_view_bit = MostSignificantBit(subpass.viewMask);
-
-                for (uint32_t k = 0; k < rpci->pSubpasses[j].inputAttachmentCount; ++k) {
-                    if (subpass.pInputAttachments[k].attachment == i) {
-                        used_as_input_color_resolve_depth_stencil_attachment = true;
-                        break;
-                    }
+        if (IsIdentitySwizzle(ivci.components) == false) {
+            LogObjectList objlist(create_info.renderPass, image_views[i]);
+            skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00884", objlist, attachment_loc,
+                             "has non-identy swizzle. All "
+                             "framebuffer attachments must have been created with the identity swizzle. Here are the actual "
+                             "swizzle values:\n"
+                             "r swizzle = %s\n"
+                             "g swizzle = %s\n"
+                             "b swizzle = %s\n"
+                             "a swizzle = %s\n",
+                             string_VkComponentSwizzle(ivci.components.r), string_VkComponentSwizzle(ivci.components.g),
+                             string_VkComponentSwizzle(ivci.components.b), string_VkComponentSwizzle(ivci.components.a));
+        }
+        if ((ivci.viewType == VK_IMAGE_VIEW_TYPE_2D) || (ivci.viewType == VK_IMAGE_VIEW_TYPE_2D)) {
+            auto image_state = Get<vvl::Image>(ivci.image);
+            if (image_state && image_state->create_info.imageType == VK_IMAGE_TYPE_3D) {
+                if (vkuFormatIsDepthOrStencil(ivci.format)) {
+                    LogObjectList objlist(create_info.renderPass, image_views[i], ivci.image);
+                    skip |= LogError("VUID-VkFramebufferCreateInfo-pAttachments-00891", objlist, attachment_loc,
+                                     "has an image view type of %s which was taken from image %s of type "
+                                     "VK_IMAGE_TYPE_3D, but the image view format is a "
+                                     "depth/stencil format %s.",
+                                     string_VkImageViewType(ivci.viewType), FormatHandle(ivci.image).c_str(),
+                                     string_VkFormat(ivci.format));
                 }
+            }
+        }
+        if (ivci.viewType == VK_IMAGE_VIEW_TYPE_3D) {
+            LogObjectList objlist(create_info.renderPass, image_views[i]);
+            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04113", objlist, attachment_loc,
+                             "has an image view type of VK_IMAGE_VIEW_TYPE_3D.");
+        }
+    }
 
-                for (uint32_t k = 0; k < rpci->pSubpasses[j].colorAttachmentCount; ++k) {
-                    if (subpass.pColorAttachments[k].attachment == i ||
-                        (subpass.pResolveAttachments && subpass.pResolveAttachments[k].attachment == i)) {
-                        used_as_input_color_resolve_depth_stencil_attachment = true;
-                        break;
-                    }
-                }
+    return skip;
+}
 
-                if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment == i) {
+bool CoreChecks::ValidateFrameBufferAttachmentsImageless(
+    const VkFramebufferCreateInfo &create_info, const Location &create_info_loc, const VkRenderPassCreateInfo2 &rpci,
+    const VkFramebufferAttachmentsCreateInfo &framebuffer_attachments_create_info) const {
+    bool skip = false;
+
+    for (uint32_t i = 0; i < create_info.attachmentCount; ++i) {
+        const Location attachment_loc = create_info_loc.dot(Field::pAttachments, i);
+        auto &aii = framebuffer_attachments_create_info.pAttachmentImageInfos[i];
+        bool format_found = false;
+        for (uint32_t j = 0; j < aii.viewFormatCount; ++j) {
+            if (aii.pViewFormats[j] == rpci.pAttachments[i].format) {
+                format_found = true;
+            }
+        }
+        if (!format_found) {
+            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03205", create_info.renderPass,
+                             create_info_loc.pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, i)
+                                 .dot(Field::pViewFormats),
+                             "does not include format %s used by the corresponding attachment for renderPass (%s).",
+                             string_VkFormat(rpci.pAttachments[i].format), FormatHandle(create_info.renderPass).c_str());
+        }
+
+        bool used_as_input_color_resolve_depth_stencil_attachment = false;
+        bool used_as_fragment_shading_rate_attachment = false;
+        bool fsr_non_zero_viewmasks = false;
+
+        for (uint32_t j = 0; j < rpci.subpassCount; ++j) {
+            const VkSubpassDescription2 &subpass = rpci.pSubpasses[j];
+
+            int highest_view_bit = MostSignificantBit(subpass.viewMask);
+
+            for (uint32_t k = 0; k < rpci.pSubpasses[j].inputAttachmentCount; ++k) {
+                if (subpass.pInputAttachments[k].attachment == i) {
                     used_as_input_color_resolve_depth_stencil_attachment = true;
+                    break;
                 }
+            }
 
-                if (enabled_features.attachmentFragmentShadingRate) {
-                    const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
-                    if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
-                        used_as_fragment_shading_rate_attachment = true;
-                        const bool validate_render_area =
-                            !enabled_features.maintenance7 ||
-                            !phys_dev_ext_props.maintenance7_props.robustFragmentShadingRateAttachmentAccess;
-                        if (validate_render_area &&
-                            (aii.width * fsr_attachment->shadingRateAttachmentTexelSize.width) < pCreateInfo->width) {
-                            skip |=
-                                LogError("VUID-VkFramebufferCreateInfo-flags-04543", pCreateInfo->renderPass, attachment_loc,
+            for (uint32_t k = 0; k < rpci.pSubpasses[j].colorAttachmentCount; ++k) {
+                if (subpass.pColorAttachments[k].attachment == i ||
+                    (subpass.pResolveAttachments && subpass.pResolveAttachments[k].attachment == i)) {
+                    used_as_input_color_resolve_depth_stencil_attachment = true;
+                    break;
+                }
+            }
+
+            if (subpass.pDepthStencilAttachment && subpass.pDepthStencilAttachment->attachment == i) {
+                used_as_input_color_resolve_depth_stencil_attachment = true;
+            }
+
+            if (enabled_features.attachmentFragmentShadingRate) {
+                const auto *fsr_attachment = vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
+                if (fsr_attachment && fsr_attachment->pFragmentShadingRateAttachment->attachment == i) {
+                    used_as_fragment_shading_rate_attachment = true;
+                    const bool validate_render_area =
+                        !enabled_features.maintenance7 ||
+                        !phys_dev_ext_props.maintenance7_props.robustFragmentShadingRateAttachmentAccess;
+                    if (validate_render_area &&
+                        (aii.width * fsr_attachment->shadingRateAttachmentTexelSize.width) < create_info.width) {
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04543", create_info.renderPass, attachment_loc,
                                          "is used as a fragment shading rate attachment in subpass %" PRIu32
                                          ", but the product of its width (%" PRIu32
                                          ") and the "
                                          "specified shading rate texel width (%" PRIu32
                                          ") are smaller than the corresponding framebuffer "
                                          "width (%" PRIu32 ").",
-                                         j, aii.width, fsr_attachment->shadingRateAttachmentTexelSize.width, pCreateInfo->width);
-                        }
-                        if (validate_render_area &&
-                            (aii.height * fsr_attachment->shadingRateAttachmentTexelSize.height) < pCreateInfo->height) {
-                            skip |=
-                                LogError("VUID-VkFramebufferCreateInfo-flags-04544", pCreateInfo->renderPass, attachment_loc,
+                                         j, aii.width, fsr_attachment->shadingRateAttachmentTexelSize.width, create_info.width);
+                    }
+                    if (validate_render_area &&
+                        (aii.height * fsr_attachment->shadingRateAttachmentTexelSize.height) < create_info.height) {
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04544", create_info.renderPass, attachment_loc,
                                          "is used as a fragment shading rate attachment in subpass %" PRIu32
                                          ", but the product of its "
                                          "height (%" PRIu32
@@ -4734,220 +4689,211 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
                                          "specified shading rate texel height (%" PRIu32
                                          ") are smaller than the corresponding "
                                          "framebuffer height (%" PRIu32 ").",
-                                         j, aii.height, fsr_attachment->shadingRateAttachmentTexelSize.height, pCreateInfo->height);
-                        }
-                        if (highest_view_bit >= 0) {
-                            fsr_non_zero_viewmasks = true;
-                        }
-                        if (aii.layerCount != 1 && static_cast<int32_t>(aii.layerCount) <= highest_view_bit) {
-                            skip |=
-                                LogError("VUID-VkFramebufferCreateInfo-renderPass-08921", pCreateInfo->renderPass, attachment_loc,
+                                         j, aii.height, fsr_attachment->shadingRateAttachmentTexelSize.height, create_info.height);
+                    }
+                    if (highest_view_bit >= 0) {
+                        fsr_non_zero_viewmasks = true;
+                    }
+                    if (aii.layerCount != 1 && static_cast<int32_t>(aii.layerCount) <= highest_view_bit) {
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-08921", create_info.renderPass, attachment_loc,
                                          "has a layer count (%" PRIu32
                                          ") "
                                          "less than or equal to the highest bit in the view mask (%i) of subpass %" PRIu32 ".",
                                          aii.layerCount, highest_view_bit, j);
-                        }
-                    }
-                }
-
-                if (enabled_features.fragmentDensityMap) {
-                    const auto *fdm_attachment =
-                        vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci->pNext);
-
-                    if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
-                        const auto &maxFragmentDensityTexelSize =
-                            phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize;
-                        const uint32_t ceiling_width = vvl::GetQuotientCeil(pCreateInfo->width, maxFragmentDensityTexelSize.width);
-                        if (aii.width < ceiling_width) {
-                            LogObjectList objlist(pCreateInfo->renderPass);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03196", objlist, attachment_loc,
-                                             "is used as a fragment density map attachment in subpass %" PRIu32
-                                             ", but the quotient of the framebuffer width (%" PRIu32
-                                             ") and the allowed maximum fragment density texel width (%" PRIu32
-                                             ") is greater than the corresponding fragment density attachment "
-                                             "width (%" PRIu32 ").",
-                                             j, pCreateInfo->width, maxFragmentDensityTexelSize.width, aii.width);
-                        }
-                        const uint32_t ceiling_height =
-                            vvl::GetQuotientCeil(pCreateInfo->height, maxFragmentDensityTexelSize.height);
-                        if (aii.height < ceiling_height) {
-                            LogObjectList objlist(pCreateInfo->renderPass);
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03197", objlist, attachment_loc,
-                                             "is used as a fragment density map attachment in subpass %" PRIu32
-                                             ", but the quotient of the framebuffer height (%" PRIu32
-                                             ") and the allowed maximum fragment density texel height (%" PRIu32
-                                             ") is greater than the corresponding fragment density attachment "
-                                             "height (%" PRIu32 ").",
-                                             j, pCreateInfo->height, maxFragmentDensityTexelSize.height, aii.height);
-                        }
                     }
                 }
             }
 
-            if (used_as_input_color_resolve_depth_stencil_attachment) {
-                if (aii.width < pCreateInfo->width) {
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04541", pCreateInfo->renderPass, attachment_loc,
-                                     "has a width of only %" PRIu32 ", but framebuffer has a width of %" PRIu32 ".", aii.width,
-                                     pCreateInfo->width);
-                }
+            if (enabled_features.fragmentDensityMap) {
+                const auto *fdm_attachment = vku::FindStructInPNextChain<VkRenderPassFragmentDensityMapCreateInfoEXT>(rpci.pNext);
 
-                if (aii.height < pCreateInfo->height) {
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04542", pCreateInfo->renderPass, attachment_loc,
-                                     "has a height of only %" PRIu32 ", but framebuffer has a height of %" PRIu32 ".", aii.height,
-                                     pCreateInfo->height);
-                }
-
-                if ((rpci->subpassCount == 0) || (rpci->pSubpasses[0].viewMask == 0)) {
-                    if (aii.layerCount < pCreateInfo->layers) {
-                        skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-04546", pCreateInfo->renderPass, attachment_loc,
-                                         "has only %" PRIu32 " layers, but framebuffer has %" PRIu32 " layers.", aii.layerCount,
-                                         pCreateInfo->layers);
+                if (fdm_attachment && fdm_attachment->fragmentDensityMapAttachment.attachment == i) {
+                    const auto &maxFragmentDensityTexelSize =
+                        phys_dev_ext_props.fragment_density_map_props.maxFragmentDensityTexelSize;
+                    const uint32_t ceiling_width = vvl::GetQuotientCeil(create_info.width, maxFragmentDensityTexelSize.width);
+                    if (aii.width < ceiling_width) {
+                        LogObjectList objlist(create_info.renderPass);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03196", objlist, attachment_loc,
+                                         "is used as a fragment density map attachment in subpass %" PRIu32
+                                         ", but the quotient of the framebuffer width (%" PRIu32
+                                         ") and the allowed maximum fragment density texel width (%" PRIu32
+                                         ") is greater than the corresponding fragment density attachment "
+                                         "width (%" PRIu32 ").",
+                                         j, create_info.width, maxFragmentDensityTexelSize.width, aii.width);
                     }
-                }
-            }
-
-            if (used_as_fragment_shading_rate_attachment && !fsr_non_zero_viewmasks) {
-                if (aii.layerCount != 1 && aii.layerCount < pCreateInfo->layers) {
-                    skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04545", pCreateInfo->renderPass, attachment_loc,
-                                     "has a layer count (%" PRIu32
-                                     ") smaller than the corresponding framebuffer layer count (%" PRIu32 ").",
-                                     aii.layerCount, pCreateInfo->layers);
+                    const uint32_t ceiling_height = vvl::GetQuotientCeil(create_info.height, maxFragmentDensityTexelSize.height);
+                    if (aii.height < ceiling_height) {
+                        LogObjectList objlist(create_info.renderPass);
+                        skip |= LogError("VUID-VkFramebufferCreateInfo-flags-03197", objlist, attachment_loc,
+                                         "is used as a fragment density map attachment in subpass %" PRIu32
+                                         ", but the quotient of the framebuffer height (%" PRIu32
+                                         ") and the allowed maximum fragment density texel height (%" PRIu32
+                                         ") is greater than the corresponding fragment density attachment "
+                                         "height (%" PRIu32 ").",
+                                         j, create_info.height, maxFragmentDensityTexelSize.height, aii.height);
+                    }
                 }
             }
         }
 
-        // Validate image usage
-        uint32_t attachment_index = VK_ATTACHMENT_UNUSED;
-        for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
-            skip |= MatchUsage(rpci->pSubpasses[i].colorAttachmentCount, rpci->pSubpasses[i].pColorAttachments, pCreateInfo,
-                               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03201", create_info_loc);
-            skip |= MatchUsage(rpci->pSubpasses[i].colorAttachmentCount, rpci->pSubpasses[i].pResolveAttachments, pCreateInfo,
-                               VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03201", create_info_loc);
-            skip |=
-                MatchUsage(1, rpci->pSubpasses[i].pDepthStencilAttachment, pCreateInfo, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+        if (used_as_input_color_resolve_depth_stencil_attachment) {
+            if (aii.width < create_info.width) {
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04541", create_info.renderPass, attachment_loc,
+                                 "has a width of only %" PRIu32 ", but framebuffer has a width of %" PRIu32 ".", aii.width,
+                                 create_info.width);
+            }
+
+            if (aii.height < create_info.height) {
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04542", create_info.renderPass, attachment_loc,
+                                 "has a height of only %" PRIu32 ", but framebuffer has a height of %" PRIu32 ".", aii.height,
+                                 create_info.height);
+            }
+
+            if ((rpci.subpassCount == 0) || (rpci.pSubpasses[0].viewMask == 0)) {
+                if (aii.layerCount < create_info.layers) {
+                    skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-04546", create_info.renderPass, attachment_loc,
+                                     "has only %" PRIu32 " layers, but framebuffer has %" PRIu32 " layers.", aii.layerCount,
+                                     create_info.layers);
+                }
+            }
+        }
+
+        if (used_as_fragment_shading_rate_attachment && !fsr_non_zero_viewmasks) {
+            if (aii.layerCount != 1 && aii.layerCount < create_info.layers) {
+                skip |= LogError("VUID-VkFramebufferCreateInfo-flags-04545", create_info.renderPass, attachment_loc,
+                                 "has a layer count (%" PRIu32 ") smaller than the corresponding framebuffer layer count (%" PRIu32
+                                 ").",
+                                 aii.layerCount, create_info.layers);
+            }
+        }
+    }
+
+    // Validate image usage
+    uint32_t attachment_index = VK_ATTACHMENT_UNUSED;
+    for (uint32_t i = 0; i < rpci.subpassCount; ++i) {
+        const VkSubpassDescription2 &subpass = rpci.pSubpasses[i];
+
+        skip |= MatchUsage(subpass.colorAttachmentCount, subpass.pColorAttachments, create_info,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03201", create_info_loc);
+        skip |= MatchUsage(subpass.colorAttachmentCount, subpass.pResolveAttachments, create_info,
+                           VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03201", create_info_loc);
+        skip |= MatchUsage(1, subpass.pDepthStencilAttachment, create_info, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
                            "VUID-VkFramebufferCreateInfo-flags-03202", create_info_loc);
-            skip |= MatchUsage(rpci->pSubpasses[i].inputAttachmentCount, rpci->pSubpasses[i].pInputAttachments, pCreateInfo,
-                               VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03204", create_info_loc);
+        skip |= MatchUsage(subpass.inputAttachmentCount, subpass.pInputAttachments, create_info,
+                           VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03204", create_info_loc);
 
-            const auto *depth_stencil_resolve =
-                vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(rpci->pSubpasses[i].pNext);
-            if (depth_stencil_resolve != nullptr) {
-                skip |= MatchUsage(1, depth_stencil_resolve->pDepthStencilResolveAttachment, pCreateInfo,
-                                   VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03203",
-                                   create_info_loc);
-            }
-
-            const auto *fragment_shading_rate_attachment_info =
-                vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(rpci->pSubpasses[i].pNext);
-            if (enabled_features.attachmentFragmentShadingRate &&
-                fragment_shading_rate_attachment_info != nullptr) {
-                skip |= MatchUsage(1, fragment_shading_rate_attachment_info->pFragmentShadingRateAttachment, pCreateInfo,
-                                   VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR,
-                                   "VUID-VkFramebufferCreateInfo-flags-04549", create_info_loc);
-            }
+        const auto *depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
+        if (depth_stencil_resolve != nullptr) {
+            skip |= MatchUsage(1, depth_stencil_resolve->pDepthStencilResolveAttachment, create_info,
+                               VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-flags-03203",
+                               create_info_loc);
         }
 
-        // VUID-VkSubpassDescription2-multiview-06558 forces viewMask to be zero if not using multiView
-        if ((rpci->subpassCount > 0) && (rpci->pSubpasses[0].viewMask != 0)) {
-            for (uint32_t i = 0; i < rpci->subpassCount; ++i) {
-                const auto *depth_stencil_resolve =
-                    vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(rpci->pSubpasses[i].pNext);
-                uint32_t view_bits = rpci->pSubpasses[i].viewMask;
-                int highest_view_bit = MostSignificantBit(view_bits);
+        const auto *fragment_shading_rate_attachment_info =
+            vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass.pNext);
+        if (enabled_features.attachmentFragmentShadingRate && fragment_shading_rate_attachment_info != nullptr) {
+            skip |= MatchUsage(1, fragment_shading_rate_attachment_info->pFragmentShadingRateAttachment, create_info,
+                               VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, "VUID-VkFramebufferCreateInfo-flags-04549",
+                               create_info_loc);
+        }
+    }
 
-                for (uint32_t j = 0; j < rpci->pSubpasses[i].colorAttachmentCount; ++j) {
-                    attachment_index = rpci->pSubpasses[i].pColorAttachments[j].attachment;
-                    if (attachment_index != VK_ATTACHMENT_UNUSED) {
-                        int32_t layer_count =
-                            framebuffer_attachments_create_info->pAttachmentImageInfos[attachment_index].layerCount;
-                        if (layer_count <= highest_view_bit) {
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", pCreateInfo->renderPass,
-                                             create_info_loc
-                                                 .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos,
-                                                        attachment_index)
-                                                 .dot(Field::layerCount),
-                                             "is %" PRId32 ", but the view mask for subpass %" PRIu32
-                                             " in renderPass (%s) "
-                                             "includes layer %i, with that attachment specified as a color attachment %" PRIu32 ".",
-                                             layer_count, i, FormatHandle(pCreateInfo->renderPass).c_str(), highest_view_bit, j);
-                        }
-                    }
-                    if (rpci->pSubpasses[i].pResolveAttachments) {
-                        attachment_index = rpci->pSubpasses[i].pResolveAttachments[j].attachment;
-                        if (attachment_index != VK_ATTACHMENT_UNUSED) {
-                            int32_t layer_count =
-                                framebuffer_attachments_create_info->pAttachmentImageInfos[attachment_index].layerCount;
-                            if (layer_count <= highest_view_bit) {
-                                skip |= LogError(
-                                    "VUID-VkFramebufferCreateInfo-renderPass-03198", pCreateInfo->renderPass,
-                                    create_info_loc
-                                        .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos,
-                                               attachment_index)
-                                        .dot(Field::layerCount),
-                                    "is %" PRId32 ", but the view mask for subpass %" PRIu32
-                                    " in renderPass (%s) "
-                                    "includes layer %i, with that attachment specified as a resolve attachment %" PRIu32 ".",
-                                    layer_count, i, FormatHandle(pCreateInfo->renderPass).c_str(), highest_view_bit, j);
-                            }
-                        }
+    // VUID-VkSubpassDescription2-multiview-06558 forces viewMask to be zero if not using multiView
+    if ((rpci.subpassCount > 0) && (rpci.pSubpasses[0].viewMask != 0)) {
+        for (uint32_t i = 0; i < rpci.subpassCount; ++i) {
+            const VkSubpassDescription2 &subpass = rpci.pSubpasses[i];
+            const auto *depth_stencil_resolve = vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass.pNext);
+            uint32_t view_bits = subpass.viewMask;
+            int highest_view_bit = MostSignificantBit(view_bits);
+
+            for (uint32_t j = 0; j < subpass.colorAttachmentCount; ++j) {
+                attachment_index = subpass.pColorAttachments[j].attachment;
+                if (attachment_index != VK_ATTACHMENT_UNUSED) {
+                    int32_t layer_count = framebuffer_attachments_create_info.pAttachmentImageInfos[attachment_index].layerCount;
+                    if (layer_count <= highest_view_bit) {
+                        skip |= LogError(
+                            "VUID-VkFramebufferCreateInfo-renderPass-03198", create_info.renderPass,
+                            create_info_loc
+                                .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, attachment_index)
+                                .dot(Field::layerCount),
+                            "is %" PRId32 ", but the view mask for subpass %" PRIu32
+                            " in renderPass (%s) "
+                            "includes layer %i, with that attachment specified as a color attachment %" PRIu32 ".",
+                            layer_count, i, FormatHandle(create_info.renderPass).c_str(), highest_view_bit, j);
                     }
                 }
-
-                for (uint32_t j = 0; j < rpci->pSubpasses[i].inputAttachmentCount; ++j) {
-                    attachment_index = rpci->pSubpasses[i].pInputAttachments[j].attachment;
+                if (subpass.pResolveAttachments) {
+                    attachment_index = subpass.pResolveAttachments[j].attachment;
                     if (attachment_index != VK_ATTACHMENT_UNUSED) {
                         int32_t layer_count =
-                            framebuffer_attachments_create_info->pAttachmentImageInfos[attachment_index].layerCount;
+                            framebuffer_attachments_create_info.pAttachmentImageInfos[attachment_index].layerCount;
                         if (layer_count <= highest_view_bit) {
                             skip |=
-                                LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", pCreateInfo->renderPass,
+                                LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", create_info.renderPass,
                                          create_info_loc
                                              .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos,
                                                     attachment_index)
                                              .dot(Field::layerCount),
                                          "is %" PRId32 ", but the view mask for subpass %" PRIu32
                                          " in renderPass (%s) "
-                                         "includes layer %i, with that attachment specified as an input attachment %" PRIu32 ".",
-                                         layer_count, i, FormatHandle(pCreateInfo->renderPass).c_str(), highest_view_bit, j);
+                                         "includes layer %i, with that attachment specified as a resolve attachment %" PRIu32 ".",
+                                         layer_count, i, FormatHandle(create_info.renderPass).c_str(), highest_view_bit, j);
                         }
                     }
                 }
+            }
 
-                if (rpci->pSubpasses[i].pDepthStencilAttachment != nullptr) {
-                    attachment_index = rpci->pSubpasses[i].pDepthStencilAttachment->attachment;
+            for (uint32_t j = 0; j < subpass.inputAttachmentCount; ++j) {
+                attachment_index = subpass.pInputAttachments[j].attachment;
+                if (attachment_index != VK_ATTACHMENT_UNUSED) {
+                    int32_t layer_count = framebuffer_attachments_create_info.pAttachmentImageInfos[attachment_index].layerCount;
+                    if (layer_count <= highest_view_bit) {
+                        skip |= LogError(
+                            "VUID-VkFramebufferCreateInfo-renderPass-03198", create_info.renderPass,
+                            create_info_loc
+                                .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, attachment_index)
+                                .dot(Field::layerCount),
+                            "is %" PRId32 ", but the view mask for subpass %" PRIu32
+                            " in renderPass (%s) "
+                            "includes layer %i, with that attachment specified as an input attachment %" PRIu32 ".",
+                            layer_count, i, FormatHandle(create_info.renderPass).c_str(), highest_view_bit, j);
+                    }
+                }
+            }
+
+            if (subpass.pDepthStencilAttachment != nullptr) {
+                attachment_index = subpass.pDepthStencilAttachment->attachment;
+                if (attachment_index != VK_ATTACHMENT_UNUSED) {
+                    int32_t layer_count = framebuffer_attachments_create_info.pAttachmentImageInfos[attachment_index].layerCount;
+                    if (layer_count <= highest_view_bit) {
+                        skip |= LogError(
+                            "VUID-VkFramebufferCreateInfo-renderPass-03198", create_info.renderPass,
+                            create_info_loc
+                                .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos, attachment_index)
+                                .dot(Field::layerCount),
+                            "is %" PRId32 ", but the view mask for subpass %" PRIu32
+                            " in renderPass (%s) "
+                            "includes layer %i, with that attachment specified as a depth/stencil attachment.",
+                            layer_count, i, FormatHandle(create_info.renderPass).c_str(), highest_view_bit);
+                    }
+                }
+
+                if (depth_stencil_resolve != nullptr && depth_stencil_resolve->pDepthStencilResolveAttachment != nullptr) {
+                    attachment_index = depth_stencil_resolve->pDepthStencilResolveAttachment->attachment;
                     if (attachment_index != VK_ATTACHMENT_UNUSED) {
                         int32_t layer_count =
-                            framebuffer_attachments_create_info->pAttachmentImageInfos[attachment_index].layerCount;
+                            framebuffer_attachments_create_info.pAttachmentImageInfos[attachment_index].layerCount;
                         if (layer_count <= highest_view_bit) {
-                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", pCreateInfo->renderPass,
+                            skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", create_info.renderPass,
                                              create_info_loc
                                                  .pNext(Struct::VkFramebufferAttachmentsCreateInfo, Field::pAttachmentImageInfos,
                                                         attachment_index)
                                                  .dot(Field::layerCount),
                                              "is %" PRId32 ", but the view mask for subpass %" PRIu32
                                              " in renderPass (%s) "
-                                             "includes layer %i, with that attachment specified as a depth/stencil attachment.",
-                                             layer_count, i, FormatHandle(pCreateInfo->renderPass).c_str(), highest_view_bit);
-                        }
-                    }
-
-                    if (depth_stencil_resolve != nullptr && depth_stencil_resolve->pDepthStencilResolveAttachment != nullptr) {
-                        attachment_index = depth_stencil_resolve->pDepthStencilResolveAttachment->attachment;
-                        if (attachment_index != VK_ATTACHMENT_UNUSED) {
-                            int32_t layer_count =
-                                framebuffer_attachments_create_info->pAttachmentImageInfos[attachment_index].layerCount;
-                            if (layer_count <= highest_view_bit) {
-                                skip |= LogError("VUID-VkFramebufferCreateInfo-renderPass-03198", pCreateInfo->renderPass,
-                                                 create_info_loc
-                                                     .pNext(Struct::VkFramebufferAttachmentsCreateInfo,
-                                                            Field::pAttachmentImageInfos, attachment_index)
-                                                     .dot(Field::layerCount),
-                                                 "is %" PRId32 ", but the view mask for subpass %" PRIu32
-                                                 " in renderPass (%s) "
-                                                 "includes layer %i, with that attachment specified as a depth/stencil resolve "
-                                                 "attachment.",
-                                                 layer_count, i, FormatHandle(pCreateInfo->renderPass).c_str(), highest_view_bit);
-                            }
+                                             "includes layer %i, with that attachment specified as a depth/stencil resolve "
+                                             "attachment.",
+                                             layer_count, i, FormatHandle(create_info.renderPass).c_str(), highest_view_bit);
                         }
                     }
                 }
@@ -4955,64 +4901,56 @@ bool CoreChecks::PreCallValidateCreateFramebuffer(VkDevice device, const VkFrame
         }
     }
 
-    if ((pCreateInfo->flags & VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT) == 0) {
-        // Verify correct attachment usage flags
-        for (uint32_t subpass = 0; subpass < rpci->subpassCount; subpass++) {
-            const VkSubpassDescription2 &subpass_description = rpci->pSubpasses[subpass];
-            const auto *ms_rendered_to_single_sampled =
-                vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(subpass_description.pNext);
-            // Verify input attachments:
-            skip |=
-                MatchUsage(subpass_description.inputAttachmentCount, subpass_description.pInputAttachments, pCreateInfo,
+    return skip;
+}
+
+bool CoreChecks::ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo &create_info, const Location &create_info_loc,
+                                              const VkRenderPassCreateInfo2 &rpci) const {
+    bool skip = false;
+    for (uint32_t subpass = 0; subpass < rpci.subpassCount; subpass++) {
+        const VkSubpassDescription2 &subpass_description = rpci.pSubpasses[subpass];
+        const auto *ms_rendered_to_single_sampled =
+            vku::FindStructInPNextChain<VkMultisampledRenderToSingleSampledInfoEXT>(subpass_description.pNext);
+        // Verify input attachments:
+        skip |= MatchUsage(subpass_description.inputAttachmentCount, subpass_description.pInputAttachments, create_info,
                            VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-pAttachments-00879", create_info_loc);
-            // Verify color attachments:
-            skip |=
-                MatchUsage(subpass_description.colorAttachmentCount, subpass_description.pColorAttachments, pCreateInfo,
+        // Verify color attachments:
+        skip |= MatchUsage(subpass_description.colorAttachmentCount, subpass_description.pColorAttachments, create_info,
                            VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-pAttachments-00877", create_info_loc);
-            // Verify depth/stencil attachments:
-            skip |=
-                MatchUsage(1, subpass_description.pDepthStencilAttachment, pCreateInfo, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+        // Verify depth/stencil attachments:
+        skip |= MatchUsage(1, subpass_description.pDepthStencilAttachment, create_info, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
                            "VUID-VkFramebufferCreateInfo-pAttachments-02633", create_info_loc);
-            // Verify depth/stecnil resolve
-            const auto *ds_resolve =
-                vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass_description.pNext);
-            if (ds_resolve) {
-                skip |= MatchUsage(1, ds_resolve->pDepthStencilResolveAttachment, pCreateInfo,
-                                   VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, "VUID-VkFramebufferCreateInfo-pAttachments-02634",
-                                   create_info_loc);
-            }
+        // Verify depth/stecnil resolve
+        if (const auto *ds_resolve =
+                vku::FindStructInPNextChain<VkSubpassDescriptionDepthStencilResolve>(subpass_description.pNext)) {
+            skip |=
+                MatchUsage(1, ds_resolve->pDepthStencilResolveAttachment, create_info, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT,
+                           "VUID-VkFramebufferCreateInfo-pAttachments-02634", create_info_loc);
+        }
 
-            // Verify fragment shading rate attachments
-            if (enabled_features.attachmentFragmentShadingRate) {
-                const auto *fragment_shading_rate_attachment_info =
-                    vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass_description.pNext);
-                if (fragment_shading_rate_attachment_info) {
-                    skip |= MatchUsage(1, fragment_shading_rate_attachment_info->pFragmentShadingRateAttachment, pCreateInfo,
-                                       VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR,
-                                       "VUID-VkFramebufferCreateInfo-flags-04548", create_info_loc);
-                }
-            }
-            if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
-                skip |= MsRenderedToSingleSampledValidateFBAttachments(
-                    subpass_description.inputAttachmentCount, subpass_description.pInputAttachments, pCreateInfo, rpci, subpass,
-                    ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
-                skip |= MsRenderedToSingleSampledValidateFBAttachments(
-                    subpass_description.colorAttachmentCount, subpass_description.pColorAttachments, pCreateInfo, rpci, subpass,
-                    ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
-                if (subpass_description.pDepthStencilAttachment) {
-                    skip |= MsRenderedToSingleSampledValidateFBAttachments(
-                        1, subpass_description.pDepthStencilAttachment, pCreateInfo, rpci, subpass,
-                        ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
-                }
+        // Verify fragment shading rate attachments
+        if (enabled_features.attachmentFragmentShadingRate) {
+            const auto *fragment_shading_rate_attachment_info =
+                vku::FindStructInPNextChain<VkFragmentShadingRateAttachmentInfoKHR>(subpass_description.pNext);
+            if (fragment_shading_rate_attachment_info) {
+                skip |= MatchUsage(1, fragment_shading_rate_attachment_info->pFragmentShadingRateAttachment, create_info,
+                                   VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR,
+                                   "VUID-VkFramebufferCreateInfo-flags-04548", create_info_loc);
             }
         }
-    }
-
-    if (b_has_non_zero_view_masks && pCreateInfo->layers != 1) {
-        skip |=
-            LogError("VUID-VkFramebufferCreateInfo-renderPass-02531", pCreateInfo->renderPass, create_info_loc.dot(Field::layers),
-                     "is %" PRIu32 " but renderPass (%s) was specified with non-zero view masks.", pCreateInfo->layers,
-                     FormatHandle(pCreateInfo->renderPass).c_str());
+        if (ms_rendered_to_single_sampled && ms_rendered_to_single_sampled->multisampledRenderToSingleSampledEnable) {
+            skip |= MsRenderedToSingleSampledValidateFBAttachments(
+                subpass_description.inputAttachmentCount, subpass_description.pInputAttachments, create_info, rpci, subpass,
+                ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
+            skip |= MsRenderedToSingleSampledValidateFBAttachments(
+                subpass_description.colorAttachmentCount, subpass_description.pColorAttachments, create_info, rpci, subpass,
+                ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
+            if (subpass_description.pDepthStencilAttachment) {
+                skip |= MsRenderedToSingleSampledValidateFBAttachments(
+                    1, subpass_description.pDepthStencilAttachment, create_info, rpci, subpass,
+                    ms_rendered_to_single_sampled->rasterizationSamples, create_info_loc);
+            }
+        }
     }
 
     return skip;

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -250,7 +250,7 @@ class CoreChecks : public ValidationStateTracker {
     bool ValidateCmdEndRenderPass(VkCommandBuffer commandBuffer, const VkSubpassEndInfo* pSubpassEndInfo,
                                   const ErrorObject& error_obj) const;
     void RecordCmdEndRenderPassLayouts(VkCommandBuffer commandBuffer);
-    bool MatchUsage(uint32_t count, const VkAttachmentReference2* attachments, const VkFramebufferCreateInfo* fbci,
+    bool MatchUsage(uint32_t count, const VkAttachmentReference2* attachments, const VkFramebufferCreateInfo& fbci,
                     VkImageUsageFlagBits usage_flag, const char* vuid, const Location& create_info_loc) const;
     bool ValidateBindImageMemory(uint32_t bindInfoCount, const VkBindImageMemoryInfo* pBindInfos,
                                  const ErrorObject& error_obj) const;
@@ -1756,6 +1756,13 @@ class CoreChecks : public ValidationStateTracker {
                                                                   const VkAccelerationStructureKHR* pAccelerationStructures,
                                                                   VkQueryType queryType, VkQueryPool queryPool, uint32_t firstQuery,
                                                                   const RecordObject& record_obj) override;
+    bool ValidateFrameBufferAttachments(const VkFramebufferCreateInfo& create_info, const Location& create_info_loc,
+                                        const vvl::RenderPass& rp_state, const VkRenderPassCreateInfo2& rpci) const;
+    bool ValidateFrameBufferAttachmentsImageless(
+        const VkFramebufferCreateInfo& create_info, const Location& create_info_loc, const VkRenderPassCreateInfo2& rpci,
+        const VkFramebufferAttachmentsCreateInfo& framebuffer_attachments_create_info) const;
+    bool ValidateFrameBufferSubpasses(const VkFramebufferCreateInfo& create_info, const Location& create_info_loc,
+                                      const VkRenderPassCreateInfo2& rpci) const;
     bool PreCallValidateCreateFramebuffer(VkDevice device, const VkFramebufferCreateInfo* pCreateInfo,
                                           const VkAllocationCallbacks* pAllocator, VkFramebuffer* pFramebuffer,
                                           const ErrorObject& error_obj) const override;
@@ -1765,7 +1772,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateGetDeviceMemoryCommitment(VkDevice device, VkDeviceMemory memory, VkDeviceSize* pCommittedMem,
                                                   const ErrorObject& error_obj) const override;
     bool MsRenderedToSingleSampledValidateFBAttachments(uint32_t count, const VkAttachmentReference2* attachments,
-                                                        const VkFramebufferCreateInfo* fbci, const VkRenderPassCreateInfo2* rpci,
+                                                        const VkFramebufferCreateInfo& fbci, const VkRenderPassCreateInfo2& rpci,
                                                         uint32_t subpass, VkSampleCountFlagBits sample_count,
                                                         const Location& create_info_loc) const;
     bool ValidateFragmentShadingRateAttachments(const VkRenderPassCreateInfo2* pCreateInfo, const ErrorObject& error_obj) const;

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -1084,6 +1084,10 @@ class StatelessValidation : public ValidationObject {
                                                    const VkSubpassBeginInfo *, const ErrorObject &error_obj) const;
     bool manual_PreCallValidateCmdBeginRendering(VkCommandBuffer commandBuffer, const VkRenderingInfo *pRenderingInfo,
                                                  const ErrorObject &error_obj) const;
+    bool ValidateBeginRenderingFragmentShadingRateAttachment(
+        VkCommandBuffer commandBuffer, const VkRenderingInfo &rendering_info,
+        const VkRenderingFragmentShadingRateAttachmentInfoKHR &rendering_fsr_attachment_info,
+        const Location &rendering_info_loc) const;
 
     bool manual_PreCallValidateCmdSetDiscardRectangleEXT(VkCommandBuffer commandBuffer, uint32_t firstDiscardRectangle,
                                                          uint32_t discardRectangleCount, const VkRect2D *pDiscardRectangles,

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -1426,17 +1426,9 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     AddRequiredExtensions(VK_KHR_SWAPCHAIN_EXTENSION_NAME);
     AddRequiredExtensions(VK_KHR_DYNAMIC_RENDERING_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitFramework());
-    VkPhysicalDeviceDynamicRenderingFeatures dynamic_features = vku::InitStructHelper();
-    VkPhysicalDeviceFragmentDensityMapFeaturesEXT fdm_features = vku::InitStructHelper(&dynamic_features);
-    GetPhysicalDeviceFeatures2(fdm_features);
-    if (!dynamic_features.dynamicRendering) {
-        GTEST_SKIP() << "dynamicRendering not supported";
-    }
-    if (!fdm_features.fragmentDensityMap) {
-        GTEST_SKIP() << "fragmentDensityMap not supported";
-    }
-    RETURN_IF_SKIP(InitState(nullptr, &fdm_features));
+    AddRequiredFeature(vkt::Feature::dynamicRendering);
+    AddRequiredFeature(vkt::Feature::fragmentDensityMap);
+    RETURN_IF_SKIP(Init());
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
@@ -1464,7 +1456,7 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper(&fragment_density_map);
     begin_rendering_info.pDepthAttachment = &depth_attachment;
-    begin_rendering_info.viewMask = 0x4;
+    begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
     m_commandBuffer->begin();
@@ -1473,8 +1465,6 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     m_errorMonitor->VerifyFound();
     fragment_density_map.imageView = depth_image_view_fragment;
 
-    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-multiview-06127");
-    m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06108");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06145");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06146");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06861");
@@ -3305,7 +3295,6 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
     m_commandBuffer->begin();
-    m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-apiVersion-07908");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-multiview-06127");
     m_commandBuffer->BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();


### PR DESCRIPTION
The Renderpass/Framebuffer creations checks were getting long and a tad out-of-hand

This does 3 things

- Moves more checks to stateless where possible
- Groups logical extension logic to own function
- Pass by reference as much as possible (instead of pointers)