### PR TITLE
layers: Add more tests and bounds checks for DPB slots

### DIFF
--- a/layers/state_tracker/video_session_state.cpp
+++ b/layers/state_tracker/video_session_state.cpp
@@ -339,6 +339,11 @@ void VideoSessionDeviceState::Reset() {
 void VideoSessionDeviceState::Activate(int32_t slot_index, const VideoPictureID &picture_id, const VideoPictureResource &res) {
     assert(!picture_id.IsBothFields());
 
+    if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
+        // Out-of-bounds slot index
+        return;
+    }
+
     is_active_[slot_index] = true;
 
     if (picture_id.IsFrame()) {
@@ -359,6 +364,11 @@ void VideoSessionDeviceState::Activate(int32_t slot_index, const VideoPictureID 
 
 void VideoSessionDeviceState::Invalidate(int32_t slot_index, const VideoPictureID &picture_id) {
     assert(!picture_id.IsBothFields());
+
+    if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
+        // Out-of-bounds slot index
+        return;
+    }
 
     bool previous_is_frame = pictures_per_id_[slot_index].find(VideoPictureID::Frame()) != pictures_per_id_[slot_index].end();
     if (picture_id.IsFrame() || previous_is_frame) {
@@ -389,6 +399,11 @@ void VideoSessionDeviceState::Invalidate(int32_t slot_index, const VideoPictureI
 }
 
 void VideoSessionDeviceState::Deactivate(int32_t slot_index) {
+    if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
+        // Out-of-bounds slot index
+        return;
+    }
+
     is_active_[slot_index] = false;
     all_pictures_[slot_index].clear();
     pictures_per_id_[slot_index].clear();

--- a/layers/state_tracker/video_session_state.h
+++ b/layers/state_tracker/video_session_state.h
@@ -427,13 +427,27 @@ class VideoSessionDeviceState {
           encode_() {}
 
     bool IsInitialized() const { return initialized_; }
-    bool IsSlotActive(int32_t slot_index) const { return is_active_[slot_index]; }
+    bool IsSlotActive(int32_t slot_index) const {
+        if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= is_active_.size()) {
+            // Out-of-bounds slot index
+            return false;
+        }
+        return is_active_[slot_index];
+    }
 
     bool IsSlotPicture(int32_t slot_index, const VideoPictureResource &res) const {
+        if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= all_pictures_.size()) {
+            // Out-of-bounds slot index
+            return false;
+        }
         return all_pictures_[slot_index].find(res) != all_pictures_[slot_index].end();
     }
 
     bool IsSlotPicture(int32_t slot_index, const VideoPictureID &picture_id, const VideoPictureResource &res) const {
+        if (slot_index < 0 || static_cast<uint32_t>(slot_index) >= pictures_per_id_.size()) {
+            // Out-of-bounds slot index
+            return false;
+        }
         auto it = pictures_per_id_[slot_index].find(picture_id);
         return it != pictures_per_id_[slot_index].end() && it->second == res;
     }


### PR DESCRIPTION
Note that the test passes even without the additional bounds check, and these safety measures were added in response to https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8267.