### PR TITLE
gpu: Add setting to override disable GPU-AV

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1207,6 +1207,26 @@
                                             },
                                             "settings": [
                                                 {
+                                                    "key": "gpuav_debug_disable_all",
+                                                    "label": "Disable all of GPU-AV",
+                                                    "description": "Acts as a VkValidationFeatureDisableEXT to override the VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT passed by the user",
+                                                    "type": "BOOL",
+                                                    "default": false,
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "validate_gpu_based",
+                                                                "value": "GPU_BASED_GPU_ASSISTED"
+                                                            }
+                                                        ]
+                                                    }
+                                                },
+                                                {
                                                     "key": "gpuav_debug_validate_instrumented_shaders",
                                                     "label": "Validate instrumented shaders",
                                                     "description": "Run spirv-val after doing shader instrumentation",

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -90,6 +90,7 @@ const char *VK_LAYER_GPUAV_BUFFER_COPIES = "gpuav_buffer_copies";
 const char *VK_LAYER_GPUAV_RESERVE_BINDING_SLOT = "gpuav_reserve_binding_slot";
 const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 
+const char *VK_LAYER_GPUAV_DEBUG_DISABLE_ALL = "gpuav_debug_disable_all";
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
 
@@ -576,6 +577,15 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     const auto *validation_flags_ext = vku::FindStructInPNextChain<VkValidationFlagsEXT>(settings_data->create_info);
     if (validation_flags_ext) {
         SetValidationFlags(settings_data->disables, validation_flags_ext);
+    }
+
+    // if app is setting VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT, we can use this to disable it for debugging
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DISABLE_ALL)) {
+        bool disable_gpuav = false;
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_DISABLE_ALL, disable_gpuav);
+        if (disable_gpuav) {
+            settings_data->enables[gpu_validation] = false;
+        }
     }
 
     const bool use_fine_grained_settings = disables.empty() && enables.empty();


### PR DESCRIPTION
The app might be setting `VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT` and there is no `VkValidationFeatureDisableEXT` to disable it, so this adds a `VK_LAYER_GPUAV_DEBUG_DISABLE_ALL` option

this is useful for debugging if GPU-AV is the issue or not for app that is forcing it on