### PR TITLE
Add missing VUID-vkCmdExecuteCommand-pCommandBuffers checks and tests

### DIFF
--- a/layers/core_checks/cc_cmd_buffer.cpp
+++ b/layers/core_checks/cc_cmd_buffer.cpp
@@ -244,7 +244,8 @@ bool CoreChecks::PreCallValidateBeginCommandBuffer(VkCommandBuffer commandBuffer
                                  "occulusionQuery is disabled or the device does not support precise occlusion queries.",
                                  FormatHandle(commandBuffer).c_str());
             }
-            auto p_inherited_viewport_scissor_info = vku::FindStructInPNextChain<VkCommandBufferInheritanceViewportScissorInfoNV>(info->pNext);
+            auto p_inherited_viewport_scissor_info =
+                vku::FindStructInPNextChain<VkCommandBufferInheritanceViewportScissorInfoNV>(info->pNext);
             if (p_inherited_viewport_scissor_info != nullptr && p_inherited_viewport_scissor_info->viewportScissor2D) {
                 if (!enabled_features.inheritedViewportScissor2D) {
                     skip |= LogError(
@@ -891,24 +892,27 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         skip |= ValidateRenderingAttachmentLocationsKHR(*location_info, objlist, cb_loc.dot(Field::pNext));
 
                         if (location_info->colorAttachmentCount != cb_state.rendering_attachments.color_indexes.size()) {
-                            skip |=
-                                LogError(vuid_090504, objlist, cb_loc.dot(Field::pNext),
-                                         "VkRenderingAttachmentLocationInfoKHR::colorAttachmentCount = %" PRIu32
-                                         " does not match the implicit or explicit state in the primary command buffer, "
-                                         "colorAttachmentCount = %" PRIu64 ".",
-                                         location_info->colorAttachmentCount, cb_state.rendering_attachments.color_indexes.size());
+                            skip |= LogError(
+                                vuid_090504, objlist,
+                                cb_loc.pNext(Struct::VkRenderingAttachmentLocationInfoKHR, Field::colorAttachmentCount),
+                                "(%" PRIu32
+                                ") does not match the implicit or explicit state in the primary command buffer ("
+                                "%" PRIu32 ").",
+                                location_info->colorAttachmentCount, unsigned(cb_state.rendering_attachments.color_indexes.size()));
                         } else {
                             for (uint32_t idx = 0; idx < location_info->colorAttachmentCount; idx++) {
                                 if (location_info->pColorAttachmentLocations &&
                                     location_info->pColorAttachmentLocations[idx] !=
                                         cb_state.rendering_attachments.color_locations[idx]) {
-                                    skip |= LogError(vuid_090504, objlist, cb_loc.dot(Field::pNext),
-                                                     "VkRenderingAttachmentLocationInfoKHR::pColorAttachmentsLocations[%" PRIu32
-                                                     "] = %" PRIu32
-                                                     " does not match the implicit or explicit state in the primary command "
-                                                     "buffer, pColorAttachmentsLocations[%" PRIu32 "] = %" PRIu32 ".",
-                                                     idx, location_info->pColorAttachmentLocations[idx], idx,
-                                                     cb_state.rendering_attachments.color_locations[idx]);
+                                    skip |= LogError(
+                                        vuid_090504, objlist,
+                                        cb_loc.pNext(Struct::VkRenderingAttachmentLocationInfoKHR,
+                                                     Field::pColorAttachmentInputIndices, idx),
+                                        "(%" PRIu32
+                                        ") does not match the implicit or explicit state in the primary command buffer (%" PRIu32
+                                        ").",
+                                        location_info->pColorAttachmentLocations[idx],
+                                        cb_state.rendering_attachments.color_locations[idx]);
                                 }
                             }
                         }
@@ -923,21 +927,24 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
                         skip |= ValidateRenderingInputAttachmentIndicesKHR(*index_info, objlist, cb_loc.dot(Field::pNext));
 
                         if (index_info->colorAttachmentCount != cb_state.rendering_attachments.color_indexes.size()) {
-                            skip |= LogError(vuid_090505, objlist, cb_loc.dot(Field::pNext),
-                                             "VkRenderingInputAttachmentIndexInfoKHR::colorAttachmentCount = %" PRIu32
-                                             " does not match the implicit or explicit state in the primary command buffer, "
-                                             "colorAttachmentCount = %" PRIu64 ".",
-                                             index_info->colorAttachmentCount, cb_state.rendering_attachments.color_indexes.size());
+                            skip |= LogError(
+                                vuid_090505, objlist,
+                                cb_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfoKHR, Field::colorAttachmentCount),
+                                "(%" PRIu32
+                                ") does not match the implicit or explicit state in the primary command buffer ("
+                                "%" PRIu32 ").",
+                                index_info->colorAttachmentCount, unsigned(cb_state.rendering_attachments.color_indexes.size()));
                         } else {
                             for (uint32_t idx = 0; idx < index_info->colorAttachmentCount; idx++) {
                                 if (index_info->pColorAttachmentInputIndices && cb_state.rendering_attachments.color_indexes[idx] !=
                                                                                     index_info->pColorAttachmentInputIndices[idx]) {
-                                    skip |= LogError(vuid_090505, objlist, cb_loc.dot(Field::pNext),
-                                                     "VkRenderingInputAttachmentIndexInfoKHR::pColorAttachmentInputIndices[%" PRIu32
-                                                     "] = %" PRIu32
-                                                     " does not match the implicit or explicit state in the primary command "
-                                                     "buffer, pColorAttachmentInputIndices[%" PRIu32 "] = %" PRIu32 ".",
-                                                     idx, index_info->pColorAttachmentInputIndices[idx], idx,
+                                    skip |= LogError(vuid_090505, objlist,
+                                                     cb_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfoKHR,
+                                                                  Field::pColorAttachmentInputIndices, idx),
+                                                     "(%" PRIu32
+                                                     ") does not match the implicit or explicit state in the primary command "
+                                                     "buffer (%" PRIu32 ").",
+                                                     index_info->pColorAttachmentInputIndices[idx],
                                                      cb_state.rendering_attachments.color_indexes[idx]);
                                 }
                             }
@@ -945,21 +952,24 @@ bool CoreChecks::PreCallValidateCmdExecuteCommands(VkCommandBuffer commandBuffer
 
                         if (cb_state.rendering_attachments.depth_index && index_info->pDepthInputAttachmentIndex &&
                             *cb_state.rendering_attachments.depth_index != *index_info->pDepthInputAttachmentIndex) {
-                            skip |= LogError(vuid_090505, objlist, cb_loc.dot(Field::pNext),
-                                             "VkRenderingInputAttachmentIndexInfoKHR::pDepthAttachmentIndex = %" PRIu32
-                                             " does not match the implicit or explicit state in the primary command buffer, "
-                                             "pDepthAttachmentIndex = %" PRIu32 ".",
-                                             *index_info->pDepthInputAttachmentIndex, *cb_state.rendering_attachments.depth_index);
+                            skip |= LogError(
+                                vuid_090505, objlist,
+                                cb_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfoKHR, Field::pDepthInputAttachmentIndex),
+                                "(%" PRIu32
+                                ") does not match the implicit or explicit state in the primary command buffer ("
+                                "%" PRIu32 ").",
+                                *index_info->pDepthInputAttachmentIndex, *cb_state.rendering_attachments.depth_index);
                         }
 
                         if (cb_state.rendering_attachments.stencil_index && index_info->pStencilInputAttachmentIndex &&
                             *cb_state.rendering_attachments.stencil_index != *index_info->pStencilInputAttachmentIndex) {
-                            skip |=
-                                LogError(vuid_090505, objlist, cb_loc.dot(Field::pNext),
-                                         "VkRenderingInputAttachmentIndexInfoKHR::pStencilAttachmentIndex = %" PRIu32
-                                         " does not match the implicit or explicit state in the primary command buffer, "
-                                         "pStencilAttachmentIndex = %" PRIu32 ".",
-                                         *index_info->pStencilInputAttachmentIndex, *cb_state.rendering_attachments.stencil_index);
+                            skip |= LogError(
+                                vuid_090505, objlist,
+                                cb_loc.pNext(Struct::VkRenderingInputAttachmentIndexInfoKHR, Field::pStencilInputAttachmentIndex),
+                                "(%" PRIu32
+                                ") does not match the implicit or explicit state in the primary command buffer"
+                                "(%" PRIu32 ").",
+                                *index_info->pStencilInputAttachmentIndex, *cb_state.rendering_attachments.stencil_index);
                         }
                     }
                 }

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -1248,3 +1248,107 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingAttachmentLocationInfoMismatc
 
     m_command_buffer.end();
 }
+
+TEST_F(NegativeDynamicRenderingLocalRead, RenderingInputAttachmentIndexInfoMismatch) {
+    RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
+    InitDynamicRenderTarget();
+
+    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->width(), m_renderTargets[0]->height(),
+                                                                m_renderTargets[0]->create_info().mipLevels, 1,
+                                                                m_renderTargets[0]->format(), m_renderTargets[0]->usage());
+
+    vkt::Image render_target(*m_device, render_target_ci, vkt::set_layout);
+    vkt::ImageView render_target_view = render_target.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, render_target_ci.arrayLayers);
+
+    VkCommandBufferAllocateInfo secondary_cmd_buffer_alloc_info = vku::InitStructHelper();
+    secondary_cmd_buffer_alloc_info.commandPool = m_command_pool.handle();
+    secondary_cmd_buffer_alloc_info.level = VK_COMMAND_BUFFER_LEVEL_SECONDARY;
+    secondary_cmd_buffer_alloc_info.commandBufferCount = 1;
+
+    vkt::CommandBuffer secondary_cmd_buffer(*m_device, secondary_cmd_buffer_alloc_info);
+
+    uint32_t color_attachment_indices[1] = {1};
+    uint32_t invalid_color_attachment_indices[1] = {0};
+
+    const uint32_t depth_attachment_index = VK_ATTACHMENT_UNUSED;
+    const uint32_t stencil_attachment_index = VK_ATTACHMENT_UNUSED;
+    const uint32_t invalid_depth_attachment_index = 0;
+    const uint32_t invalid_stencil_attachment_index = 0;
+
+    VkRenderingInputAttachmentIndexInfoKHR rendering_input_attachment_index_info = vku::InitStructHelper{};
+    rendering_input_attachment_index_info.colorAttachmentCount = 1;
+    rendering_input_attachment_index_info.pColorAttachmentInputIndices = color_attachment_indices;
+    rendering_input_attachment_index_info.pDepthInputAttachmentIndex = &depth_attachment_index;
+    rendering_input_attachment_index_info.pStencilInputAttachmentIndex = &stencil_attachment_index;
+
+    VkRenderingInputAttachmentIndexInfoKHR invalid_rendering_input_attachment_index_info = vku::InitStructHelper{};
+    invalid_rendering_input_attachment_index_info.colorAttachmentCount = 1;
+    invalid_rendering_input_attachment_index_info.pColorAttachmentInputIndices = color_attachment_indices;
+    invalid_rendering_input_attachment_index_info.pDepthInputAttachmentIndex = &depth_attachment_index;
+    invalid_rendering_input_attachment_index_info.pStencilInputAttachmentIndex = &stencil_attachment_index;
+
+    VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info =
+        vku::InitStructHelper(&invalid_rendering_input_attachment_index_info);
+    inheritance_rendering_info.colorAttachmentCount = 1;
+    inheritance_rendering_info.pColorAttachmentFormats = &render_target_ci.format;
+    inheritance_rendering_info.rasterizationSamples = VK_SAMPLE_COUNT_1_BIT;
+    VkCommandBufferInheritanceInfo cmd_buffer_inheritance_info = vku::InitStructHelper(&inheritance_rendering_info);
+
+    VkCommandBufferBeginInfo secondary_cmd_buffer_begin_info = vku::InitStructHelper{};
+    secondary_cmd_buffer_begin_info.flags =
+        VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
+    secondary_cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
+
+    VkRenderingAttachmentInfoKHR color_attachment_info = vku::InitStructHelper{};
+    color_attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
+    color_attachment_info.imageView = render_target_view.handle();
+
+    VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
+
+    VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper{};
+    begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT_KHR;
+    begin_rendering_info.renderArea = clear_rect.rect;
+    begin_rendering_info.layerCount = 2;
+    begin_rendering_info.colorAttachmentCount = 1;
+    begin_rendering_info.pColorAttachments = &color_attachment_info;
+
+    const auto begin_record_and_verify_cmd_buffers = [&](const VkCommandBufferBeginInfo &commandBufferBeginInfo) {
+        secondary_cmd_buffer.begin(&commandBufferBeginInfo);
+        secondary_cmd_buffer.end();
+
+        m_command_buffer.begin();
+        m_command_buffer.BeginRendering(begin_rendering_info);
+
+        vk::CmdSetRenderingInputAttachmentIndicesKHR(m_command_buffer.handle(), &rendering_input_attachment_index_info);
+
+        m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-09505");
+        vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_cmd_buffer.handle());
+        m_errorMonitor->VerifyFound();
+
+        m_command_buffer.EndRendering();
+        m_command_buffer.end();
+    };
+
+    // Force invalid colorAttachmentCount
+    invalid_rendering_input_attachment_index_info.colorAttachmentCount = 0;
+
+    begin_record_and_verify_cmd_buffers(secondary_cmd_buffer_begin_info);
+
+    // Force colorAttachmentIndices mismatch.
+    invalid_rendering_input_attachment_index_info.colorAttachmentCount = 1;
+    invalid_rendering_input_attachment_index_info.pColorAttachmentInputIndices = invalid_color_attachment_indices;
+
+    begin_record_and_verify_cmd_buffers(secondary_cmd_buffer_begin_info);
+
+    // Force pDepthInputAttachmentIndex mismatch
+    invalid_rendering_input_attachment_index_info.pColorAttachmentInputIndices = color_attachment_indices;
+    invalid_rendering_input_attachment_index_info.pDepthInputAttachmentIndex = &invalid_depth_attachment_index;
+
+    begin_record_and_verify_cmd_buffers(secondary_cmd_buffer_begin_info);
+
+    // Force pStencilInputAttachmentIndex mismatch
+    invalid_rendering_input_attachment_index_info.pDepthInputAttachmentIndex = &depth_attachment_index;
+    invalid_rendering_input_attachment_index_info.pStencilInputAttachmentIndex = &invalid_stencil_attachment_index;
+
+    begin_record_and_verify_cmd_buffers(secondary_cmd_buffer_begin_info);
+}


### PR DESCRIPTION
MR is complete and can be reviewed, but will need an update when https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8298 lands

adds

- VUID-vkCmdExecuteCommands-pCommandBuffers-09504
- VUID-vkCmdExecuteCommands-pCommandBuffers-09505