### PR TITLE
tests: Remove unused includes

### DIFF
--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -23,9 +23,11 @@
 #include <iterator>
 #include <memory>
 #include <vector>
+#include <optional>
 
+#include "containers/custom_containers.h"
 #include "generated/vk_function_pointers.h"
-#include "generated/vk_extension_helper.h"
+#include "utils/cast_utils.h"
 #include "test_common.h"
 
 namespace vkt {

--- a/tests/framework/error_monitor.cpp
+++ b/tests/framework/error_monitor.cpp
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 #include "error_monitor.h"
+#include "test_common.h"
+#include "generated/vk_function_pointers.h"
 
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
 // Note. VK_EXT_debug_report is deprecated by the VK_EXT_debug_utils extension.

--- a/tests/framework/error_monitor.h
+++ b/tests/framework/error_monitor.h
@@ -17,8 +17,13 @@
  */
 #pragma once
 
-#include "test_common.h"
+#include <atomic>
+#include <mutex>
 #include <regex>
+#include <cassert>
+
+#include "vk_layer_config.h"
+#include <vulkan/vulkan.h>
 
 // ErrorMonitor Usage:
 //

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -30,6 +30,7 @@
 #include <vulkan/utility/vk_struct_helper.hpp>
 
 #include "test_common.h"
+#include "binding.h"
 #include "containers/custom_containers.h"
 #include "generated/vk_extension_helper.h"
 #include "render.h"

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "queue_submit_context.h"
-#include "render.h"
 
 QSTestContext::QSTestContext(vkt::Device* device, vkt::Queue* force_q0, vkt::Queue* force_q1)
     : dev(device), q0(VK_NULL_HANDLE), q1(VK_NULL_HANDLE) {

--- a/tests/framework/queue_submit_context.h
+++ b/tests/framework/queue_submit_context.h
@@ -12,7 +12,9 @@
  */
 
 #pragma once
-#include "test_common.h"
+
+#include <vulkan/vulkan.h>
+#include "binding.h"
 
 struct QSTestContext {
     vkt::Device* dev;

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -13,8 +13,6 @@
 
 #include "utils/vk_layer_utils.h"
 
-#include <iostream>
-
 namespace vkt {
 namespace as {
 
@@ -1348,7 +1346,7 @@ void Pipeline::BuildSbt() {
 
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     test_.GetPhysicalDeviceProperties2(rt_pipeline_props);
-    
+
     // Allocate buffer to store SBT, and fill it with sbt_host_storage
     VkBufferCreateInfo sbt_buffer_info = vku::InitStructHelper();
     sbt_buffer_info.size = Align<VkDeviceSize>(sbt_host_storage.size() + 2 * rt_pipeline_props.shaderGroupBaseAlignment, 4096);
@@ -1426,7 +1424,7 @@ vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt() {
 
     VkStridedDeviceAddressRegionKHR closest_hit_sbt{};
     if (!closest_hit_shaders_.empty()) {
-        sbt_offseted_address = Align<VkDeviceAddress>(sbt_offseted_address, rt_pipeline_props.shaderGroupBaseAlignment);        
+        sbt_offseted_address = Align<VkDeviceAddress>(sbt_offseted_address, rt_pipeline_props.shaderGroupBaseAlignment);
         closest_hit_sbt.deviceAddress = sbt_offseted_address;
         closest_hit_sbt.stride = handle_size_aligned;
         closest_hit_sbt.size = closest_hit_shaders_.size() * handle_size_aligned;

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -25,7 +25,6 @@
 #include <vulkan/utility/vk_format_utils.h>
 
 #include "generated/vk_extension_helper.h"
-#include "utils/vk_layer_utils.h"
 #include "layer_validation_tests.h"
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -18,22 +18,17 @@
 
 #pragma once
 
-#include "generated/vk_function_pointers.h"
 #include "error_monitor.h"
 #include "test_framework.h"
 #include "feature_requirements.h"
+#include "binding.h"
 
 #if defined(VK_USE_PLATFORM_ANDROID_KHR)
 #include <android/log.h>
 #include <android_native_app_glue.h>
 #endif
 
-#include <algorithm>
-#include <array>
-#include <memory>
 #include <vector>
-#include <unordered_map>
-#include <unordered_set>
 
 using vkt::MakeVkHandles;
 

--- a/tests/framework/test_common.h
+++ b/tests/framework/test_common.h
@@ -17,16 +17,9 @@
  */
 #pragma once
 
-#include <cassert>
-#include <cstdio>
-#include <cstdlib>
-#include <cstring>
-
-#include "error_message/logging.h"
-
 #include <vulkan/vulkan.h>
-
 #include <vulkan/vk_enum_string_helper.h>
+#include <vulkan/utility/vk_struct_helper.hpp>
 
 // GTest and Xlib collide due to redefinitions of "None" and "Bool"
 #ifdef VK_USE_PLATFORM_XLIB_KHR
@@ -49,8 +42,6 @@
 #define RETURN_IF_SKIP(function) \
     function;                    \
     if (::testing::Test::IsSkipped()) return;
-
-#include "binding.h"
 
 // Stream operator for VkResult so GTEST will print out error codes as strings (automatically)
 inline std::ostream& operator<<(std::ostream& os, const VkResult& result) { return os << string_VkResult(result); }

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "test_framework.h"
+#include "vk_layer_config.h"
+#include "generated/vk_function_pointers.h"
 #include CONFIG_HEADER_FILE
 #include <filesystem>
 #include <cmath>

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -21,13 +21,8 @@
 #include <glslang/Public/ShaderLang.h>
 #include "test_common.h"
 
-#include <fstream>
-#include <iostream>
-#include <list>
 #include <stdbool.h>
-#include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
 
 #ifdef _WIN32
 #include <windows.h>

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -12,7 +12,6 @@
 #pragma once
 
 #include "layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 #include <vk_video/vulkan_video_codecs_common.h>
 #include <vk_video/vulkan_video_codec_h264std.h>
 #include <vk_video/vulkan_video_codec_h264std_decode.h>
@@ -23,7 +22,6 @@
 
 #include <memory>
 #include <vector>
-#include <tuple>
 #include <functional>
 #include <math.h>
 

--- a/tests/icd/test_icd.cpp
+++ b/tests/icd/test_icd.cpp
@@ -14,6 +14,7 @@
 ** limitations under the License.
 */
 
+#include <algorithm>
 #include "test_icd.h"
 #include "test_icd_helper.h"
 #include <vulkan/utility/vk_format_utils.h>

--- a/tests/icd/test_icd.h
+++ b/tests/icd/test_icd.h
@@ -19,12 +19,10 @@
 #include <stdlib.h>
 #include <cstring>
 
-#include <algorithm>
 #include <array>
 #include <mutex>
 #include <unordered_set>
 #include <unordered_map>
-#include <string>
 #include <vector>
 
 #include "vulkan/vulkan.h"

--- a/tests/spirv/instrumentation.cpp
+++ b/tests/spirv/instrumentation.cpp
@@ -12,7 +12,6 @@
 #include <iostream>
 #include <filesystem>
 #include <vector>
-#include <memory>
 #include <cstring>
 #include <chrono>
 

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -11,7 +11,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -11,7 +11,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -13,7 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveAtomic : public VkLayerTest {};
 

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -12,12 +12,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
-#include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "utils/vk_layer_utils.h"
 
 class NegativeBuffer : public VkLayerTest {};
 

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/barrier_queue_family.h"
 #include "../framework/pipeline_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveBuffer : public VkLayerTest {};
 

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -12,8 +12,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class NegativeDebugPrintfShaderDebugInfo : public DebugPrintfTests {};
 

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -14,7 +14,6 @@
  *
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void DynamicRenderingTest::InitBasicDynamicRendering() {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void DynamicStateTest::InitBasicExtendedDynamicState() {
     AddRequiredExtensions(VK_EXT_EXTENDED_DYNAMIC_STATE_EXTENSION_NAME);

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 #include "../layers/containers/range_vector.h"
 
 class NegativeGpuAVBufferDeviceAddress : public GpuAVBufferDeviceAddressTest {};

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 void GpuAVBufferDeviceAddressTest::InitGpuVUBufferDeviceAddress(void *p_next) {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 #include "../layers/gpu/shaders/gpu_shaders_constants.h"
 

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -18,8 +18,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
-#include "../../layers/gpu/shaders/gpu_shaders_constants.h"
 
 void GpuAVDescriptorIndexingTest::InitGpuVUDescriptorIndexing() {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_4_EXTENSION_NAME);

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -18,9 +18,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 #include "../framework/ray_tracing_objects.h"
-#include "../../layers/gpu/shaders/gpu_shaders_constants.h"
 
 void GpuAVRayQueryTest::InitGpuAVRayQuery() {
     SetTargetApiVersion(VK_API_VERSION_1_2);

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -12,10 +12,8 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "../framework/ray_tracing_objects.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/shader_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class NegativeGpuAVRayTracing : public GpuAVRayTracingTest {};
 

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -12,7 +12,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/shader_object_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class PositiveGpuAVShaderObject : public GpuAVTest {
   public:

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -18,7 +18,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "../framework/gpu_av_helper.h"
 
 class NegativeGpuAVSpirv : public GpuAVTest {};
 

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class NegativeGraphicsLibrary : public GraphicsLibraryTest {};
 

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void GraphicsLibraryTest::InitBasicGraphicsLibrary() {
     AddRequiredExtensions(VK_EXT_GRAPHICS_PIPELINE_LIBRARY_EXTENSION_NAME);

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -12,8 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "utils/vk_layer_utils.h"
-#include "generated/enum_flag_bits.h"
 
 class NegativeHostImageCopy : public HostImageCopyTest {};
 

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "utils/vk_layer_utils.h"
 
 bool HostImageCopyTest::CopyLayoutSupported(const std::vector<VkImageLayout> &src_layouts,
                                             const std::vector<VkImageLayout> &dst_layouts, VkImageLayout layout) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -16,7 +16,6 @@
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
 #include "../framework/barrier_queue_family.h"
-#include "generated/vk_extension_helper.h"
 
 #include "utils/vk_layer_utils.h"
 

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -13,7 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveMesh : public VkLayerTest {};
 

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -14,7 +14,6 @@
 #include <chrono>
 #include <thread>
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/ray_tracing_objects.h"

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -1067,7 +1067,7 @@ TEST_F(NegativeObjectLifetime, ImportWin32SemaphoreInUse) {
 
     // Try to import Win32 handle while semaphore is still in use
     // Waiting for: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3507
-    m_errorMonitor->SetDesiredError(kVUIDUndefined);
+    m_errorMonitor->SetDesiredError("VUID_Undefined");
     semaphore.import_handle(handle, handle_type);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -12,11 +12,8 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "utils/vk_layer_utils.h"
 #include "utils/hash_util.h"
 #include "generated/vk_validation_error_messages.h"
 

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -9,8 +9,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/shader_helper.h"
 #include "../framework/pipeline_helper.h"

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -15,7 +15,6 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositivePipeline : public VkLayerTest {};
 

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -10,7 +10,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 
 class PositiveProtectedMemory : public VkLayerTest {};

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -13,7 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "generated/vk_extension_helper.h"
 
 bool QueryTest::HasZeroTimestampValidBits() {
     uint32_t queue_count;

--- a/tests/unit/ray_tracing_pipeline_positive.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "../framework/pipeline_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
 class PositiveRayTracingPipeline : public RayTracingTest {};

--- a/tests/unit/ray_tracing_pipeline_positive_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_positive_nv.cpp
@@ -13,7 +13,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/ray_tracing_helper_nv.h"
-#include "../framework/pipeline_helper.h"
 
 class PositiveRayTracingPipelineNV : public RayTracingTest {};
 

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -15,7 +15,6 @@
 #include "../framework/ray_tracing_objects.h"
 #include "../framework/shader_helper.h"
 #include "../framework/feature_requirements.h"
-#include "generated/vk_extension_helper.h"
 #include "../layers/utils/vk_layer_utils.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/pipeline_helper.h"

--- a/tests/unit/robustness.cpp
+++ b/tests/unit/robustness.cpp
@@ -10,7 +10,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/robustness_positive.cpp
+++ b/tests/unit/robustness_positive.cpp
@@ -13,7 +13,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveRobustness : public VkLayerTest {};
 

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -12,8 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/sampler_positive.cpp
+++ b/tests/unit/sampler_positive.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveSampler : public VkLayerTest {};
 

--- a/tests/unit/shader_cooperative_matrix.cpp
+++ b/tests/unit/shader_cooperative_matrix.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -14,7 +14,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/descriptor_helper.h"
 
 class NegativeShaderLimits : public VkLayerTest {};
 

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -14,7 +14,6 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "../framework/render_pass_helper.h"
 
 struct icd_spv_header {
     uint32_t magic = 0x07230203;

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -13,7 +13,6 @@
  */
 
 #include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 
 class NegativeSparseBuffer : public VkLayerTest {};

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -12,9 +12,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "utils/vk_layer_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/external_memory_sync.h"
 

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -13,7 +13,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -11,9 +11,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include <type_traits>
-
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 
 class NegativeTooling : public VkLayerTest {};
 

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -12,7 +12,6 @@
  */
 
 #include "../framework/layer_validation_tests.h"
-#include "generated/vk_extension_helper.h"
 
 class PositiveTooling : public VkLayerTest {};
 

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -12,7 +12,6 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -10,7 +10,6 @@
  */
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void WsiTest::SetImageLayoutPresentSrc(VkImage image) {
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -12,12 +12,9 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 
-#include "utils/cast_utils.h"
-#include "generated/enum_flag_bits.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/pipeline_helper.h"
-#include "utils/vk_layer_utils.h"
 
 class NegativeYcbcr : public YcbcrTest {};
 

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -14,7 +14,6 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
-#include "generated/vk_extension_helper.h"
 
 void YcbcrTest::InitBasicYcbcr(void *pNextFeatures) {
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/vvl_utils/small_vector.cpp
+++ b/tests/vvl_utils/small_vector.cpp
@@ -11,6 +11,16 @@
  */
 
 #include "../framework/test_common.h"
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <array>
+#include <cstdarg>
+#include <vector>
+
+#include <vulkan/utility/vk_struct_helper.hpp>
+#include "containers/custom_containers.h"
 
 template <typename T, typename U>
 bool HaveSameElementsUpTo(const T& l1, const U& l2, size_t n) {


### PR DESCRIPTION
One more "remove unused includes" this time focused on `./tests` only ... we had a lot of random stuff shoved in `test_common.h` that I have always wanted to clean up and just needed a better tool to help