### PR TITLE
gpu: Unify error message and DeviceCreation

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
@@ -45,7 +45,7 @@ struct SharedCopyBufferToImageValidationResources final {
         ds_layout_ci.pBindings = bindings.data();
         result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &ds_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc, "Unable to create descriptor set layout. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create descriptor set layout.");
             return;
         }
 
@@ -65,8 +65,7 @@ struct SharedCopyBufferToImageValidationResources final {
         pool_create_info.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
         result = vmaCreatePool(vma_allocator, &pool_create_info, &copy_regions_pool);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc,
-                                "Unable to create VMA memory pool for buffer to image copies validation. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create VMA memory pool for buffer to image copies validation.");
             return;
         }
 
@@ -76,7 +75,7 @@ struct SharedCopyBufferToImageValidationResources final {
         pipeline_layout_ci.pSetLayouts = set_layouts.data();
         result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &pipeline_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc, "Unable to create pipeline layout. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create pipeline layout.");
             return;
         }
 
@@ -86,7 +85,7 @@ struct SharedCopyBufferToImageValidationResources final {
         VkShaderModule validation_shader = VK_NULL_HANDLE;
         result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &validation_shader);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc, "Unable to create shader module. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create shader module.");
             return;
         }
 
@@ -102,8 +101,7 @@ struct SharedCopyBufferToImageValidationResources final {
 
         result = DispatchCreateComputePipelines(device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &pipeline);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc,
-                                "Failed to create compute pipeline for copy buffer to image validation. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Failed to create compute pipeline for copy buffer to image validation.");
         }
 
         DispatchDestroyShaderModule(device, validation_shader, nullptr);
@@ -149,8 +147,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
 
     auto image_state = gpuav.Get<vvl::Image>(copy_buffer_to_img_info->dstImage);
     if (!image_state) {
-        gpuav.InternalError(cmd_buffer, loc,
-                            "AllocatePreCopyBufferToImageValidationResources: Unrecognized image. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "AllocatePreCopyBufferToImageValidationResources: Unrecognized image.");
         return;
     }
 
@@ -162,8 +159,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
 
     auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
     if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc,
-                            "AllocatePreCopyBufferToImageValidationResources: Unrecognized command buffer. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "AllocatePreCopyBufferToImageValidationResources: Unrecognized command buffer.");
         return;
     }
 
@@ -213,8 +209,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
         VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &copy_src_regions_mem_block.buffer,
                                           &copy_src_regions_mem_block.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(cmd_buffer, loc, "Unable to allocate device memory for GPU copy of pRegions. Aborting GPU-AV.",
-                                true);
+            gpuav.InternalError(cmd_buffer, loc, "Unable to allocate device memory for GPU copy of pRegions.", true);
             return;
         }
         cb_state->gpu_resources_manager.ManageDeviceMemoryBlock(copy_src_regions_mem_block);
@@ -224,7 +219,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
                               reinterpret_cast<void **>(&gpu_regions_u32_ptr));
 
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(cmd_buffer, loc, "Unable to map device memory for GPU copy of pRegions. Aborting GPU-AV.", true);
+            gpuav.InternalError(cmd_buffer, loc, "Unable to map device memory for GPU copy of pRegions.", true);
             return;
         }
 
@@ -292,8 +287,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
     {
         validation_desc_set = cb_state->gpu_resources_manager.GetManagedDescriptorSet(shared_copy_validation_resources.ds_layout);
         if (validation_desc_set == VK_NULL_HANDLE) {
-            gpuav.InternalError(cmd_buffer, loc,
-                                "Unable to allocate descriptor set for copy buffer to image validation. Aborting GPU-AV");
+            gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set for copy buffer to image validation");
             return;
         }
 

--- a/layers/gpu/cmd_validation/gpuav_dispatch.cpp
+++ b/layers/gpu/cmd_validation/gpuav_dispatch.cpp
@@ -47,7 +47,7 @@ struct SharedDispatchValidationResources final {
         ds_layout_ci.pBindings = bindings.data();
         result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &ds_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc, "Unable to create descriptor set layout. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create descriptor set layout.");
             return;
         }
 
@@ -64,7 +64,7 @@ struct SharedDispatchValidationResources final {
         pipeline_layout_ci.pSetLayouts = set_layouts.data();
         result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &pipeline_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc, "Unable to create pipeline layout. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create pipeline layout.");
             return;
         }
 
@@ -81,7 +81,7 @@ struct SharedDispatchValidationResources final {
             shader_ci.pPushConstantRanges = pipeline_layout_ci.pPushConstantRanges;
             result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &shader_object);
             if (result != VK_SUCCESS) {
-                gpuav.InternalError(device, loc, "Unable to create shader object. Aborting GPU-AV.");
+                gpuav.InternalError(device, loc, "Unable to create shader object.");
                 return;
             }
         } else {
@@ -91,7 +91,7 @@ struct SharedDispatchValidationResources final {
             VkShaderModule validation_shader = VK_NULL_HANDLE;
             result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &validation_shader);
             if (result != VK_SUCCESS) {
-                gpuav.InternalError(device, loc, "Unable to create shader module. Aborting GPU-AV.");
+                gpuav.InternalError(device, loc, "Unable to create shader module.");
                 return;
             }
 
@@ -110,7 +110,7 @@ struct SharedDispatchValidationResources final {
             DispatchDestroyShaderModule(device, validation_shader, nullptr);
 
             if (result != VK_SUCCESS) {
-                gpuav.InternalError(device, loc, "Failed to create compute pipeline for dispatch validation. Aborting GPU-AV.");
+                gpuav.InternalError(device, loc, "Failed to create compute pipeline for dispatch validation.");
                 return;
             }
         }
@@ -149,7 +149,7 @@ void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, VkC
 
     auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
     if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer.");
         return;
     }
 
@@ -174,7 +174,7 @@ void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, VkC
     VkDescriptorSet indirect_buffer_desc_set =
         cb_state->gpu_resources_manager.GetManagedDescriptorSet(shared_dispatch_resources.ds_layout);
     if (indirect_buffer_desc_set == VK_NULL_HANDLE) {
-        gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set.");
         return;
     }
 

--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -52,8 +52,7 @@ struct SharedDrawValidationResources final {
         ds_layout_ci.pBindings = bindings.data();
         result = DispatchCreateDescriptorSetLayout(device, &ds_layout_ci, nullptr, &ds_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc,
-                                "Unable to create descriptor set layout for SharedDrawValidationResources. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create descriptor set layout for SharedDrawValidationResources.");
             return;
         }
 
@@ -70,8 +69,7 @@ struct SharedDrawValidationResources final {
         pipeline_layout_ci.pSetLayouts = set_layouts.data();
         result = DispatchCreatePipelineLayout(device, &pipeline_layout_ci, nullptr, &pipeline_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(device, loc,
-                                "Unable to create pipeline layout for SharedDrawValidationResources. Aborting GPU-AV.");
+            gpuav.InternalError(device, loc, "Unable to create pipeline layout for SharedDrawValidationResources.");
             return;
         }
 
@@ -88,7 +86,7 @@ struct SharedDrawValidationResources final {
             shader_ci.pPushConstantRanges = &push_constant_range;
             result = DispatchCreateShadersEXT(device, 1u, &shader_ci, nullptr, &shader_object);
             if (result != VK_SUCCESS) {
-                gpuav.InternalError(device, loc, "Unable to create shader object. Aborting GPU-AV.");
+                gpuav.InternalError(device, loc, "Unable to create shader object.");
                 return;
             }
         } else {
@@ -97,7 +95,7 @@ struct SharedDrawValidationResources final {
             shader_module_ci.pCode = cmd_validation_draw_vert;
             result = DispatchCreateShaderModule(device, &shader_module_ci, nullptr, &shader_module);
             if (result != VK_SUCCESS) {
-                gpuav.InternalError(device, loc, "Unable to create shader module. Aborting GPU-AV.");
+                gpuav.InternalError(device, loc, "Unable to create shader module.");
                 return;
             }
         }
@@ -172,7 +170,7 @@ static VkPipeline GetDrawValidationPipeline(Validator &gpuav, SharedDrawValidati
 
     VkResult result = DispatchCreateGraphicsPipelines(gpuav.device, VK_NULL_HANDLE, 1, &pipeline_ci, nullptr, &validation_pipeline);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to create graphics pipeline. Aborting GPU-AV.");
+        gpuav.InternalError(gpuav.device, loc, "Unable to create graphics pipeline.");
         return VK_NULL_HANDLE;
     }
 
@@ -202,7 +200,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
 
     auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
     if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer.");
         return;
     }
 
@@ -224,7 +222,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
         validation_pipeline =
             GetDrawValidationPipeline(gpuav, shared_draw_resources, cb_state->activeRenderPass.get()->VkHandle(), loc);
         if (validation_pipeline == VK_NULL_HANDLE) {
-            gpuav.InternalError(cmd_buffer, loc, "Could not find or create a pipeline. Aborting GPU-AV.");
+            gpuav.InternalError(cmd_buffer, loc, "Could not find or create a pipeline.");
             return;
         }
     }
@@ -232,7 +230,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
     const VkDescriptorSet draw_validation_desc_set =
         cb_state->gpu_resources_manager.GetManagedDescriptorSet(shared_draw_resources.ds_layout);
     if (draw_validation_desc_set == VK_NULL_HANDLE) {
-        gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set.");
         return;
     }
 
@@ -277,8 +275,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
     if (is_count_call) {
         // Validate count buffer
         if (count_buffer_offset > std::numeric_limits<uint32_t>::max()) {
-            gpuav.InternalError(cmd_buffer, loc,
-                                "Count buffer offset is larger than can be contained in an unsigned int. Aborting GPU-AV.");
+            gpuav.InternalError(cmd_buffer, loc, "Count buffer offset is larger than can be contained in an unsigned int.");
             return;
         }
 

--- a/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
+++ b/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
@@ -55,7 +55,7 @@ struct SharedTraceRaysValidationResources final {
         pipeline_layout_ci.pSetLayouts = &error_output_desc_layout;
         result = DispatchCreatePipelineLayout(gpuav.device, &pipeline_layout_ci, nullptr, &pipeline_layout);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to create pipeline layout. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Unable to create pipeline layout.");
             return;
         }
 
@@ -65,7 +65,7 @@ struct SharedTraceRaysValidationResources final {
         VkShaderModule validation_shader = VK_NULL_HANDLE;
         result = DispatchCreateShaderModule(gpuav.device, &shader_module_ci, nullptr, &validation_shader);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to create ray tracing shader module. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Unable to create ray tracing shader module.");
             return;
         }
 
@@ -95,8 +95,7 @@ struct SharedTraceRaysValidationResources final {
         DispatchDestroyShaderModule(gpuav.device, validation_shader, nullptr);
 
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc,
-                                "Failed to create ray tracing pipeline for pre trace rays validation. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Failed to create ray tracing pipeline for pre trace rays validation.");
             return;
         }
 
@@ -112,7 +111,7 @@ struct SharedTraceRaysValidationResources final {
         result = DispatchGetRayTracingShaderGroupHandlesKHR(gpuav.device, pipeline, 0, rt_pipeline_create_info.groupCount, sbt_size,
                                                             sbt_host_storage.data());
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Failed to call vkGetRayTracingShaderGroupHandlesKHR. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Failed to call vkGetRayTracingShaderGroupHandlesKHR.");
             return;
         }
 
@@ -133,15 +132,14 @@ struct SharedTraceRaysValidationResources final {
         pool_create_info.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
         result = vmaCreatePool(vma_allocator, &pool_create_info, &sbt_pool);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to create VMA memory pool for SBT. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Unable to create VMA memory pool for SBT.", true);
             return;
         }
 
         alloc_info.pool = sbt_pool;
         result = vmaCreateBuffer(vma_allocator, &buffer_info, &alloc_info, &sbt_buffer, &sbt_allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for shader binding table. Aborting GPU-AV.",
-                                true);
+            gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for shader binding table.", true);
             return;
         }
 
@@ -149,9 +147,8 @@ struct SharedTraceRaysValidationResources final {
         result = vmaMapMemory(vma_allocator, sbt_allocation, reinterpret_cast<void **>(&mapped_sbt));
 
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(
-                gpuav.device, loc,
-                "Failed to map shader binding table when creating trace rays validation resources. Aborting GPU-AV.", true);
+            gpuav.InternalError(gpuav.device, loc,
+                                "Failed to map shader binding table when creating trace rays validation resources.", true);
             return;
         }
 
@@ -165,7 +162,7 @@ struct SharedTraceRaysValidationResources final {
         const VkDeviceAddress sbt_address = GetBufferDeviceAddress(gpuav, sbt_buffer, loc);
         assert(sbt_address != 0);
         if (sbt_address == 0) {
-            gpuav.InternalError(gpuav.device, loc, "Retrieved SBT buffer device address is null. Aborting GPU-AV.");
+            gpuav.InternalError(gpuav.device, loc, "Retrieved SBT buffer device address is null.");
             return;
         }
         assert(sbt_address == Align(sbt_address, static_cast<VkDeviceAddress>(rt_pipeline_props.shaderGroupBaseAlignment)));
@@ -211,7 +208,7 @@ void InsertIndirectTraceRaysValidation(Validator &gpuav, const Location &loc, Vk
 
     auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
     if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer. Aborting GPU-AV.");
+        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer.");
         return;
     }
 

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -385,7 +385,7 @@ std::shared_ptr<DescriptorSet::State> DescriptorSet::GetOutputState(Validator &g
     VkResult result =
         vmaCreateBuffer(next_state->allocator, &buffer_info, &alloc_info, &next_state->buffer, &next_state->allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for error output buffer. Aborting GPU-AV.", true);
+        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for error output buffer.", true);
         return nullptr;
     }
     uint32_t *data = nullptr;

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -97,14 +97,14 @@ void UpdateBoundDescriptors(Validator &gpuav, VkCommandBuffer cb, VkPipelineBind
     VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &di_buffers.bindless_state_buffer,
                                       &di_buffers.bindless_state_buffer_allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state->Handle(), loc, "Unable to allocate device memory. Device could become unstable.", true);
+        gpuav.InternalError(cb_state->Handle(), loc, "Unable to allocate device memory.", true);
         return;
     }
     glsl::BindlessStateBuffer *bindless_state{nullptr};
     result =
         vmaMapMemory(gpuav.vma_allocator_, di_buffers.bindless_state_buffer_allocation, reinterpret_cast<void **>(&bindless_state));
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state->Handle(), loc, "Unable to map device memory. Device could become unstable.", true);
+        gpuav.InternalError(cb_state->Handle(), loc, "Unable to map device memory.", true);
         return;
     }
     memset(bindless_state, 0, static_cast<size_t>(buffer_info.size));
@@ -153,8 +153,7 @@ void UpdateBoundDescriptors(Validator &gpuav, VkCommandBuffer cb, VkPipelineBind
         VkResult result =
             vmaMapMemory(vma_allocator, cmd_info.bindless_state_buffer_allocation, reinterpret_cast<void **>(&bindless_state));
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc,
-                                "Unable to map device memory allocated for error output buffer. Aborting GPU-AV.", true);
+            gpuav.InternalError(gpuav.device, loc, "Unable to map device memory allocated for error output buffer.", true);
             return false;
         }
         for (size_t i = 0; i < cmd_info.descriptor_set_buffers.size(); i++) {

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -25,28 +25,30 @@
 
 namespace gpuav {
 
-void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<CommandBuffer, WriteLockGuard> &cmd_buffer,
-                                         VkPipelineBindPoint bind_point, const Location &loc) {
-    if (bind_point != VK_PIPELINE_BIND_POINT_GRAPHICS && bind_point != VK_PIPELINE_BIND_POINT_COMPUTE &&
-        bind_point != VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR) {
-        assert(false);
+void SetupShaderInstrumentationResources(Validator &gpuav, VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point,
+                                         const Location &loc) {
+    assert(bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS || bind_point == VK_PIPELINE_BIND_POINT_COMPUTE ||
+           bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR);
+
+    auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
+    if (!cb_state) {
+        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer.");
         return;
     }
 
     const auto lv_bind_point = ConvertToLvlBindPoint(bind_point);
-    auto const &last_bound = cmd_buffer->lastBound[lv_bind_point];
+    auto const &last_bound = cb_state->lastBound[lv_bind_point];
     const auto *pipeline_state = last_bound.pipeline_state;
 
     if (!pipeline_state && !last_bound.HasShaderObjects()) {
-        gpuav.InternalError(cmd_buffer->VkHandle(), loc,
-                            "Neither pipeline state nor shader object states were found. Aborting GPU-AV.");
+        gpuav.InternalError(cb_state->VkHandle(), loc, "Neither pipeline state nor shader object states were found.");
         return;
     }
 
     VkDescriptorSet instrumentation_desc_set =
-        cmd_buffer->gpu_resources_manager.GetManagedDescriptorSet(cmd_buffer->GetInstrumentationDescriptorSetLayout());
+        cb_state->gpu_resources_manager.GetManagedDescriptorSet(cb_state->GetInstrumentationDescriptorSetLayout());
     if (!instrumentation_desc_set) {
-        gpuav.InternalError(cmd_buffer->VkHandle(), loc, "Unable to allocate instrumentation descriptor sets. Aborting GPU-AV.");
+        gpuav.InternalError(cb_state->VkHandle(), loc, "Unable to allocate instrumentation descriptor sets.");
         return;
     }
 
@@ -61,7 +63,7 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
         VkDescriptorBufferInfo error_output_desc_buffer_info = {};
         {
             error_output_desc_buffer_info.range = VK_WHOLE_SIZE;
-            error_output_desc_buffer_info.buffer = cmd_buffer->GetErrorOutputBuffer();
+            error_output_desc_buffer_info.buffer = cb_state->GetErrorOutputBuffer();
             error_output_desc_buffer_info.offset = 0;
 
             VkWriteDescriptorSet wds = vku::InitStructHelper();
@@ -104,7 +106,7 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
         VkDescriptorBufferInfo cmd_errors_counts_desc_buffer_info = {};
         {
             cmd_errors_counts_desc_buffer_info.range = VK_WHOLE_SIZE;
-            cmd_errors_counts_desc_buffer_info.buffer = cmd_buffer->GetCmdErrorsCountsBuffer();
+            cmd_errors_counts_desc_buffer_info.buffer = cb_state->GetCmdErrorsCountsBuffer();
             cmd_errors_counts_desc_buffer_info.offset = 0;
 
             VkWriteDescriptorSet wds = vku::InitStructHelper();
@@ -118,9 +120,9 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
 
         // Current bindless buffer
         VkDescriptorBufferInfo di_input_desc_buffer_info = {};
-        if (cmd_buffer->current_bindless_buffer != VK_NULL_HANDLE) {
+        if (cb_state->current_bindless_buffer != VK_NULL_HANDLE) {
             di_input_desc_buffer_info.range = VK_WHOLE_SIZE;
-            di_input_desc_buffer_info.buffer = cmd_buffer->current_bindless_buffer;
+            di_input_desc_buffer_info.buffer = cb_state->current_bindless_buffer;
             di_input_desc_buffer_info.offset = 0;
 
             VkWriteDescriptorSet wds = vku::InitStructHelper();
@@ -136,7 +138,7 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
         VkDescriptorBufferInfo bda_input_desc_buffer_info = {};
         if (gpuav.gpuav_settings.validate_bda) {
             bda_input_desc_buffer_info.range = VK_WHOLE_SIZE;
-            bda_input_desc_buffer_info.buffer = cmd_buffer->GetBdaRangesSnapshot().buffer;
+            bda_input_desc_buffer_info.buffer = cb_state->GetBdaRangesSnapshot().buffer;
             bda_input_desc_buffer_info.offset = 0;
 
             VkWriteDescriptorSet wds = vku::InitStructHelper();
@@ -167,68 +169,57 @@ void SetupShaderInstrumentationResources(Validator &gpuav, LockedSharedPtr<Comma
 
     uint32_t operation_index = 0;
     if (bind_point == VK_PIPELINE_BIND_POINT_GRAPHICS)
-        operation_index = cmd_buffer->draw_index++;
+        operation_index = cb_state->draw_index++;
     else if (bind_point == VK_PIPELINE_BIND_POINT_COMPUTE)
-        operation_index = cmd_buffer->compute_index++;
+        operation_index = cb_state->compute_index++;
     else if (bind_point == VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR)
-        operation_index = cmd_buffer->trace_rays_index++;
+        operation_index = cb_state->trace_rays_index++;
 
-    // TODO: Using cmd_buffer->per_command_resources.size() is kind of a hack? Worth considering passing the resource index as a
+    // TODO: Using cb_state->per_command_resources.size() is kind of a hack? Worth considering passing the resource index as a
     // parameter
-    const uint32_t error_logger_i = static_cast<uint32_t>(cmd_buffer->per_command_error_loggers.size());
+    const uint32_t error_logger_i = static_cast<uint32_t>(cb_state->per_command_error_loggers.size());
     const std::array<uint32_t, 2> dynamic_offsets = {
         {operation_index * static_cast<uint32_t>(sizeof(uint32_t)), error_logger_i * static_cast<uint32_t>(sizeof(uint32_t))}};
     if ((pipeline_layout && pipeline_layout->set_layouts.size() <= gpuav.desc_set_bind_index_) &&
         pipeline_layout_handle != VK_NULL_HANDLE) {
-        DispatchCmdBindDescriptorSets(cmd_buffer->VkHandle(), bind_point, pipeline_layout_handle, gpuav.desc_set_bind_index_, 1,
+        DispatchCmdBindDescriptorSets(cb_state->VkHandle(), bind_point, pipeline_layout_handle, gpuav.desc_set_bind_index_, 1,
                                       &instrumentation_desc_set, static_cast<uint32_t>(dynamic_offsets.size()),
                                       dynamic_offsets.data());
     } else {
         // If no pipeline layout was bound when using shader objects that don't use any descriptor set, bind the debug pipeline
         // layout
-        DispatchCmdBindDescriptorSets(cmd_buffer->VkHandle(), bind_point, gpuav.GetDebugPipelineLayout(),
-                                      gpuav.desc_set_bind_index_, 1, &instrumentation_desc_set,
-                                      static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
+        DispatchCmdBindDescriptorSets(cb_state->VkHandle(), bind_point, gpuav.GetDebugPipelineLayout(), gpuav.desc_set_bind_index_,
+                                      1, &instrumentation_desc_set, static_cast<uint32_t>(dynamic_offsets.size()),
+                                      dynamic_offsets.data());
     }
 
     if (pipeline_state && pipeline_layout_handle == VK_NULL_HANDLE) {
-        gpuav.InternalError(cmd_buffer->Handle(), loc,
-                            "Unable to find pipeline layout to bind debug descriptor set. Aborting GPU-AV");
+        gpuav.InternalError(cb_state->Handle(), loc, "Unable to find pipeline layout to bind debug descriptor set");
         return;
     }
 
     // It is possible to have no descriptor sets bound, for example if using push constants.
     const uint32_t desc_binding_index =
-        !cmd_buffer->di_input_buffer_list.empty() ? uint32_t(cmd_buffer->di_input_buffer_list.size()) - 1 : vvl::kU32Max;
+        !cb_state->di_input_buffer_list.empty() ? uint32_t(cb_state->di_input_buffer_list.size()) - 1 : vvl::kU32Max;
 
     const bool uses_robustness = (gpuav.enabled_features.robustBufferAccess || gpuav.enabled_features.robustBufferAccess2 ||
                                   (pipeline_state && pipeline_state->uses_pipeline_robustness));
 
-    CommandBuffer::ErrorLoggerFunc error_logger = [loc, desc_binding_index, desc_binding_list = &cmd_buffer->di_input_buffer_list,
-                                                   cmd_buffer_handle = cmd_buffer->VkHandle(), bind_point, operation_index,
+    CommandBuffer::ErrorLoggerFunc error_logger = [loc, desc_binding_index, desc_binding_list = &cb_state->di_input_buffer_list,
+                                                   cb_state_handle = cb_state->VkHandle(), bind_point, operation_index,
                                                    uses_shader_object = pipeline_state == nullptr,
                                                    uses_robustness](Validator &gpuav, const uint32_t *error_record,
                                                                     const LogObjectList &objlist) {
         bool skip = false;
 
         const DescBindingInfo *di_info = desc_binding_index != vvl::kU32Max ? &(*desc_binding_list)[desc_binding_index] : nullptr;
-        skip |= LogInstrumentationError(gpuav, cmd_buffer_handle, objlist, operation_index, error_record,
+        skip |= LogInstrumentationError(gpuav, cb_state_handle, objlist, operation_index, error_record,
                                         di_info ? di_info->descriptor_set_buffers : std::vector<DescSetState>(), bind_point,
                                         uses_shader_object, uses_robustness, loc);
         return skip;
     };
 
-    cmd_buffer->per_command_error_loggers.emplace_back(error_logger);
-}
-
-void SetupShaderInstrumentationResources(Validator &gpuav, VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point,
-                                         const Location &loc) {
-    auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
-    if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer. Aborting GPU-AV.");
-        return;
-    }
-    return SetupShaderInstrumentationResources(gpuav, cb_state, bind_point, loc);
+    cb_state->per_command_error_loggers.emplace_back(error_logger);
 }
 
 bool LogMessageInstBindlessDescriptor(const uint32_t *error_record, std::string &out_error_msg, std::string &out_vuid_msg,

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -23,8 +23,6 @@ namespace gpuav {
 
 struct DescSetState;
 
-void SetupShaderInstrumentationResources(Validator& gpuav, LockedSharedPtr<gpuav::CommandBuffer, WriteLockGuard>& cmd_buffer,
-                                         VkPipelineBindPoint bind_point, const Location& loc);
 void SetupShaderInstrumentationResources(Validator& gpuav, VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point,
                                          const Location& loc);
 

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -138,7 +138,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, gpu::DeviceMemoryBlock &er
     VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &error_logs_mem.buffer,
                                       &error_logs_mem.allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for error output buffer. Aborting GPU-AV.", true);
+        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for error output buffer.", true);
         return false;
     }
 
@@ -151,8 +151,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, gpu::DeviceMemoryBlock &er
         }
         vmaUnmapMemory(gpuav.vma_allocator_, error_logs_mem.allocation);
     } else {
-        gpuav.InternalError(gpuav.device, loc, "Unable to map device memory allocated for error output buffer. Aborting GPU-AV.",
-                            true);
+        gpuav.InternalError(gpuav.device, loc, "Unable to map device memory allocated for error output buffer.", true);
         return false;
     }
 
@@ -173,7 +172,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = DispatchCreateDescriptorSetLayout(gpuav->device, &instrumentation_desc_set_layout_ci, nullptr,
                                                    &instrumentation_desc_set_layout_);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc, "Unable to create instrumentation descriptor set layout. Aborting GPU-AV.");
+            gpuav->InternalError(gpuav->device, loc, "Unable to create instrumentation descriptor set layout.");
             return;
         }
     }
@@ -194,8 +193,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = vmaCreateBuffer(gpuav->vma_allocator_, &buffer_info, &alloc_info, &cmd_errors_counts_buffer_.buffer,
                                  &cmd_errors_counts_buffer_.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc,
-                                 "Unable to allocate device memory for commands errors counts buffer. Aborting GPU-AV.", true);
+            gpuav->InternalError(gpuav->device, loc, "Unable to allocate device memory for commands errors counts buffer.", true);
             return;
         }
 
@@ -215,8 +213,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = vmaCreateBuffer(gpuav->vma_allocator_, &buffer_info, &alloc_info, &bda_ranges_snapshot_.buffer,
                                  &bda_ranges_snapshot_.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc,
-                                 "Unable to allocate device memory for buffer device address data. Aborting GPU-AV.", true);
+            gpuav->InternalError(gpuav->device, loc, "Unable to allocate device memory for buffer device address data.", true);
             return;
         }
     }
@@ -241,8 +238,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
             result = DispatchCreateDescriptorSetLayout(gpuav->device, &validation_cmd_desc_set_layout_ci, nullptr,
                                                        &validation_cmd_desc_set_layout_);
             if (result != VK_SUCCESS) {
-                gpuav->InternalError(gpuav->device, loc,
-                                     "Unable to create descriptor set layout used for validation commands. Aborting GPU-AV.");
+                gpuav->InternalError(gpuav->device, loc, "Unable to create descriptor set layout used for validation commands.");
                 return;
             }
         }
@@ -252,8 +248,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = gpuav->desc_set_manager_->GetDescriptorSet(&validation_cmd_desc_pool_, validation_cmd_desc_set_layout_,
                                                             &validation_cmd_desc_set_);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc,
-                                 "Unable to create descriptor set used for validation commands. Aborting GPU-AV.");
+            gpuav->InternalError(gpuav->device, loc, "Unable to create descriptor set used for validation commands.");
             return;
         }
 
@@ -323,7 +318,7 @@ bool CommandBuffer::UpdateBdaRangesBuffer(const Location &loc) {
     VkResult result =
         vmaMapMemory(gpuav->vma_allocator_, bda_ranges_snapshot_.allocation, reinterpret_cast<void **>(&bda_table_ptr));
     if (result != VK_SUCCESS) {
-        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory in UpdateBdaRangesBuffer. Aborting GPU-AV.", true);
+        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory in UpdateBdaRangesBuffer.", true);
         return false;
     }
 
@@ -348,7 +343,7 @@ bool CommandBuffer::UpdateBdaRangesBuffer(const Location &loc) {
         problem_string << "Number of buffer device addresses ranges in use (" << total_address_ranges_count
                        << ") is greater than khronos_validation.gpuav_max_buffer_device_addresses ("
                        << gpuav->gpuav_settings.max_bda_in_use
-                       << "). Truncating buffer device address table could result in invalid validation. Aborting GPU-AV.";
+                       << "). Truncating buffer device address table could result in invalid validation.";
         gpuav->InternalError(gpuav->device, loc, problem_string.str().c_str());
         return false;
     }
@@ -435,8 +430,7 @@ void CommandBuffer::ClearCmdErrorsCountsBuffer(const Location &loc) const {
     VkResult result = vmaMapMemory(gpuav->vma_allocator_, cmd_errors_counts_buffer_.allocation,
                                    reinterpret_cast<void **>(&cmd_errors_counts_buffer_ptr));
     if (result != VK_SUCCESS) {
-        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory for commands errors counts buffer. Aborting GPU-AV.",
-                             true);
+        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory for commands errors counts buffer.", true);
         return;
     }
     std::memset(cmd_errors_counts_buffer_ptr, 0, static_cast<size_t>(GetCmdErrorsCountsBufferByteSize()));


### PR DESCRIPTION
The current `InternalError` messages for GPU-AV say "Aborting GPU-AV" and "GPU-AV is being disabled"... this removes the inconsistent one so that it just only is said once inside the function

Currently both DebugPrintf and GPU-AV share device creation setup and require same global requirements, but were being checked separately