### PR TITLE
gpu: Combine ShaderObject in Printf/GPU-AV

### DIFF
--- a/layers/chassis/chassis_modification_state.h
+++ b/layers/chassis/chassis_modification_state.h
@@ -42,6 +42,13 @@ struct CreateShaderModule {
     spirv::StatelessData stateless_data;
 };
 
+struct ShaderObjectInstrumentationMetadata {
+    // Need to hold this in memory between the PreCallRecord and the Dispatch
+    std::vector<uint32_t> instrumented_spirv;
+    // Need to hold this in memory between the PreCallRecord and the PostCallRecord
+    uint32_t unique_shader_ids;
+};
+
 // VkShaderEXT (VK_EXT_shader_object)
 struct ShaderObject {
     // allows PreCallRecord to return a value like PreCallValidate
@@ -49,20 +56,16 @@ struct ShaderObject {
 
     std::vector<std::shared_ptr<spirv::Module>> module_states;  // contains SPIR-V to validate
     std::vector<spirv::StatelessData> stateless_data;
-    std::vector<uint32_t> unique_shader_ids;
 
     // Pass the instrumented SPIR-V info from PreCallRecord to Dispatch (so GPU-AV logic can run with it)
     VkShaderCreateInfoEXT* instrumented_create_info = nullptr;
-    std::vector<std::vector<uint32_t>> instrumented_spirv;
-
+    std::vector<ShaderObjectInstrumentationMetadata> shader_instrumentations_metadata;
     std::vector<VkDescriptorSetLayout> new_layouts;
 
     ShaderObject(uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos) {
         instrumented_create_info = const_cast<VkShaderCreateInfoEXT*>(pCreateInfos);
         module_states.resize(createInfoCount);
         stateless_data.resize(createInfoCount);
-        unique_shader_ids.resize(createInfoCount);
-        instrumented_spirv.resize(createInfoCount);
     }
 };
 

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -93,9 +93,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
     void PreCallRecordDestroyRenderPass(VkDevice device, VkRenderPass renderPass, const VkAllocationCallbacks* pAllocator,
                                         const RecordObject& record_obj) final;
 
-    void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
-                                       const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
-                                       const RecordObject& record_obj, chassis::ShaderObject& chassis_state) final;
     void RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo* pRenderPassBegin,
                                          const VkSubpassContents contents);
     void RecordCmdEndRenderPassLayouts(VkCommandBuffer commandBuffer);

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -66,25 +66,6 @@ void Validator::DestroyBuffer(BufferInfo &buffer_info) {
     }
 }
 
-void Validator::PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
-                                              const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
-                                              const RecordObject &record_obj, chassis::ShaderObject &chassis_state) {
-    ValidationStateTracker::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
-                                                          chassis_state);
-    BaseClass::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
-                                             chassis_state);
-    for (uint32_t i = 0; i < createInfoCount; ++i) {
-        chassis_state.unique_shader_ids[i] = unique_shader_module_id_++;
-        const bool pass = InstrumentShader(
-            vvl::make_span(static_cast<const uint32_t *>(pCreateInfos[i].pCode), pCreateInfos[i].codeSize / sizeof(uint32_t)),
-            chassis_state.unique_shader_ids[i], record_obj.location, chassis_state.instrumented_spirv[i]);
-        if (pass) {
-            chassis_state.instrumented_create_info[i].pCode = chassis_state.instrumented_spirv[i].data();
-            chassis_state.instrumented_create_info[i].codeSize = chassis_state.instrumented_spirv[i].size() * sizeof(uint32_t);
-        }
-    }
-}
-
 enum NumericType {
     NumericTypeUnknown = 0,
     NumericTypeFloat = 1,

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -66,9 +66,6 @@ class Validator : public gpu::GpuShaderInstrumentor {
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
                                    vku::safe_VkDeviceCreateInfo* modified_create_info) final;
     void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) override;
-    void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT* pCreateInfos,
-                                       const VkAllocationCallbacks* pAllocator, VkShaderEXT* pShaders,
-                                       const RecordObject& record_obj, chassis::ShaderObject& chassis_state) override;
     void AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueue queue, BufferInfo& buffer_info, uint32_t operation_index,
                                    uint32_t* const debug_output_buffer, const Location& loc);
     void PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex,

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -482,13 +482,13 @@ void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, co
 }
 
 void GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
-    const VkShaderCreateInfoEXT &create_info, const Location &create_info_loc, VkShaderCreateInfoEXT &instrumented_create_info,
-    chassis::ShaderObjectInstrumentationMetadata &shader_instrumentation_metadata) {
+    VkShaderCreateInfoEXT &create_info, const Location &create_info_loc,
+    chassis::ShaderObjectInstrumentationData &instrumentation_data) {
     if (gpuav_settings.select_instrumented_shaders && !IsSelectiveInstrumentationEnabled(create_info.pNext)) return;
     uint32_t unique_shader_id = 0;
     bool cached = false;
     bool pass = false;
-    std::vector<uint32_t> &instrumented_spirv = shader_instrumentation_metadata.instrumented_spirv;
+    std::vector<uint32_t> &instrumented_spirv = instrumentation_data.instrumented_spirv;
     if (gpuav_settings.cache_instrumented_shaders) {
         unique_shader_id = hash_util::ShaderHash(create_info.pCode, create_info.codeSize);
         if (const auto spirv = instrumented_shaders_cache_.Get(unique_shader_id)) {
@@ -506,9 +506,9 @@ void GpuShaderInstrumentor::PreCallRecordShaderObjectInstrumentation(
     }
 
     if (cached || pass) {
-        shader_instrumentation_metadata.unique_shader_ids = unique_shader_id;
-        instrumented_create_info.pCode = instrumented_spirv.data();
-        instrumented_create_info.codeSize = instrumented_spirv.size() * sizeof(uint32_t);
+        instrumentation_data.unique_shader_id = unique_shader_id;
+        create_info.pCode = instrumented_spirv.data();
+        create_info.codeSize = instrumented_spirv.size() * sizeof(uint32_t);
         if (gpuav_settings.cache_instrumented_shaders) {
             instrumented_shaders_cache_.Add(unique_shader_id, instrumented_spirv);
         }
@@ -522,14 +522,18 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
     BaseClass::PreCallRecordCreateShadersEXT(device, createInfoCount, pCreateInfos, pAllocator, pShaders, record_obj,
                                              chassis_state);
 
+    chassis_state.modified_create_infos.reserve(createInfoCount);
+
     // Resize here so if using just CoreCheck we don't waste time allocating this
-    chassis_state.shader_instrumentations_metadata.resize(createInfoCount);
+    chassis_state.instrumentations_data.resize(createInfoCount);
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        // TODO - Should check descriptor set layout per-createInfoCount
-        if (chassis_state.instrumented_create_info[i].setLayoutCount > desc_set_bind_index_) {
+        VkShaderCreateInfoEXT new_create_info = pCreateInfos[i];
+        auto &instrumentation_data = chassis_state.instrumentations_data[i];
+
+        if (new_create_info.setLayoutCount > desc_set_bind_index_) {
             std::ostringstream strm;
-            strm << "pCreateInfos[" << i << "]::setLayoutCount (" << chassis_state.instrumented_create_info[i].setLayoutCount
+            strm << "pCreateInfos[" << i << "]::setLayoutCount (" << new_create_info.setLayoutCount
                  << ") will conflicts with validation's descriptor set at slot " << desc_set_bind_index_ << ". "
                  << "This Shader Object has too many descriptor sets that will not allow GPU shader instrumentation to be setup "
                     "for VkShaderEXT created with it, therefor no validation error will be repored for them by GPU-AV at "
@@ -540,21 +544,24 @@ void GpuShaderInstrumentor::PreCallRecordCreateShadersEXT(VkDevice device, uint3
             // 1. Copying the caller's descriptor set desc_layouts
             // 2. Fill in dummy descriptor layouts up to the max binding
             // 3. Fill in with the debug descriptor layout at the max binding slot
-            chassis_state.new_layouts.reserve(desc_set_bind_index_ + 1);
-            chassis_state.new_layouts.insert(chassis_state.new_layouts.end(), pCreateInfos[i].pSetLayouts,
-                                             &pCreateInfos[i].pSetLayouts[pCreateInfos[i].setLayoutCount]);
+            instrumentation_data.new_layouts.reserve(desc_set_bind_index_ + 1);
+            instrumentation_data.new_layouts.insert(instrumentation_data.new_layouts.end(), pCreateInfos[i].pSetLayouts,
+                                                    &pCreateInfos[i].pSetLayouts[pCreateInfos[i].setLayoutCount]);
             for (uint32_t j = pCreateInfos[i].setLayoutCount; j < desc_set_bind_index_; ++j) {
-                chassis_state.new_layouts.push_back(dummy_desc_layout_);
+                instrumentation_data.new_layouts.push_back(dummy_desc_layout_);
             }
-            chassis_state.new_layouts.push_back(debug_desc_layout_);
-            chassis_state.instrumented_create_info[i].pSetLayouts = chassis_state.new_layouts.data();
-            chassis_state.instrumented_create_info[i].setLayoutCount = desc_set_bind_index_ + 1;
+            instrumentation_data.new_layouts.push_back(debug_desc_layout_);
+            new_create_info.pSetLayouts = instrumentation_data.new_layouts.data();
+            new_create_info.setLayoutCount = desc_set_bind_index_ + 1;
         }
 
-        PreCallRecordShaderObjectInstrumentation(pCreateInfos[i], record_obj.location.dot(vvl::Field::pCreateInfos, i),
-                                                 chassis_state.instrumented_create_info[i],
-                                                 chassis_state.shader_instrumentations_metadata[i]);
+        PreCallRecordShaderObjectInstrumentation(new_create_info, record_obj.location.dot(vvl::Field::pCreateInfos, i),
+                                                 instrumentation_data);
+
+        chassis_state.modified_create_infos.emplace_back(std::move(new_create_info));
     }
+
+    chassis_state.pCreateInfos = reinterpret_cast<VkShaderCreateInfoEXT *>(chassis_state.modified_create_infos.data());
 }
 
 void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount,
@@ -565,9 +572,9 @@ void GpuShaderInstrumentor::PostCallRecordCreateShadersEXT(VkDevice device, uint
                                               chassis_state);
 
     for (uint32_t i = 0; i < createInfoCount; ++i) {
-        auto &shader_instrumentation_metadata = chassis_state.shader_instrumentations_metadata[i];
-        shader_map_.insert_or_assign(shader_instrumentation_metadata.unique_shader_ids, VK_NULL_HANDLE, VK_NULL_HANDLE, pShaders[i],
-                                     shader_instrumentation_metadata.instrumented_spirv);
+        auto &instrumentation_data = chassis_state.instrumentations_data[i];
+        shader_map_.insert_or_assign(instrumentation_data.unique_shader_id, VK_NULL_HANDLE, VK_NULL_HANDLE, pShaders[i],
+                                     instrumentation_data.instrumented_spirv);
     }
 }
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -31,6 +31,7 @@ class Validator;
 
 namespace chassis {
 struct ShaderInstrumentationMetadata;
+struct ShaderObjectInstrumentationMetadata;
 }
 
 namespace gpu {
@@ -52,7 +53,6 @@ class SpirvCache {
     void Add(uint32_t hash, std::vector<uint32_t> spirv);
     std::vector<uint32_t> *Get(uint32_t spirv_hash);
     bool IsEmpty() { return spirv_shaders_.empty(); }
-    bool IsSpirvCached(uint32_t index, uint32_t spirv_hash, chassis::ShaderObject &chassis_state) const;
 
   private:
     friend class gpuav::Validator;
@@ -111,6 +111,9 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                           const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) override;
+    void PreCallRecordShaderObjectInstrumentation(const VkShaderCreateInfoEXT &create_info, const Location &create_info_loc,
+                                                  VkShaderCreateInfoEXT &instrumented_create_info,
+                                                  chassis::ShaderObjectInstrumentationMetadata &shader_instrumentation_metadata);
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
                                        const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
                                        const RecordObject &record_obj, chassis::ShaderObject &chassis_state) override;

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -31,7 +31,7 @@ class Validator;
 
 namespace chassis {
 struct ShaderInstrumentationMetadata;
-struct ShaderObjectInstrumentationMetadata;
+struct ShaderObjectInstrumentationData;
 }
 
 namespace gpu {
@@ -111,9 +111,8 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PostCallRecordCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo *pCreateInfo,
                                           const VkAllocationCallbacks *pAllocator, VkShaderModule *pShaderModule,
                                           const RecordObject &record_obj, chassis::CreateShaderModule &chassis_state) override;
-    void PreCallRecordShaderObjectInstrumentation(const VkShaderCreateInfoEXT &create_info, const Location &create_info_loc,
-                                                  VkShaderCreateInfoEXT &instrumented_create_info,
-                                                  chassis::ShaderObjectInstrumentationMetadata &shader_instrumentation_metadata);
+    void PreCallRecordShaderObjectInstrumentation(VkShaderCreateInfoEXT &create_info, const Location &create_info_loc,
+                                                  chassis::ShaderObjectInstrumentationData &shader_instrumentation_data);
     void PreCallRecordCreateShadersEXT(VkDevice device, uint32_t createInfoCount, const VkShaderCreateInfoEXT *pCreateInfos,
                                        const VkAllocationCallbacks *pAllocator, VkShaderEXT *pShaders,
                                        const RecordObject &record_obj, chassis::ShaderObject &chassis_state) override;

--- a/layers/state_tracker/shader_object_state.cpp
+++ b/layers/state_tracker/shader_object_state.cpp
@@ -29,14 +29,12 @@ static ShaderObject::SetLayoutVector GetSetLayouts(ValidationStateTracker &dev_d
 }
 
 ShaderObject::ShaderObject(ValidationStateTracker &dev_data, const VkShaderCreateInfoEXT &create_info_i, VkShaderEXT handle,
-                           std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
-                           uint32_t unique_shader_id)
+                           std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders)
     : StateObject(handle, kVulkanObjectTypeShaderEXT),
       safe_create_info(&create_info_i),
       create_info(*safe_create_info.ptr()),
       spirv(spirv_module),
       entrypoint(spirv ? spirv->FindEntrypoint(create_info.pName, create_info.stage) : nullptr),
-      gpu_validation_shader_id(unique_shader_id),
       active_slots(GetActiveSlots(entrypoint)),
       max_active_slot(GetMaxActiveSlot(active_slots)),
       set_layouts(GetSetLayouts(dev_data, create_info)),

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -29,8 +29,7 @@ namespace vvl {
 // Represents a VkShaderEXT (VK_EXT_shader_object) handle
 struct ShaderObject : public StateObject {
     ShaderObject(ValidationStateTracker &dev_data, const VkShaderCreateInfoEXT &create_info, VkShaderEXT shader_object,
-                 std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders,
-                 uint32_t unique_shader_id = 0);
+                 std::shared_ptr<spirv::Module> &spirv_module, uint32_t createInfoCount, VkShaderEXT *pShaders);
 
     const vku::safe_VkShaderCreateInfoEXT safe_create_info;
     const VkShaderCreateInfoEXT &create_info;
@@ -38,9 +37,6 @@ struct ShaderObject : public StateObject {
     std::shared_ptr<const spirv::Module> spirv;
     std::shared_ptr<const spirv::EntryPoint> entrypoint;
     std::vector<VkShaderEXT> linked_shaders;
-
-    // Used as way to match instrumented GPU-AV shader to a VkShaderEXT handle
-    uint32_t gpu_validation_shader_id = 0;
 
     // NOTE: this map is 'almost' const and used in performance critical code paths.
     // The values of existing entries in the samplers_used_by_image map

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -4795,7 +4795,7 @@ void ValidationStateTracker::PostCallRecordCreateShadersEXT(VkDevice device, uin
     for (uint32_t i = 0; i < createInfoCount; ++i) {
         if (pShaders[i] != VK_NULL_HANDLE) {
             Add(std::make_shared<vvl::ShaderObject>(*this, pCreateInfos[i], pShaders[i], chassis_state.module_states[i],
-                                                    createInfoCount, pShaders, chassis_state.unique_shader_ids[i]));
+                                                    createInfoCount, pShaders));
         }
     }
 }

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -1110,12 +1110,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(VkDevice device, uint32_t create
     bool skip = false;
     ErrorObject error_obj(vvl::Func::vkCreateShadersEXT, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-    std::vector<VkShaderCreateInfoEXT> new_shader_create_infos;
-    new_shader_create_infos.reserve(createInfoCount);
-    for (uint32_t i = 0; i < createInfoCount; i++) {
-        new_shader_create_infos.emplace_back(pCreateInfos[i]);
-    }
-    chassis::ShaderObject chassis_state(createInfoCount, new_shader_create_infos.data());
+    chassis::ShaderObject chassis_state(createInfoCount, pCreateInfos);
 
     {
         VVL_ZoneScopedN("PreCallValidate");
@@ -1143,7 +1138,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateShadersEXT(VkDevice device, uint32_t create
     VkResult result;
     {
         VVL_ZoneScopedN("Dispatch");
-        result = DispatchCreateShadersEXT(device, createInfoCount, new_shader_create_infos.data(), pAllocator, pShaders);
+        result = DispatchCreateShadersEXT(device, createInfoCount, chassis_state.pCreateInfos, pAllocator, pShaders);
     }
     record_obj.result = result;
 

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1728,12 +1728,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 bool skip = false;
                 ErrorObject error_obj(vvl::Func::vkCreateShadersEXT, VulkanTypedHandle(device, kVulkanObjectTypeDevice));
 
-                std::vector<VkShaderCreateInfoEXT> new_shader_create_infos;
-                new_shader_create_infos.reserve(createInfoCount);
-                for (uint32_t i = 0; i < createInfoCount; i++) {
-                    new_shader_create_infos.emplace_back(pCreateInfos[i]);
-                }
-                chassis::ShaderObject chassis_state(createInfoCount, new_shader_create_infos.data());
+                chassis::ShaderObject chassis_state(createInfoCount, pCreateInfos);
 
                 {
                     VVL_ZoneScopedN("PreCallValidate");
@@ -1759,7 +1754,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 VkResult result;
                 {
                     VVL_ZoneScopedN("Dispatch");
-                    result = DispatchCreateShadersEXT(device, createInfoCount, new_shader_create_infos.data(), pAllocator, pShaders);
+                    result = DispatchCreateShadersEXT(device, createInfoCount, chassis_state.pCreateInfos, pAllocator, pShaders);
                 }
                 record_obj.result = result;
 


### PR DESCRIPTION
Combine the `PreCallRecordCreateShadersEXT` for GPU-AV and DebugPrintf as they use the same flow now

Also make it look like the Pipeline path for code consistency