### PR TITLE
core: Use robin hood map to improve perf

### DIFF
--- a/layers/state_tracker/query_state.h
+++ b/layers/state_tracker/query_state.h
@@ -154,7 +154,7 @@ inline bool operator==(const QueryObject &query1, const QueryObject &query2) {
     return ((query1.pool == query2.pool) && (query1.slot == query2.slot) && (query1.perf_pass == query2.perf_pass));
 }
 
-typedef std::map<QueryObject, QueryState> QueryMap;
+using QueryMap = vvl::unordered_map<QueryObject, QueryState>;
 
 enum QueryResultType {
     QUERYRESULT_UNKNOWN,


### PR DESCRIPTION
Turns out adding/updating elements to this map is an hot spot for Doom Eternal. Did not improve game frame rate when actually playing the game, at least in the menu, but with a GFXR trace, the difference is drastic: Saved 19 seconds on a replay that is less than 2 minutes long 

![image](https://github.com/user-attachments/assets/9ecd397d-7397-49b2-b4ee-545a58bf0072)
