### PR TITLE
spirv: Create dedicated InjectConditionalFunctionPass class

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -197,6 +197,8 @@ vvl_sources = [
   "layers/gpu/spirv/link.h",
   "layers/gpu/spirv/module.cpp",
   "layers/gpu/spirv/module.h",
+  "layers/gpu/spirv/inject_conditional_function_pass.cpp",
+  "layers/gpu/spirv/inject_conditional_function_pass.h",
   "layers/gpu/spirv/inject_function_pass.cpp",
   "layers/gpu/spirv/inject_function_pass.h",
   "layers/gpu/spirv/pass.cpp",

--- a/layers/gpu/spirv/CMakeLists.txt
+++ b/layers/gpu/spirv/CMakeLists.txt
@@ -36,6 +36,8 @@ target_sources(gpu_av_spirv PRIVATE
     module.cpp
     type_manager.h
     type_manager.cpp
+    inject_conditional_function_pass.h
+    inject_conditional_function_pass.cpp
     inject_function_pass.h
     inject_function_pass.cpp
     pass.h

--- a/layers/gpu/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu/spirv/bindless_descriptor_pass.cpp
@@ -119,7 +119,7 @@ uint32_t BindlessDescriptorPass::GetLastByte(BasicBlock& block, InstructionIt* i
                 // Get array stride and multiply by current index
                 uint32_t arr_stride = GetDecoration(current_type_id, spv::DecorationArrayStride)->Word(3);
                 const uint32_t arr_stride_id = module_.type_manager_.GetConstantUInt32(arr_stride).Id();
-                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block);
+                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block, inst_it);
 
                 current_offset_id = module_.TakeNextId();
                 block.CreateInstruction(spv::OpIMul, {uint32_type.Id(), current_offset_id, arr_stride_id, ac_index_id_32}, inst_it);
@@ -145,7 +145,7 @@ uint32_t BindlessDescriptorPass::GetLastByte(BasicBlock& block, InstructionIt* i
                     col_stride_id = module_.type_manager_.GetConstantUInt32(col_stride).Id();
                 }
 
-                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block);
+                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block, inst_it);
                 current_offset_id = module_.TakeNextId();
                 block.CreateInstruction(spv::OpIMul, {uint32_type.Id(), current_offset_id, col_stride_id, ac_index_id_32}, inst_it);
 
@@ -157,7 +157,7 @@ uint32_t BindlessDescriptorPass::GetLastByte(BasicBlock& block, InstructionIt* i
                 // If inside a row major matrix type, multiply index by matrix stride,
                 // else multiply by component size
                 const uint32_t component_type_id = current_type->inst_.Operand(0);
-                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block);
+                const uint32_t ac_index_id_32 = ConvertTo32(ac_index_id, block, inst_it);
                 if (in_matrix && !col_major) {
                     current_offset_id = module_.TakeNextId();
                     block.CreateInstruction(spv::OpIMul, {uint32_type.Id(), current_offset_id, matrix_stride_id, ac_index_id_32},
@@ -224,7 +224,7 @@ uint32_t BindlessDescriptorPass::CreateFunctionCall(BasicBlock& block, Instructi
                                                     const InjectionData& injection_data) {
     const Constant& set_constant = module_.type_manager_.GetConstantUInt32(descriptor_set_);
     const Constant& binding_constant = module_.type_manager_.GetConstantUInt32(descriptor_binding_);
-    const uint32_t descriptor_index_id = CastToUint32(descriptor_index_id_, block);  // might be int32
+    const uint32_t descriptor_index_id = CastToUint32(descriptor_index_id_, block, inst_it);  // might be int32
 
     if (image_inst_) {
         // Get Texel buffer offset
@@ -245,7 +245,7 @@ uint32_t BindlessDescriptorPass::CreateFunctionCall(BasicBlock& block, Instructi
                 const uint32_t arrayed = image_type->inst_.Operand(3);
                 const uint32_t ms = image_type->inst_.Operand(4);
                 if (depth == 0 && arrayed == 0 && ms == 0) {
-                    descriptor_offset_id_ = CastToUint32(target_instruction_->Operand(1), block);
+                    descriptor_offset_id_ = CastToUint32(target_instruction_->Operand(1), block, inst_it);
                 }
             }
         } else {

--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdint.h>
-#include "inject_function_pass.h"
+#include "inject_conditional_function_pass.h"
 
 namespace gpu {
 namespace spirv {
@@ -24,9 +24,9 @@ namespace spirv {
 // This pass instruments all bindless references to check that descriptor
 // array indices are inbounds, and if the descriptor indexing extension is
 // enabled, that the descriptor has been initialized.
-class BindlessDescriptorPass : public InjectFunctionPass {
+class BindlessDescriptorPass : public InjectConditionalFunctionPass {
   public:
-    BindlessDescriptorPass(Module& module) : InjectFunctionPass(module, true) {}
+    BindlessDescriptorPass(Module& module) : InjectConditionalFunctionPass(module) {}
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -15,7 +15,7 @@
 #pragma once
 
 #include <stdint.h>
-#include "inject_function_pass.h"
+#include "inject_conditional_function_pass.h"
 
 namespace gpu {
 namespace spirv {
@@ -23,9 +23,9 @@ namespace spirv {
 // Create a pass to instrument physical buffer address checking
 // This pass instruments all physical buffer address references to check that
 // all referenced bytes fall in a valid buffer.
-class BufferDeviceAddressPass : public InjectFunctionPass {
+class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
   public:
-    BufferDeviceAddressPass(Module& module) : InjectFunctionPass(module, true) {}
+    BufferDeviceAddressPass(Module& module) : InjectConditionalFunctionPass(module) {}
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/debug_printf_pass.cpp
+++ b/layers/gpu/spirv/debug_printf_pass.cpp
@@ -100,7 +100,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
                 block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
                 params.push_back(uconvert_low_id);
             } else {
-                assert(false && "unsupported for int width");
+                module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported for int width");
             }
             break;
         }
@@ -151,7 +151,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
                 block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
                 params.push_back(uconvert_low_id);
             } else {
-                assert(false && "unsupported for float width");
+                module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported for float width");
             }
             break;
         }
@@ -168,7 +168,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
         }
 
         default:
-            assert(false && "unsupported for function param type");
+            module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported function param type");
             break;
     }
 }

--- a/layers/gpu/spirv/inject_conditional_function_pass.cpp
+++ b/layers/gpu/spirv/inject_conditional_function_pass.cpp
@@ -1,0 +1,153 @@
+/* Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "inject_conditional_function_pass.h"
+#include "module.h"
+
+namespace gpu {
+namespace spirv {
+
+InjectConditionalFunctionPass::InjectConditionalFunctionPass(Module& module) : Pass(module) { module.use_bda_ = true; }
+
+BasicBlockIt InjectConditionalFunctionPass::InjectFunction(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
+                                                           const InjectionData& injection_data) {
+    // We turn the block into 4 separate blocks
+    block_it = function->InsertNewBlock(block_it);
+    block_it = function->InsertNewBlock(block_it);
+    block_it = function->InsertNewBlock(block_it);
+    BasicBlock& original_block = **(std::prev(block_it, 3));
+    // Where we call targeted instruction if it is valid
+    BasicBlock& valid_block = **(std::prev(block_it, 2));
+    // will be an empty block, used for the Phi node, even if no result, create for simplicity
+    BasicBlock& invalid_block = **(std::prev(block_it, 1));
+    // All the remaining block instructions after targeted instruction
+    BasicBlock& merge_block = **block_it;
+
+    const uint32_t original_label = original_block.GetLabelId();
+    const uint32_t valid_block_label = valid_block.GetLabelId();
+    const uint32_t invalid_block_label = invalid_block.GetLabelId();
+    const uint32_t merge_block_label = merge_block.GetLabelId();
+
+    // need to preserve the control-flow of how things, like a OpPhi, are accessed from a predecessor block
+    function->ReplaceAllUsesWith(original_label, merge_block_label);
+
+    // Move the targeted instruction to a valid block
+    const Instruction& target_inst = *valid_block.instructions_.emplace_back(std::move(*inst_it));
+    inst_it = original_block.instructions_.erase(inst_it);
+    valid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
+
+    // If thre is a result, we need to create an additional BasicBlock to hold the |else| case, then after we create a Phi node to
+    // hold the result
+    const uint32_t target_inst_id = target_inst.ResultId();
+    if (target_inst_id != 0) {
+        const uint32_t phi_id = module_.TakeNextId();
+        const Type& phi_type = *module_.type_manager_.FindTypeById(target_inst.TypeId());
+        uint32_t null_id = 0;
+        // Can't create ConstantNull of pointer type, so convert uint64 zero to pointer
+        if (phi_type.spv_type_ == SpvType::kPointer) {
+            const Type& uint64_type = module_.type_manager_.GetTypeInt(64, false);
+            const Constant& null_constant = module_.type_manager_.GetConstantNull(uint64_type);
+            null_id = module_.TakeNextId();
+            // We need to put any intermittent instructions here so Phi is first in the merge block
+            invalid_block.CreateInstruction(spv::OpConvertUToPtr, {phi_type.Id(), null_id, null_constant.Id()});
+            module_.AddCapability(spv::CapabilityInt64);
+        } else {
+            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) && phi_type.inst_.Word(2) < 32) {
+                // You can't make a constant of a 8-int, 16-int, 16-float without having the capability
+                // The only way this situation occurs if they use something like
+                //     OpCapability StorageBuffer8BitAccess
+                // but there is not explicit Int8
+                // It should be more than safe to inject it for them
+                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat) ? spv::CapabilityFloat16
+                                             : (phi_type.inst_.Word(2) == 16)        ? spv::CapabilityInt16
+                                                                                     : spv::CapabilityInt8;
+                module_.AddCapability(capability);
+            }
+
+            null_id = module_.type_manager_.GetConstantNull(phi_type).Id();
+        }
+
+        // replace before creating instruction, otherwise will over-write itself
+        function->ReplaceAllUsesWith(target_inst_id, phi_id);
+        merge_block.CreateInstruction(spv::OpPhi,
+                                      {phi_type.Id(), phi_id, target_inst_id, valid_block_label, null_id, invalid_block_label});
+    }
+
+    // When skipping some instructions, we need something valid to replace it
+    if (target_inst.Opcode() == spv::OpRayQueryInitializeKHR) {
+        // Currently assume the RayQuery and AS object were valid already
+        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
+        const uint32_t float32_0_id = module_.type_manager_.GetConstantZeroFloat32().Id();
+        const uint32_t vec3_0_id = module_.type_manager_.GetConstantZeroVec3().Id();
+        invalid_block.CreateInstruction(spv::OpRayQueryInitializeKHR,
+                                        {target_inst.Operand(0), target_inst.Operand(1), uint32_0_id, uint32_0_id, vec3_0_id,
+                                         float32_0_id, vec3_0_id, float32_0_id});
+    }
+
+    invalid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
+
+    // move all remaining instructions to the newly created merge block
+    merge_block.instructions_.insert(merge_block.instructions_.end(), std::make_move_iterator(inst_it),
+                                     std::make_move_iterator(original_block.instructions_.end()));
+    original_block.instructions_.erase(inst_it, original_block.instructions_.end());
+
+    // Go back to original Block and add function call and branch from the bool result
+    const uint32_t function_result = CreateFunctionCall(original_block, nullptr, injection_data);
+
+    original_block.CreateInstruction(spv::OpSelectionMerge, {merge_block_label, spv::SelectionControlMaskNone});
+    original_block.CreateInstruction(spv::OpBranchConditional, {function_result, valid_block_label, invalid_block_label});
+
+    Reset();
+
+    return block_it;
+}
+
+bool InjectConditionalFunctionPass::Run() {
+    // Can safely loop function list as there is no injecting of new Functions until linking time
+    for (const auto& function : module_.functions_) {
+        for (auto block_it = function->blocks_.begin(); block_it != function->blocks_.end(); ++block_it) {
+            if ((*block_it)->loop_header_) {
+                continue;  // Currently can't properly handle injecting CFG logic into a loop header block
+            }
+            auto& block_instructions = (*block_it)->instructions_;
+            for (auto inst_it = block_instructions.begin(); inst_it != block_instructions.end(); ++inst_it) {
+                // Every instruction is analyzed by the specific pass and lets us know if we need to inject a function or not
+                if (!AnalyzeInstruction(*function, *(inst_it->get()))) continue;
+
+                if (module_.max_instrumented_count_ != 0 && instrumented_count_ >= module_.max_instrumented_count_) {
+                    return true;  // hit limit
+                }
+                instrumented_count_++;
+
+                // Add any debug information to pass into the function call
+                InjectionData injection_data;
+                injection_data.stage_info_id = GetStageInfo(*function, block_it, inst_it);
+                const uint32_t inst_position = target_instruction_->position_index_;
+                auto inst_position_constant = module_.type_manager_.CreateConstantUInt32(inst_position);
+                injection_data.inst_position_id = inst_position_constant.Id();
+
+                block_it = InjectFunction(function.get(), block_it, inst_it, injection_data);
+                // will start searching again from newly split merge block
+                block_it--;
+                break;
+            }
+        }
+    }
+
+    return instrumented_count_ != 0;
+}
+
+}  // namespace spirv
+}  // namespace gpu

--- a/layers/gpu/spirv/inject_function_pass.cpp
+++ b/layers/gpu/spirv/inject_function_pass.cpp
@@ -19,108 +19,7 @@
 namespace gpu {
 namespace spirv {
 
-InjectFunctionPass::InjectFunctionPass(Module& module, bool conditional_function_check)
-    : Pass(module), conditional_function_check_(conditional_function_check) {
-    module.use_bda_ = true;
-}
-
-BasicBlockIt InjectFunctionPass::InjectConditionalFunctionCheck(Function* function, BasicBlockIt block_it, InstructionIt inst_it,
-                                                                const InjectionData& injection_data) {
-    // We turn the block into 4 separate blocks
-    block_it = function->InsertNewBlock(block_it);
-    block_it = function->InsertNewBlock(block_it);
-    block_it = function->InsertNewBlock(block_it);
-    BasicBlock& original_block = **(std::prev(block_it, 3));
-    // Where we call targeted instruction if it is valid
-    BasicBlock& valid_block = **(std::prev(block_it, 2));
-    // will be an empty block, used for the Phi node, even if no result, create for simplicity
-    BasicBlock& invalid_block = **(std::prev(block_it, 1));
-    // All the remaining block instructions after targeted instruction
-    BasicBlock& merge_block = **block_it;
-
-    const uint32_t original_label = original_block.GetLabelId();
-    const uint32_t valid_block_label = valid_block.GetLabelId();
-    const uint32_t invalid_block_label = invalid_block.GetLabelId();
-    const uint32_t merge_block_label = merge_block.GetLabelId();
-
-    // need to preserve the control-flow of how things, like a OpPhi, are accessed from a predecessor block
-    function->ReplaceAllUsesWith(original_label, merge_block_label);
-
-    // Move the targeted instruction to a valid block
-    const Instruction& target_inst = *valid_block.instructions_.emplace_back(std::move(*inst_it));
-    inst_it = original_block.instructions_.erase(inst_it);
-    valid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
-
-    // If thre is a result, we need to create an additional BasicBlock to hold the |else| case, then after we create a Phi node to
-    // hold the result
-    const uint32_t target_inst_id = target_inst.ResultId();
-    if (target_inst_id != 0) {
-        const uint32_t phi_id = module_.TakeNextId();
-        const Type& phi_type = *module_.type_manager_.FindTypeById(target_inst.TypeId());
-        uint32_t null_id = 0;
-        // Can't create ConstantNull of pointer type, so convert uint64 zero to pointer
-        if (phi_type.spv_type_ == SpvType::kPointer) {
-            const Type& uint64_type = module_.type_manager_.GetTypeInt(64, false);
-            const Constant& null_constant = module_.type_manager_.GetConstantNull(uint64_type);
-            null_id = module_.TakeNextId();
-            // We need to put any intermittent instructions here so Phi is first in the merge block
-            invalid_block.CreateInstruction(spv::OpConvertUToPtr, {phi_type.Id(), null_id, null_constant.Id()});
-            module_.AddCapability(spv::CapabilityInt64);
-        } else {
-            if ((phi_type.spv_type_ == SpvType::kInt || phi_type.spv_type_ == SpvType::kFloat) && phi_type.inst_.Word(2) < 32) {
-                // You can't make a constant of a 8-int, 16-int, 16-float without having the capability
-                // The only way this situation occurs if they use something like
-                //     OpCapability StorageBuffer8BitAccess
-                // but there is not explicit Int8
-                // It should be more than safe to inject it for them
-                spv::Capability capability = (phi_type.spv_type_ == SpvType::kFloat) ? spv::CapabilityFloat16
-                                             : (phi_type.inst_.Word(2) == 16)        ? spv::CapabilityInt16
-                                                                                     : spv::CapabilityInt8;
-                module_.AddCapability(capability);
-            }
-
-            null_id = module_.type_manager_.GetConstantNull(phi_type).Id();
-        }
-
-        // replace before creating instruction, otherwise will over-write itself
-        function->ReplaceAllUsesWith(target_inst_id, phi_id);
-        merge_block.CreateInstruction(spv::OpPhi,
-                                      {phi_type.Id(), phi_id, target_inst_id, valid_block_label, null_id, invalid_block_label});
-    }
-
-    // When skipping some instructions, we need something valid to replace it
-    if (target_inst.Opcode() == spv::OpRayQueryInitializeKHR) {
-        // Currently assume the RayQuery and AS object were valid already
-        const uint32_t uint32_0_id = module_.type_manager_.GetConstantZeroUint32().Id();
-        const uint32_t float32_0_id = module_.type_manager_.GetConstantZeroFloat32().Id();
-        const uint32_t vec3_0_id = module_.type_manager_.GetConstantZeroVec3().Id();
-        invalid_block.CreateInstruction(spv::OpRayQueryInitializeKHR,
-                                        {target_inst.Operand(0), target_inst.Operand(1), uint32_0_id, uint32_0_id, vec3_0_id,
-                                         float32_0_id, vec3_0_id, float32_0_id});
-    }
-
-    invalid_block.CreateInstruction(spv::OpBranch, {merge_block_label});
-
-    // move all remaining instructions to the newly created merge block
-    merge_block.instructions_.insert(merge_block.instructions_.end(), std::make_move_iterator(inst_it),
-                                     std::make_move_iterator(original_block.instructions_.end()));
-    original_block.instructions_.erase(inst_it, original_block.instructions_.end());
-
-    // Go back to original Block and add function call and branch from the bool result
-    const uint32_t function_result = CreateFunctionCall(original_block, nullptr, injection_data);
-
-    original_block.CreateInstruction(spv::OpSelectionMerge, {merge_block_label, spv::SelectionControlMaskNone});
-    original_block.CreateInstruction(spv::OpBranchConditional, {function_result, valid_block_label, invalid_block_label});
-
-    Reset();
-
-    return block_it;
-}
-
-void InjectFunctionPass::InjectFunctionCheck(BasicBlockIt block_it, InstructionIt* inst_it, const InjectionData& injection_data) {
-    CreateFunctionCall(**block_it, inst_it, injection_data);
-    Reset();
-}
+InjectFunctionPass::InjectFunctionPass(Module& module) : Pass(module) { module.use_bda_ = true; }
 
 bool InjectFunctionPass::Run() {
     // Can safely loop function list as there is no injecting of new Functions until linking time
@@ -146,15 +45,9 @@ bool InjectFunctionPass::Run() {
                 auto inst_position_constant = module_.type_manager_.CreateConstantUInt32(inst_position);
                 injection_data.inst_position_id = inst_position_constant.Id();
 
-                if (conditional_function_check_) {
-                    block_it = InjectConditionalFunctionCheck(function.get(), block_it, inst_it, injection_data);
-                    // will start searching again from newly split merge block
-                    block_it--;
-                    break;
-                } else {
-                    // inst_it is updated to the instruction after the new function call, it will not add/remove any Blocks
-                    InjectFunctionCheck(block_it, &inst_it, injection_data);
-                }
+                // inst_it is updated to the instruction after the new function call, it will not add/remove any Blocks
+                CreateFunctionCall(**block_it, &inst_it, injection_data);
+                Reset();
             }
         }
     }

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -160,9 +160,9 @@ uint32_t Pass::GetStageInfo(Function& function, BasicBlockIt target_block_it, In
                     stage_info[i + 2] = extract_id;
                 }
             } break;
-            default: {
-                assert(false && "unsupported stage");
-            } break;
+            default:
+                module_.InternalError("Passs", "GetStageInfo has unsupported stage");
+                break;
         }
     }
 
@@ -274,7 +274,8 @@ InstructionIt Pass::FindTargetInstruction(BasicBlock& block) const {
             }
         }
     }
-    assert(false);
+
+    module_.InternalError("FindTargetInstruction", "failed to find instruction");
     return block.instructions_.end();
 }
 

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -25,6 +25,12 @@ class Module;
 struct Variable;
 struct BasicBlock;
 
+// Info we know is the same regardless what pass is consuming the CreateFunctionCall()
+struct InjectionData {
+    uint32_t stage_info_id;
+    uint32_t inst_position_id;
+};
+
 // Common helpers for all passes
 class Pass {
   public:
@@ -44,8 +50,8 @@ class Pass {
 
     // Generate SPIR-V needed to help convert things to be uniformly uint32_t
     // If no inst_it is passed in, any new instructions will be added to end of the Block
-    uint32_t ConvertTo32(uint32_t id, BasicBlock& block, InstructionIt* inst_it = nullptr);
-    uint32_t CastToUint32(uint32_t id, BasicBlock& block, InstructionIt* inst_it = nullptr);
+    uint32_t ConvertTo32(uint32_t id, BasicBlock& block, InstructionIt* inst_it);
+    uint32_t CastToUint32(uint32_t id, BasicBlock& block, InstructionIt* inst_it);
 
   protected:
     Pass(Module& module) : module_(module) {}

--- a/layers/gpu/spirv/ray_query_pass.h
+++ b/layers/gpu/spirv/ray_query_pass.h
@@ -15,15 +15,15 @@
 #pragma once
 
 #include <stdint.h>
-#include "inject_function_pass.h"
+#include "inject_conditional_function_pass.h"
 
 namespace gpu {
 namespace spirv {
 
 // Create a pass to instrument SPV_KHR_ray_query instructions
-class RayQueryPass : public InjectFunctionPass {
+class RayQueryPass : public InjectConditionalFunctionPass {
   public:
-    RayQueryPass(Module& module) : InjectFunctionPass(module, true) {}
+    RayQueryPass(Module& module) : InjectConditionalFunctionPass(module) {}
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/type_manager.cpp
+++ b/layers/gpu/spirv/type_manager.cpp
@@ -38,7 +38,7 @@ bool Type::operator==(Type const& other) const {
 //   %B = OpTypePointer Input %A
 //   %C = OpVariable %B Input
 const Type* Variable::PointerType(TypeManager& type_manager_) const {
-    assert(type_.inst_.Opcode() == spv::OpTypePointer);
+    assert(type_.spv_type_ == SpvType::kPointer || type_.spv_type_ == SpvType::kForwardPointer);
     uint32_t type_id = type_.inst_.Word(3);
     return type_manager_.FindTypeById(type_id);
 }


### PR DESCRIPTION
This creates a dedicated `InjectConditionalFunctionPass` and `InjectFunctionPass` to allow future passes to better separate the logic if it wants to use 

```
if (check_logic()) {
   // original code
} else {
   // safe code
}
```

vs

```
check_logic();
// original_code
```