### PR TITLE
🌴sync: Fix iteration over queue batch contexts

### DIFF
--- a/layers/sync/sync_image.h
+++ b/layers/sync/sync_image.h
@@ -67,6 +67,7 @@ class Swapchain : public vvl::Swapchain {
     ~Swapchain() { Destroy(); }
     void RecordPresentedImage(PresentedImage &&presented_images);
     PresentedImage MovePresentedImage(uint32_t image_index);
+    void GetPresentBatches(std::vector<QueueBatchContext::Ptr> &batches) const;
     std::shared_ptr<const Swapchain> shared_from_this() const { return SharedFromThisImpl(this); }
     std::shared_ptr<Swapchain> shared_from_this() { return SharedFromThisImpl(this); }
 

--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -107,6 +107,14 @@ PresentedImage syncval_state::Swapchain::MovePresentedImage(uint32_t image_index
     return ret_val;
 }
 
+void syncval_state::Swapchain::GetPresentBatches(std::vector<QueueBatchContext::Ptr>& batches) const {
+    for (const auto& presented_image : presented) {
+        if (presented_image.batch) {
+            batches.push_back(presented_image.batch);
+        }
+    }
+}
+
 class ApplySemaphoreBarrierAction {
   public:
     ApplySemaphoreBarrierAction(const SemaphoreScope& signal, const SemaphoreScope& wait) : signal_(signal), wait_(wait) {}

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -74,6 +74,8 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
 
     void ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag);
     void ApplyAcquireWait(const AcquiredImage &acquired);
+
+     // Go through every queue batch context and apply synchronization operation
     template <typename BatchOp>
     void ForAllQueueBatchContexts(BatchOp &&op);
 


### PR DESCRIPTION
Take into account present batches.

One example when ignoring present batches caused the problem is `vkWaitForFences` did not apply tagged wait to the accesses from the present batch. As a result those accesses tunneled through the fence wait and caused hazards.

Potentially fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8291
