### PR TITLE
layers: Cleanup Global and Shader settings

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -613,7 +613,7 @@
                                 {
                                     "key": "check_shaders",
                                     "label": "Shader",
-                                    "description": "Shader checks. These checks can be CPU intensive during application start up, especially if Shader Validation Caching is also disabled.",
+                                    "description": "This will validate the contents of the SPIR-V which can be CPU intensive during application start up. This does internal checks as well as calling spirv-val.",
                                     "type": "BOOL",
                                     "default": true,
                                     "expanded": true,
@@ -630,7 +630,7 @@
                                         {
                                             "key": "check_shaders_caching",
                                             "label": "Caching",
-                                            "description": "Enable caching of shader validation results.",
+                                            "description": "Creates an internal instance of VK_EXT_validation_cache and upon vkDestroyInstance, will cache the shader validation so sequential usage of the validation layers will be skipped.",
                                             "type": "BOOL",
                                             "default": true,
                                             "dependence": {
@@ -646,6 +646,14 @@
                                                     }
                                                 ]
                                             }
+                                        },
+                                        {
+                                            "key": "debug_disable_spirv_val",
+                                            "label": "Disable spirv-val",
+                                            "view": "ADVANCED",
+                                            "description": "Allows normal shader validation to run, but removes just spirv-val for performance reasons",
+                                            "type": "BOOL",
+                                            "default": false
                                         }
                                     ]
                                 }

--- a/layers/best_practices/best_practices_utils.cpp
+++ b/layers/best_practices/best_practices_utils.cpp
@@ -36,7 +36,7 @@ const auto& GetVendorInfo() {
 }
 
 ReadLockGuard BestPractices::ReadLock() const {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return ReadLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return ReadLockGuard(validation_object_mutex);
@@ -44,7 +44,7 @@ ReadLockGuard BestPractices::ReadLock() const {
 }
 
 WriteLockGuard BestPractices::WriteLock() {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return WriteLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return WriteLockGuard(validation_object_mutex);

--- a/layers/core_checks/cc_shader_object.cpp
+++ b/layers/core_checks/cc_shader_object.cpp
@@ -275,6 +275,11 @@ bool CoreChecks::PreCallValidateCreateShadersEXT(VkDevice device, uint32_t creat
                                                  VkShaderEXT* pShaders, const ErrorObject& error_obj) const {
     bool skip = false;
 
+    // the spec clarifies that VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT works on VK_EXT_shader_object as well
+    if (disabled[shader_validation]) {
+        return skip; // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
+    }
+
     skip |= ValidateDeviceQueueSupport(error_obj.location);
     if (enabled_features.shaderObject == VK_FALSE) {
         skip |=

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -2488,6 +2488,10 @@ void CoreChecks::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createI
 bool CoreChecks::RunSpirvValidation(spv_const_binary_t &binary, const Location &loc, ValidationCache *cache) const {
     bool skip = false;
 
+    if (global_settings.debug_disable_spirv_val) {
+        return skip;
+    }
+
     uint32_t hash = 0;
     if (cache) {
         hash = hash_util::ShaderHash((void *)binary.code, binary.wordCount * sizeof(uint32_t));
@@ -2530,7 +2534,7 @@ bool CoreChecks::ValidateShaderModuleCreateInfo(const VkShaderModuleCreateInfo &
     bool skip = false;
 
     if (disabled[shader_validation]) {
-        return skip;
+        return skip; // VK_VALIDATION_FEATURE_DISABLE_SHADERS_EXT
     }
 
     if (!create_info.pCode) {

--- a/layers/core_checks/cc_synchronization.cpp
+++ b/layers/core_checks/cc_synchronization.cpp
@@ -42,7 +42,7 @@ using sync_utils::MemoryBarrier;
 using sync_utils::QueueFamilyBarrier;
 
 ReadLockGuard CoreChecks::ReadLock() const {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return ReadLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return ReadLockGuard(validation_object_mutex);
@@ -50,7 +50,7 @@ ReadLockGuard CoreChecks::ReadLock() const {
 }
 
 WriteLockGuard CoreChecks::WriteLock() {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return WriteLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return WriteLockGuard(validation_object_mutex);

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -165,7 +165,7 @@ bool SpirvCache::IsSpirvCached(uint32_t index, uint32_t spirv_hash, chassis::Sha
 }
 
 ReadLockGuard GpuShaderInstrumentor::ReadLock() const {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return ReadLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return ReadLockGuard(validation_object_mutex);
@@ -173,7 +173,7 @@ ReadLockGuard GpuShaderInstrumentor::ReadLock() const {
 }
 
 WriteLockGuard GpuShaderInstrumentor::WriteLock() {
-    if (fine_grained_locking) {
+    if (global_settings.fine_grained_locking) {
         return WriteLockGuard(validation_object_mutex, std::defer_lock);
     } else {
         return WriteLockGuard(validation_object_mutex);

--- a/layers/layer_options.cpp
+++ b/layers/layer_options.cpp
@@ -113,6 +113,7 @@ const std::vector<std::string> &GetEnableFlagNameHelper() {
     };
     return enable_flag_name_helper;
 }
+
 // To enable "my_setting",
 // Set env var VK_LAYER_MY_SETTING to 1
 //
@@ -120,6 +121,9 @@ const std::vector<std::string> &GetEnableFlagNameHelper() {
 //
 // To quickly be able to find the env var corresponding to a setting,
 // the following `const char*` holding setting names match their corresponding environment variable
+
+// Corresponding to VkValidationFeatureEnableEXT
+// ---
 const char *VK_LAYER_ENABLES = "enables";
 const char *VK_LAYER_VALIDATE_BEST_PRACTICES = "validate_best_practices";
 const char *VK_LAYER_VALIDATE_BEST_PRACTICES_ARM = "validate_best_practices_arm";
@@ -129,24 +133,38 @@ const char *VK_LAYER_VALIDATE_BEST_PRACTICES_NVIDIA = "validate_best_practices_n
 const char *VK_LAYER_VALIDATE_SYNC = "validate_sync";
 const char *VK_LAYER_VALIDATE_GPU_BASED = "validate_gpu_based";
 
+// Corresponding to VkValidationFeatureDisableEXT
+// ---
 const char *VK_LAYER_DISABLES = "disables";
-const char *VK_LAYER_STATELESS_PARAM = "stateless_param";
+const char *VK_LAYER_CHECK_SHADERS = "check_shaders";
 const char *VK_LAYER_THREAD_SAFETY = "thread_safety";
+const char *VK_LAYER_STATELESS_PARAM = "stateless_param";
+const char *VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
 const char *VK_LAYER_VALIDATE_CORE = "validate_core";
+const char *VK_LAYER_UNIQUE_HANDLES = "unique_handles";
+const char *VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
+
+// Additional checks exposed in vkconfig, but not in VkValidationFeatureDisableEXT
+// ---
 const char *VK_LAYER_CHECK_COMMAND_BUFFER = "check_command_buffer";
 const char *VK_LAYER_CHECK_OBJECT_IN_USE = "check_object_in_use";
 const char *VK_LAYER_CHECK_QUERY = "check_query";
 const char *VK_LAYER_CHECK_IMAGE_LAYOUT = "check_image_layout";
-const char *VK_LAYER_UNIQUE_HANDLES = "unique_handles";
-const char *VK_LAYER_OBJECT_LIFETIME = "object_lifetime";
-const char *VK_LAYER_CHECK_SHADERS = "check_shaders";
-const char *VK_LAYER_CHECK_SHADERS_CACHING = "check_shaders_caching";
 
+// Options related to debug reporting
+// ---
 const char *VK_LAYER_MESSAGE_ID_FILTER = "message_id_filter";
 const char *VK_LAYER_CUSTOM_STYPE_LIST = "custom_stype_list";
 const char *VK_LAYER_DUPLICATE_MESSAGE_LIMIT = "duplicate_message_limit";
-const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
 
+// GloablSettings
+// ---
+const char *VK_LAYER_FINE_GRAINED_LOCKING = "fine_grained_locking";
+// Debug settings used for internal development
+const char *VK_LAYER_DEBUG_DISABLE_SPIRV_VAL = "debug_disable_spirv_val";
+
+// DebugPrintf
+// ---
 const char *VK_LAYER_PRINTF_TO_STDOUT = "printf_to_stdout";
 const char *VK_LAYER_PRINTF_VERBOSE = "printf_verbose";
 const char *VK_LAYER_PRINTF_BUFFER_SIZE = "printf_buffer_size";
@@ -182,6 +200,7 @@ const char *VK_LAYER_SYNCVAL_SUBMIT_TIME_VALIDATION = "syncval_submit_time_valid
 const char *VK_LAYER_SYNCVAL_SHADER_ACCESSES_HEURISTIC = "syncval_shader_accesses_heuristic";
 
 // Message Formatting
+// ---
 const char *VK_LAYER_MESSAGE_FORMAT_DISPLAY_APPLICATION_NAME = "message_format_display_application_name";
 
 // These were deprecated after the 1.3.280 SDK release
@@ -489,10 +508,13 @@ void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data) {
     const std::string string_disables = Merge(disables);
     SetLocalDisableSetting(string_disables, ",", settings_data->disables);
 
-    // Fine Grained Locking
-    *settings_data->fine_grained_locking = true;
+    GlobalSettings &global_settings = *settings_data->global_settings;
     if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING)) {
-        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING, *settings_data->fine_grained_locking);
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_FINE_GRAINED_LOCKING, global_settings.fine_grained_locking);
+    }
+
+    if (vkuHasLayerSetting(layer_setting_set, VK_LAYER_DEBUG_DISABLE_SPIRV_VAL)) {
+        vkuGetLayerSettingValue(layer_setting_set, VK_LAYER_DEBUG_DISABLE_SPIRV_VAL, global_settings.debug_disable_spirv_val);
     }
 
     // Message ID Filtering

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -78,25 +78,42 @@ enum EnableFlags {
 using CHECK_DISABLED = std::array<bool, kMaxDisableFlags>;
 using CHECK_ENABLED = std::array<bool, kMaxEnableFlags>;
 
-// Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
+// General settings to be used by all parts of the Validation Layers
+struct GlobalSettings {
+    bool fine_grained_locking = true;
+
+    bool debug_disable_spirv_val = false;
+};
 
 struct GpuAVSettings;
 struct DebugPrintfSettings;
 struct SyncValSettings;
 struct MessageFormatSettings;
 struct ConfigAndEnvSettings {
+    // Matches up with what is passed down to VK_EXT_layer_settings
     const char *layer_description;
+
+    // Used so we can find things like VkValidationFeaturesEXT
     const VkInstanceCreateInfo *create_info;
+
+    // Find grain way to turn off/on parts of validation
     CHECK_ENABLED &enables;
     CHECK_DISABLED &disables;
+
+    // Settings for DebugReport
     vvl::unordered_set<uint32_t> &message_filter_list;
     uint32_t *duplicate_message_limit;
     MessageFormatSettings *message_format_settings;
-    bool *fine_grained_locking;
+
+    GlobalSettings* global_settings;
+
+    // Individual settings for different internal layers
     GpuAVSettings *gpuav_settings;
     DebugPrintfSettings *printf_settings;
     SyncValSettings *syncval_settings;
 };
 const std::vector<std::string> &GetDisableFlagNameHelper();
 const std::vector<std::string> &GetEnableFlagNameHelper();
+
+// Process validation features, flags and settings specified through extensions, a layer settings file, or environment variables
 void ProcessConfigAndEnvSettings(ConfigAndEnvSettings *settings_data);

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -378,7 +378,7 @@ void OutputLayerStatusInfo(ValidationObject* context) {
     context->LogPerformanceWarning("WARNING-CreateInstance-debug-warning", context->instance, loc,
                                    "Using debug builds of the validation layers *will* adversely affect performance.");
 #endif
-    if (!context->fine_grained_locking) {
+    if (!context->global_settings.fine_grained_locking) {
         context->LogPerformanceWarning(
             "WARNING-CreateInstance-locking-warning", context->instance, loc,
             "Fine-grained locking is disabled, this will adversely affect performance of multithreaded applications.");
@@ -488,7 +488,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     // Set up enable and disable features flags
     CHECK_ENABLED local_enables{};
     CHECK_DISABLED local_disables{};
-    bool lock_setting;
+    GlobalSettings local_global_settings = {};
     GpuAVSettings local_gpuav_settings = {};
     DebugPrintfSettings local_printf_settings = {};
     SyncValSettings local_syncval_settings = {};
@@ -499,7 +499,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
                                                       debug_report->filter_message_ids,
                                                       &debug_report->duplicate_message_limit,
                                                       &debug_report->message_format_settings,
-                                                      &lock_setting,
+                                                      &local_global_settings,
                                                       &local_gpuav_settings,
                                                       &local_printf_settings,
                                                       &local_syncval_settings};
@@ -560,7 +560,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     framework->container_type = LayerObjectTypeInstance;
     framework->disabled = local_disables;
     framework->enabled = local_enables;
-    framework->fine_grained_locking = lock_setting;
+    framework->global_settings = local_global_settings;
     framework->gpuav_settings = local_gpuav_settings;
     framework->printf_settings = local_printf_settings;
     framework->syncval_settings = local_syncval_settings;
@@ -581,7 +581,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
         intercept->instance_dispatch_table = framework->instance_dispatch_table;
         intercept->enabled = framework->enabled;
         intercept->disabled = framework->disabled;
-        intercept->fine_grained_locking = framework->fine_grained_locking;
+        intercept->global_settings = framework->global_settings;
         intercept->gpuav_settings = framework->gpuav_settings;
         intercept->printf_settings = framework->printf_settings;
         intercept->syncval_settings = framework->syncval_settings;
@@ -733,7 +733,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         object->api_version = device_interceptor->api_version;
         object->disabled = instance_interceptor->disabled;
         object->enabled = instance_interceptor->enabled;
-        object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+        object->global_settings = instance_interceptor->global_settings;
         object->gpuav_settings = instance_interceptor->gpuav_settings;
         object->printf_settings = instance_interceptor->printf_settings;
         object->syncval_settings = instance_interceptor->syncval_settings;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2227,7 +2227,7 @@ class ValidationObject {
     DeviceExtensions device_extensions = {};
     CHECK_DISABLED disabled = {};
     CHECK_ENABLED enabled = {};
-    bool fine_grained_locking{true};
+    GlobalSettings global_settings = {};
     GpuAVSettings gpuav_settings = {};
     DebugPrintfSettings printf_settings = {};
     SyncValSettings syncval_settings = {};

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -424,7 +424,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 DeviceExtensions device_extensions = {};
                 CHECK_DISABLED disabled = {};
                 CHECK_ENABLED enabled = {};
-                bool fine_grained_locking{true};
+                GlobalSettings global_settings = {};
                 GpuAVSettings gpuav_settings = {};
                 DebugPrintfSettings printf_settings = {};
                 SyncValSettings syncval_settings = {};
@@ -1008,7 +1008,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     "WARNING-CreateInstance-debug-warning", context->instance, loc,
                     "Using debug builds of the validation layers *will* adversely affect performance.");
             #endif
-                if (!context->fine_grained_locking) {
+                if (!context->global_settings.fine_grained_locking) {
                     context->LogPerformanceWarning(
                         "WARNING-CreateInstance-locking-warning", context->instance, loc,
                         "Fine-grained locking is disabled, this will adversely affect performance of multithreaded applications.");
@@ -1118,7 +1118,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 // Set up enable and disable features flags
                 CHECK_ENABLED local_enables{};
                 CHECK_DISABLED local_disables{};
-                bool lock_setting;
+                GlobalSettings local_global_settings = {};
                 GpuAVSettings local_gpuav_settings = {};
                 DebugPrintfSettings local_printf_settings = {};
                 SyncValSettings local_syncval_settings = {};
@@ -1129,7 +1129,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                                                                 debug_report->filter_message_ids,
                                                                 &debug_report->duplicate_message_limit,
                                                                 &debug_report->message_format_settings,
-                                                                &lock_setting,
+                                                                &local_global_settings,
                                                                 &local_gpuav_settings,
                                                                 &local_printf_settings,
                                                                 &local_syncval_settings};
@@ -1190,7 +1190,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 framework->container_type = LayerObjectTypeInstance;
                 framework->disabled = local_disables;
                 framework->enabled = local_enables;
-                framework->fine_grained_locking = lock_setting;
+                framework->global_settings = local_global_settings;
                 framework->gpuav_settings = local_gpuav_settings;
                 framework->printf_settings = local_printf_settings;
                 framework->syncval_settings = local_syncval_settings;
@@ -1211,7 +1211,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     intercept->instance_dispatch_table = framework->instance_dispatch_table;
                     intercept->enabled = framework->enabled;
                     intercept->disabled = framework->disabled;
-                    intercept->fine_grained_locking = framework->fine_grained_locking;
+                    intercept->global_settings = framework->global_settings;
                     intercept->gpuav_settings = framework->gpuav_settings;
                     intercept->printf_settings = framework->printf_settings;
                     intercept->syncval_settings = framework->syncval_settings;
@@ -1256,7 +1256,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 VVL_TracyCZone(tracy_zone_dispatch, true);
                 layer_data->instance_dispatch_table.DestroyInstance(instance, pAllocator);
                 VVL_TracyCZoneEnd(tracy_zone_dispatch);
-                
+
                 VVL_TracyCZone(tracy_zone_postcall, true);
                 for (ValidationObject* intercept : layer_data->object_dispatch) {
                     auto lock = intercept->WriteLock();
@@ -1277,7 +1277,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
 
                 FreeLayerDataPtr(key, layer_data_map);
                 VVL_TracyCZoneEnd(tracy_zone_postcall);
-                
+
 #if TRACY_MANUAL_LIFETIME
                 tracy::ShutdownProfiler();
 #endif
@@ -1362,7 +1362,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     object->api_version = device_interceptor->api_version;
                     object->disabled = instance_interceptor->disabled;
                     object->enabled = instance_interceptor->enabled;
-                    object->fine_grained_locking = instance_interceptor->fine_grained_locking;
+                    object->global_settings = instance_interceptor->global_settings;
                     object->gpuav_settings = instance_interceptor->gpuav_settings;
                     object->printf_settings = instance_interceptor->printf_settings;
                     object->syncval_settings = instance_interceptor->syncval_settings;
@@ -1494,7 +1494,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
                 chassis::CreateComputePipelines chassis_state(pCreateInfos);
 
-                {    
+                {
                     VVL_ZoneScopedN("PreCallValidate");
                     for (const ValidationObject* intercept : layer_data->object_dispatch) {
                         auto lock = intercept->ReadLock();
@@ -1582,7 +1582,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 PipelineStates pipeline_states[LayerObjectTypeMaxEnum];
                 chassis::CreateRayTracingPipelinesKHR chassis_state(pCreateInfos);
 
-                {    
+                {
                     VVL_ZoneScopedN("PreCallValidate");
                     for (const ValidationObject* intercept : layer_data->object_dispatch) {
                         auto lock = intercept->ReadLock();


### PR DESCRIPTION
This adds a `VK_LAYER_DEBUG_DISABLE_SPIRV_VAL` setting to allow quick profiling testing with/without `spirv-val`

In order to add it, had to cleanup the settings a bit

Also improved the description of the current shader settings