### PR TITLE
gpu: Add setting to limit shader instrumentation

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1245,6 +1245,29 @@
                                                             }
                                                         ]
                                                     }
+                                                },
+                                                {
+                                                    "key": "gpuav_debug_max_instrumented_count",
+                                                    "label": "Limit how many time a pass can instrument the SPIR-V",
+                                                    "description": "Zero is same as unlimited",
+                                                    "type": "INT",
+                                                    "default": 0,
+                                                    "range": {
+                                                        "min": 0
+                                                    },
+                                                    "platforms": [
+                                                        "WINDOWS",
+                                                        "LINUX"
+                                                    ],
+                                                    "dependence": {
+                                                        "mode": "ALL",
+                                                        "settings": [
+                                                            {
+                                                                "key": "validate_gpu_based",
+                                                                "value": "GPU_BASED_GPU_ASSISTED"
+                                                            }
+                                                        ]
+                                                    }
                                                 }
                                             ]
                                         }

--- a/layers/gpu/core/gpu_settings.h
+++ b/layers/gpu/core/gpu_settings.h
@@ -40,6 +40,7 @@ struct GpuAVSettings {
 
     bool debug_validate_instrumented_shaders = false;
     bool debug_dump_instrumented_shaders = false;
+    uint32_t debug_max_instrumented_count = 0;  // zero is same as "unlimited"
 
     bool IsShaderInstrumentationEnabled() const { return validate_descriptors || validate_bda || validate_ray_query; }
     // Also disables shader caching and select shader instrumentation

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -79,7 +79,7 @@ bool Validator::InstrumentShader(const vvl::span<const uint32_t> &input, uint32_
     spv_target_env target_env = PickSpirvEnv(api_version, IsExtEnabled(device_extensions.vk_khr_spirv_1_4));
 
     // Use the unique_shader_id as a shader ID so we can look up its handle later in the shader_map.
-    spirv::Module module(binaries[0], unique_shader_id, desc_set_bind_index_);
+    spirv::Module module(binaries[0], unique_shader_id, desc_set_bind_index_, gpuav_settings.debug_max_instrumented_count);
 
     // If descriptor indexing is enabled, enable length checks and updated descriptor checks
     if (gpuav_settings.validate_descriptors) {

--- a/layers/gpu/spirv/module.cpp
+++ b/layers/gpu/spirv/module.cpp
@@ -24,8 +24,12 @@
 namespace gpuav {
 namespace spirv {
 
-Module::Module(std::vector<uint32_t> words, uint32_t shader_id, uint32_t output_buffer_descriptor_set)
-    : type_manager_(*this), shader_id_(shader_id), output_buffer_descriptor_set_(output_buffer_descriptor_set) {
+Module::Module(std::vector<uint32_t> words, uint32_t shader_id, uint32_t output_buffer_descriptor_set,
+               uint32_t max_instrumented_count)
+    : type_manager_(*this),
+      max_instrumented_count_(max_instrumented_count),
+      shader_id_(shader_id),
+      output_buffer_descriptor_set_(output_buffer_descriptor_set) {
     uint32_t instruction_count = 0;
     std::vector<uint32_t>::const_iterator it = words.cbegin();
     header_.magic_number = *it++;

--- a/layers/gpu/spirv/module.h
+++ b/layers/gpu/spirv/module.h
@@ -37,7 +37,8 @@ struct ModuleHeader {
 // There are other helper classes that are charge of handling the various parts of the module.
 class Module {
   public:
-    Module(std::vector<uint32_t> words, uint32_t shader_id, uint32_t output_buffer_descriptor_set);
+    Module(std::vector<uint32_t> words, uint32_t shader_id, uint32_t output_buffer_descriptor_set,
+           uint32_t max_instrumented_count = 0);
 
     // Memory that holds all the actual SPIR-V data, replicate the "Logical Layout of a Module" of SPIR-V.
     // Divided into sections to make easier to modify each part at different times, but still keeps it simple to write out all the
@@ -79,6 +80,8 @@ class Module {
     bool HasCapability(spv::Capability capability);
     void AddCapability(spv::Capability capability);
     void AddExtension(const char* extension);
+
+    const uint32_t max_instrumented_count_ = 0;  // zero is same as "unlimited"
 
   private:
     // provides a way to map back and know which original SPIR-V this was from

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -384,6 +384,11 @@ void Pass::Run() {
                 // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
                 if (!AnalyzeInstruction(*function, *(inst_it->get()))) continue;
 
+                if (module_.max_instrumented_count_ != 0 && instrumented_count_ >= module_.max_instrumented_count_) {
+                    return;
+                }
+                instrumented_count_++;
+
                 // Add any debug information to pass into the function call
                 InjectionData injection_data;
                 injection_data.stage_info_id = GetStageInfo(*function, block_it, inst_it);

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -104,6 +104,8 @@ class Pass {
 
   private:
     InstructionIt FindTargetInstruction(BasicBlock& block) const;
+
+    uint32_t instrumented_count_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -92,6 +92,7 @@ const char *VK_LAYER_GPUAV_VMA_LINEAR_OUTPUT = "gpuav_vma_linear_output";
 
 const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_validate_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
+const char *VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT = "gpuav_debug_max_instrumented_count";
 
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
@@ -557,6 +558,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     if (gpuav_settings.debug_validate_instrumented_shaders || gpuav_settings.debug_dump_instrumented_shaders) {
         // When debugging instrumented shaders, if it is cached, it will never get to the InstrumentShader() call
         gpuav_settings.cache_instrumented_shaders = false;
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT,
+                                gpuav_settings.debug_max_instrumented_count);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {


### PR DESCRIPTION
Adds a `VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT` setting to help quickly limit how much we instrument shaders to easily see if limiting it fixes perf issues and understand how it scales easier

Also in future can add a "debug verbose" option to get this information as well