### PR TITLE
bp: Return on invalid image in zcull scope

### DIFF
--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -187,7 +187,7 @@ void BestPractices::RecordZcullDraw(bp_state::CommandBuffer& cmd_state) {
     auto& scope = cmd_state.nv.zcull_scope;
 
     auto image = Get<vvl::Image>(scope.image);
-    ASSERT_AND_RETURN(image);
+    if (!image) return;
 
     ForEachSubresource(*image, scope.range, [&scope](uint32_t layer, uint32_t level) {
         auto& subresource = scope.tree->GetState(layer, level);


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8293

clearly from vkcube we can get here with an invalid `vvl::Image`

without knowing enough of zcull scope this is the best quick fix... I added the original `ASSERT_AND_RETURN` as it "seemed" it should be always valid, but clearly my assumption was wrong and good to know now