### PR TITLE
layers: Add VK_EXT_layer_settings param validation

### DIFF
--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -85,6 +85,7 @@ struct GlobalSettings {
     bool debug_disable_spirv_val = false;
 };
 
+class DebugReport;
 struct GpuAVSettings;
 struct DebugPrintfSettings;
 struct SyncValSettings;
@@ -101,9 +102,7 @@ struct ConfigAndEnvSettings {
     CHECK_DISABLED &disables;
 
     // Settings for DebugReport
-    vvl::unordered_set<uint32_t> &message_filter_list;
-    uint32_t *duplicate_message_limit;
-    MessageFormatSettings *message_format_settings;
+    DebugReport *debug_report;
 
     GlobalSettings* global_settings;
 

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -484,6 +484,7 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     auto debug_report = new DebugReport{};
     debug_report->instance_pnext_chain = vku::SafePnextCopy(pCreateInfo->pNext);
     ActivateInstanceDebugCallbacks(debug_report);
+    LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
     // Set up enable and disable features flags
     CHECK_ENABLED local_enables{};
@@ -492,19 +493,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     GpuAVSettings local_gpuav_settings = {};
     DebugPrintfSettings local_printf_settings = {};
     SyncValSettings local_syncval_settings = {};
-    ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
-                                                      pCreateInfo,
-                                                      local_enables,
-                                                      local_disables,
-                                                      debug_report->filter_message_ids,
-                                                      &debug_report->duplicate_message_limit,
-                                                      &debug_report->message_format_settings,
-                                                      &local_global_settings,
-                                                      &local_gpuav_settings,
-                                                      &local_printf_settings,
-                                                      &local_syncval_settings};
+    ConfigAndEnvSettings config_and_env_settings_data{
+        OBJECT_LAYER_DESCRIPTION, pCreateInfo, local_enables, local_disables, debug_report,
+        // All settings for various internal layers
+        &local_global_settings, &local_gpuav_settings, &local_printf_settings, &local_syncval_settings};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
-    LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
     // Create temporary dispatch vector for pre-calls until instance is created
     std::vector<ValidationObject*> local_object_dispatch = CreateObjectDispatch(local_enables, local_disables);

--- a/layers/vulkan/generated/stateless_validation_helper.cpp
+++ b/layers/vulkan/generated/stateless_validation_helper.cpp
@@ -9328,34 +9328,6 @@ bool StatelessValidation::ValidatePnextStructContents(const Location& loc, const
         // No Validation code for VkAmigoProfilingSubmitInfoSEC structure members  -- Covers
         // VUID-VkAmigoProfilingSubmitInfoSEC-sType-sType
 
-        // Validation code for VkLayerSettingsCreateInfoEXT structure members
-        case VK_STRUCTURE_TYPE_LAYER_SETTINGS_CREATE_INFO_EXT: {  // Covers VUID-VkLayerSettingsCreateInfoEXT-sType-sType
-            if (is_const_param) {
-                [[maybe_unused]] const Location pNext_loc = loc.pNext(Struct::VkLayerSettingsCreateInfoEXT);
-                VkLayerSettingsCreateInfoEXT* structure = (VkLayerSettingsCreateInfoEXT*)header;
-                skip |= ValidateArray(pNext_loc.dot(Field::settingCount), pNext_loc.dot(Field::pSettings), structure->settingCount,
-                                      &structure->pSettings, false, true, kVUIDUndefined,
-                                      "VUID-VkLayerSettingsCreateInfoEXT-pSettings-parameter");
-
-                if (structure->pSettings != nullptr) {
-                    for (uint32_t settingIndex = 0; settingIndex < structure->settingCount; ++settingIndex) {
-                        [[maybe_unused]] const Location pSettings_loc = pNext_loc.dot(Field::pSettings, settingIndex);
-                        skip |= ValidateRequiredPointer(pSettings_loc.dot(Field::pLayerName),
-                                                        structure->pSettings[settingIndex].pLayerName,
-                                                        "VUID-VkLayerSettingEXT-pLayerName-parameter");
-
-                        skip |= ValidateRequiredPointer(pSettings_loc.dot(Field::pSettingName),
-                                                        structure->pSettings[settingIndex].pSettingName,
-                                                        "VUID-VkLayerSettingEXT-pSettingName-parameter");
-
-                        skip |=
-                            ValidateRangedEnum(pSettings_loc.dot(Field::type), vvl::Enum::VkLayerSettingTypeEXT,
-                                               structure->pSettings[settingIndex].type, "VUID-VkLayerSettingEXT-type-parameter");
-                    }
-                }
-            }
-        } break;
-
         // No Validation code for VkLatencySubmissionPresentIdNV structure members  -- Covers
         // VUID-VkLatencySubmissionPresentIdNV-sType-sType
 

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -1114,6 +1114,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 auto debug_report = new DebugReport{};
                 debug_report->instance_pnext_chain = vku::SafePnextCopy(pCreateInfo->pNext);
                 ActivateInstanceDebugCallbacks(debug_report);
+                LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
                 // Set up enable and disable features flags
                 CHECK_ENABLED local_enables{};
@@ -1122,19 +1123,11 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 GpuAVSettings local_gpuav_settings = {};
                 DebugPrintfSettings local_printf_settings = {};
                 SyncValSettings local_syncval_settings = {};
-                ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION,
-                                                                pCreateInfo,
-                                                                local_enables,
-                                                                local_disables,
-                                                                debug_report->filter_message_ids,
-                                                                &debug_report->duplicate_message_limit,
-                                                                &debug_report->message_format_settings,
-                                                                &local_global_settings,
-                                                                &local_gpuav_settings,
-                                                                &local_printf_settings,
-                                                                &local_syncval_settings};
+                ConfigAndEnvSettings config_and_env_settings_data{
+                    OBJECT_LAYER_DESCRIPTION, pCreateInfo, local_enables, local_disables, debug_report,
+                    // All settings for various internal layers
+                    &local_global_settings, &local_gpuav_settings, &local_printf_settings, &local_syncval_settings};
                 ProcessConfigAndEnvSettings(&config_and_env_settings_data);
-                LayerDebugMessengerActions(debug_report, OBJECT_LAYER_DESCRIPTION);
 
                 // Create temporary dispatch vector for pre-calls until instance is created
                 std::vector<ValidationObject*> local_object_dispatch = CreateObjectDispatch(local_enables, local_disables);

--- a/scripts/generators/stateless_validation_helper_generator.py
+++ b/scripts/generators/stateless_validation_helper_generator.py
@@ -209,6 +209,11 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
             'vkGetDeviceGroupSurfacePresentModes2EXT'
             ]
 
+        # Very rare case when structs are needed prior to setting up everything
+        self.structs_with_manual_checks = [
+            'VkLayerSettingsCreateInfoEXT'
+        ]
+
         # Validation conditions for some special case struct members that are conditionally validated
         self.structMemberValidationConditions = [
             {
@@ -377,7 +382,7 @@ class StatelessValidationHelperOutputGenerator(BaseGenerator):
         extended_structs = [x for x in self.vk.structs.values() if x.extends]
         feature_structs = [x for x in extended_structs if x.extends == ["VkPhysicalDeviceFeatures2", "VkDeviceCreateInfo"]]
         property_structs = [x for x in extended_structs if x.extends == ["VkPhysicalDeviceProperties2"]]
-        other_structs = [x for x in extended_structs if x not in feature_structs and x not in property_structs]
+        other_structs = [x for x in extended_structs if x not in feature_structs and x not in property_structs and x.name not in self.structs_with_manual_checks]
 
         out.append('''
             bool StatelessValidation::ValidatePnextFeatureStructContents(const Location& loc,

--- a/tests/unit/instanceless.cpp
+++ b/tests/unit/instanceless.cpp
@@ -354,3 +354,43 @@ TEST_F(NegativeInstanceless, ExtensionStructsWithoutExtensions) {
     m_errorMonitor->VerifyFound();
 }
 #endif
+
+// The test works, you will see the errors, but the test framework is not setup to hook into the debug callback before the create
+// instance so no way to detect it
+TEST_F(NegativeInstanceless, DISABLED_VkLayerSettingEXT) {
+    const char* ids[] = {"something"};
+    VkLayerSettingEXT setting = {nullptr, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids};
+    VkLayerSettingsCreateInfoEXT layer_settings_create_info = vku::InitStructHelper();
+    layer_settings_create_info.settingCount = 1;
+    layer_settings_create_info.pSettings = &setting;
+
+    auto ici = GetInstanceCreateInfo();
+    ici.pNext = &layer_settings_create_info;
+
+    {
+        Monitor().SetDesiredError("VUID-VkLayerSettingEXT-pLayerName-parameter");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+    }
+
+    {
+        setting = {OBJECT_LAYER_NAME, nullptr, VK_LAYER_SETTING_TYPE_STRING_EXT, 1, ids};
+        Monitor().SetDesiredError("VUID-VkLayerSettingEXT-pSettingName-parameter");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+    }
+
+    {
+        setting = {OBJECT_LAYER_NAME, "message_id_filter", VK_LAYER_SETTING_TYPE_STRING_EXT, 1, nullptr};
+        Monitor().SetDesiredError("VUID-VkLayerSettingEXT-valueCount-10070");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+    }
+
+    {
+        layer_settings_create_info.pSettings = nullptr;
+        Monitor().SetDesiredError("VUID-VkLayerSettingsCreateInfoEXT-pSettings-parameter");
+        vk::CreateInstance(&ici, nullptr, &dummy_instance);
+        Monitor().VerifyFound();
+    }
+}


### PR DESCRIPTION
The `VkLayerSettingsCreateInfoEXT`/`VkLayerSettingEXT` param validation was not possible as it needs to be done before the Create Instance setup

This will help give some error if people have null values in those structs by accident