### PR TITLE
layers: Use emplace_back where possible

### DIFF
--- a/layers/best_practices/bp_image.cpp
+++ b/layers/best_practices/bp_image.cpp
@@ -173,8 +173,8 @@ void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std:
 
 void BestPractices::QueueValidateImage(QueueCallbacks& funcs, Func command, std::shared_ptr<bp_state::Image>& state,
                                        IMAGE_SUBRESOURCE_USAGE_BP usage, uint32_t array_layer, uint32_t mip_level) {
-    funcs.push_back([this, command, state, usage, array_layer, mip_level](const ValidationStateTracker& vst, const vvl::Queue& qs,
-                                                                          const vvl::CommandBuffer& cbs) -> bool {
+    funcs.emplace_back([this, command, state, usage, array_layer, mip_level](
+                           const ValidationStateTracker& vst, const vvl::Queue& qs, const vvl::CommandBuffer& cbs) -> bool {
         ValidateImageInQueue(qs, cbs, command, *state, usage, array_layer, mip_level);
         return false;
     });

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -143,7 +143,7 @@ bool BestPractices::PreCallValidateCreateDevice(VkPhysicalDevice physicalDevice,
                 VK_SUCCESS) {
                 extensions.reserve(property_list.size());
                 for (const VkExtensionProperties& properties : property_list) {
-                    extensions.push_back(properties.extensionName);
+                    extensions.emplace_back(properties.extensionName);
                 }
             }
         }

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -212,7 +212,7 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
             if (create_info.pColorBlendState->pAttachments[j].colorWriteMask != 0) {
                 uint32_t attachment = subpass.pColorAttachments[j].attachment;
                 if (attachment != VK_ATTACHMENT_UNUSED) {
-                    result.push_back({attachment, VK_IMAGE_ASPECT_COLOR_BIT});
+                    result.emplace_back(attachment, VK_IMAGE_ASPECT_COLOR_BIT);
                 }
             }
         }
@@ -230,7 +230,7 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
             if (create_info.pDepthStencilState->stencilTestEnable) {
                 aspects |= VK_IMAGE_ASPECT_STENCIL_BIT;
             }
-            result.push_back({attachment, aspects});
+            result.emplace_back(attachment, aspects);
         }
     }
     return result;

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -847,7 +847,7 @@ void BestPractices::RecordAttachmentAccess(bp_state::CommandBuffer& cb_state, ui
     if (itr != rp_state.touchesAttachments.end()) {
         itr->aspects |= aspects;
     } else {
-        rp_state.touchesAttachments.push_back({fb_attachment, aspects});
+        rp_state.touchesAttachments.emplace_back(fb_attachment, aspects);
     }
 }
 
@@ -866,7 +866,7 @@ void BestPractices::RecordAttachmentClearAttachments(bp_state::CommandBuffer& cm
         new_aspects = aspects & ~itr->aspects;
         itr->aspects |= aspects;
     } else {
-        rp_state.touchesAttachments.push_back({fb_attachment, aspects});
+        rp_state.touchesAttachments.emplace_back(fb_attachment, aspects);
     }
 
     if (new_aspects == 0) {

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -120,6 +120,9 @@ class DeviceMemory : public vvl::DeviceMemory {
 struct AttachmentInfo {
     uint32_t framebufferAttachment;
     VkImageAspectFlags aspects;
+
+    AttachmentInfo(uint32_t framebufferAttachment_, VkImageAspectFlags aspects_)
+        : framebufferAttachment(framebufferAttachment_), aspects(aspects_) {}
 };
 
 // used to track state regarding render pass heuristic checks

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -466,9 +466,9 @@ void BestPractices::RecordCmdPipelineBarrierImageBarrier(VkCommandBuffer command
         auto image = Get<bp_state::Image>(barrier.image);
         ASSERT_AND_RETURN(image);
         auto subresource_range = barrier.subresourceRange;
-        cb_state->queue_submit_functions.push_back([image, subresource_range](const ValidationStateTracker& vst,
-                                                                              const vvl::Queue& qs,
-                                                                              const vvl::CommandBuffer& cbs) -> bool {
+        cb_state->queue_submit_functions.emplace_back([image, subresource_range](const ValidationStateTracker& vst,
+                                                                                 const vvl::Queue& qs,
+                                                                                 const vvl::CommandBuffer& cbs) -> bool {
             ForEachSubresource(*image, subresource_range, [&](uint32_t layer, uint32_t level) {
                 // Update queue family index without changing usage, signifying a correct queue family transfer
                 image->UpdateUsage(layer, level, image->GetUsageType(layer, level), qs.queue_family_index);

--- a/layers/core_checks/cc_image_layout.cpp
+++ b/layers/core_checks/cc_image_layout.cpp
@@ -897,7 +897,7 @@ bool CoreChecks::FindLayouts(const vvl::Image &image_state, std::vector<VkImageL
     }
 
     for (const auto &entry : *layout_range_map) {
-        layouts.push_back(entry.second);
+        layouts.emplace_back(entry.second);
     }
     return true;
 }

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -109,7 +109,7 @@ private:
         }
         for (const auto &command : cb_state.GetLabelCommands()) {
             if (command.begin) {
-                cmdbuf_label_stack.push_back(command.label_name);
+                cmdbuf_label_stack.emplace_back(command.label_name);
             } else {
                 if (cmdbuf_label_stack.empty()) {
                     found_unbalanced_cmdbuf_label = true;

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -343,7 +343,7 @@ void DebugReport::BeginQueueDebugUtilsLabel(VkQueue queue, const VkDebugUtilsLab
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
         auto *label_state = GetLoggingLabelState(&debug_utils_queue_labels, queue, /* insert */ true);
         assert(label_state);
-        label_state->labels.emplace_back(label_info);
+        label_state->labels.push_back(label_info);
 
         // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
         label_state->insert_label.Reset();
@@ -377,7 +377,7 @@ void DebugReport::BeginCmdDebugUtilsLabel(VkCommandBuffer command_buffer, const 
     if (nullptr != label_info && nullptr != label_info->pLabelName) {
         auto *label_state = GetLoggingLabelState(&debug_utils_cmd_buffer_labels, command_buffer, /* insert */ true);
         assert(label_state);
-        label_state->labels.push_back(LoggingLabel(label_info));
+        label_state->labels.push_back(label_info);
 
         // TODO: Determine if this is the correct semantics for insert label vs. begin/end, perserving existing semantics for now
         label_state->insert_label.Reset();

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
@@ -68,7 +68,7 @@ void RestorablePipelineState::Create(vvl::CommandBuffer &cb_state, VkPipelineBin
     for (std::size_t i = 0; i < last_bound.per_set.size(); i++) {
         const auto &bound_descriptor_set = last_bound.per_set[i].bound_descriptor_set;
         if (bound_descriptor_set) {
-            descriptor_sets_.push_back(std::make_pair(bound_descriptor_set->VkHandle(), static_cast<uint32_t>(i)));
+            descriptor_sets_.emplace_back(bound_descriptor_set->VkHandle(), static_cast<uint32_t>(i));
             if (bound_descriptor_set->IsPushDescriptor()) {
                 push_descriptor_set_index_ = static_cast<uint32_t>(i);
             }

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -51,10 +51,9 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     }
 
     binding_slot_ = (uint32_t)instrumentation_bindings_.size();  // get next free binding
-    VkDescriptorSetLayoutBinding binding = {binding_slot_, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,
-                                            kShaderStageAllGraphics | VK_SHADER_STAGE_COMPUTE_BIT | kShaderStageAllRayTracing,
-                                            nullptr};
-    instrumentation_bindings_.push_back(binding);
+    instrumentation_bindings_.emplace_back(
+        VkDescriptorSetLayoutBinding{binding_slot_, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1,
+                                     kShaderStageAllGraphics | VK_SHADER_STAGE_COMPUTE_BIT | kShaderStageAllRayTracing, nullptr});
 
     BaseClass::PostCreateDevice(pCreateInfo, loc);  // will set up bindings
 
@@ -223,7 +222,7 @@ std::vector<Substring> Validator::ParseFormatString(const std::string &format_st
         if (pos == std::string::npos) {
             // End of the format string   Push the rest of the characters
             substring.string = format_string.substr(begin, format_string.length());
-            parsed_strings.push_back(substring);
+            parsed_strings.emplace_back(substring);
             break;
         }
         pos++;
@@ -265,14 +264,14 @@ std::vector<Substring> Validator::ParseFormatString(const std::string &format_st
                 substring.string = format_string.substr(begin, percent - begin);
                 substring.string += specifier;
                 substring.type = NumericTypeLookup(specifier.back());
-                parsed_strings.push_back(substring);
+                parsed_strings.emplace_back(substring);
 
                 // Continue with a comma separated list
                 char temp_string[32];
                 snprintf(temp_string, sizeof(temp_string), ", %s", specifier.c_str());
                 substring.string = temp_string;
                 for (int i = 0; i < (vec_size - 1); i++) {
-                    parsed_strings.push_back(substring);
+                    parsed_strings.emplace_back(substring);
                 }
             } else {
                 // Single non-vector value
@@ -284,7 +283,7 @@ std::vector<Substring> Validator::ParseFormatString(const std::string &format_st
                 }
                 substring.string = format_string.substr(begin, pos - begin + 1);
                 substring.type = NumericTypeLookup(format_string[pos]);
-                parsed_strings.push_back(substring);
+                parsed_strings.emplace_back(substring);
             }
             begin = pos + 1;
         }

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -960,7 +960,7 @@ static void ReadOpSource(const std::vector<spirv::Instruction> &instructions, co
             std::string cur_line;
             in_stream.str(insn.GetAsString(4));
             while (std::getline(in_stream, cur_line)) {
-                opsource_lines.push_back(cur_line);
+                opsource_lines.emplace_back(cur_line);
             }
 
             for (size_t k = i + 1; k < instructions.size(); k++) {
@@ -970,7 +970,7 @@ static void ReadOpSource(const std::vector<spirv::Instruction> &instructions, co
                 }
                 in_stream.str(continue_insn.GetAsString(1));
                 while (std::getline(in_stream, cur_line)) {
-                    opsource_lines.push_back(cur_line);
+                    opsource_lines.emplace_back(cur_line);
                 }
             }
             break;

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1805,19 +1805,19 @@ void CommandBuffer::GetCurrentPipelineAndDesriptorSets(VkPipelineBindPoint pipel
 
 void CommandBuffer::BeginLabel(const char *label_name) {
     ++label_stack_depth_;
-    label_commands_.push_back(LabelCommand{true, label_name});
+    label_commands_.emplace_back(LabelCommand{true, label_name});
 }
 
 void CommandBuffer::EndLabel() {
     --label_stack_depth_;
-    label_commands_.push_back(LabelCommand{false, std::string()});
+    label_commands_.emplace_back(LabelCommand{false, std::string()});
 }
 
 void CommandBuffer::ReplayLabelCommands(const vvl::span<const LabelCommand> &label_commands,
                                         std::vector<std::string> &label_stack) {
     for (const LabelCommand &command : label_commands) {
         if (command.begin) {
-            label_stack.push_back(command.label_name.empty() ? "(empty label)" : command.label_name);
+            label_stack.emplace_back(command.label_name.empty() ? "(empty label)" : command.label_name);
         } else if (!label_stack.empty()) {
             // The above condition is needed for several reasons. On the primary command buffer level
             // the labels are not necessary balanced. And if the empty stack is detected in the context

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -312,8 +312,8 @@ BoundMemoryRange vvl::BindableMultiplanarMemoryTracker::GetBoundMemoryRange(cons
         if (plane.binding.memory_state && range.intersects(plane_range)) {
             VkDeviceSize range_end = range.end > plane_range.end ? plane_range.end : range.end;
             const VkDeviceMemory dev_mem = plane.binding.memory_state->VkHandle();
-            mem_ranges[dev_mem].emplace_back(MemoryRange{plane.binding.memory_offset + range.begin,
-                                                                                   plane.binding.memory_offset + range_end});
+            mem_ranges[dev_mem].emplace_back((plane.binding.memory_offset + range.begin),
+                                             (plane.binding.memory_offset + range_end));
         }
         start_offset += plane.size;
     }

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -725,7 +725,7 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
         } else {
             result.resize(count);
             for (uint32_t surface_format_index = 0; surface_format_index < count; ++surface_format_index) {
-                result.emplace_back(vku::safe_VkSurfaceFormat2KHR(&formats2[surface_format_index]));
+                result.emplace_back(&formats2[surface_format_index]);
             }
         }
     } else {
@@ -743,7 +743,7 @@ vvl::span<const vku::safe_VkSurfaceFormat2KHR> Surface::GetFormats(bool get_surf
             VkSurfaceFormat2KHR format2 = vku::InitStructHelper();
             for (const auto &format : formats) {
                 format2.surfaceFormat = format;
-                result.emplace_back(vku::safe_VkSurfaceFormat2KHR(&format2));
+                result.emplace_back(&format2);
             }
         }
     }
@@ -783,7 +783,7 @@ void Surface::UpdateCapabilitiesCache(VkPhysicalDevice phys_dev, const VkSurface
         }
     }
     if (!info) {
-        cache.present_mode_infos.push_back(PresentModeInfo{});
+        cache.present_mode_infos.emplace_back(PresentModeInfo{});
         info = &cache.present_mode_infos.back();
         info->present_mode = present_mode;
     }

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1031,8 +1031,8 @@ void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateI
         for (uint32_t i = 0; i < pCreateInfo->queueCreateInfoCount; ++i) {
             const VkDeviceQueueCreateInfo &queue_create_info = pCreateInfo->pQueueCreateInfos[i];
             queue_family_index_set.insert(queue_create_info.queueFamilyIndex);
-            device_queue_info_list.push_back(
-                {i, queue_create_info.queueFamilyIndex, queue_create_info.flags, queue_create_info.queueCount});
+            device_queue_info_list.emplace_back(
+                DeviceQueueInfo{i, queue_create_info.queueFamilyIndex, queue_create_info.flags, queue_create_info.queueCount});
         }
         for (const auto &queue_info : device_queue_info_list) {
             for (uint32_t i = 0; i < queue_info.queue_count; i++) {
@@ -4153,8 +4153,7 @@ void ValidationStateTracker::PostCallRecordGetPhysicalDeviceSurfaceFormats2KHR(V
             pd_state->surfaceless_query_state.formats.clear();
             pd_state->surfaceless_query_state.formats.reserve(*pSurfaceFormatCount);
             for (uint32_t surface_format_index = 0; surface_format_index < *pSurfaceFormatCount; ++surface_format_index) {
-                pd_state->surfaceless_query_state.formats.emplace_back(
-                    vku::safe_VkSurfaceFormat2KHR(&pSurfaceFormats[surface_format_index]));
+                pd_state->surfaceless_query_state.formats.emplace_back(&pSurfaceFormats[surface_format_index]);
             }
         }
     }

--- a/tests/framework/descriptor_helper.cpp
+++ b/tests/framework/descriptor_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,7 +18,7 @@ OneOffDescriptorSet::OneOffDescriptorSet(vkt::Device *device, const Bindings &bi
     : device_{device}, pool_{}, layout_(*device, bindings, layout_flags, layout_pnext), set_(VK_NULL_HANDLE) {
     VkResult err;
     std::vector<VkDescriptorPoolSize> sizes;
-    for (const auto &b : bindings) sizes.push_back({b.descriptorType, std::max(1u, b.descriptorCount)});
+    for (const auto &b : bindings) sizes.emplace_back(VkDescriptorPoolSize{b.descriptorType, std::max(1u, b.descriptorCount)});
 
     VkDescriptorPoolCreateInfo dspci = {
         VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO, create_pool_pnext, poolFlags, 1, uint32_t(sizes.size()), sizes.data()};

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -593,7 +593,7 @@ std::vector<std::string> get_args(android_app &app, const char *intent_extra_dat
     std::stringstream ss(args_str);
     std::string arg;
     while (std::getline(ss, arg, ' ')) {
-        if (!arg.empty()) args.push_back(arg);
+        if (!arg.empty()) args.emplace_back(arg);
     }
 
     return args;

--- a/tests/framework/render_pass_helper.cpp
+++ b/tests/framework/render_pass_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -46,15 +46,16 @@ VkRenderPassCreateInfo RenderPassSingleSubpass::GetCreateInfo() {
 
 void RenderPassSingleSubpass::AddAttachmentDescription(VkFormat format, VkImageLayout initialLayout, VkImageLayout finalLayout,
                                                        VkAttachmentLoadOp loadOp, VkAttachmentStoreOp storeOp) {
-    attachment_descriptions_.push_back({0, format, VK_SAMPLE_COUNT_1_BIT, loadOp, storeOp, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
-                                        VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout});
+    attachment_descriptions_.emplace_back(VkAttachmentDescription{0, format, VK_SAMPLE_COUNT_1_BIT, loadOp, storeOp,
+                                                                  VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
+                                                                  initialLayout, finalLayout});
 }
 
 void RenderPassSingleSubpass::AddAttachmentDescription(VkFormat format, VkSampleCountFlagBits samples, VkImageLayout initialLayout,
                                                        VkImageLayout finalLayout) {
-    attachment_descriptions_.push_back({0, format, samples, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
-                                        VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout,
-                                        finalLayout});
+    attachment_descriptions_.emplace_back(VkAttachmentDescription{0, format, samples, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                                  VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+                                                                  VK_ATTACHMENT_STORE_OP_DONT_CARE, initialLayout, finalLayout});
 }
 
 void RenderPassSingleSubpass::AddAttachmentReference(VkAttachmentReference reference) {

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -950,7 +950,7 @@ TEST_F(VkBestPracticesLayerTest, ExpectedQueryDetails) {
     // Vulkan 1.1 required to test vkGetPhysicalDeviceQueueFamilyProperties2
     app_info_.apiVersion = VK_API_VERSION_1_1;
     // VK_KHR_get_physical_device_properties2 required to test vkGetPhysicalDeviceQueueFamilyProperties2KHR
-    m_instance_extension_names.emplace_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
+    m_instance_extension_names.push_back(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBestPracticesFramework());
     const vkt::PhysicalDevice phys_device_obj(gpu_);
 

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -316,10 +316,10 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
     buff_view_ci.offset = 1;
     std::vector<std::string> expectedErrors;
     if (buff_view_ci.offset < align_props.storageTexelBufferOffsetAlignmentBytes) {
-        expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02750");
+        expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02750");
     }
     if (buff_view_ci.offset < align_props.uniformTexelBufferOffsetAlignmentBytes) {
-        expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02751");
+        expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02751");
     }
     CreateBufferViewTest(*this, &buff_view_ci, expectedErrors);
     expectedErrors.clear();
@@ -327,11 +327,11 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
     buff_view_ci.offset = 4;
     if (buff_view_ci.offset < align_props.storageTexelBufferOffsetAlignmentBytes &&
         !align_props.storageTexelBufferOffsetSingleTexelAlignment) {
-        expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02750");
+        expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02750");
     }
     if (buff_view_ci.offset < align_props.uniformTexelBufferOffsetAlignmentBytes &&
         !align_props.uniformTexelBufferOffsetSingleTexelAlignment) {
-        expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02751");
+        expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02751");
     }
     CreateBufferViewTest(*this, &buff_view_ci, expectedErrors);
     expectedErrors.clear();
@@ -350,7 +350,7 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
         buff_view_ci.format = VK_FORMAT_R32G32B32_SFLOAT;
         buff_view_ci.offset = 1;
         if (buff_view_ci.offset < align_props.uniformTexelBufferOffsetAlignmentBytes) {
-            expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02751");
+            expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02751");
         }
         CreateBufferViewTest(*this, &buff_view_ci, expectedErrors);
         expectedErrors.clear();
@@ -358,7 +358,7 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
         buff_view_ci.offset = 4;
         if (buff_view_ci.offset < align_props.uniformTexelBufferOffsetAlignmentBytes &&
             !align_props.uniformTexelBufferOffsetSingleTexelAlignment) {
-            expectedErrors.push_back("VUID-VkBufferViewCreateInfo-buffer-02751");
+            expectedErrors.emplace_back("VUID-VkBufferViewCreateInfo-buffer-02751");
         }
         CreateBufferViewTest(*this, &buff_view_ci, expectedErrors);
         expectedErrors.clear();

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -1171,19 +1171,19 @@ TEST_F(NegativeDebugPrintf, GPL) {
     m_commandBuffer->end();
 
     std::vector<char const *> messages;
-    messages.push_back("Here are two float values 1.000000, 3.141500");
-    messages.push_back("Here's a smaller float value 3.14");
-    messages.push_back("Here's an integer -135 with text before and after it");
-    messages.push_back("Here's an integer in octal 400 and hex 0x100");
-    messages.push_back("-135 is a negative integer");
-    messages.push_back("Here's a vector of floats 1.20, 2.20, 3.20, 4.20");
-    messages.push_back("Here's a float in sn 3.141500e+00");
-    messages.push_back("Here's a float in sn 3.14e+00");
-    messages.push_back("Here's a float in shortest 3.1415");
-    messages.push_back("Here's a float in hex 0x1.921cac000p+1");
+    messages.emplace_back("Here are two float values 1.000000, 3.141500");
+    messages.emplace_back("Here's a smaller float value 3.14");
+    messages.emplace_back("Here's an integer -135 with text before and after it");
+    messages.emplace_back("Here's an integer in octal 400 and hex 0x100");
+    messages.emplace_back("-135 is a negative integer");
+    messages.emplace_back("Here's a vector of floats 1.20, 2.20, 3.20, 4.20");
+    messages.emplace_back("Here's a float in sn 3.141500e+00");
+    messages.emplace_back("Here's a float in sn 3.14e+00");
+    messages.emplace_back("Here's a float in shortest 3.1415");
+    messages.emplace_back("Here's a float in hex 0x1.921cac000p+1");
     // Two error messages have to be last in the vector
-    messages.push_back("First printf with a % and no value");
-    messages.push_back("Second printf with a value -135");
+    messages.emplace_back("First printf with a % and no value");
+    messages.emplace_back("Second printf with a value -135");
     for (uint32_t i = 0; i < messages.size(); i++) {
         VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.memory().map();
         data[0] = i;

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -637,7 +637,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     std::vector<vkt::Buffer> dummy_storage_buffers;
     for (int i = 0; i < 1024; ++i) {
         const VkDeviceAddress addr =
-            dummy_storage_buffers.emplace_back(vkt::Buffer(*m_device, storage_buffer_size, 0, vkt::device_address)).address();
+            dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
         const AddrRange addr_range(addr, addr + storage_buffer_size);
         // If new buffer address range overlaps with storage buffer range,
         // writes past its end may be valid, so remove dummy buffer
@@ -1023,8 +1023,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
             storage_buffer_size = 2 * sizeof(float);
         }
 
-        const VkDeviceAddress addr =
-            storage_buffers.emplace_back(vkt::Buffer(*m_device, storage_buffer_size, 0, vkt::device_address)).address();
+        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
         uniform_buffer_ptr[i] = addr;
     }
 

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -150,7 +150,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
     // Create storage buffers for the sake of storing multiple device address ranges
     std::vector<vkt::Buffer> dummy_storage_buffers;
     for (int i = 0; i < 1024; ++i) {
-        (void)dummy_storage_buffers.emplace_back(vkt::Buffer(*m_device, storage_buffer_size, 0, vkt::device_address)).address();
+        (void)dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
     }
 
     auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
@@ -872,8 +872,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
 
     for (size_t i = 0; i < nodes_count; ++i) {
-        const VkDeviceAddress addr =
-            storage_buffers.emplace_back(vkt::Buffer(*m_device, storage_buffer_size, 0, vkt::device_address)).address();
+        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
         uniform_buffer_ptr[i] = addr;
     }
 
@@ -1124,11 +1123,11 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
     std::vector<vkt::CommandBuffer> cmd_buffers;
     std::vector<vkt::Buffer> storage_buffers;
     for (int i = 0; i < 64; ++i) {
-        auto &cb = cmd_buffers.emplace_back(vkt::CommandBuffer(*m_device, m_command_pool));
+        auto &cb = cmd_buffers.emplace_back(*m_device, m_command_pool);
 
         // Create a storage buffer and get its address,
         // effectively adding it to the BDA table
-        auto &storage_buffer = storage_buffers.emplace_back(vkt::Buffer(*m_device, storage_buffer_size, 0, vkt::device_address));
+        auto &storage_buffer = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address);
 
         auto storage_buffer_addr = storage_buffer.address();
 

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -369,36 +369,36 @@ TEST_F(NegativeMesh, RuntimeSpirv) {
     uint32_t max_mesh_workgroup_size_z = mesh_shader_properties.maxMeshWorkGroupSize[2];
 
     if (max_task_workgroup_size_x < vvl::MaxTypeValue(max_task_workgroup_size_x)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07291");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07291");
         max_task_workgroup_size_x += 1;
     }
 
     if (max_task_workgroup_size_y < vvl::MaxTypeValue(max_task_workgroup_size_y)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07292");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07292");
         max_task_workgroup_size_y += 1;
     }
 
     if (max_task_workgroup_size_z < vvl::MaxTypeValue(max_task_workgroup_size_z)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07293");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07293");
         max_task_workgroup_size_z += 1;
     }
-    error_vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07294");
+    error_vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07294");
 
     if (max_mesh_workgroup_size_x < vvl::MaxTypeValue(max_mesh_workgroup_size_x)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07295");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07295");
         max_mesh_workgroup_size_x += 1;
     }
 
     if (max_mesh_workgroup_size_y < vvl::MaxTypeValue(max_mesh_workgroup_size_y)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07296");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07296");
         max_mesh_workgroup_size_y += 1;
     }
 
     if (max_mesh_workgroup_size_z < vvl::MaxTypeValue(max_mesh_workgroup_size_z)) {
-        error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07297");
+        error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07297");
         max_mesh_workgroup_size_z += 1;
     }
-    error_vuids.push_back("VUID-RuntimeSpirv-MeshEXT-07298");
+    error_vuids.emplace_back("VUID-RuntimeSpirv-MeshEXT-07298");
 
     std::string task_src = R"(
                OpCapability MeshShadingEXT
@@ -1290,7 +1290,7 @@ TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
     };
     std::vector<std::string> vuids = {"VUID-RuntimeSpirv-TaskEXT-07299"};
     if (mesh_shader_properties.maxMeshWorkGroupCount[0] == mesh_shader_properties.maxMeshWorkGroupTotalCount) {
-        vuids.push_back("VUID-RuntimeSpirv-TaskEXT-07302");
+        vuids.emplace_back("VUID-RuntimeSpirv-TaskEXT-07302");
     }
     if (mesh_shader_properties.maxMeshWorkGroupCount[0] != std::numeric_limits<uint32_t>::max()) {
         CreatePipelineHelper::OneshotTest(*this, mesh_tasks_x, kErrorBit, vuids);

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -3156,9 +3156,9 @@ TEST_F(NegativeSyncVal, RenderPassAsyncHazard) {
     dst_img_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
 
     std::vector<std::unique_ptr<vkt::Image>> images;
-    images.emplace_back(new vkt::Image(*m_device, src_img_info));
+    images.emplace_back(std::make_unique<vkt::Image>(*m_device, src_img_info));
     for (uint32_t i = 1; i < kNumImages; i++) {
-        images.emplace_back(new vkt::Image(*m_device, dst_img_info));
+        images.emplace_back(std::make_unique<vkt::Image>(*m_device, dst_img_info));
     }
 
     vkt::ImageView attachment_wrappers[kNumImages];


### PR DESCRIPTION
Basic attempt to use `emplace_back` where it should have an obvious benefits

prepared to criticism and "well technically in c++... " responses :shield: 