### PR TITLE
layers: Fix compatible image VU for 291 headers

### DIFF
--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -625,9 +625,9 @@ bool StatelessValidation::ValidateCreateImageSwapchain(const VkImageCreateInfo &
     const auto swapchain_create_info = vku::FindStructInPNextChain<VkImageSwapchainCreateInfoKHR>(create_info.pNext);
     if (!swapchain_create_info || swapchain_create_info->swapchain == VK_NULL_HANDLE) return skip;
 
-    // All the following fall under the same VU that checks that the swapchain image uses parameters limited by the
-    // table in #swapchain-wsi-image-create-info. Breaking up into multiple checks allows for more useful information
-    // returned why this error occured. Check for matching Swapchain flags is done later in state tracking validation
+    // All the following fall under the same VU that checks that the swapchain image uses parameters listed in the
+    // #swapchain-wsi-image-create-info table. Breaking up into multiple checks allows for more useful information
+    // to be returned when this error occurs. Check for matching Swapchain flags is done later in state tracking validation
     const char *vuid = "VUID-VkImageSwapchainCreateInfoKHR-swapchain-00995";
     const Location swapchain_loc = create_info_loc.pNext(Struct::VkImageSwapchainCreateInfoKHR, Field::swapchain);
 

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -341,7 +341,8 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
 
     if (format_list_info) {
         const uint32_t viewFormatCount = format_list_info->viewFormatCount;
-        if (((image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) == 0) && (viewFormatCount > 1)) {
+        const bool mutable_image = (image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) != 0;
+        if (!mutable_image && viewFormatCount > 1) {
             skip |= LogError("VUID-VkImageCreateInfo-flags-04738", device,
                              create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
                              "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.", viewFormatCount,
@@ -356,7 +357,7 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
             if (view_format == VK_FORMAT_UNDEFINED) {
                 skip |= LogError("VUID-VkImageFormatListCreateInfo-viewFormatCount-09540", device, format_loc,
                                  "is VK_FORMAT_UNDEFINED.");
-            } else if (!class_compatible) {
+            } else if (!class_compatible && !vkuFormatIsMultiplane(image_format)) {
                 if (image_flags & VK_IMAGE_CREATE_BLOCK_TEXEL_VIEW_COMPATIBLE_BIT) {
                     const bool size_compatible = !vkuFormatIsCompressed(view_format) &&
                                                  vkuFormatElementSize(view_format) == vkuFormatElementSize(image_format);

--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -567,6 +567,12 @@ class StatelessValidation : public ValidationObject {
     bool manual_PreCallValidateCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
                                            const VkAllocationCallbacks *pAllocator, VkImage *pImage,
                                            const ErrorObject &error_obj) const;
+    bool ValidateCreateImageSparse(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateImageFragmentShadingRate(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateImageCornerSampled(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateImageStencilUsage(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateImageSwapchain(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
+    bool ValidateCreateImageMetalObject(const VkImageCreateInfo &create_info, const Location &create_info_loc) const;
 
     bool manual_PreCallValidateCreateImageView(VkDevice device, const VkImageViewCreateInfo *pCreateInfo,
                                                const VkAllocationCallbacks *pAllocator, VkImageView *pView,


### PR DESCRIPTION
- first commit is just cleanup as the function was getting unnecessarily/complex
- adds changes to Image creation VU change for `VUID-VkImageCreateInfo-pNext-06722` (from https://gitlab.khronos.org/vulkan/vulkan/-/merge_requests/6774)