### PR TITLE
layers: Hide deprecated 'enables/disables' in vkconfig

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -1597,6 +1597,7 @@
                     "label": "Disables",
                     "description": "Specify areas of validation to be disabled",
                     "type": "FLAGS",
+                    "view": "HIDDEN",
                     "env": "VK_LAYER_DISABLES",
                     "flags": [
                         {
@@ -1670,6 +1671,7 @@
                     "label": "Enables",
                     "description": "Setting an option here will enable specialized areas of validation",
                     "type": "FLAGS",
+                    "view": "HIDDEN",
                     "env": "VK_LAYER_ENABLES",
                     "flags": [
                         {


### PR DESCRIPTION
No need for a workaround in vkconfig to hide the old and deprecated 'enables' and 'disables' settings in Vulkan Configurator, the manifest can notify Vulkan Configurator.