### PR TITLE
layers: Acknowledge allocation memory priority in NVIDIA best practices

### DIFF
--- a/layers/best_practices/bp_device_memory.cpp
+++ b/layers/best_practices/bp_device_memory.cpp
@@ -291,7 +291,8 @@ bool BestPractices::ValidateBindMemory(VkDevice device, VkDeviceMemory memory, c
 
     if (VendorCheckEnabled(kBPVendorNVIDIA) && IsExtEnabled(device_extensions.vk_ext_pageable_device_local_memory)) {
         auto mem_info = std::static_pointer_cast<const bp_state::DeviceMemory>(Get<vvl::DeviceMemory>(memory));
-        if (!mem_info->dynamic_priority) {
+        bool has_static_priority = vku::FindStructInPNextChain<VkMemoryPriorityAllocateInfoEXT>(mem_info->allocate_info.pNext);
+        if (!mem_info->dynamic_priority && !has_static_priority) {
             skip |=
                 LogPerformanceWarning("BestPractices-NVIDIA-BindMemory-NoPriority", device, loc,
                                       "%s Use vkSetDeviceMemoryPriorityEXT to provide the OS with information on which allocations "


### PR DESCRIPTION
Acknowledge VkMemoryPriorityAllocateInfoEXT as a memory priority when checking for VK_EXT_pageable_device_local_memory memory priorities in NVIDIA best practices. Add a unit test to verify this is working.

Fix #8276.
