### PR TITLE
gpu: Move ShaderCacheHash to a separate file

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -158,6 +158,7 @@ vvl_sources = [
   "layers/gpu/cmd_validation/gpuav_trace_rays.cpp",
   "layers/gpu/cmd_validation/gpuav_trace_rays.h",
   "layers/gpu/core/gpu_settings.h",
+  "layers/gpu/core/gpu_shader_cache_hash.h",
   "layers/gpu/core/gpu_state_tracker.cpp",
   "layers/gpu/core/gpu_state_tracker.h",
   "layers/gpu/core/gpuav.h",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -218,6 +218,7 @@ target_sources(vvl PRIVATE
     ${API_TYPE}/generated/cmd_validation_trace_rays_rgen.h
     ${API_TYPE}/generated/cmd_validation_trace_rays_rgen.cpp
     gpu/core/gpu_settings.h
+    gpu/core/gpu_shader_cache_hash.h
     gpu/core/gpuav_constants.h
     gpu/cmd_validation/gpuav_cmd_validation_common.h
     gpu/cmd_validation/gpuav_cmd_validation_common.cpp

--- a/layers/gpu/core/gpu_settings.h
+++ b/layers/gpu/core/gpu_settings.h
@@ -18,8 +18,6 @@
 #pragma once
 // Default values for those settings should match layers/VkLayer_khronos_validation.json.in
 
-#include "generated/gpu_av_shader_hash.h"
-
 struct GpuAVSettings {
     bool shader_instrumentation_enabled = true;
     bool validate_descriptors = true;
@@ -65,14 +63,6 @@ struct GpuAVSettings {
         validate_buffer_copies = enabled;
     }
 };
-
-#pragma pack(push, 1)
-struct ShaderCacheHash {
-    ShaderCacheHash(const GpuAVSettings& gpuav_settings) : gpuav_settings(gpuav_settings) {}
-    GpuAVSettings gpuav_settings{};
-    const char gpu_av_shader_git_hash[sizeof(GPU_AV_SHADER_GIT_HASH)] = GPU_AV_SHADER_GIT_HASH;
-};
-#pragma pack(pop)
 
 struct DebugPrintfSettings {
     bool to_stdout = false;

--- a/layers/gpu/core/gpu_shader_cache_hash.h
+++ b/layers/gpu/core/gpu_shader_cache_hash.h
@@ -1,0 +1,33 @@
+
+/* Copyright (c) 2020-2024 The Khronos Group Inc.
+ * Copyright (c) 2020-2024 Valve Corporation
+ * Copyright (c) 2020-2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+// Default values for those settings should match layers/VkLayer_khronos_validation.json.in
+
+#include "generated/gpu_av_shader_hash.h"
+#include "gpu/core/gpu_settings.h"
+
+// This structure is included in the shader cache to make sure is invalidated if a setting
+// or a GPUAV shader changes.
+#pragma pack(push, 1)
+struct ShaderCacheHash {
+    ShaderCacheHash(const GpuAVSettings& gpuav_settings) : gpuav_settings(gpuav_settings) {}
+    GpuAVSettings gpuav_settings{};
+    const char gpu_av_shader_git_hash[sizeof(GPU_AV_SHADER_GIT_HASH)] = GPU_AV_SHADER_GIT_HASH;
+};
+#pragma pack(pop)
+

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -29,6 +29,7 @@
 #include "gpu/instrumentation/gpuav_instrumentation.h"
 #include "gpu/shaders/gpu_shaders_constants.h"
 #include "chassis/chassis_modification_state.h"
+#include "gpu/core/gpu_shader_cache_hash.h"
 
 // Generated shaders
 #include "generated/gpu_av_shader_hash.h"

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -27,6 +27,7 @@
 #include "gpu/shaders/gpu_error_header.h"
 #include "gpu/shaders/gpu_shaders_constants.h"
 #include "generated/chassis.h"
+#include "gpu/core/gpu_shader_cache_hash.h"
 
 namespace gpuav {
 


### PR DESCRIPTION
This was in gpu_settings.h which is included by chassis.h. And it includes the autogenerated shader hash, which changes frequently when working on gpuav shaders and thus the whole world rebuilds every time a shader changes. It is really only needed in 2 cpp files so move it there.