### PR TITLE
layers: Apply some clang-tidy fixes

### DIFF
--- a/layers/best_practices/bp_buffer.cpp
+++ b/layers/best_practices/bp_buffer.cpp
@@ -18,7 +18,6 @@
  */
 
 #include "best_practices/best_practices_validation.h"
-#include "state_tracker/image_state.h"
 
 bool BestPractices::PreCallValidateCreateBuffer(VkDevice device, const VkBufferCreateInfo* pCreateInfo,
                                                 const VkAllocationCallbacks* pAllocator, VkBuffer* pBuffer,

--- a/layers/best_practices/bp_cmd_buffer_nv.cpp
+++ b/layers/best_practices/bp_cmd_buffer_nv.cpp
@@ -119,14 +119,14 @@ void BestPractices::RecordResetScopeZcullDirection(bp_state::CommandBuffer& cmd_
 
 template <typename Func>
 static void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
-    const uint32_t layerCount =
+    const uint32_t layer_count =
         (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (image.full_range.layerCount - range.baseArrayLayer) : range.layerCount;
-    const uint32_t levelCount =
+    const uint32_t level_count =
         (range.levelCount == VK_REMAINING_MIP_LEVELS) ? (image.full_range.levelCount - range.baseMipLevel) : range.levelCount;
 
-    for (uint32_t i = 0; i < layerCount; ++i) {
+    for (uint32_t i = 0; i < layer_count; ++i) {
         const uint32_t layer = range.baseArrayLayer + i;
-        for (uint32_t j = 0; j < levelCount; ++j) {
+        for (uint32_t j = 0; j < level_count; ++j) {
             const uint32_t level = range.baseMipLevel + j;
             func(layer, level);
         }

--- a/layers/best_practices/bp_copy_blit_resolve.cpp
+++ b/layers/best_practices/bp_copy_blit_resolve.cpp
@@ -403,9 +403,9 @@ void BestPractices::PostCallRecordCmdResolveImage2(VkCommandBuffer commandBuffer
     auto& funcs = cb_state->queue_submit_functions;
     auto src = Get<bp_state::Image>(pResolveImageInfo->srcImage);
     auto dst = Get<bp_state::Image>(pResolveImageInfo->dstImage);
-    uint32_t regionCount = pResolveImageInfo->regionCount;
+    uint32_t region_count = pResolveImageInfo->regionCount;
 
-    for (uint32_t i = 0; i < regionCount; i++) {
+    for (uint32_t i = 0; i < region_count; i++) {
         QueueValidateImage(funcs, record_obj.location.function, src, IMAGE_SUBRESOURCE_USAGE_BP::RESOLVE_READ,
                            pResolveImageInfo->pRegions[i].srcSubresource);
         QueueValidateImage(funcs, record_obj.location.function, dst, IMAGE_SUBRESOURCE_USAGE_BP::RESOLVE_WRITE,
@@ -602,9 +602,9 @@ bool BestPractices::PreCallValidateCmdCopyImage(VkCommandBuffer commandBuffer, V
         auto dst_state = Get<vvl::Image>(dstImage);
 
         if (src_state && dst_state) {
-            VkImageTiling src_Tiling = src_state->create_info.tiling;
-            VkImageTiling dst_Tiling = dst_state->create_info.tiling;
-            if (src_Tiling != dst_Tiling && (src_Tiling == VK_IMAGE_TILING_LINEAR || dst_Tiling == VK_IMAGE_TILING_LINEAR)) {
+            VkImageTiling src_tiling = src_state->create_info.tiling;
+            VkImageTiling dst_tiling = dst_state->create_info.tiling;
+            if (src_tiling != dst_tiling && (src_tiling == VK_IMAGE_TILING_LINEAR || dst_tiling == VK_IMAGE_TILING_LINEAR)) {
                 const LogObjectList objlist(commandBuffer, srcImage, dstImage);
                 skip |= LogPerformanceWarning("BestPractices-AMD-vkImage-AvoidImageToImageCopy", objlist, error_obj.location,
                                               "%s srcImage (%s) and dstImage (%s) have differing tilings. Use buffer to "

--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -109,12 +109,13 @@ void BestPractices::RecordCmdDrawTypeArm(bp_state::CommandBuffer& cb_state, uint
     auto& render_pass_state = cb_state.render_pass_state;
     // Each TBDR vendor requires a depth pre-pass draw call to have a minimum number of vertices/indices before it counts towards
     // depth prepass warnings First find the lowest enabled draw count
-    uint32_t lowestEnabledMinDrawCount = 0;
-    lowestEnabledMinDrawCount = VendorCheckEnabled(kBPVendorArm) * kDepthPrePassMinDrawCountArm;
-    if (VendorCheckEnabled(kBPVendorIMG) && kDepthPrePassMinDrawCountIMG < lowestEnabledMinDrawCount)
-        lowestEnabledMinDrawCount = kDepthPrePassMinDrawCountIMG;
+    uint32_t lowest_enabled_min_draw_count = 0;
+    lowest_enabled_min_draw_count = VendorCheckEnabled(kBPVendorArm) * kDepthPrePassMinDrawCountArm;
+    if (VendorCheckEnabled(kBPVendorIMG) && kDepthPrePassMinDrawCountIMG < lowest_enabled_min_draw_count) {
+        lowest_enabled_min_draw_count = kDepthPrePassMinDrawCountIMG;
+    }
 
-    if (draw_count >= lowestEnabledMinDrawCount) {
+    if (draw_count >= lowest_enabled_min_draw_count) {
         if (render_pass_state.depthOnly) render_pass_state.numDrawCallsDepthOnly++;
         if (render_pass_state.depthEqualComparison) render_pass_state.numDrawCallsDepthEqualCompare++;
     }

--- a/layers/best_practices/bp_instance_device.cpp
+++ b/layers/best_practices/bp_instance_device.cpp
@@ -331,6 +331,7 @@ void BestPractices::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount
 namespace {
 struct EventValidator {
     const ValidationStateTracker& state_tracker;
+
     vvl::unordered_map<VkEvent, bool> signaling_state;
 
     EventValidator(const ValidationStateTracker& state_tracker) : state_tracker(state_tracker) {}

--- a/layers/best_practices/bp_render_pass.cpp
+++ b/layers/best_practices/bp_render_pass.cpp
@@ -65,10 +65,10 @@ static inline bool RenderPassUsesAttachmentAsImageOnly(const vku::safe_VkRenderP
     }
 
     for (uint32_t subpass = 0; subpass < create_info.subpassCount; subpass++) {
-        const auto& subpassInfo = create_info.pSubpasses[subpass];
+        const auto& subpass_info = create_info.pSubpasses[subpass];
 
-        for (uint32_t i = 0; i < subpassInfo.inputAttachmentCount; i++) {
-            if (subpassInfo.pInputAttachments[i].attachment == attachment) {
+        for (uint32_t i = 0; i < subpass_info.inputAttachmentCount; i++) {
+            if (subpass_info.pInputAttachments[i].attachment == attachment) {
                 return true;
             }
         }

--- a/layers/best_practices/bp_synchronization.cpp
+++ b/layers/best_practices/bp_synchronization.cpp
@@ -442,14 +442,14 @@ bool BestPractices::ValidateCmdPipelineBarrierImageBarrier(VkCommandBuffer comma
 
 template <typename Func>
 static void ForEachSubresource(const vvl::Image& image, const VkImageSubresourceRange& range, Func&& func) {
-    const uint32_t layerCount =
+    const uint32_t layer_count =
         (range.layerCount == VK_REMAINING_ARRAY_LAYERS) ? (image.full_range.layerCount - range.baseArrayLayer) : range.layerCount;
-    const uint32_t levelCount =
+    const uint32_t level_count =
         (range.levelCount == VK_REMAINING_MIP_LEVELS) ? (image.full_range.levelCount - range.baseMipLevel) : range.levelCount;
 
-    for (uint32_t i = 0; i < layerCount; ++i) {
+    for (uint32_t i = 0; i < layer_count; ++i) {
         const uint32_t layer = range.baseArrayLayer + i;
-        for (uint32_t j = 0; j < levelCount; ++j) {
+        for (uint32_t j = 0; j < level_count; ++j) {
             const uint32_t level = range.baseMipLevel + j;
             func(layer, level);
         }

--- a/layers/state_tracker/cmd_buffer_state.cpp
+++ b/layers/state_tracker/cmd_buffer_state.cpp
@@ -1710,10 +1710,10 @@ bool CommandBuffer::HasExternalFormatResolveAttachment() const {
 }
 
 void CommandBuffer::BindShader(VkShaderStageFlagBits shader_stage, vvl::ShaderObject *shader_object_state) {
-    auto &lastBoundState = lastBound[ConvertToPipelineBindPoint(shader_stage)];
+    auto &last_bound_state = lastBound[ConvertToPipelineBindPoint(shader_stage)];
     const auto stage_index = static_cast<uint32_t>(ConvertToShaderObjectStage(shader_stage));
-    lastBoundState.shader_object_bound[stage_index] = true;
-    lastBoundState.shader_object_states[stage_index] = shader_object_state;
+    last_bound_state.shader_object_bound[stage_index] = true;
+    last_bound_state.shader_object_states[stage_index] = shader_object_state;
 }
 
 void CommandBuffer::UnbindResources() {

--- a/layers/state_tracker/device_state.cpp
+++ b/layers/state_tracker/device_state.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "state_tracker/device_state.h"
+#include "generated/layer_chassis_dispatch.h"
 
 namespace vvl {
 

--- a/layers/state_tracker/device_state.h
+++ b/layers/state_tracker/device_state.h
@@ -18,7 +18,6 @@
  */
 #pragma once
 #include "state_tracker/state_object.h"
-#include "generated/layer_chassis_dispatch.h"
 #include <vulkan/utility/vk_safe_struct.hpp>
 #include <vector>
 

--- a/layers/state_tracker/image_state.cpp
+++ b/layers/state_tracker/image_state.cpp
@@ -57,8 +57,8 @@ VkImageSubresourceRange NormalizeSubresourceRange(const VkImageCreateInfo &image
 }
 
 static bool IsDepthSliced(const VkImageCreateInfo &image_create_info, const VkImageViewCreateInfo &create_info) {
-    auto kDepthSlicedFlags = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
-    return ((image_create_info.flags & kDepthSlicedFlags) != 0) &&
+    auto depth_slice_flag = VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT | VK_IMAGE_CREATE_2D_VIEW_COMPATIBLE_BIT_EXT;
+    return ((image_create_info.flags & depth_slice_flag) != 0) &&
            (create_info.viewType == VK_IMAGE_VIEW_TYPE_2D || create_info.viewType == VK_IMAGE_VIEW_TYPE_2D_ARRAY);
 }
 

--- a/layers/state_tracker/image_state.h
+++ b/layers/state_tracker/image_state.h
@@ -99,10 +99,10 @@ class Image : public Bindable {
     const VkFormatFeatureFlags2KHR format_features;
     // Need to memory requirments for each plane if image is disjoint
     const bool disjoint;  // True if image was created with VK_IMAGE_CREATE_DISJOINT_BIT
-    static constexpr int MAX_PLANES = 3;
-    using MemoryReqs = std::array<VkMemoryRequirements, MAX_PLANES>;
+    static constexpr int kMaxPlanes = 3;
+    using MemoryReqs = std::array<VkMemoryRequirements, kMaxPlanes>;
     const MemoryReqs requirements;
-    std::array<bool, MAX_PLANES> memory_requirements_checked = {};
+    std::array<bool, kMaxPlanes> memory_requirements_checked = {};
 
     const bool sparse_residency;
     using SparseReqs = std::vector<VkSparseImageMemoryRequirements>;

--- a/layers/state_tracker/sampler_state.h
+++ b/layers/state_tracker/sampler_state.h
@@ -76,8 +76,8 @@ class Sampler : public StateObject {
 
   private:
     static inline VkSamplerYcbcrConversion GetConversion(const VkSamplerCreateInfo *pCreateInfo) {
-        auto *conversionInfo = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
-        return conversionInfo ? conversionInfo->conversion : VK_NULL_HANDLE;
+        auto *conversion_info = vku::FindStructInPNextChain<VkSamplerYcbcrConversionInfo>(pCreateInfo->pNext);
+        return conversion_info ? conversion_info->conversion : VK_NULL_HANDLE;
     }
     static inline VkSamplerCustomBorderColorCreateInfoEXT GetCustomCreateInfo(const VkSamplerCreateInfo *pCreateInfo) {
         VkSamplerCustomBorderColorCreateInfoEXT result{};

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -397,11 +397,13 @@ void ValidationStateTracker::PostCallRecordCreateBuffer(VkDevice device, const V
         if ((buffer_state->usage & descriptor_buffer_usages) != 0) {
             descriptorBufferAddressSpaceSize += pCreateInfo->size;
 
-            if ((buffer_state->usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+            if ((buffer_state->usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) != 0) {
                 resourceDescriptorBufferAddressSpaceSize += pCreateInfo->size;
+            }
 
-            if ((buffer_state->usage & VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) != 0)
+            if ((buffer_state->usage & VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) != 0) {
                 samplerDescriptorBufferAddressSpaceSize += pCreateInfo->size;
+            }
         }
     }
     Add(std::move(buffer_state));
@@ -521,11 +523,13 @@ void ValidationStateTracker::PreCallRecordDestroyBuffer(VkDevice device, VkBuffe
         if ((buffer_state->usage & descriptor_buffer_usages) != 0) {
             descriptorBufferAddressSpaceSize -= buffer_state->create_info.size;
 
-            if (buffer_state->usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT)
+            if (buffer_state->usage & VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT) {
                 resourceDescriptorBufferAddressSpaceSize -= buffer_state->create_info.size;
+            }
 
-            if (buffer_state->usage & VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT)
+            if (buffer_state->usage & VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT) {
                 samplerDescriptorBufferAddressSpaceSize -= buffer_state->create_info.size;
+            }
         }
 
         if (buffer_state->deviceAddress != 0) {
@@ -758,8 +762,9 @@ void ValidationStateTracker::PostCreateDevice(const VkDeviceCreateInfo *pCreateI
     if (dev_ext.vk_feature_version_1_2 || dev_ext.vk_feature_version_1_3) {
         GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_2, &phys_dev_props_core11);
         GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_2, &phys_dev_props_core12);
-        if (dev_ext.vk_feature_version_1_3)
+        if (dev_ext.vk_feature_version_1_3) {
             GetPhysicalDeviceExtProperties(physical_device, dev_ext.vk_feature_version_1_3, &phys_dev_props_core13);
+        }
     } else {
         // VkPhysicalDeviceVulkan11Properties
         //
@@ -2268,14 +2273,14 @@ void ValidationStateTracker::PreCallRecordCmdBindPipeline(VkCommandBuffer comman
         if (!has_dynamic_viewport_count) {
             cb_state->trashedViewportCount = true;
             if (viewport_state && (!pipe_state->IsDynamic(CB_DYNAMIC_STATE_VIEWPORT))) {
-                cb_state->trashedViewportMask |= (uint32_t(1) << viewport_state->viewportCount) - 1u;
+                cb_state->trashedViewportMask |= (1u << viewport_state->viewportCount) - 1u;
                 // should become = ~uint32_t(0) if the other interpretation is correct.
             }
         }
         if (!has_dynamic_scissor_count) {
             cb_state->trashedScissorCount = true;
             if (viewport_state && (!pipe_state->IsDynamic(CB_DYNAMIC_STATE_SCISSOR))) {
-                cb_state->trashedScissorMask |= (uint32_t(1) << viewport_state->scissorCount) - 1u;
+                cb_state->trashedScissorMask |= (1u << viewport_state->scissorCount) - 1u;
                 // should become = ~uint32_t(0) if the other interpretation is correct.
             }
         }

--- a/layers/stateless/sl_cmd_buffer.cpp
+++ b/layers/stateless/sl_cmd_buffer.cpp
@@ -228,17 +228,18 @@ bool StatelessValidation::manual_PreCallValidateCmdBindVertexBuffers2(VkCommandB
     // Check VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength
     // This is a special case and generator currently skips it
     {
-        const bool vuidCondition = (pSizes != nullptr) || (pStrides != nullptr);
-        const bool vuidExpectation = bindingCount > 0;
-        if (vuidCondition) {
-            if (!vuidExpectation) {
+        const bool vuid_condition = (pSizes != nullptr) || (pStrides != nullptr);
+        const bool vuid_expectation = bindingCount > 0;
+        if (vuid_condition) {
+            if (!vuid_expectation) {
                 const char *not_null_msg = "";
-                if ((pSizes != nullptr) && (pStrides != nullptr))
+                if ((pSizes != nullptr) && (pStrides != nullptr)) {
                     not_null_msg = "pSizes and pStrides are not NULL";
-                else if (pSizes != nullptr)
+                } else if (pSizes != nullptr) {
                     not_null_msg = "pSizes is not NULL";
-                else
+                } else {
                     not_null_msg = "pStrides is not NULL";
+                }
                 skip |= LogError("VUID-vkCmdBindVertexBuffers2-bindingCount-arraylength", commandBuffer, error_obj.location,
                                  "%s, so bindingCount must be greater than 0.", not_null_msg);
             }

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -935,17 +935,17 @@ static bool MutableDescriptorTypePartialOverlap(const VkDescriptorPoolCreateInfo
         vvl::span<const VkDescriptorType> first_types, second_types;
 
         if (mutable_descriptor_type->mutableDescriptorTypeListCount > i) {
-            const uint32_t descriptorTypeCount = mutable_descriptor_type->pMutableDescriptorTypeLists[i].descriptorTypeCount;
-            auto *pDescriptorTypes = mutable_descriptor_type->pMutableDescriptorTypeLists[i].pDescriptorTypes;
-            first_types = vvl::make_span(pDescriptorTypes, descriptorTypeCount);
+            const uint32_t descriptor_type_count = mutable_descriptor_type->pMutableDescriptorTypeLists[i].descriptorTypeCount;
+            auto *descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[i].pDescriptorTypes;
+            first_types = vvl::make_span(descriptor_types, descriptor_type_count);
         } else {
             first_types = vvl::make_span(all_descriptor_types.data(), all_descriptor_types.size());
         }
 
         if (mutable_descriptor_type->mutableDescriptorTypeListCount > j) {
-            const uint32_t descriptorTypeCount = mutable_descriptor_type->pMutableDescriptorTypeLists[j].descriptorTypeCount;
-            auto *pDescriptorTypes = mutable_descriptor_type->pMutableDescriptorTypeLists[j].pDescriptorTypes;
-            second_types = vvl::make_span(pDescriptorTypes, descriptorTypeCount);
+            const uint32_t descriptor_type_count = mutable_descriptor_type->pMutableDescriptorTypeLists[j].descriptorTypeCount;
+            auto *descriptor_types = mutable_descriptor_type->pMutableDescriptorTypeLists[j].pDescriptorTypes;
+            second_types = vvl::make_span(descriptor_types, descriptor_type_count);
         } else {
             second_types = vvl::make_span(all_descriptor_types.data(), all_descriptor_types.size());
         }

--- a/layers/stateless/sl_image.cpp
+++ b/layers/stateless/sl_image.cpp
@@ -340,16 +340,16 @@ bool StatelessValidation::manual_PreCallValidateCreateImage(VkDevice device, con
     }
 
     if (format_list_info) {
-        const uint32_t viewFormatCount = format_list_info->viewFormatCount;
+        const uint32_t view_format_count = format_list_info->viewFormatCount;
         const bool mutable_image = (image_flags & VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT) != 0;
-        if (!mutable_image && viewFormatCount > 1) {
+        if (!mutable_image && view_format_count > 1) {
             skip |= LogError("VUID-VkImageCreateInfo-flags-04738", device,
                              create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
-                             "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.", viewFormatCount,
+                             "is %" PRIu32 " but flag (%s) does not include VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT.", view_format_count,
                              string_VkImageCreateFlags(image_flags).c_str());
         }
         // Check if viewFormatCount is not zero that it is all compatible
-        for (uint32_t i = 0; i < viewFormatCount; i++) {
+        for (uint32_t i = 0; i < view_format_count; i++) {
             const VkFormat view_format = format_list_info->pViewFormats[i];
             const Location format_loc = create_info_loc.pNext(Struct::VkImageFormatListCreateInfo, Field::pViewFormats, i);
             const bool class_compatible = vkuFormatCompatibilityClass(view_format) == vkuFormatCompatibilityClass(image_format);

--- a/layers/stateless/sl_render_pass.cpp
+++ b/layers/stateless/sl_render_pass.cpp
@@ -35,10 +35,11 @@ bool StatelessValidation::ValidateSubpassGraphicsFlags(VkDevice device, const Vk
         ~kExcludeStages;
 
     const auto IsPipeline = [pCreateInfo](uint32_t subpass, const VkPipelineBindPoint stage) {
-        if (subpass == VK_SUBPASS_EXTERNAL || subpass >= pCreateInfo->subpassCount)
+        if (subpass == VK_SUBPASS_EXTERNAL || subpass >= pCreateInfo->subpassCount) {
             return false;
-        else
+        } else {
             return pCreateInfo->pSubpasses[subpass].pipelineBindPoint == stage;
+        }
     };
 
     const bool is_all_graphics_stages = (stages & ~kGraphicsStages) == 0;
@@ -387,13 +388,16 @@ void StatelessValidation::RecordRenderPass(VkRenderPass renderPass, const VkRend
     for (uint32_t subpass = 0; subpass < pCreateInfo->subpassCount; ++subpass) {
         bool uses_color = false;
 
-        for (uint32_t i = 0; i < pCreateInfo->pSubpasses[subpass].colorAttachmentCount && !uses_color; ++i)
+        for (uint32_t i = 0; i < pCreateInfo->pSubpasses[subpass].colorAttachmentCount && !uses_color; ++i) {
             if (pCreateInfo->pSubpasses[subpass].pColorAttachments[i].attachment != VK_ATTACHMENT_UNUSED) uses_color = true;
+        }
 
         bool uses_depthstencil = false;
-        if (pCreateInfo->pSubpasses[subpass].pDepthStencilAttachment)
-            if (pCreateInfo->pSubpasses[subpass].pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED)
+        if (pCreateInfo->pSubpasses[subpass].pDepthStencilAttachment) {
+            if (pCreateInfo->pSubpasses[subpass].pDepthStencilAttachment->attachment != VK_ATTACHMENT_UNUSED) {
                 uses_depthstencil = true;
+            }
+        }
 
         if (uses_color) renderpass_state.subpasses_using_color_attachment.insert(subpass);
         if (uses_depthstencil) renderpass_state.subpasses_using_depthstencil_attachment.insert(subpass);

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -70,16 +70,16 @@ bool StatelessValidation::ValidateSwapchainCreateInfo(const VkSwapchainCreateInf
     // Validate VK_KHR_image_format_list VkImageFormatListCreateInfo
     const auto format_list_info = vku::FindStructInPNextChain<VkImageFormatListCreateInfo>(create_info.pNext);
     if (format_list_info) {
-        const uint32_t viewFormatCount = format_list_info->viewFormatCount;
-        if (((create_info.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) == 0) && (viewFormatCount > 1)) {
+        const uint32_t view_format_count = format_list_info->viewFormatCount;
+        if (((create_info.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) == 0) && (view_format_count > 1)) {
             skip |= LogError("VUID-VkSwapchainCreateInfoKHR-flags-04100", device,
                              loc.pNext(Struct::VkImageFormatListCreateInfo, Field::viewFormatCount),
                              "is %" PRIu32 " but flag (%s) does not includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR.",
-                             viewFormatCount, string_VkImageCreateFlags(create_info.flags).c_str());
+                             view_format_count, string_VkImageCreateFlags(create_info.flags).c_str());
         }
 
         // Using the first format, compare the rest of the formats against it that they are compatible
-        for (uint32_t i = 1; i < viewFormatCount; i++) {
+        for (uint32_t i = 1; i < view_format_count; i++) {
             if (vkuFormatCompatibilityClass(format_list_info->pViewFormats[0]) !=
                 vkuFormatCompatibilityClass(format_list_info->pViewFormats[i])) {
                 skip |= LogError("VUID-VkSwapchainCreateInfoKHR-pNext-04099", device,

--- a/layers/utils/hash_util.cpp
+++ b/layers/utils/hash_util.cpp
@@ -1,6 +1,6 @@
-/* Copyright (c) 2023 The Khronos Group Inc.
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+/* Copyright (c) 2023-2024 The Khronos Group Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/layers/utils/hash_util.h
+++ b/layers/utils/hash_util.h
@@ -1,7 +1,7 @@
-/* Copyright (c) 2015-2021 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
- * Copyright (C) 2015-2021 Google Inc.
+/* Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
+ * Copyright (C) 2015-2024 Google Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,7 +20,6 @@
 
 #include <cstdint>
 #include <functional>
-#include <limits>
 #include <memory>
 #include <mutex>
 #include <type_traits>

--- a/layers/utils/ray_tracing_utils.h
+++ b/layers/utils/ray_tracing_utils.h
@@ -18,8 +18,6 @@
 
 #include "vulkan/vulkan.h"
 
-#include <functional>
-
 namespace rt {
 
 enum class BuildType { Device, Host };

--- a/layers/utils/shader_utils.cpp
+++ b/layers/utils/shader_utils.cpp
@@ -68,35 +68,35 @@ void ValidationCache::Load(VkValidationCacheCreateInfoEXT const *pCreateInfo) {
 }
 
 void ValidationCache::Write(size_t *pDataSize, void *pData) {
-    const auto headerSize = 2 * sizeof(uint32_t) + VK_UUID_SIZE;  // 4 bytes for header size + 4 bytes for version number + UUID
+    const auto header_size = 2 * sizeof(uint32_t) + VK_UUID_SIZE;  // 4 bytes for header size + 4 bytes for version number + UUID
     if (!pData) {
-        *pDataSize = headerSize + good_shader_hashes_.size() * sizeof(uint32_t);
+        *pDataSize = header_size + good_shader_hashes_.size() * sizeof(uint32_t);
         return;
     }
 
-    if (*pDataSize < headerSize) {
+    if (*pDataSize < header_size) {
         *pDataSize = 0;
         return;  // Too small for even the header!
     }
 
     uint32_t *out = (uint32_t *)pData;
-    size_t actualSize = headerSize;
+    size_t actual_size = header_size;
 
     // Write the header
-    *out++ = headerSize;
+    *out++ = header_size;
     *out++ = VK_VALIDATION_CACHE_HEADER_VERSION_ONE_EXT;
     GetUUID(reinterpret_cast<uint8_t *>(out));
     out = (uint32_t *)(reinterpret_cast<uint8_t *>(out) + VK_UUID_SIZE);
 
     {
         auto guard = ReadLock();
-        for (auto it = good_shader_hashes_.begin(); it != good_shader_hashes_.end() && actualSize < *pDataSize;
-             it++, out++, actualSize += sizeof(uint32_t)) {
+        for (auto it = good_shader_hashes_.begin(); it != good_shader_hashes_.end() && actual_size < *pDataSize;
+             it++, out++, actual_size += sizeof(uint32_t)) {
             *out = *it;
         }
     }
 
-    *pDataSize = actualSize;
+    *pDataSize = actual_size;
 }
 
 void ValidationCache::Merge(ValidationCache const *other) {

--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -20,9 +20,7 @@
 
 #include <cassert>
 #include <cctype>
-#include <cstddef>
 #include <cstring>
-#include <functional>
 #include <string>
 #include <vector>
 #include <bitset>
@@ -31,7 +29,6 @@
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_concurrent_unordered_map.hpp>
 
-#include "cast_utils.h"
 #include "generated/vk_extension_helper.h"
 #include "error_message/logging.h"
 

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -22,7 +22,6 @@
 #include <cstring>
 #include <fstream>
 #include <iostream>
-#include <sstream>
 #include <string>
 #include <charconv>
 #include <sys/stat.h>


### PR DESCRIPTION
using `Zed` took some time to look through clang-tidy warnings, a LOT were not worth fixing, but here are some good low-hanging fruit