### PR TITLE
state: Improve storage of vertex input state

### DIFF
--- a/layers/best_practices/bp_drawdispatch.cpp
+++ b/layers/best_practices/bp_drawdispatch.cpp
@@ -100,7 +100,7 @@ void BestPractices::RecordCmdDrawType(bp_state::CommandBuffer& cb_state, uint32_
     }
 
     const auto* pipeline_state = cb_state.GetCurrentPipeline(VK_PIPELINE_BIND_POINT_GRAPHICS);
-    if (pipeline_state && pipeline_state->vertex_input_state && !pipeline_state->vertex_input_state->binding_descriptions.empty()) {
+    if (pipeline_state && pipeline_state->vertex_input_state && !pipeline_state->vertex_input_state->bindings.empty()) {
         cb_state.uses_vertex_buffer = true;
     }
 }

--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1013,52 +1013,54 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                 continue;
             }
             bool location_provided = false;
-            for (uint32_t i = 0; i < cb_state.dynamic_state_value.vertex_attribute_descriptions.size(); ++i) {
-                const auto& description = cb_state.dynamic_state_value.vertex_attribute_descriptions[i];
-                if (variable_ptr->decorations.location == description.location) {
+            if (const auto* binding_state =
+                    vvl::Find(cb_state.dynamic_state_value.vertex_bindings, variable_ptr->decorations.binding)) {
+                if (const auto* attrib = vvl::Find(binding_state->locations, variable_ptr->decorations.location)) {
                     location_provided = true;
 
                     const uint32_t var_base_type_id = variable_ptr->base_type.ResultId();
-                    const uint32_t attribute_type = spirv::GetFormatType(description.format);
+                    const uint32_t attribute_type = spirv::GetFormatType(attrib->desc.format);
                     const uint32_t var_numeric_type = vert_spirv_state->GetNumericType(var_base_type_id);
 
-                    const bool attribute64 = vkuFormatIs64bit(description.format);
+                    const bool attribute64 = vkuFormatIs64bit(attrib->desc.format);
                     const bool shader64 = vert_spirv_state->GetBaseTypeInstruction(var_base_type_id)->GetBitWidth() == 64;
 
                     // first type check before doing 64-bit matching
                     if ((attribute_type & var_numeric_type) == 0) {
                         if (!enabled_features.legacyVertexAttributes || shader64) {
-                            skip |=
-                                LogError(vuid.vertex_input_08734, vert_spirv_state->handle(), vuid.loc(),
-                                         "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32
-                                         ") with format %s but the vertex shader input is numeric type %s",
-                                         i, description.location, string_VkFormat(description.format),
-                                         vert_spirv_state->DescribeType(var_base_type_id).c_str());
+                            skip |= LogError(
+                                vuid.vertex_input_08734, vert_spirv_state->handle(), vuid.loc(),
+                                "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
+                                ", location %" PRIu32 ") with format %s but the vertex shader input is numeric type %s",
+                                attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
+                                vert_spirv_state->DescribeType(var_base_type_id).c_str());
                         }
                     } else if (attribute64 && !shader64) {
-                        skip |= LogError(vuid.vertex_input_format_08936, vert_spirv_state->handle(), vuid.loc(),
-                                         "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32
-                                         ") with a 64-bit format (%s) but the vertex shader input is 32-bit type (%s)",
-                                         i, description.location, string_VkFormat(description.format),
-                                         vert_spirv_state->DescribeType(var_base_type_id).c_str());
+                        skip |= LogError(
+                            vuid.vertex_input_format_08936, vert_spirv_state->handle(), vuid.loc(),
+                            "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
+                            ", location %" PRIu32 ") with a 64-bit format (%s) but the vertex shader input is 32-bit type (%s)",
+                            attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
+                            vert_spirv_state->DescribeType(var_base_type_id).c_str());
                     } else if (!attribute64 && shader64) {
-                        skip |= LogError(vuid.vertex_input_format_08937, vert_spirv_state->handle(), vuid.loc(),
-                                         "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32
-                                         ") with a 32-bit format (%s) but the vertex shader input is 64-bit type (%s)",
-                                         i, description.location, string_VkFormat(description.format),
-                                         vert_spirv_state->DescribeType(var_base_type_id).c_str());
+                        skip |= LogError(
+                            vuid.vertex_input_format_08937, vert_spirv_state->handle(), vuid.loc(),
+                            "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "] (binding %" PRIu32
+                            ", location %" PRIu32 ") with a 32-bit format (%s) but the vertex shader input is 64-bit type (%s)",
+                            attrib->index, attrib->desc.binding, attrib->desc.location, string_VkFormat(attrib->desc.format),
+                            vert_spirv_state->DescribeType(var_base_type_id).c_str());
                     } else if (attribute64 && shader64) {
-                        const uint32_t attribute_components = vkuFormatComponentCount(description.format);
+                        const uint32_t attribute_components = vkuFormatComponentCount(attrib->desc.format);
                         const uint32_t input_components = vert_spirv_state->GetNumComponentsInBaseType(&variable_ptr->base_type);
                         if (attribute_components < input_components) {
-                            skip |=
-                                LogError(vuid.vertex_input_format_09203, vert_spirv_state->handle(), vuid.loc(),
-                                         "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32 "].location (%" PRIu32
-                                         ") with a %" PRIu32 "-wide 64-bit format (%s) but the vertex shader input is %" PRIu32
-                                         "-wide. (64-bit vertex input don't have default values and require "
-                                         "components to match what is used in the shader)",
-                                         i, description.location, attribute_components, string_VkFormat(description.format),
-                                         input_components);
+                            skip |= LogError(vuid.vertex_input_format_09203, vert_spirv_state->handle(), vuid.loc(),
+                                             "vkCmdSetVertexInputEXT set pVertexAttributeDescriptions[%" PRIu32
+                                             "] (binding %" PRIu32 ", location %" PRIu32 ") with a %" PRIu32
+                                             "-wide 64-bit format (%s) but the vertex shader input is %" PRIu32
+                                             "-wide. (64-bit vertex input don't have default values and require "
+                                             "components to match what is used in the shader)",
+                                             attrib->index, attrib->desc.binding, attrib->desc.location, attribute_components,
+                                             string_VkFormat(attrib->desc.format), input_components);
                         }
                     }
                 }

--- a/layers/core_checks/cc_drawdispatch.cpp
+++ b/layers/core_checks/cc_drawdispatch.cpp
@@ -80,16 +80,18 @@ bool CoreChecks::ValidateCmdDrawInstance(const vvl::CommandBuffer &cb_state, uin
     if (!pipeline_state || pipeline_state->IsDynamic(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT)) {
         if (cb_state.IsDynamicStateSet(CB_DYNAMIC_STATE_VERTEX_INPUT_EXT) &&
             phys_dev_ext_props.vtx_attrib_divisor_props.supportsNonZeroFirstInstance == VK_FALSE && firstInstance != 0u) {
-            for (uint32_t i = 0; i < (uint32_t)cb_state.dynamic_state_value.vertex_binding_descriptions_divisor.size(); ++i) {
-                if (cb_state.dynamic_state_value.vertex_binding_descriptions_divisor[i] != 1u) {
+            for (const auto &binding_state : cb_state.dynamic_state_value.vertex_bindings) {
+                const auto &desc = binding_state.second.desc;
+                if (desc.divisor != 1u) {
                     LogObjectList objlist(cb_state.Handle());
                     if (pipeline_state) {
                         objlist.add(pipeline_state->Handle());
                     }
                     skip |= LogError(vuid.vertex_input_09462, objlist, loc,
-                                     "vkCmdSetVertexInputEXT set pVertexBindingDivisors[%" PRIu32 "].divisor as %" PRIu32
-                                     ", but firstInstance is %" PRIu32 " and supportsNonZeroFirstInstance is VK_FALSE.",
-                                     i, cb_state.dynamic_state_value.vertex_binding_descriptions_divisor[i], firstInstance);
+                                     "vkCmdSetVertexInputEXT set pVertexBindingDivisors[%" PRIu32 "] (binding %" PRIu32
+                                     ") divisor as %" PRIu32 ", but firstInstance is %" PRIu32
+                                     " and supportsNonZeroFirstInstance is VK_FALSE.",
+                                     binding_state.second.index, desc.binding, desc.divisor, firstInstance);
                     break;
                 }
             }

--- a/layers/state_tracker/cmd_buffer_state.h
+++ b/layers/state_tracker/cmd_buffer_state.h
@@ -282,9 +282,8 @@ class CommandBuffer : public RefcountedStateObject {
         std::vector<VkColorBlendEquationEXT> color_blend_equations;  // VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT
         std::vector<VkColorComponentFlags> color_write_masks;        // VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT
 
-        // VK_DYNAMIC_STATE_VERTEX_INPUT_EXT
-        std::vector<uint32_t> vertex_binding_descriptions_divisor;
-        std::vector<VkVertexInputAttributeDescription2EXT> vertex_attribute_descriptions;
+        // VK_DYNAMIC_STATE_VERTEX_INPUT_EXT, key is binding number
+        vvl::unordered_map<uint32_t, VertexBindingState> vertex_bindings;
 
         // VK_DYNAMIC_STATE_CONSERVATIVE_RASTERIZATION_MODE_EXT
         VkConservativeRasterizationModeEXT conservative_rasterization_mode;
@@ -351,8 +350,7 @@ class CommandBuffer : public RefcountedStateObject {
                 color_write_enable_attachment_count = 0u;
             }
             if (mask[CB_DYNAMIC_STATE_VERTEX_INPUT_EXT]) {
-                vertex_binding_descriptions_divisor.clear();
-                vertex_attribute_descriptions.clear();
+                vertex_bindings.clear();
             }
             if (mask[CB_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV]) {
                 viewport_w_scalings.clear();


### PR DESCRIPTION
Rather than just storing arrays of VkVertexInputBindingDescription and VkVertexAttributeBindingDescription structures that have to be corellated to do anything useful, group all of this state by binding and location for easier lookup.

Fixes #5281