### PR TITLE
sync: Update setting name

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -741,8 +741,8 @@
                                     }
                                 },
                                 {
-                                    "key": "syncval_shader_access_heuristic",
-                                    "label": "Shader access heuristic",
+                                    "key": "syncval_shader_accesses_heuristic",
+                                    "label": "Shader accesses heuristic",
                                     "description": "Takes into account memory accesses performed by the shader based on SPIR-V static analysis. Warning: can produce false-positives, can ignore certain types of accesses.",
                                     "type": "BOOL",
                                     "default": false,

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -97,7 +97,7 @@ const char *VK_LAYER_GPUAV_DEBUG_MAX_INSTRUMENTED_COUNT = "gpuav_debug_max_instr
 // SyncVal
 // ---
 const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_validation";
-const char *VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC = "syncval_shader_access_heuristic";
+const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
 
 // Message Formatting
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
@@ -581,9 +581,9 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
                DEPRECATED_VK_LAYER_VALIDATE_SYNC_QUEUE_SUBMIT, VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION);
     }
 
-    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESS_HEURISTIC,
-                                syncval_settings.shader_access_heuristic);
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC,
+                                syncval_settings.shader_accesses_heuristic);
     }
 
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME)) {

--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -299,7 +299,7 @@ void CommandBufferAccessContext::RecordEndRendering(const RecordObject &record_o
 bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
                                                                    const Location &loc) const {
     bool skip = false;
-    if (!sync_state_->syncval_settings.shader_access_heuristic) {
+    if (!sync_state_->syncval_settings.shader_accesses_heuristic) {
         return skip;
     }
     const vvl::Pipeline *pipe = nullptr;
@@ -457,7 +457,7 @@ bool CommandBufferAccessContext::ValidateDispatchDrawDescriptorSet(VkPipelineBin
 // TODO: Record structure repeats Validate. Unify this code, it was the source of bugs few times already.
 void CommandBufferAccessContext::RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint,
                                                                  const ResourceUsageTag tag) {
-    if (!sync_state_->syncval_settings.shader_access_heuristic) {
+    if (!sync_state_->syncval_settings.shader_accesses_heuristic) {
         return;
     }
     const vvl::Pipeline *pipe = nullptr;

--- a/layers/sync/sync_settings.h
+++ b/layers/sync/sync_settings.h
@@ -19,5 +19,5 @@
 
 struct SyncValSettings {
     bool submit_time_validation = true;
-    bool shader_access_heuristic = false;
+    bool shader_accesses_heuristic = false;
 };

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -37,7 +37,7 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
         // but we might still want that functionality to be available for testing.
         SyncValSettings settings;
         settings.submit_time_validation = true;
-        settings.shader_access_heuristic = true;
+        settings.shader_accesses_heuristic = true;
         return settings;
     }();
     const SyncValSettings &sync_settings = p_sync_settings ? *p_sync_settings : test_default_sync_settings;
@@ -46,9 +46,9 @@ void VkSyncValTest::InitSyncValFramework(const SyncValSettings *p_sync_settings)
     settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_submit_time_validation", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
                                             1, &submit_time_validation});
 
-    const auto shader_access_heuristic = static_cast<VkBool32>(sync_settings.shader_access_heuristic);
-    settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_shader_access_heuristic", VK_LAYER_SETTING_TYPE_BOOL32_EXT,
-                                            1, &shader_access_heuristic});
+    const auto shader_accesses_heuristic = static_cast<VkBool32>(sync_settings.shader_accesses_heuristic);
+    settings.emplace_back(VkLayerSettingEXT{OBJECT_LAYER_NAME, "syncval_shader_accesses_heuristic",
+                                            VK_LAYER_SETTING_TYPE_BOOL32_EXT, 1, &shader_accesses_heuristic});
 
     VkLayerSettingsCreateInfoEXT settings_create_info = vku::InitStructHelper();
     settings_create_info.settingCount = size32(settings);


### PR DESCRIPTION
Rename setting name until it's not too late.
Use plural form for accesses: `syncval_shader_access_heuristic` -> `syncval_shader_accesses_heuristic` and *Shader accesses heuristic* in the UI.

*heuristic* part is to indicate it is not 100% reliable feature.  This suffix might go away if we come up a with robust solution.
The base setting name is *Shader accesses*, which IMO indicates well it's about accesses performed by the shader. Old version *Shader access* sounds to my ears like it's access to the shader.

