### PR TITLE
Draft: Fix VUID-VkSwapchainCreateInfoKHR-presentMode-02839

### DIFF
--- a/layers/core_checks/cc_wsi.cpp
+++ b/layers/core_checks/cc_wsi.cpp
@@ -356,13 +356,6 @@ bool CoreChecks::ValidateCreateSwapchain(const VkSwapchainCreateInfoKHR &create_
         }
     }
 #endif
-    VkSurfacePresentModeEXT present_mode_info = vku::InitStructHelper();
-    if (IsExtEnabled(device_extensions.vk_ext_surface_maintenance1)) {
-        present_mode_info.presentMode = create_info.presentMode;
-        present_mode_info.pNext = surface_info_pnext;
-        surface_info_pnext = &present_mode_info;
-    }
-
     const auto surface_caps = surface_state->GetSurfaceCapabilities(physical_device_state->VkHandle(), surface_info_pnext);
 
     bool skip = false;


### PR DESCRIPTION
Including a VkSurfacePresentModeEXT in the call to GetSurfaceCapabilities makes this check more strict than it should be.


This will require WG discussion. Internal Khronos spec issue to follow

This PR: https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6351 was introduced to handle a case where chaining a VkSurfacePresentModeEXT lowered the minImageCount. However, we have also observed cases were it instead increases it, which causes validation errors in the opposite direction.

This PR makes validation layers actually check what VUID-VkSwapchainCreateInfoKHR-presentMode-02839 says the rule is (i.e. the value returned by the unextended function). Unfortunately this will go back to throwing errors in the case that triggered https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6351. The spec has this note describing this functionality, but no VUs corresponding to it, and so its unclear both how to validate this, and how to correctly use the functionality:

> If [VkSwapchainPresentModesCreateInfoEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSwapchainPresentModesCreateInfoEXT.html) is provided to swapchain creation, the requirements for forward progress may be less strict. For example, a FIFO swapchain might only require 2 images to guarantee forward progress, but a MAILBOX one might require 4. Without the per-present image counts, such an implementation would have to return 4 in [VkSurfaceCapabilitiesKHR](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSurfaceCapabilitiesKHR.html)::minImageCount, which pessimizes FIFO. Conversely, an implementation may return a low number for minImageCount, but internally bump the image count when application queries [vkGetSwapchainImagesKHR](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkGetSwapchainImagesKHR.html), which can surprise applications, and is not discoverable until swapchain creation. Using VkSurfacePresentModeEXT and [VkSwapchainPresentModesCreateInfoEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSwapchainPresentModesCreateInfoEXT.html) together effectively removes this problem.
> [VkSwapchainPresentModesCreateInfoEXT](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSwapchainPresentModesCreateInfoEXT.html) is required for the specification to be backwards compatible with applications that do not know about, or make use of this feature.
