### PR TITLE
build: Add -fstandalone-debug for Clang Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,11 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
             -Wimplicit-fallthrough
             -Wstring-conversion
         )
+
+        if (CMAKE_BUILD_TYPE EQUAL "DEBUG")
+            # When using tools such as lldb, strings will produce "error: summary string parsing error"
+            add_compile_options(-fstandalone-debug)
+        endif()
     endif()
 elseif(MSVC)
     add_compile_options(


### PR DESCRIPTION
For LLDB on Linux, I get `error: summary string parsing error` for any string, found from many online sources the simple fix was to add ` -fstandalone-debug` to the clang build