### PR TITLE
layers: Print ppEnabledExtensionNames string if unknown

### DIFF
--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -299,7 +299,7 @@ static void InstanceExtensionWhitelist(ValidationObject* layer_data, const VkIns
                                    loc.dot(vvl::Field::pCreateInfo).dot(vvl::Field::ppEnabledExtensionNames, i),
                                    "%s is not supported by this layer.  Using this extension may adversely affect validation "
                                    "results and/or produce undefined behavior.",
-                                   String(extension));
+                                   pCreateInfo->ppEnabledExtensionNames[i]);
         }
     }
 }
@@ -315,7 +315,7 @@ static void DeviceExtensionWhitelist(ValidationObject* layer_data, const VkDevic
                                    loc.dot(vvl::Field::pCreateInfo).dot(vvl::Field::ppEnabledExtensionNames, i),
                                    "%s is not supported by this layer.  Using this extension may adversely affect validation "
                                    "results and/or produce undefined behavior.",
-                                   String(extension));
+                                   pCreateInfo->ppEnabledExtensionNames[i]);
         }
     }
 }

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -930,7 +930,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                         layer_data->LogWarning(kVUIDUndefined, layer_data->instance,
                                             loc.dot(vvl::Field::pCreateInfo).dot(vvl::Field::ppEnabledExtensionNames, i),
                                             "%s is not supported by this layer.  Using this extension may adversely affect validation "
-                                            "results and/or produce undefined behavior.", String(extension));
+                                            "results and/or produce undefined behavior.", pCreateInfo->ppEnabledExtensionNames[i]);
                     }
                 }
             }
@@ -945,7 +945,7 @@ class LayerChassisOutputGenerator(BaseGenerator):
                         layer_data->LogWarning(kVUIDUndefined, layer_data->device,
                                             loc.dot(vvl::Field::pCreateInfo).dot(vvl::Field::ppEnabledExtensionNames, i),
                                             "%s is not supported by this layer.  Using this extension may adversely affect validation "
-                                            "results and/or produce undefined behavior.", String(extension));
+                                            "results and/or produce undefined behavior.", pCreateInfo->ppEnabledExtensionNames[i]);
                     }
                 }
             }


### PR DESCRIPTION
If the extension is not known, it will print out `INVALID_EMPTY` (which is not helpful IMO)

We have the original `const char*` so this prints it out instead