### PR TITLE
gpu: Cleanup setting init

### DIFF
--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -55,10 +55,7 @@ class Validator : public gpu::GpuShaderInstrumentor {
     using Field = vvl::Field;
 
   public:
-    Validator() {
-        container_type = LayerObjectTypeGpuAssisted;
-        force_buffer_device_address_ = true;
-    }
+    Validator() { container_type = LayerObjectTypeGpuAssisted; }
 
     // gpuav_setup.cpp
     // -------------
@@ -83,6 +80,9 @@ class Validator : public gpu::GpuShaderInstrumentor {
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
                                    vku::safe_VkDeviceCreateInfo* modified_create_info) final;
     void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
+
+  private:
+    void InitSettings(const Location& loc);
 
     // gpuav_record.cpp
     // --------------
@@ -325,7 +325,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
   public:
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
     gpu::SharedResourcesManager shared_resources_manager;
-    bool bda_validation_possible = false;
 
   private:
     std::string instrumented_shader_cache_path_{};

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -69,29 +69,29 @@ void Validator::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const
                                           const RecordObject &record_obj, vku::safe_VkDeviceCreateInfo *modified_create_info) {
     BaseClass::PreCallRecordCreateDevice(physicalDevice, pCreateInfo, pAllocator, pDevice, record_obj, modified_create_info);
 
+    // In PreCallRecord this is all about trying to turn on as many feature/extension as possible on behalf of the app
+
     auto add_missing_features = [this, &record_obj, modified_create_info]() {
-        if (force_buffer_device_address_) {
-            // Add buffer device address feature
-            if (auto *bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
-                    vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(modified_create_info))) {
-                InternalWarning(device, record_obj.location,
-                                "Forcing VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress to VK_TRUE");
-                bda_features->bufferDeviceAddress = VK_TRUE;
-            } else {
-                InternalWarning(
-                    device, record_obj.location,
-                    "Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE");
-                VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
-                new_bda_features.bufferDeviceAddress = VK_TRUE;
-                vku::AddToPnext(*modified_create_info, new_bda_features);
-            }
+        // Add buffer device address feature
+        if (auto *bda_features = const_cast<VkPhysicalDeviceBufferDeviceAddressFeatures *>(
+                vku::FindStructInPNextChain<VkPhysicalDeviceBufferDeviceAddressFeatures>(modified_create_info))) {
+            InternalWarning(device, record_obj.location,
+                            "Forcing VkPhysicalDeviceBufferDeviceAddressFeatures::bufferDeviceAddress to VK_TRUE");
+            bda_features->bufferDeviceAddress = VK_TRUE;
+        } else {
+            InternalWarning(
+                device, record_obj.location,
+                "Adding a VkPhysicalDeviceBufferDeviceAddressFeatures to pNext with bufferDeviceAddress set to VK_TRUE");
+            VkPhysicalDeviceBufferDeviceAddressFeatures new_bda_features = vku::InitStructHelper();
+            new_bda_features.bufferDeviceAddress = VK_TRUE;
+            vku::AddToPnext(*modified_create_info, new_bda_features);
         }
     };
 
     if (api_version > VK_API_VERSION_1_1) {
         if (auto *features12 = const_cast<VkPhysicalDeviceVulkan12Features *>(
                 vku::FindStructInPNextChain<VkPhysicalDeviceVulkan12Features>(modified_create_info->pNext))) {
-            if (force_buffer_device_address_ && !features12->bufferDeviceAddress) {
+            if (!features12->bufferDeviceAddress) {
                 InternalWarning(device, record_obj.location,
                                 "Forcing VkPhysicalDeviceVulkan12Features::bufferDeviceAddress to VK_TRUE");
                 features12->bufferDeviceAddress = VK_TRUE;
@@ -104,8 +104,6 @@ void Validator::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const
         const std::string_view bda_ext{"VK_KHR_buffer_device_address"};
         vku::AddExtension(*modified_create_info, bda_ext.data());
         add_missing_features();
-    } else {
-        force_buffer_device_address_ = false;
     }
 }
 
@@ -142,67 +140,8 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     // We might fail in parent class device creation if global requirements are not met
     if (aborted_) return;
 
-    VkPhysicalDeviceFeatures supported_features{};
-    DispatchGetPhysicalDeviceFeatures(physical_device, &supported_features);
-
-    bda_validation_possible = ((IsExtEnabled(device_extensions.vk_ext_buffer_device_address) ||
-                                IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) &&
-                               supported_features.shaderInt64 && enabled_features.bufferDeviceAddress);
-    if (!bda_validation_possible) {
-        if (gpuav_settings.validate_bda) {
-            if (!supported_features.shaderInt64) {
-                InternalWarning(
-                    device, loc,
-                    "Buffer device address validation option was enabled, but required features shaderInt64 is not enabled. "
-                    "Disabling option.");
-            } else {
-                InternalWarning(device, loc,
-                                "Buffer device address validation option was enabled, but required buffer device address extension "
-                                "and/or features are not enabled. Disabling option.");
-            }
-        }
-        gpuav_settings.validate_bda = false;
-    }
-
-    if (gpuav_settings.validate_ray_query) {
-        if (!enabled_features.rayQuery) {
-            gpuav_settings.validate_ray_query = false;
-            InternalWarning(device, loc,
-                            "Ray query validation option was enabled, but required feature rayQuery is not enabled. "
-                            "Disabling option.");
-        }
-    }
-
-    // copy_buffer_to_image.comp relies on uint8_t buffers to perform validation
-    if (gpuav_settings.validate_buffer_copies) {
-        if (!enabled_features.uniformAndStorageBuffer8BitAccess) {
-            gpuav_settings.validate_buffer_copies = false;
-            InternalWarning(
-                device, loc,
-                "gpuav_validate_copies option was enabled, but uniformAndStorageBuffer8BitAccess feature is not available. "
-                "Disabling option.");
-        }
-    }
-
-    if (IsExtEnabled(device_extensions.vk_ext_descriptor_buffer)) {
-        InternalWarning(
-            device, loc,
-            "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers. "
-            "Use of descriptor buffers will result in no descriptor checking");
-    }
-
-    if (gpuav_settings.validate_descriptors && !force_buffer_device_address_) {
-        gpuav_settings.validate_descriptors = false;
-        InternalWarning(device, loc, "Buffer Device Address + feature is not available.  No descriptor checking will be attempted");
-    }
-
-    if (gpuav_settings.IsBufferValidationEnabled() && (phys_dev_props.limits.maxPushConstantsSize < 4 * sizeof(uint32_t))) {
-        gpuav_settings.SetBufferValidationEnabled(false);
-        InternalWarning(
-            device, loc,
-            "Device does not support the minimum range of push constants (32 bytes).  No indirect buffer checking will be "
-            "attempted");
-    }
+    // Need the device to be created before we can query features for settings
+    InitSettings(loc);
 
     if (gpuav_settings.validate_descriptors) {
         VkPhysicalDeviceDescriptorIndexingProperties desc_indexing_props = vku::InitStructHelper();
@@ -300,6 +239,76 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         }
 
         vmaUnmapMemory(vma_allocator_, indices_buffer_.allocation);
+    }
+}
+
+// At this point extensions/features may have been turned on by us in PreCallRecord.
+// Now that we have all the information, here is where we might disable GPU-AV settings that are missing requirements
+void Validator::InitSettings(const Location &loc) {
+    VkPhysicalDeviceFeatures supported_features{};
+    DispatchGetPhysicalDeviceFeatures(physical_device, &supported_features);
+
+    if (gpuav_settings.validate_descriptors) {
+        if (!enabled_features.bufferDeviceAddress) {
+            gpuav_settings.validate_descriptors = false;
+            InternalWarning(device, loc,
+                            "Descriptors Indexing validaiton optin was enabled. but the bufferDeviceAddress was not enabled "
+                            "[Disabling gpuav_descriptor_checks]");
+        }
+    }
+
+    if (gpuav_settings.validate_bda) {
+        const bool bda_validation_possible = ((IsExtEnabled(device_extensions.vk_ext_buffer_device_address) ||
+                                               IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) &&
+                                              supported_features.shaderInt64 && enabled_features.bufferDeviceAddress);
+        if (!bda_validation_possible) {
+            gpuav_settings.validate_bda = false;
+            if (!supported_features.shaderInt64) {
+                InternalWarning(device, loc,
+                                "Buffer device address validation option was enabled, but the shaderInt64 feature is not enabled. "
+                                "[Disabling gpuav_buffer_address_oob].");
+            } else {
+                InternalWarning(device, loc,
+                                "Buffer device address validation option was enabled, but required buffer device address extension "
+                                "and/or features are not enabled. [Disabling gpuav_buffer_address_oob]");
+            }
+        }
+    }
+
+    if (gpuav_settings.validate_ray_query) {
+        if (!enabled_features.rayQuery) {
+            gpuav_settings.validate_ray_query = false;
+            InternalWarning(device, loc,
+                            "Ray Query validation option was enabled, but the rayQuery feature is not enabled. "
+                            "[Disabling gpuav_validate_ray_query]");
+        }
+    }
+
+    // copy_buffer_to_image.comp relies on uint8_t buffers to perform validation
+    if (gpuav_settings.validate_buffer_copies) {
+        if (!enabled_features.uniformAndStorageBuffer8BitAccess) {
+            gpuav_settings.validate_buffer_copies = false;
+            InternalWarning(device, loc,
+                            "Buffer copies option was enabled, but the uniformAndStorageBuffer8BitAccess feature is not enabled. "
+                            "[Disabling gpuav_buffer_copies]");
+        }
+    }
+
+    if (IsExtEnabled(device_extensions.vk_ext_descriptor_buffer)) {
+        InternalWarning(
+            device, loc,
+            "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers. "
+            "Use of descriptor buffers will result in no descriptor checking");
+    }
+
+    if (gpuav_settings.IsBufferValidationEnabled()) {
+        if (phys_dev_props.limits.maxPushConstantsSize < 4 * sizeof(uint32_t)) {
+            gpuav_settings.SetBufferValidationEnabled(false);
+            InternalWarning(
+                device, loc,
+                "Device does not support the minimum range of push constants (32 bytes). No indirect buffer checking will be "
+                "attempted");
+        }
     }
 }
 

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -61,7 +61,7 @@ void UpdateBoundPipeline(Validator &gpuav, CommandBuffer &cb_state, VkPipelineBi
 
 void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelineBindPoint pipeline_bind_point,
                             const Location &loc) {
-    if (!gpuav.gpuav_settings.validate_descriptors || !gpuav.force_buffer_device_address_) {
+    if (!gpuav.gpuav_settings.validate_descriptors) {
         return;
     }
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -290,7 +290,7 @@ void GpuShaderInstrumentor::PostCreateDevice(const VkDeviceCreateInfo *pCreateIn
         return;
     }
 
-    VkResult result = UtilInitializeVma(instance, physical_device, device, force_buffer_device_address_, &vma_allocator_);
+    VkResult result = UtilInitializeVma(instance, physical_device, device, enabled_features.bufferDeviceAddress, &vma_allocator_);
     if (result != VK_SUCCESS) {
         InternalError(device, loc, "Could not initialize VMA", true);
         return;
@@ -1100,8 +1100,6 @@ VkDeviceAddress GpuShaderInstrumentor::GetBufferDeviceAddressHelper(VkBuffer buf
     VkBufferDeviceAddressInfo address_info = vku::InitStructHelper();
     address_info.buffer = buffer;
 
-    // We cannot rely on device_extensions here, since we may be enabling BDA support even
-    // though the application has not requested it.
     if (api_version >= VK_API_VERSION_1_2) {
         return DispatchGetBufferDeviceAddress(device, &address_info);
     } else {

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -211,7 +211,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     // sense too)
     mutable bool aborted_ = false;
 
-    bool force_buffer_device_address_;
     PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
     std::atomic<uint32_t> unique_shader_module_id_ = 1;  // zero represents no shader module found
     // The descriptor slot we will be injecting our error buffer into


### PR DESCRIPTION
we had this `force_buffer_device_address_` from back when `enabled_feature` was not working

this cleans up (unified the warning messages) for turning on/off settings in GPU-AV