### PR TITLE
sync: Disable resource reporting due to stale index issue

### DIFF
--- a/layers/sync/sync_commandbuffer.cpp
+++ b/layers/sync/sync_commandbuffer.cpp
@@ -1199,11 +1199,17 @@ std::ostream &operator<<(std::ostream &out, const ResourceUsageRecord::Formatter
         out << ", reset_no: " << std::to_string(record.reset_count);
 
         // Associated resource
+        // TODO: Fix issue in submit-time validation resource reporting.
+        // Some cases of false-positives lead to stale resource indices.
+        // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8291
+        // This can be related to command buffer Reset.
+        /*
         if (formatter.handle_index != vvl::kNoIndex32) {
             auto cb_context = static_cast<const syncval_state::CommandBuffer *>(record.cb_state);
             const HandleRecord &handle_record = cb_context->access_context.GetHandleRecord(formatter.handle_index);
             out << ", resource: " << handle_record.Formatter(formatter.sync_state);
         }
+        */
         // Report debug region name. Empty name means that we are not inside any debug region.
         if (formatter.debug_name_provider) {
             const std::string debug_region_name = formatter.debug_name_provider->GetDebugRegionName(record);

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -6222,7 +6222,7 @@ TEST_F(NegativeSyncVal, RenderPassStoreOpNone) {
     m_commandBuffer->end();
 }
 
-TEST_F(NegativeSyncVal, DebugResourceName) {
+TEST_F(NegativeSyncVal, DISABLED_DebugResourceName) {
     TEST_DESCRIPTION("Test that hazardous buffer is reported. Two copies write to a buffer");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitSyncVal());
@@ -6251,7 +6251,7 @@ TEST_F(NegativeSyncVal, DebugResourceName) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeSyncVal, DebugDescriptorBufferName) {
+TEST_F(NegativeSyncVal, DISABLED_DebugDescriptorBufferName) {
     TEST_DESCRIPTION("Test that hazardous buffer is reported. Two dispatches write to a buffer");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitSyncVal());
@@ -6309,7 +6309,7 @@ TEST_F(NegativeSyncVal, DebugDescriptorBufferName) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeSyncVal, DebugDescriptorBufferName2) {
+TEST_F(NegativeSyncVal, DISABLED_DebugDescriptorBufferName2) {
     TEST_DESCRIPTION("Test that hazardous buffer is reported. Dispatch writes to a buffer, then copy to the same buffer");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitSyncVal());
@@ -6369,7 +6369,7 @@ TEST_F(NegativeSyncVal, DebugDescriptorBufferName2) {
     m_default_queue->Wait();
 }
 
-TEST_F(NegativeSyncVal, DebugDescriptorBufferName3) {
+TEST_F(NegativeSyncVal, DISABLED_DebugDescriptorBufferName3) {
     TEST_DESCRIPTION("Different buffer of the same shader is reported depending on the previous access");
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitSyncVal());


### PR DESCRIPTION
Something to cherry pick for this SDK (and to have on the main too). Should be turned for this SDK even if we have a fix before the release. Needs more testing.

This can be related to command buffer lifetime management. Usage records can reference handles from the command buffers that were Reset (https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8291 ).
