### PR TITLE
printf: Move implementation inside VVL

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -196,6 +196,8 @@ vvl_sources = [
   "layers/gpu/spirv/link.h",
   "layers/gpu/spirv/module.cpp",
   "layers/gpu/spirv/module.h",
+  "layers/gpu/spirv/inject_function_pass.cpp",
+  "layers/gpu/spirv/inject_function_pass.h",
   "layers/gpu/spirv/pass.cpp",
   "layers/gpu/spirv/pass.h",
   "layers/gpu/spirv/ray_query_pass.cpp",

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -202,6 +202,8 @@ vvl_sources = [
   "layers/gpu/spirv/pass.h",
   "layers/gpu/spirv/ray_query_pass.cpp",
   "layers/gpu/spirv/ray_query_pass.h",
+  "layers/gpu/spirv/debug_printf_pass.cpp",
+  "layers/gpu/spirv/debug_printf_pass.h",
   "layers/gpu/spirv/type_manager.cpp",
   "layers/gpu/spirv/type_manager.h",
   "layers/layer_options.cpp",

--- a/docs/debug_printf.md
+++ b/docs/debug_printf.md
@@ -98,8 +98,7 @@ where:
 * `N2`, `N3`, ... are result ids of scalar and vector values to be printed
 * `NN` is the result id of the debug printf operation. This value is undefined.
 
-Note that the `VK_KHR_shader_non_semantic_info` device extension must also be enabled in
-the Vulkan application using this shader.
+> `OpExtInstImport` of any `NonSemantic*` is properly supported with the `VK_KHR_shader_non_semantic_info` device extension. Some older compiler stacks might not handle these unknown instructions well, some will ignore it as desired.
 
 ## Debug Printf Output
 The strings resulting from a Debug Printf will, by default, be sent to the debug callback
@@ -197,6 +196,7 @@ buffer size.
 * VkPhysicalDevice features: `fragmentStoresAndAtomics` and `vertexPipelineStoresAndAtomics`
 are required
 * The `VK_KHR_shader_non_semantic_info` extension must be supported and enabled
+  * If using the Validation Layers, we attempt to strip it out to allow wider range of users to still use Debug Printf
 * RenderDoc release 1.14 or later
 * When using Debug Printf with a debug callback, it is recommended to disable validation,
 as the debug level of INFO or DEBUG causes the validation layers to produce many messages

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -190,5 +190,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
   private:
     bool verbose = false;
     bool use_stdout = false;
+    uint32_t binding_slot_ = 0;
 };
 }  // namespace debug_printf

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -860,7 +860,7 @@ void GpuShaderInstrumentor::PreCallRecordPipelineCreations(uint32_t count, const
                 chassis_state.shader_unique_id_maps[pipeline][stage] = unique_shader_id;
             }
         }
-        new_pipeline_create_infos->push_back(std::move(new_pipeline_ci));
+        new_pipeline_create_infos->emplace_back(std::move(new_pipeline_ci));
     }
 }
 // For every pipeline:

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -31,7 +31,7 @@
 
 namespace gpuav {
 
-static bool GpuValidateShader(const std::vector<uint32_t> &input, bool SetRelaxBlockLayout, bool SetScalerBlockLayout,
+static bool GpuValidateShader(const std::vector<uint32_t> &input, bool SetRelaxBlockLayout, bool SetScalarBlockLayout,
                               spv_target_env target_env, std::string &error) {
     // Use SPIRV-Tools validator to try and catch any issues with the module
     spv_context ctx = spvContextCreate(target_env);
@@ -39,7 +39,7 @@ static bool GpuValidateShader(const std::vector<uint32_t> &input, bool SetRelaxB
     spv_diagnostic diag = nullptr;
     spv_validator_options options = spvValidatorOptionsCreate();
     spvValidatorOptionsSetRelaxBlockLayout(options, SetRelaxBlockLayout);
-    spvValidatorOptionsSetScalarBlockLayout(options, SetScalerBlockLayout);
+    spvValidatorOptionsSetScalarBlockLayout(options, SetScalarBlockLayout);
     spv_result_t result = spvValidateWithOptions(ctx, options, &binary, &diag);
     if (result != SPV_SUCCESS && diag) error = diag->error;
     return (result == SPV_SUCCESS);
@@ -100,10 +100,11 @@ bool Validator::InstrumentShader(const vvl::span<const uint32_t> &input, uint32_
         return false;
     }
 
-    for (const auto info : module.link_info_) {
+    for (const auto &info : module.link_info_) {
         module.LinkFunction(info);
     }
 
+    module.PostProcess();
     module.ToBinary(out_instrumented_spirv);
 
     if (gpuav_settings.debug_dump_instrumented_shaders) {

--- a/layers/gpu/shaders/gpu_error_header.h
+++ b/layers/gpu/shaders/gpu_error_header.h
@@ -181,6 +181,14 @@ const int kErrorBufferByteSize = 4 * kErrorRecordSize * kErrorRecordCounts + 2 *
 
 #ifdef __cplusplus
 }  // namespace glsl
+#endif
+
+// DebugPrintf
+// ---
+const int kDebugPrintfOutputBufferSize = 0;
+const int kDebugPrintfOutputBufferData = 1;
+
+#ifdef __cplusplus
 }  // namespace gpuav
 #endif
 #endif

--- a/layers/gpu/spirv/CMakeLists.txt
+++ b/layers/gpu/spirv/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(gpu_av_spirv PRIVATE
     module.cpp
     type_manager.h
     type_manager.cpp
+    inject_function_pass.h
+    inject_function_pass.cpp
     pass.h
     pass.cpp
     ${VVL_SOURCE_DIR}/layers/${API_TYPE}/generated/spirv_grammar_helper.cpp

--- a/layers/gpu/spirv/CMakeLists.txt
+++ b/layers/gpu/spirv/CMakeLists.txt
@@ -23,6 +23,8 @@ target_sources(gpu_av_spirv PRIVATE
     buffer_device_address_pass.cpp
     ray_query_pass.h
     ray_query_pass.cpp
+    debug_printf_pass.h
+    debug_printf_pass.cpp
 
     # Framework
     instruction.h

--- a/layers/gpu/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu/spirv/bindless_descriptor_pass.cpp
@@ -16,6 +16,7 @@
 #include "bindless_descriptor_pass.h"
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
+#include <iostream>
 
 #include "generated/instrumentation_bindless_descriptor_comp.h"
 
@@ -422,6 +423,10 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
     target_instruction_ = &inst;
 
     return true;
+}
+
+void BindlessDescriptorPass::PrintDebugInfo() {
+    std::cout << "BindlessDescriptorPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -15,22 +15,18 @@
 #pragma once
 
 #include <stdint.h>
-#include "pass.h"
+#include "inject_function_pass.h"
 
 namespace gpuav {
 namespace spirv {
-
-class Module;
-struct Function;
-struct BasicBlock;
 
 // Create a pass to instrument bindless descriptor checking
 // This pass instruments all bindless references to check that descriptor
 // array indices are inbounds, and if the descriptor indexing extension is
 // enabled, that the descriptor has been initialized.
-class BindlessDescriptorPass : public Pass {
+class BindlessDescriptorPass : public InjectFunctionPass {
   public:
-    BindlessDescriptorPass(Module& module) : Pass(module, true) {}
+    BindlessDescriptorPass(Module& module) : InjectFunctionPass(module, true) {}
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -27,6 +27,7 @@ namespace spirv {
 class BindlessDescriptorPass : public InjectFunctionPass {
   public:
     BindlessDescriptorPass(Module& module) : InjectFunctionPass(module, true) {}
+    void PrintDebugInfo() final;
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpu/spirv/buffer_device_address_pass.cpp
@@ -16,6 +16,7 @@
 #include "buffer_device_address_pass.h"
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
+#include <iostream>
 
 #include "generated/instrumentation_buffer_device_address_comp.h"
 
@@ -108,6 +109,10 @@ bool BufferDeviceAddressPass::AnalyzeInstruction(const Function& function, const
     target_instruction_ = &inst;
     type_length_ = module_.type_manager_.TypeLength(*accessed_type);
     return true;
+}
+
+void BufferDeviceAddressPass::PrintDebugInfo() {
+    std::cout << "BufferDeviceAddressPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -15,21 +15,17 @@
 #pragma once
 
 #include <stdint.h>
-#include "pass.h"
+#include "inject_function_pass.h"
 
 namespace gpuav {
 namespace spirv {
 
-class Module;
-struct Function;
-struct BasicBlock;
-
 // Create a pass to instrument physical buffer address checking
 // This pass instruments all physical buffer address references to check that
 // all referenced bytes fall in a valid buffer.
-class BufferDeviceAddressPass : public Pass {
+class BufferDeviceAddressPass : public InjectFunctionPass {
   public:
-    BufferDeviceAddressPass(Module& module) : Pass(module, true) {}
+    BufferDeviceAddressPass(Module& module) : InjectFunctionPass(module, true) {}
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -26,6 +26,7 @@ namespace spirv {
 class BufferDeviceAddressPass : public InjectFunctionPass {
   public:
     BufferDeviceAddressPass(Module& module) : InjectFunctionPass(module, true) {}
+    void PrintDebugInfo() final;
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/debug_printf_pass.cpp
+++ b/layers/gpu/spirv/debug_printf_pass.cpp
@@ -1,0 +1,459 @@
+/* Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "debug_printf_pass.h"
+#include "module.h"
+#include "gpu/shaders/gpu_error_header.h"
+#include <spirv/unified1/NonSemanticDebugPrintf.h>
+#include <cstring>
+#include <iostream>
+
+namespace gpuav {
+namespace spirv {
+
+// All functions are a list of uint32_t
+// The difference is just how many are passed in
+uint32_t DebugPrintfPass::GetLinkFunctionId(uint32_t argument_count) {
+    if (auto it = function_id_map_.find(argument_count); it != function_id_map_.end()) {
+        return it->second;
+    }
+
+    const uint32_t link_function_id = module_.TakeNextId();
+    function_id_map_[argument_count] = link_function_id;
+
+    return link_function_id;
+}
+
+bool DebugPrintfPass::AnalyzeInstruction(const Instruction& inst) {
+    if (inst.Opcode() == spv::OpExtInst && inst.Word(3) == ext_import_id_ && inst.Word(4) == NonSemanticDebugPrintfDebugPrintf) {
+        target_instruction_ = &inst;
+        return true;
+    }
+    return false;
+}
+
+// Takes the various arguments and casts them to a valid uint32_t to be passed as a parameter in the function
+void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& argument_type, std::vector<uint32_t>& params,
+                                           BasicBlock& block, InstructionIt* inst_it) {
+    const uint32_t uint32_type_id = module_.type_manager_.GetTypeInt(32, false).Id();
+
+    switch (argument_type.spv_type_) {
+        case SpvType::kVector: {
+            const uint32_t component_count = argument_type.inst_.Word(3);
+            const uint32_t component_type_id = argument_type.inst_.Word(2);
+            const Type* component_type = module_.type_manager_.FindTypeById(component_type_id);
+            assert(component_type);
+            for (uint32_t i = 0; i < component_count; i++) {
+                const uint32_t extract_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpCompositeExtract, {component_type_id, extract_id, argument_id, i}, inst_it);
+                CreateFunctionParams(extract_id, *component_type, params, block, inst_it);
+            }
+            break;
+        }
+
+        case SpvType::kInt: {
+            const uint32_t width = argument_type.inst_.Word(2);
+
+            // first thing is to get any signed to unsigned via bitcast
+            const bool is_signed = argument_type.inst_.Word(3) != 0;
+            uint32_t incoming_id = argument_id;
+            if (is_signed) {
+                const uint32_t bitcast_id = module_.TakeNextId();
+                const uint32_t unsigned_type_id = module_.type_manager_.GetTypeInt(width, false).Id();
+                block.CreateInstruction(spv::OpBitcast, {unsigned_type_id, bitcast_id, argument_id}, inst_it);
+                incoming_id = bitcast_id;
+            }
+
+            if (width == 8 || width == 16) {
+                const uint32_t uconvert_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_id, incoming_id}, inst_it);
+                params.push_back(uconvert_id);
+            } else if (width == 32) {
+                params.push_back(incoming_id);
+            } else if (width == 64) {
+                const uint32_t uconvert_high_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_high_id, incoming_id}, inst_it);
+                params.push_back(uconvert_high_id);
+
+                const uint32_t uint64_type_id = module_.type_manager_.GetTypeInt(64, false).Id();
+                const uint32_t shift_right_id = module_.TakeNextId();
+                const uint32_t constant_32_id = module_.type_manager_.GetConstantUInt32(32).Id();
+                block.CreateInstruction(spv::OpShiftRightLogical, {uint64_type_id, shift_right_id, incoming_id, constant_32_id},
+                                        inst_it);
+
+                const uint32_t uconvert_low_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
+                params.push_back(uconvert_low_id);
+            } else {
+                assert(false && "unsupported for int width");
+            }
+            break;
+        }
+
+        case SpvType::kFloat: {
+            const uint32_t width = argument_type.inst_.Word(2);
+            if (width == 16) {
+                const uint32_t float32_type_id = module_.type_manager_.GetTypeFloat(32).Id();
+                const uint32_t fconvert_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpFConvert, {float32_type_id, fconvert_id, argument_id}, inst_it);
+
+                const uint32_t bitcast_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpBitcast, {uint32_type_id, bitcast_id, fconvert_id}, inst_it);
+                params.push_back(bitcast_id);
+            } else if (width == 32) {
+                const uint32_t bitcast_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpBitcast, {uint32_type_id, bitcast_id, argument_id}, inst_it);
+                params.push_back(bitcast_id);
+            } else if (width == 64) {
+                const uint32_t uint64_type_id = module_.type_manager_.GetTypeInt(64, false).Id();
+                const uint32_t bitcast_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpBitcast, {uint64_type_id, bitcast_id, argument_id}, inst_it);
+
+                const uint32_t uconvert_high_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_high_id, bitcast_id}, inst_it);
+                params.push_back(uconvert_high_id);
+
+                const uint32_t shift_right_id = module_.TakeNextId();
+                const uint32_t constant_32_id = module_.type_manager_.GetConstantUInt32(32).Id();
+                block.CreateInstruction(spv::OpShiftRightLogical, {uint64_type_id, shift_right_id, bitcast_id, constant_32_id},
+                                        inst_it);
+
+                const uint32_t uconvert_low_id = module_.TakeNextId();
+                block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
+                params.push_back(uconvert_low_id);
+            } else {
+                assert(false && "unsupported for float width");
+            }
+            break;
+        }
+
+        case SpvType::kBool: {
+            // cast to uint32_t via an OpSelect
+            const uint32_t zero_id = module_.type_manager_.GetConstantZeroUint32().Id();
+            const uint32_t one_id = module_.type_manager_.GetConstantUInt32(1).Id();
+            const uint32_t select_id = module_.TakeNextId();
+            block.CreateInstruction(spv::OpSelect, {uint32_type_id, select_id, argument_id, one_id, zero_id}, inst_it);
+            params.push_back(select_id);
+            break;
+        }
+
+        default:
+            assert(false && "unsupported for function param type");
+            break;
+    }
+}
+
+void DebugPrintfPass::CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it) {
+    const uint32_t inst_position = target_instruction_->position_index_;
+    auto inst_position_constant = module_.type_manager_.CreateConstantUInt32(inst_position);
+
+    const uint32_t string_id = target_instruction_->Word(5);
+    auto string_id_constant = module_.type_manager_.CreateConstantUInt32(string_id);
+
+    const uint32_t void_type = module_.type_manager_.GetTypeVoid().Id();
+    const uint32_t function_result = module_.TakeNextId();
+
+    // We know the first part, then build up the rest from the printf arguments
+    // except the function_def, we place hold it with zero
+    std::vector<uint32_t> function_call_params = {void_type, function_result, 0, inst_position_constant.Id(),
+                                                  string_id_constant.Id()};
+
+    // where we find the first arugment in function instruction
+    const uint32_t first_argument_offset = 6;
+    const uint32_t argument_count = target_instruction_->Length() - first_argument_offset;
+    for (uint32_t i = 0; i < argument_count; i++) {
+        const uint32_t argument_id = target_instruction_->Word(first_argument_offset + i);
+        const Instruction* argument_inst = nullptr;
+        const Constant* constant = module_.type_manager_.FindConstantById(argument_id);
+        if (constant) {
+            argument_inst = &constant->inst_;
+        } else {
+            argument_inst = block.function_.FindInstruction(argument_id);
+        }
+        assert(argument_inst);  // argument is either constant or found within function block
+
+        const Type* argument_type = module_.type_manager_.FindTypeById(argument_inst->TypeId());
+        assert(argument_type);  // type needs to have been declared already
+
+        CreateFunctionParams(argument_inst->ResultId(), *argument_type, function_call_params, block, inst_it);
+    }
+
+    // 3 params are the result, function type, and function ID
+    const uint32_t param_count = (uint32_t)function_call_params.size() - 3;
+    const uint32_t function_def = GetLinkFunctionId(param_count);
+    function_call_params[2] = function_def;
+
+    block.CreateInstruction(spv::OpFunctionCall, function_call_params, inst_it);
+}
+
+void DebugPrintfPass::CreateDescriptorSet() {
+    // Create descriptor set to match output buffer
+    // The following is what the GLSL would look like
+    //
+    // layout(set = kSet, binding = kBinding, std430) buffer SSBO {
+    //     uint written_count;
+    //     uint data[];
+    // } output_buffer;
+
+    const Type& uint32_type = module_.type_manager_.GetTypeInt(32, false);
+    const uint32_t runtime_array_type_id = module_.type_manager_.GetTypeRuntimeArray(uint32_type).Id();
+
+    // if 2 OpTypeRuntimeArray are combined, we can't have ArrayStride twice
+    bool has_array_stride = false;
+    for (auto& inst : module_.annotations_) {
+        if (inst->Opcode() == spv::OpDecorate && inst->Word(1) == runtime_array_type_id &&
+            inst->Word(2) == spv::DecorationArrayStride) {
+            has_array_stride = true;
+            break;
+        }
+    }
+    if (!has_array_stride) {
+        module_.AddDecoration(runtime_array_type_id, spv::DecorationArrayStride, {4});
+    }
+
+    const uint32_t struct_type_id = module_.TakeNextId();
+    auto new_struct_inst = std::make_unique<Instruction>(4, spv::OpTypeStruct);
+    new_struct_inst->Fill({struct_type_id, uint32_type.Id(), runtime_array_type_id});
+    const Type& struct_type = module_.type_manager_.AddType(std::move(new_struct_inst), SpvType::kStruct);
+    module_.AddDecoration(struct_type_id, spv::DecorationBlock, {});
+    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintfOutputBufferSize, spv::DecorationOffset, {0});
+    module_.AddMemberDecoration(struct_type_id, gpuav::kDebugPrintfOutputBufferData, spv::DecorationOffset, {4});
+
+    // create a storage buffer interface variable
+    const Type& pointer_type = module_.type_manager_.GetTypePointer(spv::StorageClassStorageBuffer, struct_type);
+    output_buffer_variable_id_ = module_.TakeNextId();
+    auto new_inst = std::make_unique<Instruction>(4, spv::OpVariable);
+    new_inst->Fill({pointer_type.Id(), output_buffer_variable_id_, spv::StorageClassStorageBuffer});
+    module_.type_manager_.AddVariable(std::move(new_inst), pointer_type);
+    module_.AddInterfaceVariables(output_buffer_variable_id_, spv::StorageClassStorageBuffer);
+
+    module_.AddDecoration(output_buffer_variable_id_, spv::DecorationDescriptorSet, {module_.output_buffer_descriptor_set_});
+    module_.AddDecoration(output_buffer_variable_id_, spv::DecorationBinding, {binding_slot_});
+}
+
+void DebugPrintfPass::CreateBufferWriteFunction(uint32_t argument_count, uint32_t function_id) {
+    // Currently this is generated by the number of arguments
+    // The following is what the GLSL would look like
+    //
+    // void inst_debug_printf_5(uint a, uint b, uint c, uint d) {
+    //     uint offset = atomicAdd(output_buffer.written_count, 5);
+    //     if ((offset + 5) <= uint(output_buffer.data.length())) {
+    //         output_buffer.data[offset + 0] = 5;
+    //         output_buffer.data[offset + 1] = a;
+    //         output_buffer.data[offset + 2] = b;
+    //         output_buffer.data[offset + 3] = c;
+    //         output_buffer.data[offset + 4] = d;
+    //     }
+    // }
+
+    // Need 1 byte to write the "how many bytes will there be"
+    // Need 1 byte for the shader stage (which we don't pass in as we know already)
+    const uint32_t byte_written = argument_count + 2;
+
+    // Debug name is matching number of bytes written into the buffer
+    std::string function_name = "inst_debug_printf_" + std::to_string(byte_written);
+    module_.AddDebugName(function_name.c_str(), function_id);
+
+    // Need to create the function type
+    const uint32_t function_type_id = module_.TakeNextId();
+    const uint32_t void_type_id = module_.type_manager_.GetTypeVoid().Id();
+    const uint32_t uint32_type_id = module_.type_manager_.GetTypeInt(32, false).Id();
+    {
+        std::vector<uint32_t> words = {function_type_id, void_type_id};
+        for (size_t i = 0; i < argument_count; i++) {
+            words.push_back(uint32_type_id);
+        }
+        auto new_inst = std::make_unique<Instruction>(argument_count + 3, spv::OpTypeFunction);
+        new_inst->Fill(words);
+        module_.type_manager_.AddType(std::move(new_inst), SpvType::kFunction);
+    }
+
+    auto& new_function = module_.functions_.emplace_back(std::make_unique<Function>(module_));
+    std::vector<uint32_t> function_param_ids;
+    {
+        auto new_inst = std::make_unique<Instruction>(5, spv::OpFunction);
+        new_inst->Fill({void_type_id, function_id, spv::FunctionControlMaskNone, function_type_id});
+        new_function->pre_block_inst_.emplace_back(std::move(new_inst));
+
+        for (size_t i = 0; i < argument_count; i++) {
+            const uint32_t new_id = module_.TakeNextId();
+            auto param_inst = std::make_unique<Instruction>(3, spv::OpFunctionParameter);
+            param_inst->Fill({uint32_type_id, new_id});
+            new_function->pre_block_inst_.emplace_back(std::move(param_inst));
+            function_param_ids.push_back(new_id);
+        }
+    }
+
+    new_function->InitBlocks(3);
+    auto& check_block = new_function->blocks_[0];
+    auto& store_block = new_function->blocks_[1];
+    auto& merge_block = new_function->blocks_[2];
+
+    const Type& uint32_type = module_.type_manager_.GetTypeInt(32, false);
+    const uint32_t pointer_type_id = module_.type_manager_.GetTypePointer(spv::StorageClassStorageBuffer, uint32_type).Id();
+    const uint32_t zero_id = module_.type_manager_.GetConstantZeroUint32().Id();
+    const uint32_t one_id = module_.type_manager_.GetConstantUInt32(1).Id();
+    const uint32_t byte_written_id = module_.type_manager_.GetConstantUInt32(byte_written).Id();
+    uint32_t atomic_add_id = 0;
+
+    // Add atomic and check if buffer size is large enough
+    {
+        const uint32_t access_chain_id = module_.TakeNextId();
+        check_block->CreateInstruction(spv::OpAccessChain, {pointer_type_id, access_chain_id, output_buffer_variable_id_, zero_id});
+
+        atomic_add_id = module_.TakeNextId();
+        const uint32_t scope_invok_id = module_.type_manager_.GetConstantUInt32(spv::ScopeInvocation).Id();
+        const uint32_t mask_none_id = module_.type_manager_.GetConstantUInt32(spv::MemoryAccessMaskNone).Id();
+        check_block->CreateInstruction(
+            spv::OpAtomicIAdd, {uint32_type_id, atomic_add_id, access_chain_id, scope_invok_id, mask_none_id, byte_written_id});
+
+        const uint32_t int_add_id = module_.TakeNextId();
+        check_block->CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, byte_written_id});
+
+        const uint32_t array_length_id = module_.TakeNextId();
+        check_block->CreateInstruction(spv::OpArrayLength, {uint32_type_id, array_length_id, output_buffer_variable_id_, 1});
+
+        const uint32_t less_than_equal_id = module_.TakeNextId();
+        const uint32_t bool_type_id = module_.type_manager_.GetTypeBool().Id();
+        check_block->CreateInstruction(spv::OpULessThanEqual, {bool_type_id, less_than_equal_id, int_add_id, array_length_id});
+
+        const uint32_t merge_block_label_id = merge_block->GetLabelId();
+        check_block->CreateInstruction(spv::OpSelectionMerge, {merge_block_label_id, spv::SelectionControlMaskNone});
+
+        const uint32_t store_block_label_id = store_block->GetLabelId();
+        check_block->CreateInstruction(spv::OpBranchConditional, {less_than_equal_id, store_block_label_id, merge_block_label_id});
+    }
+
+    // Store how many 32-bit words
+    {
+        const uint32_t int_add_id = module_.TakeNextId();
+        store_block->CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, zero_id});
+
+        const uint32_t access_chain_id = module_.TakeNextId();
+        store_block->CreateInstruction(spv::OpAccessChain,
+                                       {pointer_type_id, access_chain_id, output_buffer_variable_id_, one_id, int_add_id});
+
+        store_block->CreateInstruction(spv::OpStore, {access_chain_id, byte_written_id});
+    }
+
+    // Store Shader Stage ID
+    {
+        const uint32_t int_add_id = module_.TakeNextId();
+        store_block->CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, one_id});
+
+        const uint32_t access_chain_id = module_.TakeNextId();
+        store_block->CreateInstruction(spv::OpAccessChain,
+                                       {pointer_type_id, access_chain_id, output_buffer_variable_id_, one_id, int_add_id});
+
+        const uint32_t shader_id = module_.type_manager_.GetConstantUInt32(module_.shader_id_).Id();
+        store_block->CreateInstruction(spv::OpStore, {access_chain_id, shader_id});
+    }
+
+    // Write a 32-bit word to the output buffer for each argument
+    for (uint32_t i = 0; i < argument_count; i++) {
+        const uint32_t int_add_id = module_.TakeNextId();
+        const uint32_t offset_id = module_.type_manager_.GetConstantUInt32(i + 2).Id();
+        store_block->CreateInstruction(spv::OpIAdd, {uint32_type_id, int_add_id, atomic_add_id, offset_id});
+
+        const uint32_t access_chain_id = module_.TakeNextId();
+        store_block->CreateInstruction(spv::OpAccessChain,
+                                       {pointer_type_id, access_chain_id, output_buffer_variable_id_, one_id, int_add_id});
+
+        store_block->CreateInstruction(spv::OpStore, {access_chain_id, function_param_ids[i]});
+    }
+
+    // merge block of the above if() check
+    {
+        store_block->CreateInstruction(spv::OpBranch, {merge_block->GetLabelId()});
+        merge_block->CreateInstruction(spv::OpReturn, {});
+    }
+
+    {
+        auto new_inst = std::make_unique<Instruction>(1, spv::OpFunctionEnd);
+        new_function->post_block_inst_.emplace_back(std::move(new_inst));
+    }
+}
+
+void DebugPrintfPass::Reset() { target_instruction_ = nullptr; }
+
+bool DebugPrintfPass::Run() {
+    for (const auto& inst : module_.ext_inst_imports_) {
+        const char* import_string = inst->GetAsString(2);
+        if (strcmp(import_string, "NonSemantic.DebugPrintf") == 0) {
+            ext_import_id_ = inst->ResultId();
+            break;
+        }
+    }
+
+    if (ext_import_id_ == 0) {
+        return false;  // no printf strings found, early return
+    }
+
+    for (const auto& function : module_.functions_) {
+        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
+            auto& block_instructions = (*block_it)->instructions_;
+            for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
+                if (!AnalyzeInstruction(*(inst_it->get()))) continue;
+                instrumented_count_++;
+
+                CreateFunctionCall(**block_it, &inst_it);
+
+                // remove the OpExtInst incase they don't support VK_KHR_non_semantic_info
+                inst_it = block_instructions.erase(inst_it);
+                inst_it--;
+
+                Reset();
+            }
+        }
+    }
+    if (instrumented_count_ == 0) {
+        return false;
+    }
+
+    CreateDescriptorSet();
+
+    // Here we "link" the functions, but since it is all generated, no need to go through the LinkInfo flow
+    for (const auto& entry : function_id_map_) {
+        CreateBufferWriteFunction(entry.first, entry.second);
+    }
+
+    // remove the everything else possible incase they don't support VK_KHR_non_semantic_info
+    bool other_non_semantic = false;
+    for (auto inst_it = module_.ext_inst_imports_.begin(); inst_it != module_.ext_inst_imports_.end(); ++inst_it) {
+        const char* import_string = (inst_it->get())->GetAsString(2);
+        if (strcmp(import_string, "NonSemantic.DebugPrintf") == 0) {
+            module_.ext_inst_imports_.erase(inst_it);
+            break;
+        } else if (strcmp(import_string, "NonSemantic.") == 0) {
+            other_non_semantic = true;
+        }
+    }
+    if (!other_non_semantic) {
+        for (auto inst_it = module_.extensions_.begin(); inst_it != module_.extensions_.end(); ++inst_it) {
+            const char* import_string = (inst_it->get())->GetAsString(1);
+            if (strcmp(import_string, "SPV_KHR_non_semantic_info") == 0) {
+                module_.extensions_.erase(inst_it);
+                break;
+            }
+        }
+    }
+
+    return true;
+}
+
+void DebugPrintfPass::PrintDebugInfo() { std::cout << "DebugPrintfPass\n\tinstrumentation count: " << instrumented_count_ << "\n"; }
+
+}  // namespace spirv
+}  // namespace gpuav

--- a/layers/gpu/spirv/debug_printf_pass.h
+++ b/layers/gpu/spirv/debug_printf_pass.h
@@ -1,0 +1,52 @@
+/* Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <stdint.h>
+#include "pass.h"
+
+namespace gpuav {
+namespace spirv {
+
+struct Type;
+
+// Create a pass to instrument NonSemantic.DebugPrintf (GL_EXT_debug_printf) instructions
+class DebugPrintfPass : public Pass {
+  public:
+    DebugPrintfPass(Module& module, uint32_t binding_slot = 0) : Pass(module), binding_slot_(binding_slot) {}
+    bool Run() final;
+    void PrintDebugInfo() final;
+
+  private:
+    bool AnalyzeInstruction(const Instruction& inst);
+    void CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it);
+    void CreateFunctionParams(uint32_t argument_id, const Type& argument_type, std::vector<uint32_t>& params, BasicBlock& block,
+                              InstructionIt* inst_it);
+    void CreateDescriptorSet();
+    void CreateBufferWriteFunction(uint32_t argument_count, uint32_t function_id);
+    void Reset() final;
+
+    const uint32_t binding_slot_;
+    uint32_t ext_import_id_ = 0;
+
+    // <number of arguments in the function call, function id>
+    vvl::unordered_map<uint32_t, uint32_t> function_id_map_;
+    uint32_t GetLinkFunctionId(uint32_t argument_count);
+
+    uint32_t output_buffer_variable_id_ = 0;
+};
+
+}  // namespace spirv
+}  // namespace gpuav

--- a/layers/gpu/spirv/function_basic_block.cpp
+++ b/layers/gpu/spirv/function_basic_block.cpp
@@ -40,7 +40,7 @@ void Function::ToBinary(std::vector<uint32_t>& out) {
 
 BasicBlock::BasicBlock(std::unique_ptr<Instruction> label, Function& function) : function_(function) {
     // Used when loading initial SPIR-V
-    instructions_.push_back(std::move(label));  // OpLabel
+    instructions_.emplace_back(std::move(label));  // OpLabel
 }
 
 BasicBlock::BasicBlock(Module& module, Function& function) : function_(function) {
@@ -106,7 +106,7 @@ void BasicBlock::CreateInstruction(spv::Op opcode, const std::vector<uint32_t>& 
 
 Function::Function(Module& module, std::unique_ptr<Instruction> function_inst) : module_(module) {
     // Used when loading initial SPIR-V
-    pre_block_inst_.push_back(std::move(function_inst));  // OpFunction
+    pre_block_inst_.emplace_back(std::move(function_inst));  // OpFunction
 }
 
 BasicBlockIt Function::InsertNewBlock(BasicBlockIt it) {
@@ -115,6 +115,14 @@ BasicBlockIt Function::InsertNewBlock(BasicBlockIt it) {
     BasicBlockIt new_block_it = blocks_.insert(it, std::move(new_block));
 
     return new_block_it;
+}
+
+void Function::InitBlocks(uint32_t count) {
+    blocks_.reserve(blocks_.size() + count);
+    for (uint32_t i = 0; i < count; i++) {
+        auto new_block = std::make_unique<BasicBlock>(module_, *this);
+        blocks_.emplace_back(std::move(new_block));
+    }
 }
 
 const Instruction* Function::FindInstruction(uint32_t id) const {

--- a/layers/gpu/spirv/function_basic_block.h
+++ b/layers/gpu/spirv/function_basic_block.h
@@ -73,6 +73,7 @@ struct Function {
 
     // Adds a new block after and returns reference to it
     BasicBlockIt InsertNewBlock(BasicBlockIt it);
+    void InitBlocks(uint32_t count);
 
     void ReplaceAllUsesWith(uint32_t old_word, uint32_t new_word);
 

--- a/layers/gpu/spirv/inject_function_pass.cpp
+++ b/layers/gpu/spirv/inject_function_pass.cpp
@@ -1,0 +1,159 @@
+/* Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "inject_function_pass.h"
+#include "module.h"
+
+namespace gpuav {
+namespace spirv {
+
+BasicBlockIt InjectFunctionPass::InjectConditionalFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
+                                                                const InjectionData& injection_data) {
+    // We turn the block into 4 separate blocks
+    block_it = function->InsertNewBlock(block_it);
+    block_it = function->InsertNewBlock(block_it);
+    block_it = function->InsertNewBlock(block_it);
+    BasicBlock& original_block = **(std::prev(block_it, 3));
+    // Where we call targeted instruction if it is valid
+    BasicBlock& valid_block = **(std::prev(block_it, 2));
+    // will be an empty block, used for the Phi node, even if no result, create for simplicity
+    BasicBlock& invalid_block = **(std::prev(block_it, 1));
+    // All the remaining block instructions after targeted instruction
+    BasicBlock& merge_block = **block_it;
+
+    const uint32_t original_label = original_block.GetLabelId();
+    const uint32_t valid_block_label = valid_block.GetLabelId();
+    const uint32_t invalid_block_label = invalid_block.GetLabelId();
+    const uint32_t merge_block_label = merge_block.GetLabelId();
+
+    // need to preserve the control-flow of how things, like a OpPhi, are accessed from a predecessor block
+    function->ReplaceAllUsesWith(original_label, merge_block_label);
+
+    // Move the targeted instruction to a valid block
+    const Instruction& target_inst = *valid_block.instructions_.emplace_back(std::move(*inst_it));
+    inst_it = original_block.instructions_.erase(inst_it);
+    valid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
+
+    // If thre is a result, we need to create an additional BasicBlock to hold the |else| case, then after we create a Phi node to
+    // hold the result
+    const uint32_t target_inst_id = target_inst.ResultId();
+    if (target_inst_id != 0) {
+        const uint32_t phi_id = module_.TakeNextId();
+        const Type& phi_type = *module_.type_manager_.FindTypeById(target_inst.TypeId());
+        uint32_t null_id = 0;
+        // Can't create ConstantNull of pointer type, so convert uint64 zero to pointer
+        if (phi_type.spv_type_ == SpvType::kPointer) {
+            const Type& uint64_type = module_.type_manager_.GetTypeInt(64, false);
+            const Constant& null_constant = module_.type_manager_.GetConstantNull(uint64_type);
+            null_id = module_.TakeNextId();
+            // We need to put any intermittent instructions here so Phi is first in the merge block
+            invalid_block.CreateInstruction(spv::OpConvertUToPtr, {phi_type.Id(), null_id, null_constant.Id()});
+            module_.AddCapability(spv::CapabilityInt64);
+        } else {
+            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) && phi_type.inst_.Word(2) < 32) {
+                // You can't make a constant of a 8-int, 16-int, 16-float without having the capability
+                // The only way this situation occurs if they use something like
+                //     OpCapability StorageBuffer8BitAccess
+                // but there is not explicit Int8
+                // It should be more than safe to inject it for them
+                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat) ? spv::CapabilityFloat16
+                                             : (phi_type.inst_.Word(2) == 16)        ? spv::CapabilityInt16
+                                                                                     : spv::CapabilityInt8;
+                module_.AddCapability(capability);
+            }
+
+            null_id = module_.type_manager_.GetConstantNull(phi_type).Id();
+        }
+
+        // replace before creating instruction, otherwise will over-write itself
+        function->ReplaceAllUsesWith(target_inst_id, phi_id);
+        merge_block.CreateInstruction(spv::OpPhi,
+                                      {phi_type.Id(), phi_id, target_inst_id, valid_block_label, null_id, invalid_block_label});
+    }
+
+    // When skipping some instructions, we need something valid to replace it
+    if (target_inst.Opcode() == spv::OpRayQueryInitializeKHR) {
+        // Currently assume the RayQuery and AS object were valid already
+        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
+        const uint32_t float32_0_id = module_.type_manager_.GetConstantZeroFloat32().Id();
+        const uint32_t vec3_0_id = module_.type_manager_.GetConstantZeroVec3().Id();
+        invalid_block.CreateInstruction(spv::OpRayQueryInitializeKHR,
+                                        {target_inst.Operand(0), target_inst.Operand(1), uint32_0_id, uint32_0_id, vec3_0_id,
+                                         float32_0_id, vec3_0_id, float32_0_id});
+    }
+
+    invalid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
+
+    // move all remaining instructions to the newly created merge block
+    merge_block.instructions_.insert(merge_block.instructions_.end(), std::make_move_iterator(inst_it),
+                                     std::make_move_iterator(original_block.instructions_.end()));
+    original_block.instructions_.erase(inst_it, original_block.instructions_.end());
+
+    // Go back to original Block and add function call and branch from the bool result
+    const uint32_t function_result = CreateFunctionCall(original_block, nullptr, injection_data);
+
+    original_block.CreateInstruction(spv::OpSelectionMerge, {merge_block_label, spv::SelectionControlMaskNone});
+    original_block.CreateInstruction(spv::OpBranchConditional, {function_result, valid_block_label, invalid_block_label});
+
+    Reset();
+
+    return block_it;
+}
+
+void InjectFunctionPass::InjectFunctionCheck(BasicBlockIt block_it, InstructionIt* inst_it, const InjectionData& injection_data) {
+    CreateFunctionCall(**block_it, inst_it, injection_data);
+    Reset();
+}
+
+void InjectFunctionPass::Run() {
+    // Can safely loop function list as there is no injecting of new Functions until linking time
+    for (const auto& function : module_.functions_) {
+        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
+            if ((*block_it)->loop_header_) {
+                continue;  // Currently can't properly handle injecting CFG logic into a loop header block
+            }
+            auto& block_instructions = (*block_it)->instructions_;
+            for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
+                // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
+                if (!AnalyzeInstruction(*function, *(inst_it->get()))) continue;
+
+                if (module_.max_instrumented_count_ != 0 && instrumented_count_ >= module_.max_instrumented_count_) {
+                    return;
+                }
+                instrumented_count_++;
+
+                // Add any debug information to pass into the function call
+                InjectionData injection_data;
+                injection_data.stage_info_id = GetStageInfo(*function, block_it, inst_it);
+                const uint32_t inst_position = target_instruction_->position_index_;
+                auto inst_position_constant = module_.type_manager_.CreateConstantUInt32(inst_position);
+                injection_data.inst_position_id = inst_position_constant.Id();
+
+                if (conditional_function_check_) {
+                    block_it = InjectConditionalFunctionCheck(function.get(), block_it, inst_it, injection_data);
+                    // will start searching again from newly split merge block
+                    block_it--;
+                    break;
+                } else {
+                    // inst_it is updated to the instruction after the new function call, it will not add/remove any Blocks
+                    InjectFunctionCheck(block_it, &inst_it, injection_data);
+                }
+            }
+        }
+    }
+}
+
+}  // namespace spirv
+}  // namespace gpuav

--- a/layers/gpu/spirv/inject_function_pass.h
+++ b/layers/gpu/spirv/inject_function_pass.h
@@ -28,11 +28,10 @@ struct InjectionData {
 // A type of common pass that will inject a function call and link it up later
 class InjectFunctionPass : public Pass {
   public:
-    void Run() override;
+    bool Run() final;
 
   protected:
-    InjectFunctionPass(Module& module, bool conditional_function_check)
-        : Pass(module), conditional_function_check_(conditional_function_check) {}
+    InjectFunctionPass(Module& module, bool conditional_function_check);
 
     BasicBlockIt InjectConditionalFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
                                                 const InjectionData& injection_data);
@@ -44,8 +43,6 @@ class InjectFunctionPass : public Pass {
     // Each pass creates a OpFunctionCall and returns its result id.
     // If |inst_it| is not null, it will update it to instruction post OpFunctionCall
     virtual uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data) = 0;
-    // clear values incase multiple injections are made
-    virtual void Reset() = 0;
 
     // If this is false, we assume through other means (such as robustness) we won't crash on bad values and go
     //     PassFunction(original_value)
@@ -76,8 +73,6 @@ class InjectFunctionPass : public Pass {
     //         int Y = 0;
     //    }
     const bool conditional_function_check_;
-
-    uint32_t instrumented_count_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpu/spirv/inject_function_pass.h
+++ b/layers/gpu/spirv/inject_function_pass.h
@@ -1,0 +1,84 @@
+/* Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include "pass.h"
+
+namespace gpuav {
+namespace spirv {
+
+// Info we know is the same regardless what pass is consuming the CreateFunctionCall()
+struct InjectionData {
+    uint32_t stage_info_id;
+    uint32_t inst_position_id;
+};
+
+// A type of common pass that will inject a function call and link it up later
+class InjectFunctionPass : public Pass {
+  public:
+    void Run() override;
+
+  protected:
+    InjectFunctionPass(Module& module, bool conditional_function_check)
+        : Pass(module), conditional_function_check_(conditional_function_check) {}
+
+    BasicBlockIt InjectConditionalFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
+                                                const InjectionData& injection_data);
+    void InjectFunctionCheck(BasicBlockIt block_it, InstructionIt* inst_it, const InjectionData& injection_data);
+
+    // Each pass decides if the instruction should needs to have its function check injected
+    virtual bool AnalyzeInstruction(const Function& function, const Instruction& inst) = 0;
+    // A callback from the function injection logic.
+    // Each pass creates a OpFunctionCall and returns its result id.
+    // If |inst_it| is not null, it will update it to instruction post OpFunctionCall
+    virtual uint32_t CreateFunctionCall(BasicBlock& block, InstructionIt* inst_it, const InjectionData& injection_data) = 0;
+    // clear values incase multiple injections are made
+    virtual void Reset() = 0;
+
+    // If this is false, we assume through other means (such as robustness) we won't crash on bad values and go
+    //     PassFunction(original_value)
+    //     value = original_value;
+    //
+    // Otherwise, we will have wrap the checks to be safe
+    // For OpStore we will just ignore the store if it is invalid, example:
+    // Before:
+    //     bda.data[index] = value;
+    // After:
+    //    if (isValid(bda.data, index)) {
+    //         bda.data[index] = value;
+    //    }
+    //
+    // For OpLoad we replace the value with Zero (via Phi node) if it is invalid, example
+    // Before:
+    //     int X = bda.data[index];
+    //     int Y = bda.data[X];
+    // After:
+    //    if (isValid(bda.data, index)) {
+    //         int X = bda.data[index];
+    //    } else {
+    //         int X = 0;
+    //    }
+    //    if (isValid(bda.data, X)) {
+    //         int Y = bda.data[X];
+    //    } else {
+    //         int Y = 0;
+    //    }
+    const bool conditional_function_check_;
+
+    uint32_t instrumented_count_ = 0;
+};
+
+}  // namespace spirv
+}  // namespace gpuav

--- a/layers/gpu/spirv/instruction.h
+++ b/layers/gpu/spirv/instruction.h
@@ -62,6 +62,12 @@ struct Instruction {
 
     bool IsArray() const { return (Opcode() == spv::OpTypeArray || Opcode() == spv::OpTypeRuntimeArray); }
 
+    // SPIR-V spec: "A string is interpreted as a nul-terminated stream of characters"
+    char const* GetAsString(uint32_t index) const {
+        assert(index < Length());
+        return (char const*)&words_[index];
+    }
+
     void ToBinary(std::vector<uint32_t>& out);
 
     bool operator==(Instruction const& other) const { return words_ == other.words_; }

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -45,10 +45,7 @@ const Variable& Pass::GetBuiltinVariable(uint32_t built_in) {
         auto new_inst = std::make_unique<Instruction>(4, spv::OpVariable);
         new_inst->Fill({pointer_type.Id(), variable_id, spv::StorageClassInput});
         built_in_variable = &module_.type_manager_.AddVariable(std::move(new_inst), pointer_type);
-
-        for (auto& entry_point : module_.entry_points_) {
-            entry_point->AppendWord(built_in_variable->Id());
-        }
+        module_.AddInterfaceVariables(built_in_variable->Id(), spv::StorageClassInput);
     }
 
     return *built_in_variable;

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -15,9 +15,7 @@
 
 #include "pass.h"
 #include "module.h"
-#include "type_manager.h"
 #include "gpu/shaders/gpu_error_codes.h"
-#include <spirv/unified1/spirv.hpp>
 
 namespace gpuav {
 namespace spirv {
@@ -263,104 +261,6 @@ uint32_t Pass::CastToUint32(uint32_t id, BasicBlock& block, InstructionIt* inst_
     return new_id;  // Return an id to the Uint equivalent.
 }
 
-BasicBlockIt Pass::InjectConditionalFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
-                                                  const InjectionData& injection_data) {
-    // We turn the block into 4 separate blocks
-    block_it = function->InsertNewBlock(block_it);
-    block_it = function->InsertNewBlock(block_it);
-    block_it = function->InsertNewBlock(block_it);
-    BasicBlock& original_block = **(std::prev(block_it, 3));
-    // Where we call targeted instruction if it is valid
-    BasicBlock& valid_block = **(std::prev(block_it, 2));
-    // will be an empty block, used for the Phi node, even if no result, create for simplicity
-    BasicBlock& invalid_block = **(std::prev(block_it, 1));
-    // All the remaining block instructions after targeted instruction
-    BasicBlock& merge_block = **block_it;
-
-    const uint32_t original_label = original_block.GetLabelId();
-    const uint32_t valid_block_label = valid_block.GetLabelId();
-    const uint32_t invalid_block_label = invalid_block.GetLabelId();
-    const uint32_t merge_block_label = merge_block.GetLabelId();
-
-    // need to preserve the control-flow of how things, like a OpPhi, are accessed from a predecessor block
-    function->ReplaceAllUsesWith(original_label, merge_block_label);
-
-    // Move the targeted instruction to a valid block
-    const Instruction& target_inst = *valid_block.instructions_.emplace_back(std::move(*inst_it));
-    inst_it = original_block.instructions_.erase(inst_it);
-    valid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
-
-    // If thre is a result, we need to create an additional BasicBlock to hold the |else| case, then after we create a Phi node to
-    // hold the result
-    const uint32_t target_inst_id = target_inst.ResultId();
-    if (target_inst_id != 0) {
-        const uint32_t phi_id = module_.TakeNextId();
-        const Type& phi_type = *module_.type_manager_.FindTypeById(target_inst.TypeId());
-        uint32_t null_id = 0;
-        // Can't create ConstantNull of pointer type, so convert uint64 zero to pointer
-        if (phi_type.spv_type_ == SpvType::kPointer) {
-            const Type& uint64_type = module_.type_manager_.GetTypeInt(64, false);
-            const Constant& null_constant = module_.type_manager_.GetConstantNull(uint64_type);
-            null_id = module_.TakeNextId();
-            // We need to put any intermittent instructions here so Phi is first in the merge block
-            invalid_block.CreateInstruction(spv::OpConvertUToPtr, {phi_type.Id(), null_id, null_constant.Id()});
-            module_.AddCapability(spv::CapabilityInt64);
-        } else {
-            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) && phi_type.inst_.Word(2) < 32) {
-                // You can't make a constant of a 8-int, 16-int, 16-float without having the capability
-                // The only way this situation occurs if they use something like
-                //     OpCapability StorageBuffer8BitAccess
-                // but there is not explicit Int8
-                // It should be more than safe to inject it for them
-                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat) ? spv::CapabilityFloat16
-                                             : (phi_type.inst_.Word(2) == 16)        ? spv::CapabilityInt16
-                                                                                     : spv::CapabilityInt8;
-                module_.AddCapability(capability);
-            }
-
-            null_id = module_.type_manager_.GetConstantNull(phi_type).Id();
-        }
-
-        // replace before creating instruction, otherwise will over-write itself
-        function->ReplaceAllUsesWith(target_inst_id, phi_id);
-        merge_block.CreateInstruction(spv::OpPhi,
-                                      {phi_type.Id(), phi_id, target_inst_id, valid_block_label, null_id, invalid_block_label});
-    }
-
-    // When skipping some instructions, we need something valid to replace it
-    if (target_inst.Opcode() == spv::OpRayQueryInitializeKHR) {
-        // Currently assume the RayQuery and AS object were valid already
-        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
-        const uint32_t float32_0_id = module_.type_manager_.GetConstantZeroFloat32().Id();
-        const uint32_t vec3_0_id = module_.type_manager_.GetConstantZeroVec3().Id();
-        invalid_block.CreateInstruction(spv::OpRayQueryInitializeKHR,
-                                        {target_inst.Operand(0), target_inst.Operand(1), uint32_0_id, uint32_0_id, vec3_0_id,
-                                         float32_0_id, vec3_0_id, float32_0_id});
-    }
-
-    invalid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
-
-    // move all remaining instructions to the newly created merge block
-    merge_block.instructions_.insert(merge_block.instructions_.end(), std::make_move_iterator(inst_it),
-                                     std::make_move_iterator(original_block.instructions_.end()));
-    original_block.instructions_.erase(inst_it, original_block.instructions_.end());
-
-    // Go back to original Block and add function call and branch from the bool result
-    const uint32_t function_result = CreateFunctionCall(original_block, nullptr, injection_data);
-
-    original_block.CreateInstruction(spv::OpSelectionMerge, {merge_block_label, spv::SelectionControlMaskNone});
-    original_block.CreateInstruction(spv::OpBranchConditional, {function_result, valid_block_label, invalid_block_label});
-
-    Reset();
-
-    return block_it;
-}
-
-void Pass::InjectFunctionCheck(BasicBlockIt block_it, InstructionIt* inst_it, const InjectionData& injection_data) {
-    CreateFunctionCall(**block_it, inst_it, injection_data);
-    Reset();
-}
-
 InstructionIt Pass::FindTargetInstruction(BasicBlock& block) const {
     const uint32_t target_id = target_instruction_->ResultId();
     for (auto inst_it = block.instructions_.begin(); inst_it != block.instructions_.end(); ++inst_it) {
@@ -374,44 +274,6 @@ InstructionIt Pass::FindTargetInstruction(BasicBlock& block) const {
     }
     assert(false);
     return block.instructions_.end();
-}
-
-void Pass::Run() {
-    // Can safely loop function list as there is no injecting of new Functions until linking time
-    for (const auto& function : module_.functions_) {
-        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
-            if ((*block_it)->loop_header_) {
-                continue;  // Currently can't properly handle injecting CFG logic into a loop header block
-            }
-            auto& block_instructions = (*block_it)->instructions_;
-            for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
-                // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
-                if (!AnalyzeInstruction(*function, *(inst_it->get()))) continue;
-
-                if (module_.max_instrumented_count_ != 0 && instrumented_count_ >= module_.max_instrumented_count_) {
-                    return;
-                }
-                instrumented_count_++;
-
-                // Add any debug information to pass into the function call
-                InjectionData injection_data;
-                injection_data.stage_info_id = GetStageInfo(*function, block_it, inst_it);
-                const uint32_t inst_position = target_instruction_->position_index_;
-                auto inst_position_constant = module_.type_manager_.CreateConstantUInt32(inst_position);
-                injection_data.inst_position_id = inst_position_constant.Id();
-
-                if (conditional_function_check_) {
-                    block_it = InjectConditionalFunctionCheck(function.get(), block_it, inst_it, injection_data);
-                    // will start searching again from newly split merge block
-                    block_it--;
-                    break;
-                } else {
-                    // inst_it is updated to the instruction after the new function call, it will not add/remove any Blocks
-                    InjectFunctionCheck(block_it, &inst_it, injection_data);
-                }
-            }
-        }
-    }
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -28,7 +28,10 @@ struct BasicBlock;
 // Common helpers for all passes
 class Pass {
   public:
-    virtual void Run() {}
+    // Return false if nothing was changed
+    virtual bool Run() { return false; }
+
+    virtual void PrintDebugInfo() {}
 
     // Finds (and creates if needed) decoration and returns the OpVariable it points to
     const Variable& GetBuiltinVariable(uint32_t built_in);
@@ -44,15 +47,19 @@ class Pass {
     uint32_t ConvertTo32(uint32_t id, BasicBlock& block, InstructionIt* inst_it = nullptr);
     uint32_t CastToUint32(uint32_t id, BasicBlock& block, InstructionIt* inst_it = nullptr);
 
-    uint32_t GetInstrumentedCount() { return instrumented_count_; }
-
   protected:
     Pass(Module& module) : module_(module) {}
     Module& module_;
 
+    // clear values between instrumented instructions
+    virtual void Reset() = 0;
+
     // As various things are modifiying the instruction streams, we need to get back to where we were.
+    // (normally set in the AnalyzeInstruction call)
     const Instruction* target_instruction_ = nullptr;
     InstructionIt FindTargetInstruction(BasicBlock& block) const;
+
+    uint32_t instrumented_count_ = 0;
 };
 
 }  // namespace spirv

--- a/layers/gpu/spirv/ray_query_pass.cpp
+++ b/layers/gpu/spirv/ray_query_pass.cpp
@@ -16,6 +16,7 @@
 #include "ray_query_pass.h"
 #include "module.h"
 #include <spirv/unified1/spirv.hpp>
+#include <iostream>
 
 #include "generated/instrumentation_ray_query_comp.h"
 
@@ -64,6 +65,10 @@ bool RayQueryPass::AnalyzeInstruction(const Function& function, const Instructio
     }
     target_instruction_ = &inst;
     return true;
+}
+
+void RayQueryPass::PrintDebugInfo() {
+    std::cout << "RayQueryPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/ray_query_pass.h
+++ b/layers/gpu/spirv/ray_query_pass.h
@@ -15,19 +15,15 @@
 #pragma once
 
 #include <stdint.h>
-#include "pass.h"
+#include "inject_function_pass.h"
 
 namespace gpuav {
 namespace spirv {
 
-class Module;
-struct Function;
-struct BasicBlock;
-
 // Create a pass to instrument SPV_KHR_ray_query instructions
-class RayQueryPass : public Pass {
+class RayQueryPass : public InjectFunctionPass {
   public:
-    RayQueryPass(Module& module) : Pass(module, true) {}
+    RayQueryPass(Module& module) : InjectFunctionPass(module, true) {}
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/ray_query_pass.h
+++ b/layers/gpu/spirv/ray_query_pass.h
@@ -24,6 +24,7 @@ namespace spirv {
 class RayQueryPass : public InjectFunctionPass {
   public:
     RayQueryPass(Module& module) : InjectFunctionPass(module, true) {}
+    void PrintDebugInfo() final;
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/tests/spirv/instrumentation.cpp
+++ b/tests/spirv/instrumentation.cpp
@@ -26,6 +26,7 @@ static bool all_passes = false;
 static bool bindless_descriptor_pass = false;
 static bool buffer_device_address_pass = false;
 static bool ray_query_pass = false;
+static bool debug_printf_pass = false;
 
 void PrintUsage(const char* program) {
     printf(R"(
@@ -44,6 +45,8 @@ USAGE: %s <input> -o <output> <passes>
                Runs BufferDeviceAddressPass
   --ray-query
                Runs RayQueryPass
+  --debug-printf
+               Runs DebugPrintfPass
   --timer
                Prints time it takes to instrument entire module
   -h, --help
@@ -75,6 +78,8 @@ bool ParseFlags(int argc, char** argv, const char** out_file) {
             buffer_device_address_pass = true;
         } else if (0 == strcmp(cur_arg, "--ray-query")) {
             ray_query_pass = true;
+        } else if (0 == strcmp(cur_arg, "--debug-printf")) {
+            debug_printf_pass = true;
         } else if (0 == strncmp(cur_arg, "--", 2)) {
             printf("Unknown pass %s\n", cur_arg);
             PrintUsage(argv[0]);
@@ -134,10 +139,15 @@ int main(int argc, char** argv) {
     if (all_passes || ray_query_pass) {
         module.RunPassRayQuery();
     }
+    if (all_passes || debug_printf_pass) {
+        module.RunPassDebugPrintf();
+    }
 
-    for (const auto info : module.link_info_) {
+    for (const auto& info : module.link_info_) {
         module.LinkFunction(info);
     }
+
+    module.PostProcess();
     module.ToBinary(spirv_data);
 
     if (timer) {

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -513,6 +513,171 @@ TEST_F(NegativeDebugPrintf, DISABLED_Float64VectorPrecision) {
     BasicComputeTest(shader_source, "vector of float64 1.23 1.23");
 }
 
+// https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7143
+TEST_F(NegativeDebugPrintf, DISABLED_FloatMix) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    AddRequiredFeature(vkt::Feature::shaderFloat64);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_float64 : enable
+        void main() {
+            float16_t a = float16_t(3.33);
+            float b = 3.33;
+            float64_t c = float64_t(3.33);
+            debugPrintfEXT("%f %f %f %f", a, b, c, 3.33f);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "32, 16, 32 | 3.300000 3.298828 3.300000");
+}
+
+TEST_F(NegativeDebugPrintf, Float16) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+        void main() {
+            float16_t foo = float16_t(3.3);
+            float bar = 3.3;
+            debugPrintfEXT("32, 16, 32 | %f %f %f", bar, foo, bar);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "32, 16, 32 | 3.300000 3.298828 3.300000");
+}
+
+TEST_F(NegativeDebugPrintf, Float16Vector) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+        void main() {
+            float16_t foo = float16_t(3.3);
+            f16vec2 vecfloat = f16vec2(foo, foo);
+            debugPrintfEXT("vector of float16 %v2f", vecfloat);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "vector of float16 3.298828, 3.298828");
+}
+
+TEST_F(NegativeDebugPrintf, Float16Precision) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderFloat16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_float16 : enable
+        void main() {
+            float16_t foo = float16_t(3.3);
+            debugPrintfEXT("float16 %1.3f", foo);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "float16 3.299");
+}
+
+// TODO casting is wrong
+TEST_F(NegativeDebugPrintf, DISABLED_Int16) {
+    AddRequiredFeature(vkt::Feature::shaderInt16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
+        void main() {
+            uint16_t foo = uint16_t(123);
+            int16_t bar = int16_t(-123);
+            debugPrintfEXT("unsigned and signed %d %d", foo, bar);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 123 -123");
+}
+
+TEST_F(NegativeDebugPrintf, DISABLED_Int16Vector) {
+    AddRequiredFeature(vkt::Feature::shaderInt16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
+        void main() {
+            uint16_t foo = uint16_t(123);
+            u16vec2 fooVec = u16vec2(foo, foo);
+            int16_t bar = int16_t(-123);
+            i16vec2 barVec = i16vec2(bar, bar);
+            debugPrintfEXT("unsigned and signed %v2d %v2d", fooVec, barVec);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 123, 123 | -123, -123");
+}
+
+TEST_F(NegativeDebugPrintf, DISABLED_Int16Hex) {
+    AddRequiredFeature(vkt::Feature::shaderInt16);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int16: enable
+        void main() {
+            uint16_t foo = uint16_t(123);
+            int16_t bar = int16_t(-123);
+            debugPrintfEXT("unsigned and signed 0x%x 0x%x", foo, bar);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 0x7b 0x85");
+}
+
+TEST_F(NegativeDebugPrintf, DISABLED_Int8) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderInt8);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
+        void main() {
+            uint8_t foo = uint8_t(123);
+            int8_t bar = int8_t(-123);
+            debugPrintfEXT("unsigned and signed %d %d", foo, bar);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 123 -123");
+}
+
+TEST_F(NegativeDebugPrintf, DISABLED_Int8Vector) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderInt8);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
+        void main() {
+            uint8_t foo = uint8_t(123);
+            u8vec2 fooVec = u8vec2(foo, foo);
+            int8_t bar = int8_t(-123);
+            i8vec2 barVec = i8vec2(bar, bar);
+            debugPrintfEXT("unsigned and signed %v2d | %v2d", fooVec, barVec);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 123, 123 | -123, -123");
+}
+
+TEST_F(NegativeDebugPrintf, Int8Hex) {
+    AddRequiredExtensions(VK_KHR_SHADER_FLOAT16_INT8_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::shaderInt8);
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+        #extension GL_EXT_shader_explicit_arithmetic_types_int8: enable
+        void main() {
+            uint8_t foo = uint8_t(123);
+            int8_t bar = int8_t(-123);
+            debugPrintfEXT("unsigned and signed 0x%x 0x%x", foo, bar);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "unsigned and signed 0x7b 0x85");
+}
+
 TEST_F(NegativeDebugPrintf, BoolAsHex) {
     char const *shader_source = R"glsl(
         #version 450
@@ -524,6 +689,41 @@ TEST_F(NegativeDebugPrintf, BoolAsHex) {
         }
     )glsl";
     BasicComputeTest(shader_source, "bool fun 0x1010");
+}
+
+TEST_F(NegativeDebugPrintf, BoolVector) {
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+
+        bool foo(int x) {
+            return x == 1;
+        }
+
+        void main() {
+            bool a = foo(1);
+            bool b = !a;
+            bvec2 c = bvec2(a, b);
+            debugPrintfEXT("bvec2 %v2u", c);
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "bvec2 1, 0");
+}
+
+TEST_F(NegativeDebugPrintf, BoolNonConstant) {
+    char const *shader_source = R"glsl(
+        #version 450
+        #extension GL_EXT_debug_printf : enable
+
+        bool foo(int x) {
+            return x == 1;
+        }
+
+        void main() {
+            debugPrintfEXT("bool %u", foo(1));
+        }
+    )glsl";
+    BasicComputeTest(shader_source, "bool 1");
 }
 
 TEST_F(NegativeDebugPrintf, Empty) {


### PR DESCRIPTION
This was brought over from the current implementations in SPIRV-Tools (`source/opt/inst_debug_printf_pass.cpp`) for 3 reasons (after lots of discussions)

1. There are bugs that need be fixed and easier to iterate without having to grab a dependency
2. To get GPU-AV and work with DebugPrintf we need a more unified way the shaders are instrumented
3. Allows future maintainer to not need to learn yet-another-code-base to make changes

There is more I want to fix/add but this is the initial "get it to work the same" change... there are limitations (as noted from disabled tests) of the old implementation and plan to fix those once this is in