### PR TITLE
sync: Make shader_access_heuristic disabled by default

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -745,7 +745,7 @@
                                     "label": "Shader access heuristic",
                                     "description": "Takes into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses.",
                                     "type": "BOOL",
-                                    "default": true,
+                                    "default": false,
                                     "status": "STABLE",
                                     "dependence": {
                                         "mode": "ALL",

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -19,5 +19,5 @@
 
 struct SyncValSettings {
     bool submit_time_validation = true;
-    bool shader_access_heuristic = true;
+    bool shader_access_heuristic = false;
 };

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -16,7 +16,6 @@
 #include <vulkan/vulkan.h>
 
 #include "../layers/vk_lunarg_device_profile_api_layer.h"
-#include "../layers/sync/sync_settings.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/log.h>
@@ -267,10 +266,11 @@ class DebugPrintfTests : public VkLayerTest {
     void InitDebugPrintfFramework(void *p_next = nullptr, bool reserve_slot = false);
 };
 
+struct SyncValSettings;
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework(const SyncValSettings &sync_settings = SyncValSettings{});
-    void InitSyncVal();
+    void InitSyncValFramework(const SyncValSettings *p_sync_settings = nullptr);
+    void InitSyncVal(const SyncValSettings *p_sync_settings = nullptr);
     void InitTimelineSemaphore();
 };
 

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -16,6 +16,7 @@
 #include <vulkan/vulkan.h>
 
 #include "../layers/vk_lunarg_device_profile_api_layer.h"
+#include "../layers/sync/sync_settings.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/log.h>
@@ -268,16 +269,9 @@ class DebugPrintfTests : public VkLayerTest {
 
 class VkSyncValTest : public VkLayerTest {
   public:
-    void InitSyncValFramework(bool disable_queue_submit_validation = false);
+    void InitSyncValFramework(const SyncValSettings &sync_settings = SyncValSettings{});
     void InitSyncVal();
     void InitTimelineSemaphore();
-
-  protected:
-    const VkValidationFeatureEnableEXT enables_[1] = {VK_VALIDATION_FEATURE_ENABLE_SYNCHRONIZATION_VALIDATION_EXT};
-    const VkValidationFeatureDisableEXT disables_[4] = {
-        VK_VALIDATION_FEATURE_DISABLE_THREAD_SAFETY_EXT, VK_VALIDATION_FEATURE_DISABLE_API_PARAMETERS_EXT,
-        VK_VALIDATION_FEATURE_DISABLE_OBJECT_LIFETIMES_EXT, VK_VALIDATION_FEATURE_DISABLE_CORE_CHECKS_EXT};
-    VkValidationFeaturesEXT features_ = {};
 };
 
 class AndroidExternalResolveTest : public VkLayerTest {


### PR DESCRIPTION
Improvements to SPIR-V static analysis allowed to properly identify
some accesses as writes (previously there were erroneously classified
as reads). This increased the number of cases where current validation
of shader accesses results in false-positive reports. This makes
current heuristic less suitable to be enabled by default.

Some additional improvements to the heuristic are planned. It can be
useful in some scenarios, but fundamentally it can't be a
false-positive free solution.