### PR TITLE
layers: Remove gpuav_debug_disable_all from vkconfig

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1232,6 +1232,7 @@
                                                     "label": "Disable all of GPU-AV",
                                                     "description": "Acts as a VkValidationFeatureDisableEXT to override the VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_EXT passed by the user",
                                                     "type": "BOOL",
+                                                    "view": "HIDDEN",
                                                     "default": false,
                                                     "platforms": [
                                                         "WINDOWS",


### PR DESCRIPTION
`VK_LAYER_GPUAV_DEBUG_DISABLE_ALL` is designed for dealing with apps that have explicitly set GPU-AV on and has no reason to be seen in `VkConfig` 