### PR TITLE
layers: Wait for present fences in QueueWaitIdle

### DIFF
--- a/layers/state_tracker/fence_state.h
+++ b/layers/state_tracker/fence_state.h
@@ -34,8 +34,10 @@ class Swapchain;
 // with submissions presented in one of the previous frames.
 // More common scheme is to use QueueSubmit fence for frame synchronization.
 struct PresentSync {
+    using SubmissionReferences = small_vector<SubmissionReference, 2>;
+
     // Queue submissions that will be notified when WaitForFences is called.
-    small_vector<SubmissionReference, 2, uint32_t> submissions;
+    SubmissionReferences submissions;
 
     // Swapchain associated with this PresentSync.
     std::shared_ptr<vvl::Swapchain> swapchain;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -87,7 +87,6 @@ vvl::SubmitResult vvl::Queue::PostSubmit(std::vector<vvl::QueueSubmission> &&sub
         }
         {
             auto guard = Lock();
-            result.last_submission_seq = submission.seq;
             PostSubmit(submission);
             submissions_.emplace_back(std::move(submission));
             if (!thread_) {

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -77,8 +77,6 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
 }
 
 struct SubmitResult {
-    uint64_t last_submission_seq = 0;
-
     bool has_external_fence = false;
     uint64_t submission_with_external_fence_seq = 0;
 };


### PR DESCRIPTION
Fixes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8376
Based on this discussion: https://gitlab.khronos.org/vulkan/vulkan/-/issues/3962

This adds `QueueSubmission` object per swapchain (instead of per present as it was before). The reason is that present fence is defined per swapchain. This allows to use `QueueSubmission::fence` field to keep present fence and reuse existing fence tracking code path without additional changes. The first commit does `QueueSubmission` per swapchain change. The fix is the second commit, just adds the fence to `QueueSubmission`.
