### PR TITLE
gpu: Move Instrumentation to Pipeline creation

### DIFF
--- a/layers/best_practices/best_practices_validation.h
+++ b/layers/best_practices/best_practices_validation.h
@@ -845,12 +845,10 @@ class BestPractices : public ValidationStateTracker {
                                                                std::optional<vvl::DedicatedBinding>&& dedicated_binding,
                                                                uint32_t physical_device_count) final;
 
-    std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(const VkGraphicsPipelineCreateInfo* create_info,
-                                                               std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
-                                                               std::shared_ptr<const vvl::RenderPass>&& render_pass,
-                                                               std::shared_ptr<const vvl::PipelineLayout>&& layout,
-                                                               spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages],
-                                                               ShaderModuleUniqueIds* shader_unique_id_map) const final;
+    std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(
+        const VkGraphicsPipelineCreateInfo* create_info, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
+        std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
+        spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) const final;
 
   private:
     // CacheEntry and PostTransformLRUCacheModel are used on the stack

--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -238,18 +238,16 @@ static std::vector<bp_state::AttachmentInfo> GetAttachmentAccess(bp_state::Pipel
 
 bp_state::Pipeline::Pipeline(const ValidationStateTracker& state_data, const VkGraphicsPipelineCreateInfo* create_info,
                              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache,
-                             std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout,
-                             ShaderModuleUniqueIds* shader_unique_id_map)
-    : vvl::Pipeline(state_data, create_info, std::move(pipe_cache), std::move(rpstate), std::move(layout), nullptr,
-                    shader_unique_id_map),
+                             std::shared_ptr<const vvl::RenderPass>&& rpstate, std::shared_ptr<const vvl::PipelineLayout>&& layout)
+    : vvl::Pipeline(state_data, create_info, std::move(pipe_cache), std::move(rpstate), std::move(layout), nullptr),
       access_framebuffer_attachments(GetAttachmentAccess(*this)) {}
 
 std::shared_ptr<vvl::Pipeline> BestPractices::CreateGraphicsPipelineState(
     const VkGraphicsPipelineCreateInfo* create_info, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
     std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
-    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds* shader_unique_id_map) const {
+    spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) const {
     return std::static_pointer_cast<vvl::Pipeline>(std::make_shared<bp_state::Pipeline>(
-        *this, create_info, std::move(pipeline_cache), std::move(render_pass), std::move(layout), shader_unique_id_map));
+        *this, create_info, std::move(pipeline_cache), std::move(render_pass), std::move(layout)));
 }
 
 void BestPractices::ManualPostCallRecordCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,

--- a/layers/best_practices/bp_state.h
+++ b/layers/best_practices/bp_state.h
@@ -233,7 +233,7 @@ class Pipeline : public vvl::Pipeline {
   public:
     Pipeline(const ValidationStateTracker& state_data, const VkGraphicsPipelineCreateInfo* create_info,
              std::shared_ptr<const vvl::PipelineCache>&& pipe_cache, std::shared_ptr<const vvl::RenderPass>&& rpstate,
-             std::shared_ptr<const vvl::PipelineLayout>&& layout, ShaderModuleUniqueIds* shader_unique_id_map);
+             std::shared_ptr<const vvl::PipelineLayout>&& layout);
 
     const std::vector<AttachmentInfo> access_framebuffer_attachments;
 };

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -93,7 +93,7 @@ void Validator::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createIn
     BaseClass::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
                                              chassis_state);
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        if (gpuav_settings.select_instrumented_shaders && !CheckForGpuAvEnabled(pCreateInfos[i].pNext)) continue;
+        if (gpuav_settings.select_instrumented_shaders && !IsSelectiveInstrumentationEnabled(pCreateInfos[i].pNext)) continue;
         if (gpuav_settings.cache_instrumented_shaders) {
             const uint32_t shader_hash = hash_util::ShaderHash(pCreateInfos[i].pCode, pCreateInfos[i].codeSize);
             if (instrumented_shaders_cache_.IsSpirvCached(i, chassis_state.unique_shader_ids[i], chassis_state)) {

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -130,12 +130,14 @@ class Pipeline : public StateObject {
     const bool uses_pipeline_vertex_robustness;
     bool ignore_color_attachments;
 
+    // We create a VkShaderModule that is instrumented and need to delete before leaving the pipeline call
+    std::vector<VkShaderModule> instrumented_shader_module;
+
     // Executable or legacy pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,
              std::shared_ptr<const vvl::PipelineCache> &&pipe_cache, std::shared_ptr<const vvl::RenderPass> &&rpstate,
              std::shared_ptr<const vvl::PipelineLayout> &&layout,
-             spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages],
-             ShaderModuleUniqueIds *shader_unique_id_map = nullptr);
+             spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
 
     // Compute pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkComputePipelineCreateInfo *pCreateInfo,
@@ -408,8 +410,7 @@ class Pipeline : public StateObject {
     const VkPipelineRenderingCreateInfo *GetPipelineRenderingCreateInfo() const { return rendering_create_info; }
 
     static std::vector<ShaderStageState> GetStageStates(const ValidationStateTracker &state_data, const Pipeline &pipe_state,
-                                                        spirv::StatelessData *stateless_data,
-                                                        ShaderModuleUniqueIds *shader_unique_id_map);
+                                                        spirv::StatelessData *stateless_data);
 
     // Return true if for a given PSO, the given state enum is dynamic, else return false
     bool IsDynamic(const CBDynamicState state) const { return dynamic_state[state]; }

--- a/layers/state_tracker/pipeline_sub_state.cpp
+++ b/layers/state_tracker/pipeline_sub_state.cpp
@@ -86,7 +86,7 @@ PreRasterState::PreRasterState(const vvl::Pipeline &p, const ValidationStateTrac
                 spirv::StatelessData *stateless_data_stage =
                     (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                 auto spirv_module = std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
-                module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);
+                module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
                 if (stateless_data_stage) {
                     stateless_data_stage->pipeline_pnext_module = spirv_module;
                 }
@@ -202,7 +202,7 @@ void SetFragmentShaderInfoPrivate(FragmentShaderState &fs_state, const Validatio
                         (stateless_data && i < kCommonMaxGraphicsShaderStages) ? &stateless_data[i] : nullptr;
                     auto spirv_module =
                         std::make_shared<spirv::Module>(shader_ci->codeSize, shader_ci->pCode, stateless_data_stage);
-                    module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module, 0);
+                    module_state = std::make_shared<vvl::ShaderModule>(VK_NULL_HANDLE, spirv_module);
                     if (stateless_data_stage) {
                         stateless_data_stage->pipeline_pnext_module = spirv_module;
                     }

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -747,15 +747,13 @@ struct Module {
 // Represents a VkShaderModule handle
 namespace vvl {
 struct ShaderModule : public StateObject {
-    ShaderModule(VkShaderModule handle, std::shared_ptr<spirv::Module> &spirv_module, uint32_t unique_shader_id)
-        : StateObject(handle, kVulkanObjectTypeShaderModule), spirv(spirv_module), gpu_validation_shader_id(unique_shader_id) {
+    ShaderModule(VkShaderModule handle, std::shared_ptr<spirv::Module> &spirv_module)
+        : StateObject(handle, kVulkanObjectTypeShaderModule), spirv(spirv_module) {
         spirv->handle_ = handle_;
     }
 
     // For when we need to create a module with no SPIR-V backing it
-    ShaderModule(uint32_t unique_shader_id)
-        : StateObject(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule),
-          gpu_validation_shader_id(unique_shader_id) {}
+    ShaderModule() : StateObject(static_cast<VkShaderModule>(VK_NULL_HANDLE), kVulkanObjectTypeShaderModule) {}
 
     VkShaderModule VkHandle() const { return handle_.Cast<VkShaderModule>(); }
 
@@ -763,8 +761,5 @@ struct ShaderModule : public StateObject {
     // TODO - This (and vvl::ShaderObject) could be unique, but need handle multiple ValidationObjects
     // https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/6265/files
     std::shared_ptr<spirv::Module> spirv;
-
-    // Used as way to match instrumented GPU-AV shader to a VkShaderModule handle
-    uint32_t gpu_validation_shader_id = 0;
 };
 }  // namespace vvl

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -79,10 +79,6 @@ namespace spirv {
 struct StatelessData;
 }  // namespace spirv
 
-// This is duplicated here because Best Practice pipeline is a derivative of vvl::Pipeline and we have a virtual function that needs
-// to know this. Idealy this will probably never need to change often, so likely won't cause issues
-using ShaderModuleUniqueIds = std::unordered_map<VkShaderStageFlagBits, uint32_t>;
-
 #define VALSTATETRACK_MAP_AND_TRAITS_IMPL(handle_type, state_type, map_member, instance_scope)        \
     vvl::concurrent_unordered_map<handle_type, std::shared_ptr<state_type>> map_member;               \
     template <typename Dummy>                                                                         \
@@ -751,7 +747,7 @@ class ValidationStateTracker : public ValidationObject {
     virtual std::shared_ptr<vvl::Pipeline> CreateGraphicsPipelineState(
         const VkGraphicsPipelineCreateInfo* create_info, std::shared_ptr<const vvl::PipelineCache> pipeline_cache,
         std::shared_ptr<const vvl::RenderPass>&& render_pass, std::shared_ptr<const vvl::PipelineLayout>&& layout,
-        spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages], ShaderModuleUniqueIds* shader_unique_id_map) const;
+        spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]) const;
 
     bool PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t count,
                                                 const VkGraphicsPipelineCreateInfo* pCreateInfos,

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -1073,7 +1073,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
     }
 
     chassis::CreateShaderModule chassis_state{};
-    chassis_state.instrumented_create_info = *pCreateInfo;
 
     RecordObject record_obj(vvl::Func::vkCreateShaderModule);
     {
@@ -1089,7 +1088,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShaderModule(VkDevice device, const VkShade
     VkResult result;
     {
         VVL_ZoneScopedN("Dispatch");
-        result = DispatchCreateShaderModule(device, &chassis_state.instrumented_create_info, pAllocator, pShaderModule);
+        result = DispatchCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
     }
     record_obj.result = result;
     {

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1691,7 +1691,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 }
 
                 chassis::CreateShaderModule chassis_state{};
-                chassis_state.instrumented_create_info = *pCreateInfo;
 
                 RecordObject record_obj(vvl::Func::vkCreateShaderModule);
                 {
@@ -1707,7 +1706,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 VkResult result;
                 {
                     VVL_ZoneScopedN("Dispatch");
-                    result = DispatchCreateShaderModule(device, &chassis_state.instrumented_create_info, pAllocator, pShaderModule);
+                    result = DispatchCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule);
                 }
                 record_obj.result = result;
                 {

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -2644,7 +2644,9 @@ void NegativeDebugPrintf::BasicFormattingTest(const char *shader, bool warning) 
     RETURN_IF_SKIP(InitState());
 
     m_errorMonitor->SetDesiredFailureMsg(warning ? kWarningBit : kErrorBit, "DEBUG-PRINTF-FORMATTING");
-    VkShaderObj cs(this, shader, VK_SHADER_STAGE_COMPUTE_BIT);
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, shader, VK_SHADER_STAGE_COMPUTE_BIT);
+    pipe.CreateComputePipeline();
     m_errorMonitor->VerifyFound();
 }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7804

This move is done because the next change to improve descriptor indexing checks will requires use to know if `VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT_EXT` is used or not

Luckily because of `VK_KHR_maintenance5`

![image](https://github.com/user-attachments/assets/9ffd5799-5551-4e2a-adb4-3a890f438f0f)

we already had a path to do stuff at pipeline creation time

This change actually removed a lot of ugly tracking we did to match the `vkCreateShaderModule` at create pipeline time, having it all in a single chassis call allows us to save more data on the stack and remove it when the pipeline is created