### PR TITLE
gpu: Pipe Location through for internal errors

### DIFF
--- a/layers/gpu/core/gpu_state_tracker.cpp
+++ b/layers/gpu/core/gpu_state_tracker.cpp
@@ -122,14 +122,15 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
 
 vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
     for (const auto &submission : submissions) {
+        auto loc = submission.loc.Get();
         for (auto &cb : submission.cbs) {
             auto gpu_cb = std::static_pointer_cast<CommandBuffer>(cb);
             auto guard = gpu_cb->ReadLock();
-            gpu_cb->PreProcess();
+            gpu_cb->PreProcess(loc);
             for (auto *secondary_cb : gpu_cb->linkedCommandBuffers) {
                 auto secondary_guard = secondary_cb->ReadLock();
                 auto *secondary_gpu_cb = static_cast<CommandBuffer *>(secondary_cb);
-                secondary_gpu_cb->PreProcess();
+                secondary_gpu_cb->PreProcess(loc);
             }
         }
     }

--- a/layers/gpu/core/gpu_state_tracker.h
+++ b/layers/gpu/core/gpu_state_tracker.h
@@ -48,7 +48,7 @@ class CommandBuffer : public vvl::CommandBuffer {
     CommandBuffer(gpu::GpuShaderInstrumentor &shader_instrumentor_, VkCommandBuffer handle,
                   const VkCommandBufferAllocateInfo *pCreateInfo, const vvl::CommandPool *pool);
 
-    virtual bool PreProcess() = 0;
+    virtual bool PreProcess(const Location &loc) = 0;
     virtual void PostProcess(VkQueue queue, const Location &loc) = 0;
 };
 }  // namespace gpu_tracker

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -725,8 +725,8 @@ void CommandBuffer::Destroy() {
     vvl::CommandBuffer::Destroy();
 }
 
-void CommandBuffer::Reset() {
-    vvl::CommandBuffer::Reset();
+void CommandBuffer::Reset(const Location &loc) {
+    vvl::CommandBuffer::Reset(loc);
     ResetCBState();
 }
 

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -63,11 +63,11 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
                   const vvl::CommandPool* pool);
     ~CommandBuffer();
 
-    bool PreProcess() final { return !buffer_infos.empty(); }
+    bool PreProcess(const Location& loc) final { return !buffer_infos.empty(); }
     void PostProcess(VkQueue queue, const Location& loc) final;
 
     void Destroy() final;
-    void Reset() final;
+    void Reset(const Location& loc) final;
 
   private:
     void ResetCBState();

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -51,7 +51,7 @@ class DescriptorSet : public vvl::DescriptorSet {
 
     VkDeviceAddress GetLayoutState();
     std::shared_ptr<State> GetCurrentState();
-    std::shared_ptr<State> GetOutputState(Validator &gpuav);
+    std::shared_ptr<State> GetOutputState(Validator &gpuav, const Location &loc);
 
   protected:
     bool SkipBinding(const vvl::DescriptorBinding &binding, bool is_dynamic_accessed) const override { return true; }

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.h
@@ -29,5 +29,6 @@ class Validator;
 void UpdateBoundPipeline(Validator& gpuav, VkCommandBuffer cb, VkPipelineBindPoint pipeline_bind_point, VkPipeline pipeline,
                          const Location& loc);
 void UpdateBoundDescriptors(Validator& gpuav, VkCommandBuffer cb, VkPipelineBindPoint pipeline_bind_point, const Location& loc);
-[[nodiscard]] bool UpdateBindlessStateBuffer(Validator& gpuav, CommandBuffer& cb_state, VmaAllocator vma_allocator);
+[[nodiscard]] bool UpdateBindlessStateBuffer(Validator& gpuav, CommandBuffer& cb_state, VmaAllocator vma_allocator,
+                                             const Location& loc);
 }  // namespace gpuav

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -82,9 +82,9 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
                   const vvl::CommandPool *pool);
     ~CommandBuffer();
 
-    bool PreProcess() final;
+    bool PreProcess(const Location &loc) final;
     void PostProcess(VkQueue queue, const Location &loc) final;
-    [[nodiscard]] bool ValidateBindlessDescriptorSets();
+    [[nodiscard]] bool ValidateBindlessDescriptorSets(const Location &loc);
 
     const VkDescriptorSetLayout &GetInstrumentationDescriptorSetLayout() const {
         assert(instrumentation_desc_set_layout_ != VK_NULL_HANDLE);
@@ -118,10 +118,10 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
 
     const gpu::DeviceMemoryBlock &GetBdaRangesSnapshot() const { return bda_ranges_snapshot_; }
 
-    void ClearCmdErrorsCountsBuffer() const;
+    void ClearCmdErrorsCountsBuffer(const Location &loc) const;
 
     void Destroy() final;
-    void Reset() final;
+    void Reset(const Location &loc) final;
 
     gpu::GpuResourcesManager gpu_resources_manager;
     // Using stdext::inplace_function over std::function to allocate memory in place
@@ -130,12 +130,12 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
     std::vector<ErrorLoggerFunc> per_command_error_loggers;
 
   private:
-    void AllocateResources();
+    void AllocateResources(const Location &loc);
     void ResetCBState();
     bool NeedsPostProcess();
 
     VkDeviceSize GetBdaRangesBufferByteSize() const;
-    [[nodiscard]] bool UpdateBdaRangesBuffer();
+    [[nodiscard]] bool UpdateBdaRangesBuffer(const Location &loc);
 
     Validator &state_;
 

--- a/layers/gpu/shaders/instrumentation/buffer_device_address.comp
+++ b/layers/gpu/shaders/instrumentation/buffer_device_address.comp
@@ -36,7 +36,7 @@ struct Range {
     uint64_t end;
 };
 
-// See gpuav::CommandBuffer::UpdateBdaRangesBuffer in gpuav.cpp for a description of the table format
+// See gpuav::CommandBuffer::UpdateBdaRangesBuffer for a description of the table format
 // Ranges are supposed to:
 // 1) be stored for low to high
 // 2) not overlap
@@ -46,9 +46,9 @@ layout(set = kInstDefaultDescriptorSet, binding = kBindingInstBufferDeviceAddres
 };
 
 bool inst_buffer_device_address(
-    const uint inst_num, 
-    const uvec4 stage_info, 
-    const uint64_t addr, 
+    const uint inst_num,
+    const uvec4 stage_info,
+    const uint64_t addr,
     const uint access_byte_size,
     const uint access_instruction)
 {

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -144,10 +144,10 @@ void CommandPool::Free(uint32_t count, const VkCommandBuffer *command_buffers) {
     }
 }
 
-void CommandPool::Reset() {
+void CommandPool::Reset(const Location &loc) {
     for (auto &entry : commandBuffers) {
         auto guard = entry.second->WriteLock();
-        entry.second->Reset();
+        entry.second->Reset(loc);
     }
 }
 
@@ -310,7 +310,7 @@ void CommandBuffer::ResetCBState() {
     dev_data.debug_report->ResetCmdDebugUtilsLabel(VkHandle());
 }
 
-void CommandBuffer::Reset() {
+void CommandBuffer::Reset(const Location &loc) {
     ResetCBState();
     // Remove reverse command buffer links.
     Invalidate(true);
@@ -988,7 +988,8 @@ void vvl::CommandBuffer::EncodeVideo(const VkVideoEncodeInfoKHR *pEncodeInfo) {
 
 void CommandBuffer::Begin(const VkCommandBufferBeginInfo *pBeginInfo) {
     if (CbState::Recorded == state || CbState::InvalidComplete == state) {
-        Reset();
+        Location loc(Func::vkBeginCommandBuffer);
+        Reset(loc);
     }
 
     // Set updated state here in case implicit reset occurs above

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -145,7 +145,7 @@ class CommandPool : public StateObject {
 
     void Allocate(const VkCommandBufferAllocateInfo *create_info, const VkCommandBuffer *command_buffers);
     void Free(uint32_t count, const VkCommandBuffer *command_buffers);
-    void Reset();
+    void Reset(const Location &loc);
 
     void Destroy() override;
 };
@@ -564,7 +564,7 @@ class CommandBuffer : public RefcountedStateObject {
         RemoveChild(base);
     }
 
-    virtual void Reset();
+    virtual void Reset(const Location &loc);
 
     void IncrementResources();
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1838,7 +1838,7 @@ void ValidationStateTracker::PostCallRecordResetCommandPool(VkDevice device, VkC
     if (VK_SUCCESS != record_obj.result) return;
     // Reset all of the CBs allocated from this pool
     if (auto pool = Get<vvl::CommandPool>(commandPool)) {
-        pool->Reset();
+        pool->Reset(record_obj.location);
     }
 }
 
@@ -2227,7 +2227,7 @@ void ValidationStateTracker::PostCallRecordResetCommandBuffer(VkCommandBuffer co
     if (VK_SUCCESS == record_obj.result) {
         auto cb_state = GetWrite<vvl::CommandBuffer>(commandBuffer);
         if (cb_state) {
-            cb_state->Reset();
+            cb_state->Reset(record_obj.location);
         }
     }
 }

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1259,8 +1259,8 @@ void syncval_state::CommandBuffer::Destroy() {
     vvl::CommandBuffer::Destroy();
 }
 
-void syncval_state::CommandBuffer::Reset() {
-    vvl::CommandBuffer::Reset();
+void syncval_state::CommandBuffer::Reset(const Location &loc) {
+    vvl::CommandBuffer::Reset(loc);
     access_context.Reset();
 }
 

--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -418,7 +418,7 @@ class CommandBuffer : public vvl::CommandBuffer {
     void NotifyInvalidate(const vvl::StateObject::NodeList &invalid_nodes, bool unlink) override;
 
     void Destroy() override;
-    void Reset() override;
+    void Reset(const Location &loc) override;
 };
 }  // namespace syncval_state
 


### PR DESCRIPTION
For our `InternalError` we seem to have random `Location` used. When I hit this error I expected to know which original incoming function was coming in. For things like `Reset()` there are many things that can reset the command buffer and very helpful to have that information