### PR TITLE
sync: Make queue submit validation regular layer option

### DIFF
--- a/docs/synchronization_usage.md
+++ b/docs/synchronization_usage.md
@@ -22,14 +22,9 @@ For an overview of how to configure layers, refer to the [Layers Overview and Co
 Synchronization Validation settings are managed by configuring the Validation Layer. These settings are described in the
 [VK_LAYER_KHRONOS_validation](https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html#user-content-layer-details) document.
 
-Synchronization Validation settings can also be enabled and configured using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html) included with the Vulkan SDK.
+The `khronos_validation.validate_sync` configuration variable enables Synchronization Validation. Additional configuration settings have this naming pattern: `khronos_validation.syncval_*`.
 
-Queue submit time validation can be disabled using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html), or by adding:
-
-`VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT`
-
-to the "Disables" as documented in [VK_LAYER_KHRONOS_validation](https://vulkan.lunarg.com/doc/sdk/latest/windows/khronos_validation_layer.html#user-content-layer-details).
-
+Synchronization Validation settings can also be managed using the [Vulkan Configurator](https://vulkan.lunarg.com/doc/sdk/latest/windows/vkconfig.html) included with the Vulkan SDK.
 
 ## Synchronization Validation Functionality
 

--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -351,10 +351,6 @@
                             "value": true
                         },
                         {
-                            "key": "sync_queue_submit",
-                            "value": true
-                        },
-                        {
                             "key": "validate_gpu_based",
                             "value": "GPU_BASED_NONE"
                         },
@@ -714,7 +710,7 @@
                         {
                             "key": "validate_sync",
                             "label": "Synchronization",
-                            "description": "Enable synchronization validation during command buffers recording. This feature reports resource access conflicts due to missing or incorrect synchronization operations between actions (Draw, Copy, Dispatch, Blit) reading or writing the same regions of memory.",
+                            "description": "Check for resource access conflicts caused by missing or incorrectly used synchronization operations.",
                             "url": "${LUNARG_SDK}/synchronization_usage.html",
                             "type": "BOOL",
                             "default": false,
@@ -728,9 +724,9 @@
                             ],
                             "settings": [
                                 {
-                                    "key": "sync_queue_submit",
-                                    "label": "QueueSubmit Synchronization Validation",
-                                    "description": "Enable synchronization validation between submitted command buffers when Synchronization Validation is enabled. This option will increase the synchronization performance cost.",
+                                    "key": "syncval_submit_time_validation",
+                                    "label": "Submit time validation",
+                                    "description": "Enable synchronization validation between submitted command buffers and also for presentation operations. This option can incur a significant performance cost.",
                                     "type": "BOOL",
                                     "default": true,
                                     "status": "STABLE",
@@ -1591,12 +1587,6 @@
                             "key": "VALIDATION_CHECK_DISABLE_OBJECT_IN_USE",
                             "label": "Object in Use",
                             "description": "Check that Vulkan objects are not in use by a command buffer when they are destroyed.",
-                            "view": "ADVANCED"
-                        },
-                        {
-                            "key": "VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
-                            "label": "QueueSubmit Synchronization Validation",
-                            "description": "Check synchronization validation between submitted command buffers when Synchronization Validation is enabled.",
                             "view": "ADVANCED"
                         },
                         {

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -59,7 +59,6 @@ const char *VK_LAYER_UNIQUE_HANDLES = "unique_handles";
 const char *VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
 const char *VK_LAYER_CHECK_SHADERS = "check_shaders";
 const char *VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
-const char *VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 
 const char *VK_LAYER_MESSAGE_ID_FILTER = "message_id_filter";
 const char *VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
@@ -94,6 +93,10 @@ const char *VK_LAYER_GPUAV_DEBUG_VALIDATE_INSTRUMENTED_SHADERS = "gpuav_debug_va
 const char *VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS = "gpuav_debug_dump_instrumented_shaders";
 const char *VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT = "gpuav_debug_max_instrumented_count";
 
+// SyncVal
+// ---
+const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
+
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 
@@ -105,6 +108,9 @@ const char *DEPRECATED_GPUAV_VMA_LINEAR_OUTPUT = "vma_linear_output";
 const char *DEPRECATED_GPUAV_WARN_ON_ROBUST_OOB = "warn_on_robust_oob";
 const char *DEPRECATED_GPUAV_USE_INSTRUMENTED_SHADER_CACHE = "use_instrumented_shader_cache";
 const char *DEPRECATED_GPUAV_SELECT_INSTRUMENTED_SHADERS = "select_instrumented_shaders";
+
+// These were deprecated after the 1.3.283 SDK release
+const char *DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT = "sync_queue_submit";
 
 // Set the local disable flag for the appropriate VALIDATION_CHECK_DISABLE enum
 void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDisables disable_id) {
@@ -120,9 +126,6 @@ void SetValidationDisable(CHECK_DISABLED &disable_data, const ValidationCheckDis
             break;
         case VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION:
             disable_data[image_layout_validation] = true;
-            break;
-        case VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT:
-            disable_data[sync_validation_queue_submit] = true;
             break;
         default:
             assert(false);
@@ -565,6 +568,17 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 gpuav_settings.debug_max_instrumented_count);
     }
 
+    SyncValSettings &syncval_settings = *settings_data->syncval_settings;
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION,
+                                syncval_settings.submit_time_validation);
+    } else if (vkuHasLayerSetting(layer_setting_set, DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT)) {
+        vkuGetLayerSettingValue(layer_setting_set, DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT,
+                                syncval_settings.submit_time_validation);
+        printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
+               DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION);
+    }
+
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {
         vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME,
                                 settings_data->message_format_settings->display_application_name);
@@ -619,8 +633,6 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
         SetValidationSetting(layer_setting_set, settings_data->disables, object_tracking, VK_LAYER_OBJECT_LIFETIME);
         SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation, VK_LAYER_CHECK_SHADERS);
         SetValidationSetting(layer_setting_set, settings_data->disables, shader_validation_caching, VK_LAYER_CHECK_SHADERS_CACHING);
-        SetValidationSetting(layer_setting_set, settings_data->disables, sync_validation_queue_submit,
-                             VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT);
     }
 
     vkuDestroyLayerSettingSet(layer_setting_set, nullptr);

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -34,7 +34,6 @@ enum ValidationCheckDisables {
     VALIDATION_CHECK_DISABLE_OBJECT_IN_USE,
     VALIDATION_CHECK_DISABLE_QUERY_VALIDATION,
     VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION,
-    VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT,
 };
 
 enum ValidationCheckEnables {
@@ -60,7 +59,6 @@ enum DisableFlags {
     handle_wrapping,
     shader_validation,
     shader_validation_caching,
-    sync_validation_queue_submit,
     // Insert new disables above this line
     kMaxDisableFlags,
 };
@@ -127,8 +125,6 @@ static const vvl::unordered_map<std::string, ValidationCheckDisables> Validation
     {"VALIDATION_CHECK_DISABLE_OBJECT_IN_USE", VALIDATION_CHECK_DISABLE_OBJECT_IN_USE},
     {"VALIDATION_CHECK_DISABLE_QUERY_VALIDATION", VALIDATION_CHECK_DISABLE_QUERY_VALIDATION},
     {"VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION", VALIDATION_CHECK_DISABLE_IMAGE_LAYOUT_VALIDATION},
-    {"VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT",
-     VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT},
 };
 
 static const vvl::unordered_map<std::string, ValidationCheckEnables> ValidationEnableLookup = {
@@ -152,7 +148,6 @@ static const std::vector<std::string> DisableFlagNameHelper = {
     "VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT",                 // handle_wrapping,
     "VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT",                        // shader_validation,
     "VK_VALIDATION_FEATURE_DISABLE_SHADER_VALIDATION_CACHING_EXT",      // shader_validation_caching
-    "VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"  // queuesubmit time sync_validation,
 };
 
 // This should mirror the 'EnableFlags' enumerated type

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -17,4 +17,6 @@
 
 #pragma once
 
-struct SyncValSettings {};
+struct SyncValSettings {
+    bool submit_time_validation = true;
+};

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -30,18 +30,19 @@ void VkSyncValTest::InitSyncValFramework(bool disable_queue_submit_validation) {
         features_.disabledValidationFeatureCount = 0;
     }
 
-    static VkLayerSettingEXT settings[2];
+    static VkLayerSettingEXT settings[1];
     uint32_t setting_count = 0;
 
-    static const char *kDisableQueuSubmitSyncValidation[] = {"VALIDATION_CHECK_DISABLE_SYNCHRONIZATION_VALIDATION_QUEUE_SUBMIT"};
+    static const VkBool32 submit_time_validation = false;
     if (disable_queue_submit_validation) {
-        settings[setting_count++] = {OBJECT_LAYER_NAME, "disables", VK_LAYER_SETTING_TYPE_STRING_EXT, 1,
-                                     kDisableQueuSubmitSyncValidation};
+        settings[setting_count++] = {OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1,
+                                     &submit_time_validation};
     }
 
     // The pNext of syncval_setting is modified by InitFramework that's why it can't
     // be static (should be separate instance per stack frame). Also we show
     // explicitly that it's not const (InitFramework casts const pNext to non-const).
+    assert(setting_count <= std::size(settings));
     VkLayerSettingsCreateInfoEXT syncval_setting = {VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT, nullptr, setting_count,
                                                     settings};
 


### PR DESCRIPTION
Remove some legacy configuration and make queue submit validation a regular layer setting of synchronization validation.

New setting is called: `syncval_submit_time_validation`.

Decided to go with `Submit time validation` term. One example it is used here: https://vulkan.org/user/pages/09.events/vulkanised-2024/vulkanised-2024-john-zulauf-lunarg.pdf. The `time` suffix is often added because it is more about the place where the validation happens and to less degree about validating vkQueueSubmit itself. The validation also happens for presentation request, so not only vkQueueSubmit(2) specific.
