### PR TITLE
gpu: Have all Passes have a name function

### DIFF
--- a/layers/gpu/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu/spirv/bindless_descriptor_pass.cpp
@@ -160,7 +160,7 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
         if (storage_class == spv::StorageClassUniform) {
             const uint32_t block_type_id = (pointer_type->inst_.IsArray()) ? pointer_type->inst_.Operand(0) : pointer_type->Id();
             if (module_.type_manager_.FindTypeById(block_type_id)->spv_type_ != SpvType::kStruct) {
-                module_.InternalError("BindlessDescriptorPass", "Uniform variable block type is not OpTypeStruct");
+                module_.InternalError(Name(), "Uniform variable block type is not OpTypeStruct");
                 return false;
             }
 
@@ -169,7 +169,7 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
             // If block decoration not found, verify deprecated form of SSBO
             if (!block_found) {
                 if (GetDecoration(block_type_id, spv::DecorationBufferBlock) == nullptr) {
-                    module_.InternalError("BindlessDescriptorPass", "Uniform variable block decoration not found");
+                    module_.InternalError(Name(), "Uniform variable block decoration not found");
                     return false;
                 }
                 storage_class = spv::StorageClassStorageBuffer;
@@ -227,13 +227,13 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
             descriptor_index_id_ = var_inst_->Operand(1);
 
             if (var_inst_->Length() > 5) {
-                module_.InternalError("BindlessDescriptorPass", "OpAccessChain has more than 1 indexes");
+                module_.InternalError(Name(), "OpAccessChain has more than 1 indexes");
                 return false;
             }
 
             const Variable* variable = module_.type_manager_.FindVariableById(var_inst_->Operand(0));
             if (!variable) {
-                module_.InternalError("BindlessDescriptorPass", "OpAccessChain base is not a variable");
+                module_.InternalError(Name(), "OpAccessChain base is not a variable");
                 return false;
             }
             var_inst_ = &variable->inst_;
@@ -255,7 +255,7 @@ bool BindlessDescriptorPass::AnalyzeInstruction(const Function& function, const 
     }
 
     if (descriptor_set_ >= gpuav::glsl::kDebugInputBindlessMaxDescSets) {
-        module_.InternalWarning("BindlessDescriptorPass", "Tried to use a descriptor slot over the current max limit");
+        module_.InternalWarning(Name(), "Tried to use a descriptor slot over the current max limit");
         return false;
     }
 

--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -27,6 +27,7 @@ namespace spirv {
 class BindlessDescriptorPass : public InjectConditionalFunctionPass {
   public:
     BindlessDescriptorPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    const char* Name() const final { return "BindlessDescriptorPass"; }
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -26,6 +26,7 @@ namespace spirv {
 class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
   public:
     BufferDeviceAddressPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    const char* Name() const final { return "BufferDeviceAddressPass"; }
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/debug_printf_pass.cpp
+++ b/layers/gpu/spirv/debug_printf_pass.cpp
@@ -118,7 +118,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
                 block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
                 params.push_back(uconvert_low_id);
             } else {
-                module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported for int width");
+                module_.InternalError(Name(), "CreateFunctionParams has unsupported for int width");
             }
             break;
         }
@@ -174,7 +174,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
                 block.CreateInstruction(spv::OpUConvert, {uint32_type_id, uconvert_low_id, shift_right_id}, inst_it);
                 params.push_back(uconvert_low_id);
             } else {
-                module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported for float width");
+                module_.InternalError(Name(), "CreateFunctionParams has unsupported for float width");
             }
             break;
         }
@@ -191,7 +191,7 @@ void DebugPrintfPass::CreateFunctionParams(uint32_t argument_id, const Type& arg
         }
 
         default:
-            module_.InternalError("DebugPrintfPass", "CreateFunctionParams has unsupported function param type");
+            module_.InternalError(Name(), "CreateFunctionParams has unsupported function param type");
             break;
     }
 }

--- a/layers/gpu/spirv/debug_printf_pass.h
+++ b/layers/gpu/spirv/debug_printf_pass.h
@@ -26,6 +26,8 @@ struct Type;
 class DebugPrintfPass : public Pass {
   public:
     DebugPrintfPass(Module& module, uint32_t binding_slot = 0) : Pass(module), binding_slot_(binding_slot) {}
+    const char* Name() const final { return "DebugPrintfPass"; }
+
     bool Run() final;
     void PrintDebugInfo() final;
 

--- a/layers/gpu/spirv/non_bindless_oob_buffer_pass.cpp
+++ b/layers/gpu/spirv/non_bindless_oob_buffer_pass.cpp
@@ -158,7 +158,7 @@ bool NonBindlessOOBBufferPass::AnalyzeInstruction(const Function& function, cons
     }
 
     if (descriptor_set_ >= gpuav::glsl::kDebugInputBindlessMaxDescSets) {
-        module_.InternalWarning("BindlessDescriptorPass", "Tried to use a descriptor slot over the current max limit");
+        module_.InternalWarning(Name(), "Tried to use a descriptor slot over the current max limit");
         return false;
     }
 

--- a/layers/gpu/spirv/non_bindless_oob_buffer_pass.h
+++ b/layers/gpu/spirv/non_bindless_oob_buffer_pass.h
@@ -26,6 +26,7 @@ class NonBindlessOOBBufferPass : public Pass {
   public:
     NonBindlessOOBBufferPass(Module& module);
     void PrintDebugInfo() final;
+    const char* Name() const final { return "NonBindlessOOBBufferPass"; }
     bool Run() final;
 
   private:

--- a/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.cpp
+++ b/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.cpp
@@ -136,14 +136,13 @@ bool NonBindlessOOBTexelBufferPass::AnalyzeInstruction(const Function& function,
         descriptor_index_id_ = var_inst_->Operand(1);
 
         if (var_inst_->Length() > 5) {
-            module_.InternalError("NonBindlessOOBTexelBufferPass",
-                                  "OpAccessChain has more than 1 indexes. 2D Texel Buffers not supported");
+            module_.InternalError(Name(), "OpAccessChain has more than 1 indexes. 2D Texel Buffers not supported");
             return false;
         }
 
         const Variable* variable = module_.type_manager_.FindVariableById(var_inst_->Operand(0));
         if (!variable) {
-            module_.InternalError("NonBindlessOOBTexelBufferPass", "OpAccessChain base is not a variable");
+            module_.InternalError(Name(), "OpAccessChain base is not a variable");
             return false;
         }
         var_inst_ = &variable->inst_;
@@ -158,7 +157,7 @@ bool NonBindlessOOBTexelBufferPass::AnalyzeInstruction(const Function& function,
             }
             descriptor_array_size_id_ = array_size_const->Id();
         } else {
-            module_.InternalError("NonBindlessOOBTexelBufferPass", "OpAccessChain has no array in it");
+            module_.InternalError(Name(), "OpAccessChain has no array in it");
             return false;
         }
 
@@ -180,7 +179,7 @@ bool NonBindlessOOBTexelBufferPass::AnalyzeInstruction(const Function& function,
     }
 
     if (descriptor_set_ >= gpuav::glsl::kDebugInputBindlessMaxDescSets) {
-        module_.InternalWarning("NonBindlessOOBTexelBufferPass", "Tried to use a descriptor slot over the current max limit");
+        module_.InternalWarning(Name(), "Tried to use a descriptor slot over the current max limit");
         return false;
     }
 

--- a/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.h
+++ b/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.h
@@ -26,6 +26,7 @@ class NonBindlessOOBTexelBufferPass : public Pass {
   public:
     NonBindlessOOBTexelBufferPass(Module& module);
     void PrintDebugInfo() final;
+    const char* Name() const final { return "NonBindlessOOBTexelBufferPass"; }
     bool Run() final;
 
   private:

--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -161,7 +161,7 @@ uint32_t Pass::GetStageInfo(Function& function, BasicBlockIt target_block_it, In
                 }
             } break;
             default:
-                module_.InternalError("Passs", "GetStageInfo has unsupported stage");
+                module_.InternalError(Name(), "GetStageInfo has unsupported stage");
                 break;
         }
     }
@@ -222,8 +222,7 @@ uint32_t Pass::GetLastByte(const Instruction& var_inst, const Instruction& acces
     } else if (descriptor_type->spv_type_ == SpvType::kStruct) {
         current_type_id = descriptor_type->Id();
     } else {
-        // TODO - Add a GetPassName() helper
-        module_.InternalError("Pass", "GetLastByte has unexpected descriptor type");
+        module_.InternalError(Name(), "GetLastByte has unexpected descriptor type");
         return 0;
     }
 
@@ -258,7 +257,7 @@ uint32_t Pass::GetLastByte(const Instruction& var_inst, const Instruction& acces
             } break;
             case SpvType::kMatrix: {
                 if (matrix_stride == 0) {
-                    module_.InternalError("Pass", "GetLastByte is missing matrix stride");
+                    module_.InternalError(Name(), "GetLastByte is missing matrix stride");
                 }
                 matrix_stride_id = module_.type_manager_.GetConstantUInt32(matrix_stride).Id();
                 uint32_t vec_type_id = current_type->inst_.Operand(0);
@@ -324,7 +323,7 @@ uint32_t Pass::GetLastByte(const Instruction& var_inst, const Instruction& acces
                 current_type_id = current_type->inst_.Operand(member_index);
             } break;
             default: {
-                module_.InternalError("Pass", "GetLastByte has unexpected non-composite type");
+                module_.InternalError(Name(), "GetLastByte has unexpected non-composite type");
             } break;
         }
 
@@ -419,7 +418,7 @@ InstructionIt Pass::FindTargetInstruction(BasicBlock& block) const {
         }
     }
 
-    module_.InternalError("FindTargetInstruction", "failed to find instruction");
+    module_.InternalError(Name(), "failed to find instruction");
     return block.instructions_.end();
 }
 

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -34,6 +34,7 @@ struct InjectionData {
 // Common helpers for all passes
 class Pass {
   public:
+    virtual const char* Name() const = 0;
     // Return false if nothing was changed
     virtual bool Run() { return false; }
 

--- a/layers/gpu/spirv/ray_query_pass.h
+++ b/layers/gpu/spirv/ray_query_pass.h
@@ -24,6 +24,7 @@ namespace spirv {
 class RayQueryPass : public InjectConditionalFunctionPass {
   public:
     RayQueryPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    const char* Name() const final { return "RayQueryPass"; }
     void PrintDebugInfo() final;
 
   private:

--- a/layers/gpu/spirv/type_manager.cpp
+++ b/layers/gpu/spirv/type_manager.cpp
@@ -555,7 +555,7 @@ uint32_t TypeManager::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride,
             break;
         case SpvType::kMatrix: {
             if (matrix_stride == 0) {
-                module_.InternalError("BindlessDescriptorPass", "FindTypeByteSize is missing matrix stride");
+                module_.InternalError("FindTypeByteSize", "missing matrix stride");
             }
             if (col_major) {
                 return type.inst_.Word(3) * matrix_stride;
@@ -574,7 +574,7 @@ uint32_t TypeManager::FindTypeByteSize(uint32_t type_id, uint32_t matrix_stride,
                 const uint32_t width = component_type->inst_.Word(2);
                 size *= width;
             } else {
-                module_.InternalError("BindlessDescriptorPass", "FindTypeByteSize has unexpected vector type");
+                module_.InternalError("FindTypeByteSize", "unexpected vector type");
             }
             return size / 8;
         }


### PR DESCRIPTION
As we add more passes, and have common `Pass` member functions that might have to report an error, it is nice to have a `Name()`function to get which pass it was