### PR TITLE
layers: Spec fixes for 1.3.293

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -21,6 +21,7 @@
 #include "generated/chassis.h"
 #include "core_validation.h"
 #include "drawdispatch/drawdispatch_vuids.h"
+#include "generated/vk_extension_helper.h"
 #include "state_tracker/image_state.h"
 #include "state_tracker/render_pass_state.h"
 #include "state_tracker/shader_object_state.h"
@@ -248,7 +249,7 @@ bool CoreChecks::ValidateGraphicsDynamicStateSetStatus(const LastBound& last_bou
             skip |= ValidateDynamicStateIsSet(last_bound_state, state_status_cb, CB_DYNAMIC_STATE_FRONT_FACE, vuid);
         }
 
-        if (last_bound_state.IsSampleLocationsEnable()) {
+        if (last_bound_state.IsSampleLocationsEnable() && IsExtEnabled(device_extensions.vk_ext_sample_locations)) {
             skip |= ValidateDynamicStateIsSet(last_bound_state, state_status_cb, CB_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT, vuid);
         }
 

--- a/layers/vulkan/generated/object_tracker.cpp
+++ b/layers/vulkan/generated/object_tracker.cpp
@@ -1110,7 +1110,7 @@ bool ObjectLifetimes::PreCallValidateCreateGraphicsPipelines(VkDevice device, Vk
                     for (uint32_t index2 = 0; index2 < pNext->pipelineCount; ++index2) {
                         skip |= ValidateObject(pNext->pPipelines[index2], kVulkanObjectTypePipeline, false,
                                                "VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-parameter",
-                                               "VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-parent",
+                                               "UNASSIGNED-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-parent",
                                                pNext_loc.dot(Field::pPipelines, index2));
                     }
                 }
@@ -1123,7 +1123,7 @@ bool ObjectLifetimes::PreCallValidateCreateGraphicsPipelines(VkDevice device, Vk
                     for (uint32_t index2 = 0; index2 < pNext->libraryCount; ++index2) {
                         skip |= ValidateObject(pNext->pLibraries[index2], kVulkanObjectTypePipeline, false,
                                                "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter",
-                                               "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parent",
+                                               "UNASSIGNED-VkPipelineLibraryCreateInfoKHR-pLibraries-parent",
                                                pNext_loc.dot(Field::pLibraries, index2));
                     }
                 }
@@ -5141,7 +5141,7 @@ bool ObjectLifetimes::PreCallValidateCreateExecutionGraphPipelinesAMDX(VkDevice 
                     for (uint32_t index2 = 0; index2 < pCreateInfos[index0].pLibraryInfo->libraryCount; ++index2) {
                         skip |= ValidateObject(pCreateInfos[index0].pLibraryInfo->pLibraries[index2], kVulkanObjectTypePipeline,
                                                false, "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter",
-                                               "VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parent",
+                                               "UNASSIGNED-VkPipelineLibraryCreateInfoKHR-pLibraries-parent",
                                                pLibraryInfo_loc.dot(Field::pLibraries, index2));
                     }
                 }
@@ -5998,9 +5998,10 @@ bool ObjectLifetimes::PreCallValidateReleaseSwapchainImagesEXT(VkDevice device, 
     // Checked by chassis: device: "VUID-vkReleaseSwapchainImagesEXT-device-parameter"
     if (pReleaseInfo) {
         [[maybe_unused]] const Location pReleaseInfo_loc = error_obj.location.dot(Field::pReleaseInfo);
-        skip |= ValidateObject(pReleaseInfo->swapchain, kVulkanObjectTypeSwapchainKHR, false,
-                               "VUID-VkReleaseSwapchainImagesInfoEXT-swapchain-parameter",
-                               "VUID-VkReleaseSwapchainImagesInfoEXT-swapchain-parent", pReleaseInfo_loc.dot(Field::swapchain));
+        skip |=
+            ValidateObject(pReleaseInfo->swapchain, kVulkanObjectTypeSwapchainKHR, false,
+                           "VUID-VkReleaseSwapchainImagesInfoEXT-swapchain-parameter",
+                           "UNASSIGNED-VkReleaseSwapchainImagesInfoEXT-swapchain-parent", pReleaseInfo_loc.dot(Field::swapchain));
     }
 
     return skip;
@@ -6847,7 +6848,7 @@ bool ObjectLifetimes::PreCallValidateCopyMicromapToMemoryEXT(VkDevice device, Vk
     if (pInfo) {
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->src, kVulkanObjectTypeMicromapEXT, false, "VUID-VkCopyMicromapToMemoryInfoEXT-src-parameter",
-                               "VUID-VkCopyMicromapToMemoryInfoEXT-src-parent", pInfo_loc.dot(Field::src));
+                               "UNASSIGNED-VkCopyMicromapToMemoryInfoEXT-src-parent", pInfo_loc.dot(Field::src));
     }
 
     return skip;
@@ -6865,7 +6866,7 @@ bool ObjectLifetimes::PreCallValidateCopyMemoryToMicromapEXT(VkDevice device, Vk
     if (pInfo) {
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->dst, kVulkanObjectTypeMicromapEXT, false, "VUID-VkCopyMemoryToMicromapInfoEXT-dst-parameter",
-                               "VUID-VkCopyMemoryToMicromapInfoEXT-dst-parent", pInfo_loc.dot(Field::dst));
+                               "UNASSIGNED-VkCopyMemoryToMicromapInfoEXT-dst-parent", pInfo_loc.dot(Field::dst));
     }
 
     return skip;
@@ -6912,7 +6913,7 @@ bool ObjectLifetimes::PreCallValidateCmdCopyMicromapToMemoryEXT(VkCommandBuffer 
     if (pInfo) {
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->src, kVulkanObjectTypeMicromapEXT, false, "VUID-VkCopyMicromapToMemoryInfoEXT-src-parameter",
-                               "VUID-VkCopyMicromapToMemoryInfoEXT-src-parent", pInfo_loc.dot(Field::src));
+                               "UNASSIGNED-VkCopyMicromapToMemoryInfoEXT-src-parent", pInfo_loc.dot(Field::src));
     }
 
     return skip;
@@ -6926,7 +6927,7 @@ bool ObjectLifetimes::PreCallValidateCmdCopyMemoryToMicromapEXT(VkCommandBuffer 
     if (pInfo) {
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->dst, kVulkanObjectTypeMicromapEXT, false, "VUID-VkCopyMemoryToMicromapInfoEXT-dst-parameter",
-                               "VUID-VkCopyMemoryToMicromapInfoEXT-dst-parent", pInfo_loc.dot(Field::dst));
+                               "UNASSIGNED-VkCopyMemoryToMicromapInfoEXT-dst-parent", pInfo_loc.dot(Field::dst));
     }
 
     return skip;
@@ -7610,7 +7611,7 @@ bool ObjectLifetimes::PreCallValidateCopyAccelerationStructureToMemoryKHR(VkDevi
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->src, kVulkanObjectTypeAccelerationStructureKHR, false,
                                "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-parameter",
-                               "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent", pInfo_loc.dot(Field::src));
+                               "UNASSIGNED-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent", pInfo_loc.dot(Field::src));
     }
 
     return skip;
@@ -7629,7 +7630,7 @@ bool ObjectLifetimes::PreCallValidateCopyMemoryToAccelerationStructureKHR(VkDevi
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->dst, kVulkanObjectTypeAccelerationStructureKHR, false,
                                "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parameter",
-                               "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent", pInfo_loc.dot(Field::dst));
+                               "UNASSIGNED-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent", pInfo_loc.dot(Field::dst));
     }
 
     return skip;
@@ -7679,7 +7680,7 @@ bool ObjectLifetimes::PreCallValidateCmdCopyAccelerationStructureToMemoryKHR(
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->src, kVulkanObjectTypeAccelerationStructureKHR, false,
                                "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-parameter",
-                               "VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent", pInfo_loc.dot(Field::src));
+                               "UNASSIGNED-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent", pInfo_loc.dot(Field::src));
     }
 
     return skip;
@@ -7693,7 +7694,7 @@ bool ObjectLifetimes::PreCallValidateCmdCopyMemoryToAccelerationStructureKHR(
         [[maybe_unused]] const Location pInfo_loc = error_obj.location.dot(Field::pInfo);
         skip |= ValidateObject(pInfo->dst, kVulkanObjectTypeAccelerationStructureKHR, false,
                                "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parameter",
-                               "VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent", pInfo_loc.dot(Field::dst));
+                               "UNASSIGNED-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent", pInfo_loc.dot(Field::dst));
     }
 
     return skip;

--- a/scripts/generators/object_tracker_generator.py
+++ b/scripts/generators/object_tracker_generator.py
@@ -649,7 +649,7 @@ bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const Loca
         if commandName == 'vkCmdBindDescriptorBuffersEXT' and memberName == 'buffer':
             return '"UNASSIGNED-VkDescriptorBufferBindingPushDescriptorBufferHandleEXT-buffer-parent"'
         if commandName == 'vkReleaseSwapchainImagesEXT' and memberName == 'swapchain':
-            return '"VUID-VkReleaseSwapchainImagesInfoEXT-swapchain-parent"'
+            return '"UNASSIGNED-VkReleaseSwapchainImagesInfoEXT-swapchain-parent"'
         if commandName == 'vkCmdBeginConditionalRenderingEXT' and memberName == 'buffer':
             return '"UNASSIGNED-VkConditionalRenderingBeginInfoEXT-buffer-parent"'
         if commandName == 'vkMapMemory2KHR' and memberName == 'memory':
@@ -691,7 +691,7 @@ bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const Loca
 
         # Same as above, but memberName has naming collision so need to use struct name as well
         if commandName == 'vkCreateGraphicsPipelines' and structName == 'VkGraphicsPipelineShaderGroupsCreateInfoNV' and memberName == 'pPipelines':
-            return '"VUID-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-parent"'
+            return '"UNASSIGNED-VkGraphicsPipelineShaderGroupsCreateInfoNV-pPipelines-parent"'
 
         # These are cases where multiple commands call the struct
         if structName == 'VkPipelineExecutableInfoKHR' and memberName == 'pipeline':
@@ -724,15 +724,15 @@ bool ObjectLifetimes::ReportUndestroyedDeviceObjects(VkDevice device, const Loca
         if structName == 'VkGeometryAABBNV' and memberName == 'aabbData':
             return '"UNASSIGNED-VkGeometryAABBNV-aabbData-parent"'
         if structName == 'VkPipelineLibraryCreateInfoKHR' and memberName == 'pLibraries':
-            return '"VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parent"'
+            return '"UNASSIGNED-VkPipelineLibraryCreateInfoKHR-pLibraries-parent"'
         if structName == 'VkCopyMicromapToMemoryInfoEXT' and memberName == 'src':
-            return '"VUID-VkCopyMicromapToMemoryInfoEXT-src-parent"'
+            return '"UNASSIGNED-VkCopyMicromapToMemoryInfoEXT-src-parent"'
         if structName == 'VkCopyMemoryToMicromapInfoEXT' and memberName == 'dst':
-            return '"VUID-VkCopyMemoryToMicromapInfoEXT-dst-parent"'
+            return '"UNASSIGNED-VkCopyMemoryToMicromapInfoEXT-dst-parent"'
         if structName == 'VkCopyAccelerationStructureToMemoryInfoKHR' and memberName == 'src':
-            return '"VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent"'
+            return '"UNASSIGNED-VkCopyAccelerationStructureToMemoryInfoKHR-src-parent"'
         if structName == 'VkCopyMemoryToAccelerationStructureInfoKHR' and memberName == 'dst':
-            return '"VUID-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent"'
+            return '"UNASSIGNED-VkCopyMemoryToAccelerationStructureInfoKHR-dst-parent"'
         if structName == 'VkSamplerYcbcrConversionInfo' and memberName == 'conversion':
             return '"UNASSIGNED-VkSamplerYcbcrConversionInfo-conversion-parent"'
         if structName == 'VkShaderModuleValidationCacheCreateInfoEXT' and memberName == 'validationCache':


### PR DESCRIPTION
2 fixes

1. ` VUID-vkCmdDraw-None-06666` now requires `VK_EXT_sample_locations` (because when using Shader Object that extension has no feature bit to turn on)
2. Fixes some VUID churn around the Object Tracker parent VUIDs not being assigned yet