### PR TITLE
layers: Allow SPIRV-Tools commit to be a tag

### DIFF
--- a/layers/utils/shader_utils.h
+++ b/layers/utils/shader_utils.h
@@ -95,7 +95,7 @@ class ValidationCache {
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
 
-    void GetUUID(uint8_t *uuid);
+    void SetUUID(uint8_t *uuid);
 
     // Can hit cases where error appear/disappear if spirv-val settings are adjusted
     // see https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8031

--- a/scripts/generators/spirv_tool_commit_id_generator.py
+++ b/scripts/generators/spirv_tool_commit_id_generator.py
@@ -33,13 +33,6 @@ class SpirvToolCommitIdOutputGenerator(BaseGenerator):
             json_data = json.load(json_stream)
             commit_id = [x for x in json_data['repos'] if x['name'] == 'SPIRV-Tools'][0]['commit']
 
-        try:
-            str_as_int = int(commit_id, 16)
-        except ValueError:
-            raise ValueError(f'commit ID for SPIRV_TOOLS_COMMIT_ID ({commit_id}) must be a SHA1 hash.')
-        if len(commit_id) != 40:
-            raise ValueError(f'commit ID for SPIRV_TOOLS_COMMIT_ID ({commit_id}) must be a SHA1 hash.')
-
         out = []
         out.append(f'''// *** THIS FILE IS GENERATED - DO NOT EDIT ***
             // See {os.path.basename(__file__)} for modifications


### PR DESCRIPTION
For people working on private extension (and possibly if SPIR-V Tools adds tags in near future) we will want to go

```patch
diff --git a/scripts/known_good.json b/scripts/known_good.json
index 4237ef3ee..66cc20a39 100755
--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=OFF"
             ],
-            "commit": "363486479d4c8dfbfdf2e2dc397cd10aa15f80b0"
+            "commit": "some tag name"
         },
```

so this removes the (honestly over complex) logic to get the git sha into the `UUID` for shader caching and just takes the string and uses the same internal hashing we use for everything else