### PR TITLE
scripts: Fix clang-format on generate_spirv.py

### DIFF
--- a/scripts/generate_spirv.py
+++ b/scripts/generate_spirv.py
@@ -116,24 +116,24 @@ def write(words, filename, apiname, outdir = None):
 // See generate_spirv.py for modifications
 
 /***************************************************************************
-*
-* Copyright (c) 2021-2024 The Khronos Group Inc.
-* Copyright (c) 2021-2024 Valve Corporation
-* Copyright (c) 2021-2024 LunarG, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-****************************************************************************/
+ *
+ * Copyright (c) 2021-2024 The Khronos Group Inc.
+ * Copyright (c) 2021-2024 Valve Corporation
+ * Copyright (c) 2021-2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
 
 #pragma once
 
@@ -148,24 +148,24 @@ extern const uint32_t {name}[];
 // See generate_spirv.py for modifications
 
 /***************************************************************************
-*
-* Copyright (c) 2021-2024 The Khronos Group Inc.
-* Copyright (c) 2021-2024 Valve Corporation
-* Copyright (c) 2021-2024 LunarG, Inc.
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*     http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*
-****************************************************************************/
+ *
+ * Copyright (c) 2021-2024 The Khronos Group Inc.
+ * Copyright (c) 2021-2024 Valve Corporation
+ * Copyright (c) 2021-2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ ****************************************************************************/
 
 #include "{name}.h"
 
@@ -268,7 +268,7 @@ def main():
     for filename in os.listdir(diagnostic_shaders):
         if (filename.split(".")[-1] in shader_type):
             shaders_to_compile.append(os.path.join(diagnostic_shaders, filename))
-    
+
     instrumentation_shaders = common_ci.RepoRelative('layers/gpu/shaders/instrumentation')
     for filename in os.listdir(instrumentation_shaders):
         if (filename.split(".")[-1] in shader_type):


### PR DESCRIPTION
currently after you run `generate_spirv.py` it will show diffs until you re-run clang-format

we could add the "automatically run clang-format" into the script, but the only spot was the copyrights and doubt another new part will come anytime soon