### PR TITLE
gpu: Don't run spirv-opt on non-instrumented shaders

### DIFF
--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -180,6 +180,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                          const SafeCreateInfo &modified_create_infos, bool passed_in_shader_stage_ci);
 
     // GPU-AV and DebugPrint are going to have a different way to do the actual shader instrumentation logic
+    // Returns if shader was instrumented successfully or not
     virtual bool InstrumentShader(const vvl::span<const uint32_t> &input, uint32_t unique_shader_id, const Location &loc,
                                   std::vector<uint32_t> &out_instrumented_spirv) = 0;
 

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -94,6 +94,11 @@ bool Validator::InstrumentShader(const vvl::span<const uint32_t> &input, uint32_
         module.RunPassRayQuery();
     }
 
+    // If nothing was instrumented, leave early to save time
+    if (!module.IsInstrumented()) {
+        return false;
+    }
+
     for (const auto info : module.link_info_) {
         module.LinkFunction(info);
     }

--- a/layers/gpu/spirv/module.h
+++ b/layers/gpu/spirv/module.h
@@ -65,6 +65,7 @@ class Module {
     // Order of functions that will try to be linked in
     std::vector<LinkInfo> link_info_;
     void LinkFunction(const LinkInfo& info);
+    bool IsInstrumented() const { return !link_info_.empty(); }
 
     // The class is designed to be written out to a binary file.
     void ToBinary(std::vector<uint32_t>& out);


### PR DESCRIPTION
Currently for ALL shaders in GPU-AV (even thoughs we don't instrument) we are still running the re-building the SPIR-V and then running it through spirv-opt

This will make things faster when we are running on shaders that don't have anything to touch

it will also allow other changes in the shader instrumentation to freely do things knowing it will be ignored if it is never used