### PR TITLE
layers: Improve perf for sparse buffer copies validation

### DIFF
--- a/layers/profiling/profiling.h
+++ b/layers/profiling/profiling.h
@@ -22,12 +22,40 @@
 #include "tracy/TracyC.h"
 #include "tracy/../client/TracyProfiler.hpp"
 
+// Define CPU zones
 #define VVL_ZoneScoped ZoneScoped
 #define VVL_ZoneScopedN(name) ZoneScopedN(name)
 #define VVL_TracyCZone(zone_name, active) TracyCZone(zone_name, active)
 #define VVL_TracyCZoneEnd(zone_name) TracyCZoneEnd(zone_name)
 #define VVL_TracyCFrameMark TracyCFrameMark
+
+// Print messages
 #define VVL_TracyMessage TracyMessage
+#define VVL_TracyMessageStream(message)                \
+    {                                                  \
+        std::stringstream tracy_ss;                    \
+        tracy_ss << message;                           \
+        const std::string tracy_s = tracy_ss.str();    \
+        TracyMessage(tracy_s.c_str(), tracy_s.size()); \
+    }
+#define VVL_TracyMessageMap(map, key_printer, value_printer)           \
+    {                                                                  \
+        static int tracy_map_log_i = 0;                                \
+        std::string tracy_map_log_str = #map " ";                      \
+        tracy_map_log_str += std::to_string(tracy_map_log_i++);        \
+        tracy_map_log_str += " - size: ";                              \
+        tracy_map_log_str += std::to_string(map.size());               \
+        tracy_map_log_str += " - one pair: ";                          \
+        for (const auto& [key, value] : map) {                         \
+            std::string key_value_str = tracy_map_log_str;             \
+            key_value_str += " | key: ";                               \
+            key_value_str += key_printer(key);                         \
+            key_value_str += " - value: ";                             \
+            key_value_str += value_printer(value);                     \
+            TracyMessage(key_value_str.c_str(), key_value_str.size()); \
+        }                                                              \
+    }
+
 #else
 #define VVL_ZoneScoped
 #define VVL_ZoneScopedN(name)
@@ -35,6 +63,8 @@
 #define VVL_TracyCZoneEnd(zone_name)
 #define VVL_TracyCFrameMark
 #define VVL_TracyMessage
+#define VVL_TracyMessageStream(message)
+#define VVL_TracyMessageMap(map, key_printer, value_printer)
 #endif
 
 #if defined(VVL_TRACY_CPU_MEMORY)

--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -100,8 +100,10 @@ struct MEM_BINDING {
 
 class BindableMemoryTracker {
   public:
+    using BufferRange = sparse_container::range<VkDeviceSize>;
     using MemoryRange = sparse_container::range<VkDeviceSize>;
     using BoundMemoryRange = std::map<VkDeviceMemory, std::vector<MemoryRange>>;
+    using BoundRanges = vvl::unordered_map<VkDeviceMemory, std::vector<std::pair<MemoryRange, BufferRange>>>;
     using DeviceMemoryState = unordered_set<std::shared_ptr<vvl::DeviceMemory>>;
 
     virtual ~BindableMemoryTracker() {}
@@ -113,6 +115,7 @@ class BindableMemoryTracker {
     virtual void BindMemory(StateObject *, std::shared_ptr<vvl::DeviceMemory> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) = 0;
 
     virtual BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const = 0;
+    virtual BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const = 0;
     virtual DeviceMemoryState GetBoundMemoryStates() const = 0;
 };
 
@@ -130,6 +133,9 @@ class BindableNoMemoryTracker : public BindableMemoryTracker {
     void BindMemory(StateObject *, std::shared_ptr<vvl::DeviceMemory> &, VkDeviceSize, VkDeviceSize, VkDeviceSize) override {}
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &) const override { return BoundMemoryRange{}; }
+    BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const override {
+        return {};
+    }
     DeviceMemoryState GetBoundMemoryStates() const override { return DeviceMemoryState{}; }
 };
 
@@ -149,6 +155,10 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
                     VkDeviceSize resource_offset, VkDeviceSize size) override;
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+    BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const override {
+        assert(false);
+        return {};
+    }
     DeviceMemoryState GetBoundMemoryStates() const override;
 
   private:
@@ -172,6 +182,13 @@ class BindableSparseMemoryTracker : public BindableMemoryTracker {
                     VkDeviceSize resource_offset, VkDeviceSize size) override;
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+    // With a list of buffer ranges as input, and `ranges_bounds` being a range that contains all of those buffer ranges,
+    // find what tracked VkDeviceMemory maps to what buffer range.
+    // Result is stored in a "VkDeviceMemory -> vector<(memory range, buffer range)>" map.
+    // Pairs in vector<(memory range, buffer range)> are sorted in ascending order with respect to memory ranges
+    // Note: The stored buffer range in the map are all subranges of the ranges listed in `buffer_ranges`,
+    // since an input range could be mapped to multiple VkDeviceMemory
+    BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &buffer_ranges) const override;
 
     DeviceMemoryState GetBoundMemoryStates() const override;
 
@@ -199,7 +216,10 @@ class BindableMultiplanarMemoryTracker : public BindableMemoryTracker {
                     VkDeviceSize resource_offset, VkDeviceSize size) override;
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
-
+    BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const override {
+        assert(false);
+        return {};
+    }
     DeviceMemoryState GetBoundMemoryStates() const override;
 
   private:
@@ -292,6 +312,11 @@ class Bindable : public StateObject {
 
     BindableMemoryTracker::BoundMemoryRange GetBoundMemoryRange(const BindableMemoryTracker::MemoryRange &range) const {
         return memory_tracker_->GetBoundMemoryRange(range);
+    }
+
+    BindableLinearMemoryTracker::BoundRanges GetBoundRanges(const BindableMemoryTracker::BufferRange &ranges_bounds,
+                                                            const std::vector<BindableMemoryTracker::BufferRange> ranges) const {
+        return memory_tracker_->GetBoundRanges(ranges_bounds, ranges);
     }
 
     BindableMemoryTracker::DeviceMemoryState GetBoundMemoryStates() const {

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -1,3 +1,4 @@
+
 /*
  * Copyright (c) 2024 The Khronos Group Inc.
  * Copyright (c) 2024 Valve Corporation
@@ -74,7 +75,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
 
     m_commandBuffer->begin();
     // This copy is be completely legal as long as we change the memory for buffer_sparse to not overlap with
-    // buffer_sparse2's memory on queue submission, or viceversa
+    // buffer_sparse2's memory on queue submission
     vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
     m_commandBuffer->end();
 
@@ -348,4 +349,193 @@ TEST_F(PositiveSparseBuffer, BindSparseEmpty) {
     vkt::Queue* sparse_queue = m_device->QueuesWithSparseCapability()[0];
     vk::QueueBindSparse(sparse_queue->handle(), 0u, nullptr, VK_NULL_HANDLE);
     sparse_queue->Wait();
+}
+
+TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest) {
+    TEST_DESCRIPTION("Validate 10,000 buffer copies");
+
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    if (m_device->QueuesWithSparseCapability().empty()) {
+        GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
+    }
+
+    vkt::Semaphore semaphore(*m_device);
+
+    constexpr VkDeviceSize copy_size = 16;
+    std::vector<VkBufferCopy> copy_info_list(4);
+    copy_info_list[3].srcOffset = 0;
+    copy_info_list[3].dstOffset = 16;
+    copy_info_list[3].size = copy_size;
+
+    copy_info_list[2].srcOffset = 64 + copy_size + 0 * 16;
+    copy_info_list[2].dstOffset = 32;
+    copy_info_list[2].size = copy_size;
+
+    copy_info_list[1].srcOffset = 64 + copy_size + 1 * 16;
+    copy_info_list[1].dstOffset = 48;
+    copy_info_list[1].size = copy_size;
+
+    copy_info_list[0].srcOffset = 64 + copy_size + 2 * 16;
+    copy_info_list[0].dstOffset = 64;
+    copy_info_list[0].size = copy_size;
+
+    const size_t size = 10000;
+    copy_info_list.resize(copy_info_list.size() + size);
+    for (size_t i = 0; i < size; ++i) {
+        copy_info_list[i + 4] = copy_info_list[i % 4];
+    }
+
+    VkBufferCreateInfo b_info =
+        vkt::Buffer::create_info(256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
+    b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
+
+    VkMemoryRequirements buffer_mem_reqs;
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_mem_alloc =
+        vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    vkt::DeviceMemory buffer_mem;
+    buffer_mem.init(*m_device, buffer_mem_alloc);
+
+    VkSparseMemoryBind buffer_memory_bind_1 = {};
+    buffer_memory_bind_1.size = buffer_mem_reqs.size;
+    buffer_memory_bind_1.memory = buffer_mem.handle();
+
+    std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
+    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].bindCount = 1;
+    buffer_memory_bind_infos[0].pBinds = &buffer_memory_bind_1;
+
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
+    bind_info.bufferBindCount = size32(buffer_memory_bind_infos);
+    bind_info.pBufferBinds = buffer_memory_bind_infos.data();
+    bind_info.signalSemaphoreCount = 1;
+    bind_info.pSignalSemaphores = &semaphore.handle();
+
+    VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
+    vkt::Fence sparse_queue_fence(*m_device);
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    // Set up complete
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
+                      copy_info_list.data());
+    m_commandBuffer->end();
+
+    VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkSubmitInfo submit_info = vku::InitStructHelper();
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &semaphore.handle();
+    submit_info.pWaitDstStageMask = &mask;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+    vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
+
+    // Wait for operations to finish before destroying anything
+    m_default_queue->Wait();
+}
+
+TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest2) {
+    TEST_DESCRIPTION("Validate 10,000 buffer copies, buffer is bound to multiple VkDeviceMemory");
+
+    AddRequiredFeature(vkt::Feature::sparseBinding);
+    RETURN_IF_SKIP(Init());
+
+    if (m_device->QueuesWithSparseCapability().empty()) {
+        GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
+    }
+
+    vkt::Semaphore semaphore(*m_device);
+
+    constexpr int memory_chunks_count = 100;
+    constexpr VkDeviceSize memory_size = 0x10000;
+    constexpr VkDeviceSize copy_size = memory_size / 8;
+    std::vector<VkBufferCopy> copy_info_list(4 * memory_chunks_count);
+    for (int i = 0; i < memory_chunks_count * 4; i += 4) {
+        copy_info_list[i + 3].srcOffset = memory_size * (i / 4);
+        copy_info_list[i + 3].dstOffset = memory_size * (i / 4) + copy_size;
+        copy_info_list[i + 3].size = copy_size;
+
+        copy_info_list[i + 2].srcOffset = copy_info_list[i + 3].dstOffset + copy_size;
+        copy_info_list[i + 2].dstOffset = copy_info_list[i + 2].srcOffset + copy_size;
+        copy_info_list[i + 2].size = copy_size;
+
+        copy_info_list[i + 1].srcOffset = copy_info_list[i + 2].dstOffset + copy_size;
+        copy_info_list[i + 1].dstOffset = copy_info_list[i + 1].srcOffset + copy_size;
+        copy_info_list[i + 1].size = copy_size;
+
+        copy_info_list[i + 0].srcOffset = copy_info_list[i + 1].dstOffset + copy_size;
+        copy_info_list[i + 0].dstOffset = copy_info_list[i + 0].srcOffset + copy_size;
+        copy_info_list[i + 0].size = copy_size;
+    }
+
+    const size_t size = 10000;
+    copy_info_list.resize(copy_info_list.size() + size);
+    for (size_t i = 0; i < size; ++i) {
+        copy_info_list[i + memory_chunks_count * 4] = copy_info_list[i % (4 * memory_chunks_count)];
+    }
+
+    VkBufferCreateInfo b_info = vkt::Buffer::create_info(
+        memory_chunks_count * memory_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr);
+    b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
+    vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
+
+    VkMemoryRequirements buffer_mem_reqs;
+    vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
+    VkMemoryAllocateInfo buffer_mem_alloc =
+        vkt::DeviceMemory::get_resource_alloc_info(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    std::vector<vkt::DeviceMemory> memory_chunks(memory_chunks_count);
+
+    for (auto& mem : memory_chunks) {
+        mem.init(*m_device, buffer_mem_alloc);
+    }
+
+    std::vector<VkSparseMemoryBind> buffer_memory_binds(memory_chunks_count);
+    for (auto& [i, mem_bind] : vvl::enumerate(buffer_memory_binds)) {
+        mem_bind->size = memory_size;
+        mem_bind->memory = memory_chunks[i].handle();
+        mem_bind->resourceOffset = i * memory_size;
+        mem_bind->memoryOffset = 0;
+    }
+
+    std::array<VkSparseBufferMemoryBindInfo, 1> buffer_memory_bind_infos = {};
+    buffer_memory_bind_infos[0].buffer = buffer_sparse.handle();
+    buffer_memory_bind_infos[0].bindCount = size32(buffer_memory_binds);
+    buffer_memory_bind_infos[0].pBinds = buffer_memory_binds.data();
+
+    VkBindSparseInfo bind_info = vku::InitStructHelper();
+    bind_info.bufferBindCount = size32(buffer_memory_bind_infos);
+    bind_info.pBufferBinds = buffer_memory_bind_infos.data();
+    bind_info.signalSemaphoreCount = 1;
+    bind_info.pSignalSemaphores = &semaphore.handle();
+
+    VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
+    vkt::Fence sparse_queue_fence(*m_device);
+    vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    // Set up complete
+
+    m_commandBuffer->begin();
+    vk::CmdCopyBuffer(m_commandBuffer->handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
+                      copy_info_list.data());
+    m_commandBuffer->end();
+
+    VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
+    VkSubmitInfo submit_info = vku::InitStructHelper();
+    submit_info.waitSemaphoreCount = 1;
+    submit_info.pWaitSemaphores = &semaphore.handle();
+    submit_info.pWaitDstStageMask = &mask;
+    submit_info.commandBufferCount = 1;
+    submit_info.pCommandBuffers = &m_commandBuffer->handle();
+
+    vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
+
+    // Wait for operations to finish before destroying anything
+    m_default_queue->Wait();
 }


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8224

Stress test:
For 10,000 copies, went down from +15 minutes (stopped measured) down to 60 ms
For 4000, went down from +6 minutes to 10ms

For the stress test, the source and destination buffer are bound to only one VkDeviceMemory, I need to make another one where they are bound to multiples to see if perf is bad

~~Need to port this logic to the non sparse buffer case, will make another PR as users do not appear to be blocked on that~~ done, see `BufferCopiesValidationStressTest2 `
