### PR TITLE
layers: Use char for new line in string stream

### DIFF
--- a/layers/core_checks/cc_copy_blit_resolve.cpp
+++ b/layers/core_checks/cc_copy_blit_resolve.cpp
@@ -2608,15 +2608,15 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_st
 
     if (src_info.flags != dst_info.flags) {
         mismatch_stream << "srcImage flags = " << string_VkImageCreateFlags(src_info.flags)
-                        << " and dstImage flags = " << string_VkImageCreateFlags(dst_info.flags) << "\n";
+                        << " and dstImage flags = " << string_VkImageCreateFlags(dst_info.flags) << '\n';
     }
     if (src_info.imageType != dst_info.imageType) {
         mismatch_stream << "srcImage imageType = " << string_VkImageType(src_info.imageType)
-                        << " and dstImage imageType = " << string_VkImageType(dst_info.imageType) << "\n";
+                        << " and dstImage imageType = " << string_VkImageType(dst_info.imageType) << '\n';
     }
     if (src_info.format != dst_info.format) {
         mismatch_stream << "srcImage format = " << string_VkFormat(src_info.format)
-                        << " and dstImage format = " << string_VkFormat(dst_info.format) << "\n";
+                        << " and dstImage format = " << string_VkFormat(dst_info.format) << '\n';
     }
     if ((src_info.extent.width != dst_info.extent.width) || (src_info.extent.height != dst_info.extent.height) ||
         (src_info.extent.depth != dst_info.extent.depth)) {
@@ -2625,31 +2625,31 @@ bool CoreChecks::ValidateHostCopyImageCreateInfos(const vvl::Image &src_image_st
     }
     if (src_info.mipLevels != dst_info.mipLevels) {
         mismatch_stream << "srcImage mipLevels = " << src_info.mipLevels << "and dstImage mipLevels = " << dst_info.mipLevels
-                        << "\n";
+                        << '\n';
     }
     if (src_info.arrayLayers != dst_info.arrayLayers) {
         mismatch_stream << "srcImage arrayLayers = " << src_info.arrayLayers
-                        << " and dstImage arrayLayers = " << dst_info.arrayLayers << "\n";
+                        << " and dstImage arrayLayers = " << dst_info.arrayLayers << '\n';
     }
     if (src_info.samples != dst_info.samples) {
         mismatch_stream << "srcImage samples = " << string_VkSampleCountFlagBits(src_info.samples)
-                        << " and dstImage samples = " << string_VkSampleCountFlagBits(dst_info.samples) << "\n";
+                        << " and dstImage samples = " << string_VkSampleCountFlagBits(dst_info.samples) << '\n';
     }
     if (src_info.tiling != dst_info.tiling) {
         mismatch_stream << "srcImage tiling = " << string_VkImageTiling(src_info.tiling)
-                        << " and dstImage tiling = " << string_VkImageTiling(dst_info.tiling) << "\n";
+                        << " and dstImage tiling = " << string_VkImageTiling(dst_info.tiling) << '\n';
     }
     if (src_info.usage != dst_info.usage) {
         mismatch_stream << "srcImage usage = " << string_VkImageUsageFlags(src_info.usage)
-                        << " and dstImage usage = " << string_VkImageUsageFlags(dst_info.usage) << "\n";
+                        << " and dstImage usage = " << string_VkImageUsageFlags(dst_info.usage) << '\n';
     }
     if (src_info.sharingMode != dst_info.sharingMode) {
         mismatch_stream << "srcImage sharingMode = " << string_VkSharingMode(src_info.sharingMode)
-                        << " and dstImage sharingMode = " << string_VkSharingMode(dst_info.sharingMode) << "\n";
+                        << " and dstImage sharingMode = " << string_VkSharingMode(dst_info.sharingMode) << '\n';
     }
     if (src_info.initialLayout != dst_info.initialLayout) {
         mismatch_stream << "srcImage initialLayout = " << string_VkImageLayout(src_info.initialLayout)
-                        << " and dstImage initialLayout = " << string_VkImageLayout(dst_info.initialLayout) << "\n";
+                        << " and dstImage initialLayout = " << string_VkImageLayout(dst_info.initialLayout) << '\n';
     }
 
     if (mismatch_stream.str().length() > 0) {

--- a/layers/core_checks/cc_shader_interface.cpp
+++ b/layers/core_checks/cc_shader_interface.cpp
@@ -664,12 +664,12 @@ bool CoreChecks::ValidateInterfaceBetweenStages(const spirv::Module &producer, c
         std::stringstream msg;
         msg << string_VkShaderStageFlagBits(producer_stage) << " Output Block {\n";
         for (size_t i = 0; i < output_builtins_block.size(); i++) {
-            msg << "\t" << i << ": " << string_SpvBuiltIn(output_builtins_block[i]) << "\n";
+            msg << '\t' << i << ": " << string_SpvBuiltIn(output_builtins_block[i]) << '\n';
         }
         msg << "}\n";
         msg << string_VkShaderStageFlagBits(consumer_stage) << " Input Block {\n";
         for (size_t i = 0; i < input_builtins_block.size(); i++) {
-            msg << "\t" << i << ": " << string_SpvBuiltIn(input_builtins_block[i]) << "\n";
+            msg << '\t' << i << ": " << string_SpvBuiltIn(input_builtins_block[i]) << '\n';
         }
         msg << "}\n";
         const LogObjectList objlist(producer.handle(), consumer.handle());

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -546,7 +546,7 @@ bool CoreChecks::ValidateCooperativeMatrix(const spirv::Module &module_state, co
                << " | AType = " << string_VkComponentTypeKHR(prop.AType) << " | BType = " << string_VkComponentTypeKHR(prop.BType)
                << " | CType = " << string_VkComponentTypeKHR(prop.CType)
                << " | ResultType = " << string_VkComponentTypeKHR(prop.ResultType) << " | scope = " << string_VkScopeKHR(prop.scope)
-               << "\n";
+               << '\n';
         }
         return ss.str();
     };

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -681,14 +681,14 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityF
     PrintMessageType(message_type, msg_type);
 
     msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
-        << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
-    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
+               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << '\n';
+    msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
     for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
         msg_buffer << "        [" << obj << "] " << std::hex << std::showbase
-            << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
-            << callback_data->pObjects[obj].objectType
-            << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
-            << "\n";
+                   << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
+                   << callback_data->pObjects[obj].objectType
+                   << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
+                   << '\n';
     }
     const std::string tmp = msg_buffer.str();
     const char *cstr = tmp.c_str();
@@ -714,15 +714,15 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageS
     PrintMessageType(message_type, msg_type);
 
     msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
-               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << "\n";
-    msg_buffer << "    Objects: " << callback_data->objectCount << "\n";
+               << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << '\n';
+    msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
 
     for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
         msg_buffer << "       [" << obj << "]  " << std::hex << std::showbase
                    << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
                    << callback_data->pObjects[obj].objectType
                    << ", name: " << (callback_data->pObjects[obj].pObjectName ? callback_data->pObjects[obj].pObjectName : "NULL")
-                   << "\n";
+                   << '\n';
     }
     const std::string tmp = msg_buffer.str();
     [[maybe_unused]] const char *cstr = tmp.c_str();

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -420,7 +420,7 @@ void Validator::AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueu
                 GenerateDebugInfoMessage(command_buffer, instructions, debug_record->instruction_position, tracker_info,
                                          buffer_info.pipeline_bind_point, operation_index);
             if (use_stdout) {
-                std::cout << "WARNING-DEBUG-PRINTF " << shader_message.str() << "\n" << debug_info_message;
+                std::cout << "WARNING-DEBUG-PRINTF " << shader_message.str() << '\n' << debug_info_message;
             } else {
                 LogInfo("WARNING-DEBUG-PRINTF", queue, loc, "%s\n%s", shader_message.str().c_str(), debug_info_message.c_str());
             }

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -1045,7 +1045,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
            << HandleToUint64(commandBuffer) << ")\n";
 
         ss << std::dec << std::noshowbase;
-        ss << "\t";  // helps to show that the index is expressed with respect to the command buffer
+        ss << '\t';  // helps to show that the index is expressed with respect to the command buffer
         if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS) {
             ss << "Draw ";
         } else if (pipeline_bind_point == VK_PIPELINE_BIND_POINT_COMPUTE) {
@@ -1056,7 +1056,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
             assert(false);
             ss << "Unknown Pipeline Operation ";
         }
-        ss << "Index " << operation_index << "\n";
+        ss << "Index " << operation_index << '\n';
         ss << std::hex << std::noshowbase;
 
         if (tracker_info->shader_module == VK_NULL_HANDLE) {
@@ -1075,7 +1075,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
     }
 
     ss << std::dec << std::noshowbase;
-    ss << "SPIR-V Instruction Index = " << instruction_position << "\n";
+    ss << "SPIR-V Instruction Index = " << instruction_position << '\n';
 
     // Find the OpLine just before the failing instruction indicated by the debug info.
     // SPIR-V can only be iterated in the forward direction due to its opcode/length encoding.
@@ -1122,7 +1122,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
             if (reported_column_number > 0) {
                 ss << ", column " << reported_column_number;
             }
-            ss << "\n";
+            ss << '\n';
             break;
         }
         // OpString can only be in the debug section, so can break early if not found
@@ -1132,7 +1132,7 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
     if (!found_opstring) {
         ss << "Unable to find SPIR-V OpString from OpLine instruction.\n";
         ss << "File ID = " << reported_file_id << ", Line Number = " << reported_line_number
-           << ", Column = " << reported_column_number << "\n";
+           << ", Column = " << reported_column_number << '\n';
     }
 
     // Create message to display source code line containing error.
@@ -1174,17 +1174,17 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
             assert(reported_line_number >= saved_line_number);
             const size_t opsource_index = (reported_line_number - saved_line_number) + 1 + saved_opsource_offset;
             if (opsource_index < opsource_lines.size()) {
-                ss << "\n" << reported_line_number << ": " << opsource_lines[opsource_index] << "\n";
+                ss << '\n' << reported_line_number << ": " << opsource_lines[opsource_index] << '\n';
             } else {
                 ss << "Internal error: calculated source line of " << opsource_index << " for source size of "
                    << opsource_lines.size() << " lines\n";
             }
         } else if (reported_line_number < opsource_lines.size() && reported_line_number != 0) {
             // file lines normally start at 1 index
-            ss << "\n" << opsource_lines[reported_line_number - 1] << "\n";
+            ss << '\n' << opsource_lines[reported_line_number - 1] << '\n';
             if (reported_column_number > 0) {
                 std::string spaces(reported_column_number - 1, ' ');
-                ss << spaces << "^";
+                ss << spaces << '^';
             }
         } else {
             ss << "Unable to find neither a suitable line in SPIR-V OpSource\n";

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -451,7 +451,7 @@ static void GenerateStageMessage(const uint32_t *error_record, std::string &msg)
             assert(false);
         } break;
     }
-    strm << "\n";
+    strm << '\n';
     msg = strm.str();
 }
 

--- a/layers/gpu/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu/spirv/bindless_descriptor_pass.cpp
@@ -426,7 +426,7 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
 }
 
 void BindlessDescriptorPass::PrintDebugInfo() {
-    std::cout << "BindlessDescriptorPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
+    std::cout << "BindlessDescriptorPass\n\tinstrumentation count: " << instrumented_count_ << '\n';
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/buffer_device_address_pass.cpp
+++ b/layers/gpu/spirv/buffer_device_address_pass.cpp
@@ -112,7 +112,7 @@ bool BufferDeviceAddressPass::AnalyzeInstruction(const Function& function, const
 }
 
 void BufferDeviceAddressPass::PrintDebugInfo() {
-    std::cout << "BufferDeviceAddressPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
+    std::cout << "BufferDeviceAddressPass\n\tinstrumentation count: " << instrumented_count_ << '\n';
 }
 
 }  // namespace spirv

--- a/layers/gpu/spirv/debug_printf_pass.cpp
+++ b/layers/gpu/spirv/debug_printf_pass.cpp
@@ -453,7 +453,7 @@ bool DebugPrintfPass::Run() {
     return true;
 }
 
-void DebugPrintfPass::PrintDebugInfo() { std::cout << "DebugPrintfPass\n\tinstrumentation count: " << instrumented_count_ << "\n"; }
+void DebugPrintfPass::PrintDebugInfo() { std::cout << "DebugPrintfPass\n\tinstrumentation count: " << instrumented_count_ << '\n'; }
 
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpu/spirv/ray_query_pass.cpp
+++ b/layers/gpu/spirv/ray_query_pass.cpp
@@ -67,9 +67,7 @@ bool RayQueryPass::AnalyzeInstruction(const Function& function, const Instructio
     return true;
 }
 
-void RayQueryPass::PrintDebugInfo() {
-    std::cout << "RayQueryPass\n\tinstrumentation count: " << instrumented_count_ << "\n";
-}
+void RayQueryPass::PrintDebugInfo() { std::cout << "RayQueryPass\n\tinstrumentation count: " << instrumented_count_ << '\n'; }
 
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -273,7 +273,7 @@ std::string DescriptorSetLayoutDef::DescribeDifference(uint32_t index, const Des
             }
         }
     }
-    ss << "\n";
+    ss << '\n';
     return ss.str();
 }
 

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -1270,7 +1270,7 @@ void Module::DescribeTypeInner(std::ostringstream& ss, uint32_t type, uint32_t i
     const Instruction* insn = FindDef(type);
     auto indent_by = [&ss](uint32_t i) {
         for (uint32_t x = 0; x < i; x++) {
-            ss << "\t";
+            ss << '\t';
         }
     };
 
@@ -1317,11 +1317,11 @@ void Module::DescribeTypeInner(std::ostringstream& ss, uint32_t type, uint32_t i
                     ss << " \"" << name << "\"";
                 }
 
-                ss << "\n";
+                ss << '\n';
             }
             indent--;
             indent_by(indent);
-            ss << "}";
+            ss << '}';
 
             auto name = GetName(type);
             if (!name.empty()) {
@@ -1361,9 +1361,9 @@ std::string Module::DescribeVariable(uint32_t id) const {
         ss << "Variable \"" << name << "\"";
         auto decorations = GetDecorations(id);
         if (!decorations.empty()) {
-            ss << " (Decorations:" << decorations << ")";
+            ss << " (Decorations:" << decorations << ')';
         }
-        ss << "\n";
+        ss << '\n';
     }
     return ss.str();
 }

--- a/layers/sync/sync_stats.cpp
+++ b/layers/sync/sync_stats.cpp
@@ -66,8 +66,8 @@ std::string Stats::CreateReport() {
         uint32_t cb_context_max = command_buffer_context_counter.max_value.u32;
 
         str << "CommandBufferAccessContext:\n";
-        str << "\tcount = " << cb_contex << "\n";
-        str << "\tmax_count = " << cb_context_max << "\n";
+        str << "\tcount = " << cb_contex << '\n';
+        str << "\tmax_count = " << cb_context_max << '\n';
     }
     {
         uint32_t handle_record = handle_record_counter.value.u32;
@@ -76,9 +76,9 @@ std::string Stats::CreateReport() {
         uint64_t handle_record_max_memory = handle_record_max * sizeof(HandleRecord);
 
         str << "HandleRecord:\n";
-        str << "\tcount = " << handle_record << "\n";
+        str << "\tcount = " << handle_record << '\n';
         str << "\tmemory = " << handle_record_memory << " bytes\n";
-        str << "\tmax_count = " << handle_record_max << "\n";
+        str << "\tmax_count = " << handle_record_max << '\n';
         str << "\tmax_memory = " << handle_record_max_memory << " bytes\n";
     }
     return str.str();

--- a/tests/spirv/instrumentation.cpp
+++ b/tests/spirv/instrumentation.cpp
@@ -111,7 +111,7 @@ int main(int argc, char** argv) {
 
     FILE* fp = fopen(argv[1], "rb");
     if (!fp) {
-        std::cout << "ERROR: Unable to open the input file " << argv[1] << "\n";
+        std::cout << "ERROR: Unable to open the input file " << argv[1] << '\n';
         return EXIT_FAILURE;
     }
 
@@ -158,7 +158,7 @@ int main(int argc, char** argv) {
 
     fp = fopen(out_file, "wb");
     if (!fp) {
-        std::cout << "ERROR: Unable to open the output file " << out_file << "\n";
+        std::cout << "ERROR: Unable to open the output file " << out_file << '\n';
         return EXIT_FAILURE;
     }
 


### PR DESCRIPTION
small cleanup suggested by @arno-lunarg to replace `"\n"` for `'\n'` which from [checking the compilation](https://godbolt.org/#g:!((g:!((g:!((h:codeEditor,i:(filename:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,selection:(endColumn:35,endLineNumber:8,positionColumn:35,positionLineNumber:8,selectionStartColumn:35,selectionStartLineNumber:8,startColumn:35,startLineNumber:8),source:'%23include+%3Ciostream%3E%0A%0Avoid+foo(int+x)+%7B%0A++++std::cout+%3C%3C+%22Test+%22+%3C%3C+x+%3C%3C+%22%5Cn%22%3B%0A%7D%0A%0Avoid+bar(int+x)+%7B%0A++++std::cout+%3C%3C+%22Test+%22+%3C%3C+x+%3C%3C+!'%5Cn!'%3B%0A%7D%0A%0Aint+main()+%7B%0A++++foo(3)%3B%0A++++bar(4)%3B%0A%7D'),l:'5',n:'1',o:'C%2B%2B+source+%231',t:'0')),k:52.375979112271544,l:'4',n:'0',o:'',s:0,t:'0'),(g:!((h:compiler,i:(compiler:clang1600,filters:(b:'0',binary:'1',binaryObject:'1',commentOnly:'0',debugCalls:'1',demangle:'0',directives:'0',execute:'1',intel:'0',libraryCode:'0',trim:'1',verboseDemangling:'0'),flagsViewOpen:'1',fontScale:14,fontUsePx:'0',j:1,lang:c%2B%2B,libs:!(),options:'',overrides:!(),selection:(endColumn:19,endLineNumber:41,positionColumn:19,positionLineNumber:41,selectionStartColumn:19,selectionStartLineNumber:41,startColumn:19,startLineNumber:41),source:1),l:'5',n:'0',o:'+x86-64+clang+16.0.0+(Editor+%231)',t:'0')),k:47.624020887728456,l:'4',n:'0',o:'',s:0,t:'0')),l:'2',n:'0',o:'',t:'0')),version:4) shows a slight enhancement not needing to carry the null string