### PR TITLE
gpu: Fix a race condition in submission processing

### DIFF
--- a/layers/gpu/core/gpu_state_tracker.h
+++ b/layers/gpu/core/gpu_state_tracker.h
@@ -27,7 +27,7 @@ namespace gpu_tracker {
 class Queue : public vvl::Queue {
   public:
     Queue(gpu::GpuShaderInstrumentor &shader_instrumentor_, VkQueue q, uint32_t family_index, uint32_t queue_index,
-          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties);
+          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties, bool timeline_khr);
     virtual ~Queue();
 
   protected:
@@ -41,6 +41,7 @@ class Queue : public vvl::Queue {
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};
     std::deque<std::vector<std::shared_ptr<vvl::CommandBuffer>>> retiring_;
+    const bool timeline_khr_;
 };
 
 class CommandBuffer : public vvl::CommandBuffer {

--- a/layers/gpu/core/gpu_state_tracker.h
+++ b/layers/gpu/core/gpu_state_tracker.h
@@ -31,8 +31,7 @@ class Queue : public vvl::Queue {
     virtual ~Queue();
 
   protected:
-    vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
-    void PostSubmit(vvl::QueueSubmission &) override;
+    vvl::SubmitResult PostSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
     void SubmitBarrier(const Location &loc, uint64_t seq);
     void Retire(vvl::QueueSubmission &) override;
 

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -83,8 +83,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
     std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet, vvl::DescriptorPool*,
                                                             const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
                                                             uint32_t variable_count) final;
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
-                                            const VkQueueFamilyProperties& queueFamilyProperties) final;
 
     void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -70,13 +70,6 @@ std::shared_ptr<vvl::CommandBuffer> Validator::CreateCmdBufferState(VkCommandBuf
     return std::static_pointer_cast<vvl::CommandBuffer>(std::make_shared<CommandBuffer>(*this, handle, pCreateInfo, pool));
 }
 
-std::shared_ptr<vvl::Queue> Validator::CreateQueue(VkQueue q, uint32_t family_index, uint32_t queue_index,
-                                                   VkDeviceQueueCreateFlags flags,
-                                                   const VkQueueFamilyProperties &queueFamilyProperties) {
-    return std::static_pointer_cast<vvl::Queue>(
-        std::make_shared<Queue>(*this, q, family_index, queue_index, flags, queueFamilyProperties));
-}
-
 void Validator::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
                                           const RecordObject &record_obj, vku::safe_VkDeviceCreateInfo *modified_create_info) {

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -184,7 +184,7 @@ std::shared_ptr<vvl::Queue> GpuShaderInstrumentor::CreateQueue(VkQueue q, uint32
                                                                VkDeviceQueueCreateFlags flags,
                                                                const VkQueueFamilyProperties &queueFamilyProperties) {
     return std::static_pointer_cast<vvl::Queue>(
-        std::make_shared<gpu_tracker::Queue>(*this, q, family_index, queue_index, flags, queueFamilyProperties));
+        std::make_shared<gpu_tracker::Queue>(*this, q, family_index, queue_index, flags, queueFamilyProperties, timeline_khr_));
 }
 
 // These are the common things required for anything that deals with shader instrumentation
@@ -239,6 +239,7 @@ void GpuShaderInstrumentor::PreCallRecordCreateDevice(VkPhysicalDevice physicalD
         const std::string_view ts_ext{"VK_KHR_timeline_semaphore"};
         vku::AddExtension(*modified_create_info, ts_ext.data());
         add_missing_features();
+        timeline_khr_ = true;
     }
 }
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -215,6 +215,8 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     // These are objects used to inject our descriptor set into the command buffer
     VkDescriptorSetLayout debug_desc_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout debug_pipeline_layout_ = VK_NULL_HANDLE;
+    // Make sure we call the right versions of any timeline semaphore functions.
+    bool timeline_khr_{false};
 };
 
 }  // namespace gpu

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -157,6 +157,13 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
                                       const RecordObject &record_obj) override;
 
+    void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
+                                  const RecordObject &record_obj) override;
+    void PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits, VkFence fence,
+                                      const RecordObject &record_obj) override;
+    void PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
+                                   const RecordObject &record_obj) override;
+
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message, bool vma_fail = false) const;
     void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     bool CheckForGpuAvEnabled(const void *pNext);

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -530,12 +530,4 @@ void CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
     }
 }
 
-Queue::Queue(Validator &state, VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
-             const VkQueueFamilyProperties &qfp)
-    : gpu_tracker::Queue(state, q, family_index, queue_index, flags, qfp) {}
-
-vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
-    return gpu_tracker::Queue::PreSubmit(std::move(submissions));
-}
-
 }  // namespace gpuav

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -155,15 +155,6 @@ class CommandBuffer : public gpu_tracker::CommandBuffer {
     uint32_t bda_ranges_snapshot_version_ = 0;
 };
 
-class Queue : public gpu_tracker::Queue {
-  public:
-    Queue(Validator &state, VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
-          const VkQueueFamilyProperties &qfp);
-
-  protected:
-    vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
-};
-
 class Buffer : public vvl::Buffer {
   public:
     Buffer(ValidationStateTracker &dev_data, VkBuffer buff, const VkBufferCreateInfo *pCreateInfo, DescriptorHeap &desc_heap_);

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -76,7 +76,7 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
     return std::chrono::steady_clock::now() + std::chrono::seconds(10);
 }
 
-struct PreSubmitResult {
+struct SubmitResult {
     uint64_t last_submission_seq = 0;
 
     bool has_external_fence = false;
@@ -99,10 +99,10 @@ class Queue : public StateObject {
 
     VkQueue VkHandle() const { return handle_.Cast<VkQueue>(); }
 
-    // called from the various PreCallRecordQueueSubmit() methods
-    virtual PreSubmitResult PreSubmit(std::vector<QueueSubmission> &&submissions);
+    void SetupSubmissions(std::vector<QueueSubmission> &submissions);
+
     // called from the various PostCallRecordQueueSubmit() methods
-    void PostSubmit();
+    virtual SubmitResult PostSubmit(std::vector<QueueSubmission> &&submissions);
 
     // Tell the queue thread that submissions up to and including the submission with
     // sequence number until_seq have finished. kU64Max means to finish all submissions.

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1108,8 +1108,26 @@ void ValidationStateTracker::PreCallRecordDestroyDevice(VkDevice device, const V
     queue_map_.clear();
 }
 
-void ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                                                      VkFence fence, const RecordObject &record_obj) {
+static void UpdateCmdBufLabelStack(const vvl::CommandBuffer &cb_state, vvl::Queue &queue_state) {
+    if (queue_state.found_unbalanced_cmdbuf_label) return;
+    for (const auto &command : cb_state.GetLabelCommands()) {
+        if (command.begin) {
+            queue_state.cmdbuf_label_stack.push_back(command.label_name);
+        } else {
+            if (queue_state.cmdbuf_label_stack.empty()) {
+                queue_state.found_unbalanced_cmdbuf_label = true;
+                return;
+            }
+            queue_state.last_closed_cmdbuf_label = queue_state.cmdbuf_label_stack.back();
+            queue_state.cmdbuf_label_stack.pop_back();
+        }
+    }
+}
+
+void ValidationStateTracker::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
+                                                       VkFence fence, const RecordObject &record_obj) {
+    if (record_obj.result != VK_SUCCESS) return;
+
     auto queue_state = Get<vvl::Queue>(queue);
 
     std::vector<vvl::QueueSubmission> submissions;
@@ -1148,6 +1166,7 @@ void ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue queue, uint32_t su
 
         for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
             if (auto cb_state = Get<vvl::CommandBuffer>(submit->pCommandBuffers[i])) {
+                UpdateCmdBufLabelStack(*cb_state, *queue_state);
                 submission.AddCommandBuffer(std::move(cb_state));
             }
         }
@@ -1156,52 +1175,24 @@ void ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue queue, uint32_t su
         }
         submissions.emplace_back(std::move(submission));
     }
-
-    vvl::PreSubmitResult result = queue_state->PreSubmit(std::move(submissions));
+    queue_state->SetupSubmissions(submissions);
+    auto result = queue_state->PostSubmit(std::move(submissions));
     if (result.has_external_fence) {
         queue_state->NotifyAndWait(record_obj.location, result.submission_with_external_fence_seq);
     }
 }
 
-static void UpdateCmdBufLabelStack(const vvl::CommandBuffer &cb_state, vvl::Queue &queue_state) {
-    if (queue_state.found_unbalanced_cmdbuf_label) return;
-    for (const auto &command : cb_state.GetLabelCommands()) {
-        if (command.begin) {
-            queue_state.cmdbuf_label_stack.push_back(command.label_name);
-        } else {
-            if (queue_state.cmdbuf_label_stack.empty()) {
-                queue_state.found_unbalanced_cmdbuf_label = true;
-                return;
-            }
-            queue_state.last_closed_cmdbuf_label = queue_state.cmdbuf_label_stack.back();
-            queue_state.cmdbuf_label_stack.pop_back();
-        }
-    }
+void ValidationStateTracker::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
+                                                           VkFence fence, const RecordObject &record_obj) {
+    PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
 }
 
-void ValidationStateTracker::PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                                                       VkFence fence, const RecordObject &record_obj) {
+void ValidationStateTracker::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits,
+                                                        VkFence fence, const RecordObject &record_obj) {
     if (record_obj.result != VK_SUCCESS) return;
-    auto queue_state = Get<vvl::Queue>(queue);
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        const VkSubmitInfo *submit = &pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            if (auto cb_state = GetRead<vvl::CommandBuffer>(submit->pCommandBuffers[i])) {
-                UpdateCmdBufLabelStack(*cb_state, *queue_state);
-            }
-        }
-    }
-    queue_state->PostSubmit();
-}
 
-void ValidationStateTracker::PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                          VkFence fence, const RecordObject &record_obj) {
-    PreCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
-}
-
-void ValidationStateTracker::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits,
-                                                       VkFence fence, const RecordObject &record_obj) {
     auto queue_state = Get<vvl::Queue>(queue);
+
     std::vector<vvl::QueueSubmission> submissions;
     submissions.reserve(submitCount);
     if (submitCount == 0) {
@@ -1229,36 +1220,21 @@ void ValidationStateTracker::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t s
         submission.perf_submit_pass = perf_submit ? perf_submit->counterPassIndex : 0;
 
         for (uint32_t i = 0; i < submit->commandBufferInfoCount; i++) {
-            submission.AddCommandBuffer(GetWrite<vvl::CommandBuffer>(submit->pCommandBufferInfos[i].commandBuffer));
+            if (auto cb_state = GetWrite<vvl::CommandBuffer>(submit->pCommandBufferInfos[i].commandBuffer)) {
+                UpdateCmdBufLabelStack(*cb_state, *queue_state);
+                submission.AddCommandBuffer(std::move(cb_state));
+            }
         }
         if (submit_idx == (submitCount - 1)) {
             submission.AddFence(Get<vvl::Fence>(fence));
         }
         submissions.emplace_back(std::move(submission));
     }
-    vvl::PreSubmitResult result = queue_state->PreSubmit(std::move(submissions));
+    queue_state->SetupSubmissions(submissions);
+    auto result = queue_state->PostSubmit(std::move(submissions));
     if (result.has_external_fence) {
         queue_state->NotifyAndWait(record_obj.location, result.submission_with_external_fence_seq);
     }
-}
-
-void ValidationStateTracker::PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                           VkFence fence, const RecordObject &record_obj) {
-    PostCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
-}
-
-void ValidationStateTracker::PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits,
-                                                        VkFence fence, const RecordObject &record_obj) {
-    if (record_obj.result != VK_SUCCESS) return;
-    auto queue_state = Get<vvl::Queue>(queue);
-    for (const auto &submit : vvl::make_span(pSubmits, submitCount)) {
-        for (const auto &cmdbuf_info : vvl::make_span(submit.pCommandBufferInfos, submit.commandBufferInfoCount)) {
-            if (auto cb_state = GetRead<vvl::CommandBuffer>(cmdbuf_info.commandBuffer)) {
-                UpdateCmdBufLabelStack(*cb_state, *queue_state);
-            }
-        }
-    }
-    queue_state->PostSubmit();
 }
 
 void ValidationStateTracker::PostCallRecordAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
@@ -1306,12 +1282,19 @@ void ValidationStateTracker::PreCallRecordFreeMemory(VkDevice device, VkDeviceMe
     Destroy<vvl::DeviceMemory>(mem);
 }
 
-void ValidationStateTracker::PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                          VkFence fence, const RecordObject &record_obj) {
+void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
+                                                           VkFence fence, const RecordObject &record_obj) {
+    if (record_obj.result != VK_SUCCESS) return;
     auto queue_state = Get<vvl::Queue>(queue);
 
     std::vector<vvl::QueueSubmission> submissions;
     submissions.reserve(bindInfoCount);
+    if (bindInfoCount == 0) {
+        vvl::QueueSubmission submission(record_obj.location);
+        submission.AddFence(Get<vvl::Fence>(fence));
+        submissions.emplace_back(std::move(submission));
+    }
+
     for (uint32_t bind_idx = 0; bind_idx < bindInfoCount; ++bind_idx) {
         const VkBindSparseInfo &bind_info = pBindInfo[bind_idx];
         // Track objects tied to memory
@@ -1382,17 +1365,11 @@ void ValidationStateTracker::PreCallRecordQueueBindSparse(VkQueue queue, uint32_
         submissions.emplace_back(std::move(submission));
     }
 
-    vvl::PreSubmitResult result = queue_state->PreSubmit(std::move(submissions));
+    queue_state->SetupSubmissions(submissions);
+    auto result = queue_state->PostSubmit(std::move(submissions));
     if (result.has_external_fence) {
         queue_state->NotifyAndWait(record_obj.location, result.submission_with_external_fence_seq);
     }
-}
-
-void ValidationStateTracker::PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo *pBindInfo,
-                                                           VkFence fence, const RecordObject &record_obj) {
-    if (record_obj.result != VK_SUCCESS) return;
-    auto queue_state = Get<vvl::Queue>(queue);
-    queue_state->PostSubmit();
 }
 
 void ValidationStateTracker::PostCallRecordCreateSemaphore(VkDevice device, const VkSemaphoreCreateInfo *pCreateInfo,
@@ -3776,7 +3753,8 @@ void ValidationStateTracker::PostCallRecordQueuePresentKHR(VkQueue queue, const 
         }
     }
 
-    vvl::PreSubmitResult result = queue_state->PreSubmit(std::move(submissions));
+    queue_state->SetupSubmissions(submissions);
+    auto result = queue_state->PostSubmit(std::move(submissions));
 
     if (result.has_external_fence) {
         queue_state->NotifyAndWait(record_obj.location, result.submission_with_external_fence_seq);

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -923,14 +923,10 @@ class ValidationStateTracker : public ValidationObject {
                                          const RecordObject& record_obj) override;
     void PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) override;
     void PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
-    void PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
-                                      const RecordObject& record_obj) override;
     void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                        const RecordObject& record_obj) override;
     void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                        const RecordObject& record_obj) override;
-    void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
-                                  const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                    const RecordObject& record_obj) override;
     void PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) override;
@@ -1614,10 +1610,6 @@ class ValidationStateTracker : public ValidationObject {
                                              uint32_t query, const RecordObject& record_obj) override;
     void PostCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                           uint32_t query, const RecordObject& record_obj) override;
-    void PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
-                                      const RecordObject& record_obj) override;
-    void PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
-                                   const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
                                        const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,


### PR DESCRIPTION
Move most submission post processing into the PostCallRecord hooks. This avoids adding submission state in the PreCall hook and then looking for it in the PostCall hook. It also avoids adding bad state in case  the submit call fails.

The remaining work in the PreCall hook is setting up resources used by the instrumented shaders we're about to execute and that must happen  before the submit is dispatched.

This problem was hidden by sometimes calling the wrong version (core vs KHR) of vkWaitSemaphores(), which would end up calling a no-op stub set up elsewhere in VVL (and being fixed separately). So if we're using vulkan 1.2 or greater we use the core versions, if we're in 1.1 and have enabled the extensions, use the KHR versions.

Fixes #7562 
