### PR TITLE
gpu: Fix when OpStore is used in first block

### DIFF
--- a/layers/gpu/spirv/instruction.h
+++ b/layers/gpu/spirv/instruction.h
@@ -64,6 +64,9 @@ struct Instruction {
 
     void ToBinary(std::vector<uint32_t>& out);
 
+    bool operator==(Instruction const& other) const { return words_ == other.words_; }
+    bool operator!=(Instruction const& other) const { return words_ != other.words_; }
+
     // Store minimal extra data
     uint32_t result_id_index_ = 0;
     uint32_t type_id_index_ = 0;

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -364,8 +364,12 @@ void Pass::InjectFunctionCheck(BasicBlockIt block_it, InstructionIt* inst_it, co
 InstructionIt Pass::FindTargetInstruction(BasicBlock& block) const {
     const uint32_t target_id = target_instruction_->ResultId();
     for (auto inst_it = block.instructions_.begin(); inst_it != block.instructions_.end(); ++inst_it) {
+        // This has to re-loop the entire block to find the instruction, using the ResultID, we can quickly compare
         if ((*inst_it)->ResultId() == target_id) {
-            return inst_it;
+            // Things like OpStore will have a result id of zero, so need to do deep instruction comparison
+            if (*(*inst_it) == *target_instruction_) {
+                return inst_it;
+            }
         }
     }
     assert(false);


### PR DESCRIPTION
Fixes issue where you have

```swift
%firstBlock = OpLabel
OpStore %a %b // don't inject anything
OpStore %c %d // inject check
```