### PR TITLE
sync: Add syncval_shader_access_heuristic setting

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -726,7 +726,24 @@
                                 {
                                     "key": "syncval_submit_time_validation",
                                     "label": "Submit time validation",
-                                    "description": "Enable synchronization validation between submitted command buffers and also for presentation operations. This option can incur a significant performance cost.",
+                                    "description": "Enable synchronization validation on the boundary between submitted command buffers. This also validates accesses from presentation operations. This option can incur a significant performance cost.",
+                                    "type": "BOOL",
+                                    "default": true,
+                                    "status": "STABLE",
+                                    "dependence": {
+                                        "mode": "ALL",
+                                        "settings": [
+                                            {
+                                                "key": "validate_sync",
+                                                "value": true
+                                            }
+                                        ]
+                                    }
+                                },
+                                {
+                                    "key": "syncval_shader_access_heuristic",
+                                    "label": "Shader access heuristic",
+                                    "description": "Takes into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses.",
                                     "type": "BOOL",
                                     "default": true,
                                     "status": "STABLE",

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -97,6 +97,7 @@ const char *VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT = "gpuav_debug_max_instr
 // SyncVal
 // ---
 const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
+const char *VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC = "syncval_shader_access_heuristic";
 
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
@@ -578,6 +579,11 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                                 syncval_settings.submit_time_validation);
         printf("Validation Setting Warning - %s was set, this is deprecated, please use %s\n",
                DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC,
+                                syncval_settings.shader_access_heuristic);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -299,6 +299,9 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
 bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
                                                                    const Location &loc) const {
     bool skip = false;
+    if (!sync_state_->syncval_settings.shader_access_heuristic) {
+        return skip;
+    }
     const vvl::Pipeline *pipe = nullptr;
     const std::vector<LastBound::PER_SET> *per_sets = nullptr;
     cb_state_->GetCurrentPipelineAndDesriptorSets(pipelineBindPoint, &pipe, &per_sets);
@@ -454,6 +457,9 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
 // TODO: Record structure repeats Validate. Unify this code, it was the source of bugs few times already.
 void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
                                                                  const ResourceUsageTag tag) {
+    if (!sync_state_->syncval_settings.shader_access_heuristic) {
+        return;
+    }
     const vvl::Pipeline *pipe = nullptr;
     const std::vector<LastBound::PER_SET> *per_sets = nullptr;
     cb_state_->GetCurrentPipelineAndDesriptorSets(pipelineBindPoint, &pipe, &per_sets);

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -19,4 +19,5 @@
 
 struct SyncValSettings {
     bool submit_time_validation = true;
+    bool shader_access_heuristic = true;
 };


### PR DESCRIPTION
Exposes syncval validation of shader accesses as configurable option, so it's possible to disable it in case of false-positives.

![image](https://github.com/user-attachments/assets/1dd4274a-52b1-460b-b9ca-3b6e59edab00)

The option can also be disabled by setting environment variable: `VK_VALIDATION_SYNCVAL_SHADER_ACCESS_HEURISTIC=0`
