### PR TITLE
🌴sync: Ensure handle index is valid

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -331,7 +331,7 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     // The following method allows to set subcommand handles independently of the main command.
     void AddSubcommandHandle(ResourceUsageTag tag, const VulkanTypedHandle &typed_handle, uint32_t index = vvl::kNoIndex32);
 
-    const HandleRecord &GetHandleRecord(uint32_t handle_index) const { return handles_[handle_index]; }
+    const std::vector<HandleRecord> &GetHandleRecords() const { return handles_; }
 
     std::shared_ptr<const vvl::CommandBuffer> GetCBStateShared() const { return cb_state_->shared_from_this(); }
 


### PR DESCRIPTION
https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8291 discovered two problems:
1) There is a potential syncval bug. Will be fixed in another PR, we have a deterministic repro case.
2) If syncval resource reporting invariants get invalidated this leads to crash/assert. The above syncval bug leads to such bad state and it will be fixed. But the same happens when we have unhandled core validation error (when core validation is disabled). The convention that syncval should handle this gracefully without crashing, although does not guarantee that reporting is correct.

This PR addresses problem 2.
