### PR TITLE
layers: Remove unused includes

### DIFF
--- a/layers/containers/subresource_adapter.h
+++ b/layers/containers/subresource_adapter.h
@@ -20,8 +20,6 @@
  */
 #pragma once
 
-#include <algorithm>
-#include <array>
 #include <vector>
 #include "range_vector.h"
 #include "custom_containers.h"

--- a/layers/core_checks/cc_buffer.cpp
+++ b/layers/core_checks/cc_buffer.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <string>
-#include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>
 #include "generated/chassis.h"

--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -23,7 +23,6 @@
 
 #include <array>
 #include <functional>
-#include <iterator>
 #include <string>
 #include <string_view>
 

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -17,8 +17,6 @@
  * limitations under the License.
  */
 
-#include <sstream>
-
 #include <vulkan/vk_enum_string_helper.h>
 #include "generated/chassis.h"
 #include "core_validation.h"

--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -27,7 +27,6 @@
 #include "state_tracker/ray_tracing_state.h"
 #include "state_tracker/shader_module.h"
 #include "cc_buffer_address.h"
-#include "generated/spirv_grammar_helper.h"
 #include "drawdispatch/descriptor_validator.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 

--- a/layers/core_checks/cc_device.cpp
+++ b/layers/core_checks/cc_device.cpp
@@ -29,10 +29,8 @@
 #include <vulkan/vk_enum_string_helper.h>
 #include "generated/chassis.h"
 #include "core_validation.h"
-#include "state_tracker/shader_stage_state.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/device_state.h"
-#include "state_tracker/buffer_state.h"
 #include "state_tracker/render_pass_state.h"
 #include <spirv-tools/libspirv.h>
 

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -20,7 +20,6 @@
 #include "generated/chassis.h"
 #include "drawdispatch/drawdispatch_vuids.h"
 #include "core_validation.h"
-#include "state_tracker/image_state.h"
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/shader_object_state.h"
 #include "state_tracker/descriptor_sets.h"

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -29,7 +29,6 @@
 #include "drawdispatch/drawdispatch_vuids.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/buffer_state.h"
-#include "state_tracker/shader_object_state.h"
 #include "chassis/chassis_modification_state.h"
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/render_pass_state.h"

--- a/layers/core_checks/cc_queue.cpp
+++ b/layers/core_checks/cc_queue.cpp
@@ -18,7 +18,6 @@
  */
 
 #include <string>
-#include <sstream>
 #include <vector>
 
 #include <vulkan/vk_enum_string_helper.h>

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -19,7 +19,6 @@
 
 #include <algorithm>
 #include <assert.h>
-#include <sstream>
 #include <string>
 
 #include <vulkan/vk_enum_string_helper.h>

--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -31,6 +31,7 @@
 #include "chassis/chassis_modification_state.h"
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/render_pass_state.h"
+#include "spirv-tools/optimizer.hpp"
 
 // Validate use of input attachments against subpass structure
 bool CoreChecks::ValidateShaderInputAttachment(const spirv::Module &module_state, const vvl::Pipeline &pipeline,

--- a/layers/error_message/error_location.cpp
+++ b/layers/error_message/error_location.cpp
@@ -16,8 +16,6 @@
  * limitations under the License.
  */
 #include "error_location.h"
-#include "utils/vk_layer_utils.h"
-#include <map>
 
 void Location::AppendFields(std::ostream& out) const {
     if (prev) {

--- a/layers/error_message/error_location.h
+++ b/layers/error_message/error_location.h
@@ -19,7 +19,6 @@
 
 #include <cstdint>
 #include <string>
-#include <limits>
 
 #include "generated/error_location_helper.h"
 #include "logging.h"

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -27,6 +27,7 @@
 #include "generated/vk_validation_error_messages.h"
 #include "error_location.h"
 #include "utils/hash_util.h"
+#include "vk_layer_config.h"
 
 [[maybe_unused]] const char *kVUIDUndefined = "VUID_Undefined";
 

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -20,7 +20,6 @@
 #include <array>
 #include <cstdarg>
 #include <mutex>
-#include <sstream>
 #include <string>
 #include <string_view>
 #include <vector>

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
@@ -19,7 +19,6 @@
 
 #include "gpu/core/gpuav.h"
 #include "gpu/core/gpuav_constants.h"
-#include "gpu/resources/gpu_resources.h"
 #include "gpu/shaders/gpu_shaders_constants.h"
 
 #include "state_tracker/descriptor_sets.h"

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -21,7 +21,6 @@
 #include "gpu/resources/gpu_resources.h"
 #include "gpu/instrumentation/gpu_shader_instrumentor.h"
 
-#include <unordered_map>
 #include <memory>
 
 namespace chassis {

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -17,7 +17,6 @@
 
 #include <cmath>
 #include <fstream>
-#include "utils/cast_utils.h"
 #include "utils/hash_util.h"
 #include "gpu/core/gpuav.h"
 #include "gpu/cmd_validation/gpuav_draw.h"
@@ -29,7 +28,6 @@
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/instrumentation/gpuav_instrumentation.h"
 #include "gpu/shaders/gpu_shaders_constants.h"
-#include "generated/layer_chassis_dispatch.h"
 #include "chassis/chassis_modification_state.h"
 
 // Generated shaders

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -20,19 +20,10 @@
 #if defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__GNU__)
 #include <unistd.h>
 #endif
-#include "utils/cast_utils.h"
-#include "state_tracker/shader_stage_state.h"
-#include "utils/hash_util.h"
 #include "gpu/core/gpuav_constants.h"
-#include "gpu/error_message/gpuav_vuids.h"
 #include "gpu/core/gpuav.h"
 #include "gpu/resources/gpuav_subclasses.h"
-#include "state_tracker/device_state.h"
-#include "state_tracker/shader_object_state.h"
-#include "spirv-tools/instrument.hpp"
-#include "spirv-tools/linker.hpp"
 #include "generated/layer_chassis_dispatch.h"
-#include "containers/custom_containers.h"
 #include "gpu/shaders/gpu_error_header.h"
 #include "gpu/shaders/gpu_shaders_constants.h"
 #include "generated/chassis.h"

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -22,8 +22,6 @@
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/resources/gpu_shader_resources.h"
 
-#include "profiling/profiling.h"
-
 namespace gpuav {
 void UpdateBoundPipeline(Validator &gpuav, VkCommandBuffer cb, VkPipelineBindPoint pipeline_bind_point, VkPipeline pipeline,
                          const Location &loc) {

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -21,7 +21,6 @@
 #include "gpu/core/gpuav.h"
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/cmd_validation/gpuav_copy_buffer_to_image.h"
-#include "generated/spirv_grammar_helper.h"
 #include "utils/image_layout_utils.h"
 #include "state_tracker/render_pass_state.h"
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -21,6 +21,7 @@
 #include "gpu/spirv/module.h"
 #include "chassis/chassis_modification_state.h"
 #include "gpu/shaders/gpu_error_codes.h"
+#include "spirv-tools/optimizer.hpp"
 
 #include <regex>
 #include <fstream>

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -22,8 +22,6 @@
 #include "gpu/error_message/gpuav_vuids.h"
 #include "gpu/resources/gpu_shader_resources.h"
 #include "gpu/shaders/gpu_error_header.h"
-#include "state_tracker/shader_stage_state.h"
-#include "spirv-tools/optimizer.hpp"
 
 namespace gpuav {
 

--- a/layers/gpu/resources/gpu_resources.cpp
+++ b/layers/gpu/resources/gpu_resources.cpp
@@ -18,7 +18,7 @@
 #include "gpu/resources/gpu_resources.h"
 
 #include "generated/layer_chassis_dispatch.h"
-#include "utils/vk_layer_utils.h"
+#include <vulkan/utility/vk_struct_helper.hpp>
 
 namespace gpu {
 

--- a/layers/gpu/resources/gpu_resources.h
+++ b/layers/gpu/resources/gpu_resources.h
@@ -18,11 +18,8 @@
 #pragma once
 
 #include "containers/custom_containers.h"
-#include "error_message/logging.h"
-#include "generated/error_location_helper.h"
 #include "vma/vma.h"
 
-#include <optional>
 #include <unordered_map>
 #include <utility>
 #include <vector>

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -21,7 +21,6 @@
 #include "gpu/core/gpuav.h"
 #include "gpu/core/gpuav_constants.h"
 #include "gpu/descriptor_validation/gpuav_image_layout.h"
-#include "gpu/error_message/gpuav_vuids.h"
 #include "gpu/descriptor_validation/gpuav_descriptor_validation.h"
 #include "gpu/shaders/gpu_error_header.h"
 

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -23,7 +23,6 @@
 #include "gpu/core/gpu_state_tracker.h"
 #include "gpu/descriptor_validation/gpuav_descriptor_set.h"
 #include "gpu/resources/gpu_resources.h"
-#include "generated/vk_object_types.h"
 
 // We pull in most the core state tracking files
 // gpuav_subclasses.h should NOT be included by any other header file

--- a/layers/gpu/spirv/instruction.cpp
+++ b/layers/gpu/spirv/instruction.cpp
@@ -15,7 +15,6 @@
 
 #include "instruction.h"
 #include "generated/spirv_grammar_helper.h"
-#include "module.h"
 
 namespace gpu {
 namespace spirv {

--- a/layers/gpu/spirv/module.h
+++ b/layers/gpu/spirv/module.h
@@ -16,7 +16,6 @@
 
 #include <stdint.h>
 #include <vector>
-#include <memory>
 #include "link.h"
 #include "instruction.h"
 #include "function_basic_block.h"

--- a/layers/gpu/spirv/type_manager.h
+++ b/layers/gpu/spirv/type_manager.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include <vector>
-#include <list>
 #include "instruction.h"
 #include "generated/spirv_grammar_helper.h"
 

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -18,7 +18,6 @@
  * limitations under the License.
  */
 #pragma once
-#include "utils/hash_vk_types.h"
 #include "state_tracker/state_object.h"
 #include "state_tracker/image_layout_map.h"
 #include "state_tracker/pipeline_state.h"

--- a/layers/state_tracker/descriptor_sets.h
+++ b/layers/state_tracker/descriptor_sets.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include "state_tracker/state_object.h"
-#include "utils/hash_vk_types.h"
+#include "utils/hash_util.h"
 #include "utils/vk_layer_utils.h"
 #include "state_tracker/shader_stage_state.h"
 #include "generated/vk_object_types.h"

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 #include "state_tracker/device_memory_state.h"
-#include "state_tracker/image_state.h"
 
 #include <algorithm>
 
@@ -373,4 +372,3 @@ void vvl::Bindable::CacheInvalidMemory() const {
         }
     }
 }
-

--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -22,7 +22,6 @@
 #include "state_tracker/state_object.h"
 #include "state_tracker/submission_reference.h"
 #include <future>
-#include <mutex>
 
 class ValidationStateTracker;
 

--- a/layers/state_tracker/image_layout_map.h
+++ b/layers/state_tracker/image_layout_map.h
@@ -21,8 +21,6 @@
 #pragma once
 
 #include <functional>
-#include <memory>
-#include <vector>
 
 #include "containers/range_vector.h"
 #include "containers/subresource_adapter.h"

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -21,8 +21,6 @@
 #include "state_tracker/pipeline_state.h"
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/shader_module.h"
-#include <limits>
-#include <string_view>
 
 static VkImageSubresourceRange MakeImageFullRange(const VkImageCreateInfo &create_info) {
     const auto format = create_info.format;

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -19,7 +19,6 @@
  */
 #pragma once
 
-#include <utility>
 #include <variant>
 
 #include "state_tracker/device_memory_state.h"

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -21,7 +21,6 @@
 
 #include <vulkan/utility/vk_safe_struct.hpp>
 
-#include "utils/hash_vk_types.h"
 #include "state_tracker/pipeline_sub_state.h"
 #include "generated/dynamic_state_helper.h"
 #include "utils/shader_utils.h"

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -21,7 +21,7 @@
 #include "state_tracker/submission_reference.h"
 #include <future>
 #include <map>
-#include <mutex>
+#include <shared_mutex>
 #include "containers/custom_containers.h"
 #include "error_message/error_location.h"
 

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -13,8 +13,8 @@
  * limitations under the License.
  */
 
+#include <sstream>
 #include "state_tracker/shader_instruction.h"
-#include "state_tracker/shader_module.h"
 #include "generated/spirv_grammar_helper.h"
 
 namespace spirv {

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <string>
 #include <vector>

--- a/layers/state_tracker/shader_module.cpp
+++ b/layers/state_tracker/shader_module.cpp
@@ -19,8 +19,7 @@
 #include <string>
 #include <queue>
 
-#include "state_tracker/pipeline_state.h"
-#include "state_tracker/descriptor_sets.h"
+#include "utils/hash_util.h"
 #include "generated/spirv_grammar_helper.h"
 #include "spirv/1.2/GLSL.std.450.h"
 

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -26,7 +26,6 @@
 #include "state_tracker/state_object.h"
 #include "state_tracker/sampler_state.h"
 #include <spirv/unified1/spirv.hpp>
-#include "spirv-tools/optimizer.hpp"
 
 namespace vvl {
 class Pipeline;

--- a/layers/state_tracker/shader_stage_state.h
+++ b/layers/state_tracker/shader_stage_state.h
@@ -17,7 +17,8 @@
  */
 
 #pragma once
-#include "utils/vk_layer_utils.h"
+#include <vulkan/vulkan.h>
+#include "containers/custom_containers.h"
 
 namespace vku {
 struct safe_VkPipelineShaderStageCreateInfo;

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -40,6 +40,7 @@
 #include "state_tracker/ray_tracing_state.h"
 #include "state_tracker/shader_object_state.h"
 #include "chassis/chassis_modification_state.h"
+#include "spirv-tools/optimizer.hpp"
 
 // NOTE:  Beware the lifespan of the rp_begin when holding  the return.  If the rp_begin isn't a "safe" copy, "IMAGELESS"
 //        attachments won't persist past the API entry point exit.

--- a/layers/utils/cast_utils.h
+++ b/layers/utils/cast_utils.h
@@ -1,6 +1,6 @@
-/* Copyright (c) 2019 The Khronos Group Inc.
- * Copyright (c) 2019-2023 Valve Corporation
- * Copyright (c) 2019-2023 LunarG, Inc.
+/* Copyright (c) 2019-2024 The Khronos Group Inc.
+ * Copyright (c) 2019-2024 Valve Corporation
+ * Copyright (c) 2019-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,11 +17,9 @@
 #pragma once
 
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <cstring>
 #include <type_traits>
-#include <functional>
 
 #define CAST_TO_FROM_UTILS
 // Casts to allow various types of less than 64 bits to be cast to and from uint64_t safely and portably

--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include "test_common.h"
-#include <unordered_set>
 #include <regex>
 
 // ErrorMonitor Usage:

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -10,11 +10,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "layer_validation_tests.h"
-#include "pipeline_helper.h"
-#include "utils/vk_layer_utils.h"
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 #include "wayland-client.h"

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -36,15 +36,11 @@
 #include "utils/convert_utils.h"
 #include "shader_templates.h"
 
-#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <limits>
-#include <memory>
 #include <string>
-#include <unordered_set>
 #include <vector>
-#include <condition_variable>
 
 using std::string;
 using std::vector;

--- a/tests/framework/test_common.h
+++ b/tests/framework/test_common.h
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2022 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <thread>
 
 #include "error_message/logging.h"
 

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "test_framework.h"
-#include "render.h"
 #include CONFIG_HEADER_FILE
 #include <filesystem>
 #include <cmath>

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -12,7 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -11,11 +11,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
 #include "../framework/thread_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveCommand : public VkLayerTest {};
 

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -11,12 +11,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
-
-#include "generated/vk_extension_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
 class PositiveDescriptors : public VkLayerTest {};

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -13,8 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/render_pass_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void DynamicRenderingTest::InitBasicDynamicRenderingLocalRead() {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -13,8 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class NegativeGpuAVIndirectBuffer : public GpuAVTest {};
 

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 #include "../layers/gpu/shaders/gpu_shaders_constants.h"
 
 class NegativeGpuAVOOB : public GpuAVTest {

--- a/tests/unit/gpu_av_oob_positive.cpp
+++ b/tests/unit/gpu_av_oob_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class PositiveGpuAVOOB : public GpuAVTest {};
 

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -18,7 +18,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 #include "../framework/ray_tracing_objects.h"
 #include "../../layers/gpu/shaders/gpu_shaders_constants.h"
 

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -13,7 +13,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class NegativeGpuAVShaderDebugInfo : public GpuAVBufferDeviceAddressTest {
   public:

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -18,7 +18,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class PositiveGpuAVSpirv : public GpuAVTest {};
 

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveInstance : public VkLayerTest {};
 

--- a/tests/unit/layer_utils_positive.cpp
+++ b/tests/unit/layer_utils_positive.cpp
@@ -11,7 +11,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 #include "utils/vk_layer_utils.h"
 
 class PositiveLayerUtils : public VkLayerTest {};

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
 #ifndef VK_USE_PLATFORM_WIN32_KHR

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 
 #ifndef VK_USE_PLATFORM_WIN32_KHR

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -13,7 +13,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/barrier_queue_family.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -11,11 +11,11 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 #include "../framework/barrier_queue_family.h"
 #include "../framework/render_pass_helper.h"
-#include "generated/vk_extension_helper.h"
 
 #ifndef VK_USE_PLATFORM_WIN32_KHR
 #include <poll.h>

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 
 struct PositiveSyncValWsi : public VkSyncValTest {};

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -12,6 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/thread_helper.h"

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -12,6 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
+#include <thread>
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/thread_helper.h"


### PR DESCRIPTION
Installed the new Zed editor for Linux, tried it out, found some unused `#include` and spent some time removing them to hopefully improve compiling speed a bit (and keep things more tidy)