### PR TITLE
gpu: Avoid multiple command buffer lookups while instrumenting

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
@@ -26,16 +26,15 @@
 
 namespace gpuav {
 
-void BindValidationCmdsCommonDescSet(const LockedSharedPtr<CommandBuffer, WriteLockGuard> &cmd_buffer_state,
-                                     VkPipelineBindPoint bind_point, VkPipelineLayout pipeline_layout, uint32_t cmd_index,
-                                     uint32_t error_logger_index) {
+void BindValidationCmdsCommonDescSet(CommandBuffer &cb_state, VkPipelineBindPoint bind_point, VkPipelineLayout pipeline_layout,
+                                     uint32_t cmd_index, uint32_t error_logger_index) {
     assert(cmd_index < cst::indices_count);
     assert(error_logger_index < cst::indices_count);
     std::array<uint32_t, 2> dynamic_offsets = {
         {cmd_index * static_cast<uint32_t>(sizeof(uint32_t)), error_logger_index * static_cast<uint32_t>(sizeof(uint32_t))}};
-    DispatchCmdBindDescriptorSets(cmd_buffer_state->VkHandle(), bind_point, pipeline_layout, glsl::kDiagCommonDescriptorSet, 1,
-                                  &cmd_buffer_state->GetValidationCmdCommonDescriptorSet(),
-                                  static_cast<uint32_t>(dynamic_offsets.size()), dynamic_offsets.data());
+    DispatchCmdBindDescriptorSets(cb_state.VkHandle(), bind_point, pipeline_layout, glsl::kDiagCommonDescriptorSet, 1,
+                                  &cb_state.GetValidationCmdCommonDescriptorSet(), static_cast<uint32_t>(dynamic_offsets.size()),
+                                  dynamic_offsets.data());
 }
 
 void RestorablePipelineState::Create(vvl::CommandBuffer &cb_state, VkPipelineBindPoint bind_point) {

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
@@ -46,9 +46,8 @@ class RestorablePipelineState {
     std::vector<vvl::ShaderObject*> shader_objects_;
 };
 
-void BindValidationCmdsCommonDescSet(const LockedSharedPtr<CommandBuffer, WriteLockGuard>& cmd_buffer_state,
-                                     VkPipelineBindPoint bind_point, VkPipelineLayout pipeline_layout, uint32_t cmd_index,
-                                     uint32_t error_logger_index);
+void BindValidationCmdsCommonDescSet(CommandBuffer& cb_state, VkPipelineBindPoint bind_point, VkPipelineLayout pipeline_layout,
+                                     uint32_t cmd_index, uint32_t error_logger_index);
 
 VkDeviceAddress GetBufferDeviceAddress(Validator& gpuav, VkBuffer buffer, const Location& loc);
 

--- a/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
@@ -318,10 +318,11 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Vk
     // Insert diagnostic dispatch
     DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, shared_copy_validation_resources.pipeline);
 
-    BindValidationCmdsCommonDescSet(cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, shared_copy_validation_resources.pipeline_layout, 0,
+    BindValidationCmdsCommonDescSet(*cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, shared_copy_validation_resources.pipeline_layout, 0,
                                     static_cast<uint32_t>(cb_state->per_command_error_loggers.size()));
-    DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, shared_copy_validation_resources.pipeline_layout,
-                                  glsl::kDiagPerCmdDescriptorSet, 1, &validation_desc_set, 0, nullptr);
+    DispatchCmdBindDescriptorSets(cb_state->VkHandle(), VK_PIPELINE_BIND_POINT_COMPUTE,
+                                  shared_copy_validation_resources.pipeline_layout, glsl::kDiagPerCmdDescriptorSet, 1,
+                                  &validation_desc_set, 0, nullptr);
     // correct_count == max texelsCount?
     const uint32_t group_count_x = max_texels_count_in_regions / 64 + uint32_t(max_texels_count_in_regions % 64 > 0);
     DispatchCmdDispatch(cmd_buffer, group_count_x, 1, 1);

--- a/layers/gpu/cmd_validation/gpuav_dispatch.h
+++ b/layers/gpu/cmd_validation/gpuav_dispatch.h
@@ -24,7 +24,7 @@ struct Location;
 namespace gpuav {
 class Validator;
 
-void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, VkCommandBuffer cmd_buffer, VkBuffer indirect_buffer,
+void InsertIndirectDispatchValidation(Validator &gpuav, const Location &loc, CommandBuffer &cb_state, VkBuffer indirect_buffer,
                                       VkDeviceSize indirect_offset);
 
 }  // namespace gpuav

--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -191,26 +191,20 @@ void DestroyRenderPassMappedResources(Validator &gpuav, VkRenderPass render_pass
     }
 }
 
-void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkCommandBuffer cmd_buffer, VkBuffer indirect_buffer,
+void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, CommandBuffer &cb_state, VkBuffer indirect_buffer,
                                   VkDeviceSize indirect_offset, uint32_t draw_count, VkBuffer count_buffer,
                                   VkDeviceSize count_buffer_offset, uint32_t stride) {
     if (!gpuav.gpuav_settings.validate_indirect_draws_buffers) {
         return;
     }
 
-    auto cb_state = gpuav.GetWrite<CommandBuffer>(cmd_buffer);
-    if (!cb_state) {
-        gpuav.InternalError(cmd_buffer, loc, "Unrecognized command buffer.");
-        return;
-    }
-
     const auto lv_bind_point = ConvertToLvlBindPoint(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    auto const &last_bound = cb_state->lastBound[lv_bind_point];
+    auto const &last_bound = cb_state.lastBound[lv_bind_point];
     const auto *pipeline_state = last_bound.pipeline_state;
     const bool use_shader_objects = pipeline_state == nullptr;
 
     auto &shared_draw_resources = gpuav.shared_resources_manager.Get<SharedDrawValidationResources>(
-        gpuav, cb_state->GetValidationCmdCommonDescriptorSetLayout(), use_shader_objects, loc);
+        gpuav, cb_state.GetValidationCmdCommonDescriptorSetLayout(), use_shader_objects, loc);
 
     assert(shared_draw_resources.IsValid());
     if (!shared_draw_resources.IsValid()) {
@@ -220,17 +214,17 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
     VkPipeline validation_pipeline = VK_NULL_HANDLE;
     if (!use_shader_objects) {
         validation_pipeline =
-            GetDrawValidationPipeline(gpuav, shared_draw_resources, cb_state->activeRenderPass.get()->VkHandle(), loc);
+            GetDrawValidationPipeline(gpuav, shared_draw_resources, cb_state.activeRenderPass.get()->VkHandle(), loc);
         if (validation_pipeline == VK_NULL_HANDLE) {
-            gpuav.InternalError(cmd_buffer, loc, "Could not find or create a pipeline.");
+            gpuav.InternalError(cb_state.VkHandle(), loc, "Could not find or create a pipeline.");
             return;
         }
     }
 
     const VkDescriptorSet draw_validation_desc_set =
-        cb_state->gpu_resources_manager.GetManagedDescriptorSet(shared_draw_resources.ds_layout);
+        cb_state.gpu_resources_manager.GetManagedDescriptorSet(shared_draw_resources.ds_layout);
     if (draw_validation_desc_set == VK_NULL_HANDLE) {
-        gpuav.InternalError(cmd_buffer, loc, "Unable to allocate descriptor set.");
+        gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to allocate descriptor set.");
         return;
     }
 
@@ -259,7 +253,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
 
     // Save current graphics pipeline state
     const vvl::Func command = loc.function;
-    RestorablePipelineState restorable_state(*cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
+    RestorablePipelineState restorable_state(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS);
     using vvl::Func;
     const bool is_mesh_call =
         (command == Func::vkCmdDrawMeshTasksIndirectCountEXT || command == Func::vkCmdDrawMeshTasksIndirectCountNV ||
@@ -275,7 +269,8 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
     if (is_count_call) {
         // Validate count buffer
         if (count_buffer_offset > std::numeric_limits<uint32_t>::max()) {
-            gpuav.InternalError(cmd_buffer, loc, "Count buffer offset is larger than can be contained in an unsigned int.");
+            gpuav.InternalError(cb_state.VkHandle(), loc,
+                                "Count buffer offset is larger than can be contained in an unsigned int.");
             return;
         }
 
@@ -347,18 +342,18 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
     // Insert diagnostic draw
     if (use_shader_objects) {
         VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT;
-        DispatchCmdBindShadersEXT(cmd_buffer, 1u, &stage, &shared_draw_resources.shader_object);
+        DispatchCmdBindShadersEXT(cb_state.VkHandle(), 1u, &stage, &shared_draw_resources.shader_object);
     } else {
-        DispatchCmdBindPipeline(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, validation_pipeline);
+        DispatchCmdBindPipeline(cb_state.VkHandle(), VK_PIPELINE_BIND_POINT_GRAPHICS, validation_pipeline);
     }
     static_assert(sizeof(push_constants) <= 128, "push_constants buffer size >128, need to consider maxPushConstantsSize.");
-    DispatchCmdPushConstants(cmd_buffer, shared_draw_resources.pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT, 0,
+    DispatchCmdPushConstants(cb_state.VkHandle(), shared_draw_resources.pipeline_layout, VK_SHADER_STAGE_VERTEX_BIT, 0,
                              static_cast<uint32_t>(sizeof(push_constants)), push_constants);
     BindValidationCmdsCommonDescSet(cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, shared_draw_resources.pipeline_layout,
-                                    cb_state->draw_index, static_cast<uint32_t>(cb_state->per_command_error_loggers.size()));
-    DispatchCmdBindDescriptorSets(cmd_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, shared_draw_resources.pipeline_layout,
+                                    cb_state.draw_index, static_cast<uint32_t>(cb_state.per_command_error_loggers.size()));
+    DispatchCmdBindDescriptorSets(cb_state.VkHandle(), VK_PIPELINE_BIND_POINT_GRAPHICS, shared_draw_resources.pipeline_layout,
                                   glsl::kDiagPerCmdDescriptorSet, 1, &draw_validation_desc_set, 0, nullptr);
-    DispatchCmdDraw(cmd_buffer, 3, 1, 0, 0);  // TODO: this 3 assumes triangles I think, probably could be 1?
+    DispatchCmdDraw(cb_state.VkHandle(), 3, 1, 0, 0);  // TODO: this 3 assumes triangles I think, probably could be 1?
 
     CommandBuffer::ErrorLoggerFunc error_logger = [loc, indirect_buffer, indirect_offset, stride, indirect_buffer_size,
                                                    emit_task_error](Validator &gpuav, const uint32_t *error_record,
@@ -466,7 +461,7 @@ void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkComma
         return skip;
     };
 
-    cb_state->per_command_error_loggers.emplace_back(std::move(error_logger));
+    cb_state.per_command_error_loggers.emplace_back(std::move(error_logger));
 }
 
 }  // namespace gpuav

--- a/layers/gpu/cmd_validation/gpuav_draw.h
+++ b/layers/gpu/cmd_validation/gpuav_draw.h
@@ -26,7 +26,7 @@ class Validator;
 
 void DestroyRenderPassMappedResources(Validator &gpuav, VkRenderPass render_pass);
 
-void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, VkCommandBuffer cmd_buffer, VkBuffer indirect_buffer,
+void InsertIndirectDrawValidation(Validator &gpuav, const Location &loc, CommandBuffer &cb_state, VkBuffer indirect_buffer,
                                   VkDeviceSize indirect_offset, uint32_t draw_count, VkBuffer count_buffer,
                                   VkDeviceSize count_buffer_offset, uint32_t stride);
 

--- a/layers/gpu/cmd_validation/gpuav_trace_rays.h
+++ b/layers/gpu/cmd_validation/gpuav_trace_rays.h
@@ -26,7 +26,7 @@ class Validator;
 
 void DestroyRenderPassMappedResources(Validator &gpuav, VkRenderPass render_pass);
 
-void InsertIndirectTraceRaysValidation(Validator &gpuav, const Location &loc, VkCommandBuffer cmd_buffer,
+void InsertIndirectTraceRaysValidation(Validator &gpuav, const Location &loc, CommandBuffer &cb_state,
                                        VkDeviceAddress indirect_data_address);
 
 }  // namespace gpuav

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -23,7 +23,7 @@ namespace gpuav {
 
 struct DescSetState;
 
-void SetupShaderInstrumentationResources(Validator& gpuav, VkCommandBuffer cmd_buffer, VkPipelineBindPoint bind_point,
+void SetupShaderInstrumentationResources(Validator& gpuav, CommandBuffer& cmd_buffer, VkPipelineBindPoint bind_point,
                                          const Location& loc);
 
 // Return true iff a error has been found


### PR DESCRIPTION
This avoids lookup and locking churn, and makes it more obvious that the state object is in use by various instrumentation subroutines.