### PR TITLE
printf: Fix printing vectors of lu lx

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,7 +129,7 @@ if(${CMAKE_CXX_COMPILER_ID} MATCHES "(GNU|Clang)")
             -Wstring-conversion
         )
 
-        if (CMAKE_BUILD_TYPE EQUAL "DEBUG")
+        if (CMAKE_BUILD_TYPE MATCHES "Debug")
             # When using tools such as lldb, strings will produce "error: summary string parsing error"
             add_compile_options(-fstandalone-debug)
         endif()

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -226,8 +226,14 @@ std::vector<Substring> Validator::ParseFormatString(const std::string &format_st
                 // skip v<count>, handle long
                 specifier.push_back(format_string[pos]);
                 if (format_string[pos + 1] == 'l') {
+                    // catches %ul
                     substring.is_64_bit = true;
                     specifier.push_back('l');
+                    pos++;
+                } else if (format_string[pos] == 'l') {
+                    // catches %lu and lx
+                    substring.is_64_bit = true;
+                    specifier.push_back(format_string[pos + 1]);
                     pos++;
                 }
 


### PR DESCRIPTION
Currently we were not supported `%v3lu` and `%v3lx` vectors