### PR TITLE
Improve buffer copy validation perf

### DIFF
--- a/layers/state_tracker/device_memory_state.h
+++ b/layers/state_tracker/device_memory_state.h
@@ -155,6 +155,7 @@ class BindableLinearMemoryTracker : public BindableMemoryTracker {
                     VkDeviceSize resource_offset, VkDeviceSize size) override;
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+    // No need to have this overload for linear memory
     BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const override {
         assert(false);
         return {};
@@ -216,6 +217,7 @@ class BindableMultiplanarMemoryTracker : public BindableMemoryTracker {
                     VkDeviceSize resource_offset, VkDeviceSize size) override;
 
     BoundMemoryRange GetBoundMemoryRange(const MemoryRange &range) const override;
+    // No reason to have this function for multi planar memory
     BoundRanges GetBoundRanges(const BufferRange &ranges_bounds, const std::vector<BufferRange> &ranges) const override {
         assert(false);
         return {};


### PR DESCRIPTION
Took care of the sparse buffer case, this PR modifies validation for non sparse buffers.
For 1000 copies, went from **24 seconds** down to **0.5 ms**. Perf gains seem even better than what I got in the sparse case