### PR TITLE
tests: More test header cleanup

### DIFF
--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -11,6 +11,7 @@
  *     http://www.apache.org/licenses/LICENSE-2.0
  */
 #include "layer_validation_tests.h"
+#include "utils/convert_utils.h"
 
 #ifdef VK_USE_PLATFORM_WAYLAND_KHR
 #include "wayland-client.h"

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -29,22 +29,16 @@
 #include <vulkan/utility/vk_format_utils.h>
 #include <vulkan/utility/vk_struct_helper.hpp>
 
-#include "test_common.h"
 #include "binding.h"
 #include "containers/custom_containers.h"
 #include "generated/vk_extension_helper.h"
 #include "render.h"
-#include "utils/convert_utils.h"
-#include "shader_templates.h"
 
 #include <cmath>
 #include <functional>
 #include <limits>
 #include <string>
 #include <vector>
-
-using std::string;
-using std::vector;
 
 // MSVC and GCC define __SANITIZE_ADDRESS__ when compiling with address sanitization
 // However, clang doesn't. Instead you have to use __has_feature to check.

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -23,6 +23,7 @@
 
 #include "render.h"
 #include "test_framework.h"
+#include "shader_templates.h"
 
 class VkRenderFramework;
 class VkTestFramework;

--- a/tests/framework/shader_object_helper.cpp
+++ b/tests/framework/shader_object_helper.cpp
@@ -11,6 +11,7 @@
  */
 
 #include "shader_object_helper.h"
+#include <vulkan/utility/vk_struct_helper.hpp>
 
 VkShaderCreateInfoEXT ShaderCreateInfo(const std::vector<uint32_t>& spirv, VkShaderStageFlagBits stage, uint32_t set_layout_count,
                                        const VkDescriptorSetLayout* set_layouts, uint32_t pc_range_count,

--- a/tests/framework/shader_object_helper.h
+++ b/tests/framework/shader_object_helper.h
@@ -12,8 +12,8 @@
 
 #pragma once
 
-#include "layer_validation_tests.h"
-#include "shader_helper.h"
+#include <vector>
+#include <vulkan/vulkan.h>
 
 // Assumes VK_SHADER_CODE_TYPE_SPIRV_EXT as that is how must tests will create the shader
 VkShaderCreateInfoEXT ShaderCreateInfo(const std::vector<uint32_t>& spirv, VkShaderStageFlagBits stage,

--- a/tests/framework/video_objects.h
+++ b/tests/framework/video_objects.h
@@ -12,6 +12,7 @@
 #pragma once
 
 #include "layer_validation_tests.h"
+#include <vulkan/utility/vk_safe_struct.hpp>
 #include <vk_video/vulkan_video_codecs_common.h>
 #include <vk_video/vulkan_video_codec_h264std.h>
 #include <vk_video/vulkan_video_codec_h264std_decode.h>

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -2405,14 +2405,15 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
     // Create pipeline with w-scaling enabled but without a valid scaling array
     vpsi.pViewportWScalings = nullptr;
     CreatePipelineHelper::OneshotTest(*this, set_vpci, kErrorBit,
-                                      vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715"}));
+                                      std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-01715"}));
 
     vpsi.pViewportWScalings = scale.data();
 
     // Create pipeline with w-scaling enabled but without matching viewport counts
     vpsi.viewportCount = 1;
-    CreatePipelineHelper::OneshotTest(*this, set_vpci, kErrorBit,
-                                      vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-viewportWScalingEnable-01726"}));
+    CreatePipelineHelper::OneshotTest(
+        *this, set_vpci, kErrorBit,
+        std::vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-viewportWScalingEnable-01726"}));
 
     VkShaderObj vs(this, vs_src, VK_SHADER_STAGE_VERTEX_BIT);
     VkShaderObj fs(this, fs_src, VK_SHADER_STAGE_FRAGMENT_BIT);

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -16,6 +16,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "utils/convert_utils.h"
 
 class NegativeDynamicRenderingLocalRead : public DynamicRenderingTest {};
 
@@ -573,8 +574,8 @@ TEST_F(NegativeDynamicRenderingLocalRead, BeginWithinRenderPass) {
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
     for (uint32_t i = 0; i < 3; i++) {
-        vector<VkAttachmentReference> color_references;
-        vector<VkAttachmentDescription> attachment_descriptions;
+        std::vector<VkAttachmentReference> color_references;
+        std::vector<VkAttachmentDescription> attachment_descriptions;
         std::shared_ptr<vkt::Framebuffer> framebuffer;
         std::vector<std::unique_ptr<vkt::Image>> renderTargets;
         std::vector<vkt::ImageView> render_target_views;   // color attachments but not depth

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -2171,7 +2171,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
             vsrisci.viewportCount = 1;
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04057"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pDynamicStates-04057"}));
     }
 
     // Create an image without the SRI bit

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -750,8 +750,8 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
         };
         if (overflow) {
             CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
-                                              vector<string>{"VUID-VkPipelineShaderStageCreateInfo-stage-00714",
-                                                             "VUID-VkPipelineShaderStageCreateInfo-stage-00715"});
+                                              std::vector<std::string>{"VUID-VkPipelineShaderStageCreateInfo-stage-00714",
+                                                                       "VUID-VkPipelineShaderStageCreateInfo-stage-00715"});
         } else {
             CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit);
         }

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -12,6 +12,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/shader_object_helper.h"
+#include "../framework/shader_templates.h"
 
 class PositiveGpuAVShaderObject : public GpuAVTest {
   public:

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -835,7 +835,7 @@ TEST_F(PositiveGraphicsLibrary, LinkingInputAttachment) {
                OpReturn
                OpFunctionEnd
         )";
-        vector<uint32_t> fs_spv;
+        std::vector<uint32_t> fs_spv;
         ASMtoSPV(SPV_ENV_VULKAN_1_0, 0, fs_src, fs_spv);
         vkt::GraphicsPipelineLibraryStage fs_stage(fs_spv, VK_SHADER_STAGE_FRAGMENT_BIT);
         frag_shader_lib.InitFragmentLibInfo(&fs_stage.stage_ci);

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -174,14 +174,14 @@ TEST_F(NegativeMesh, BasicUsage) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo(), ms.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pStages-02095"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pStages-02095"}));
 
         // vertex or mesh must be present
         // 02096 overlaps with 06896
         const auto break_vp2 = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
         CreatePipelineHelper::OneshotTest(*this, break_vp2, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
-                                                               "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
+                                                                    "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
 
         // vertexinput and inputassembly must be valid when vertex stage is present
         const auto break_vp3 = [&](CreatePipelineHelper &helper) {
@@ -196,10 +196,10 @@ TEST_F(NegativeMesh, BasicUsage) {
             helper.shader_stages_ = {ms_xfb.GetStageCreateInfo(), fs.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp4, kErrorBit,
-                                          vector<std::string>({" VUID-VkGraphicsPipelineCreateInfo-None-02322"}));
+                                          std::vector<std::string>({" VUID-VkGraphicsPipelineCreateInfo-None-02322"}));
 
         // invalid dynamic state with mesh shader
-        vector<VkDynamicState> dyn_states[] = {
+        std::vector<VkDynamicState> dyn_states[] = {
             {VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT},
             {VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT},
             {VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT},
@@ -219,7 +219,7 @@ TEST_F(NegativeMesh, BasicUsage) {
                 helper.shader_stages_ = {ms.GetStageCreateInfo(), fs.GetStageCreateInfo()};
                 helper.gp_ci_.pDynamicState = &dyn_state;
             };
-            CreatePipelineHelper::OneshotTest(*this, break_vp5, kErrorBit, vector<std::string>({err_vuids[i]}));
+            CreatePipelineHelper::OneshotTest(*this, break_vp5, kErrorBit, std::vector<std::string>({err_vuids[i]}));
         }
 
         // viewMask without enabling multiviewMeshShader feature
@@ -235,7 +235,7 @@ TEST_F(NegativeMesh, BasicUsage) {
             helper.gp_ci_.renderPass = VK_NULL_HANDLE;
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp5, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-renderPass-07720"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-renderPass-07720"}));
     }
 }
 
@@ -339,8 +339,8 @@ TEST_F(NegativeMesh, ExtensionDisabled) {
         helper.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
-                                      vector<std::string>({"VUID-VkPipelineShaderStageCreateInfo-stage-02091",
-                                                           "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
+                                      std::vector<std::string>({"VUID-VkPipelineShaderStageCreateInfo-stage-02091",
+                                                                "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
 }
 
 TEST_F(NegativeMesh, RuntimeSpirv) {
@@ -358,7 +358,7 @@ TEST_F(NegativeMesh, RuntimeSpirv) {
     VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(mesh_shader_properties);
 
-    vector<std::string> error_vuids;
+    std::vector<std::string> error_vuids;
     uint32_t max_task_workgroup_size_x = mesh_shader_properties.maxTaskWorkGroupSize[0];
     uint32_t max_task_workgroup_size_y = mesh_shader_properties.maxTaskWorkGroupSize[1];
     uint32_t max_task_workgroup_size_z = mesh_shader_properties.maxTaskWorkGroupSize[2];
@@ -647,14 +647,14 @@ TEST_F(NegativeMesh, BasicUsageNV) {
             helper.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo(), ms.GetStageCreateInfo()};
         };
         CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pStages-02095"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-pStages-02095"}));
 
         // vertex or mesh must be present
         // 02096 overlaps with 06896
         const auto break_vp2 = [&](CreatePipelineHelper &helper) { helper.shader_stages_ = {fs.GetStageCreateInfo()}; };
         CreatePipelineHelper::OneshotTest(*this, break_vp2, kErrorBit,
-                                          vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
-                                                               "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
+                                          std::vector<std::string>({"VUID-VkGraphicsPipelineCreateInfo-stage-02096",
+                                                                    "VUID-VkGraphicsPipelineCreateInfo-pStages-06896"}));
 
         // vertexinput and inputassembly must be valid when vertex stage is present
         const auto break_vp3 = [&](CreatePipelineHelper &helper) {
@@ -844,8 +844,8 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
         helper.shader_stages_ = {task_shader.GetStageCreateInfo(), mesh_shader.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp, kErrorBit,
-                                      vector<std::string>({"VUID-VkPipelineShaderStageCreateInfo-stage-02091",
-                                                           "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
+                                      std::vector<std::string>({"VUID-VkPipelineShaderStageCreateInfo-stage-02091",
+                                                                "VUID-VkPipelineShaderStageCreateInfo-stage-02092"}));
 }
 
 TEST_F(NegativeMesh, DrawCmds) {

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -17,6 +17,7 @@
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
+#include "utils/convert_utils.h"
 
 class NegativeMultiview : public VkLayerTest {};
 

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -3541,7 +3541,7 @@ TEST_F(NegativePipeline, ViewportStateScissorOverflow) {
         helper.vp_state_ci_.pScissors = &scissor_x;
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp_x, kErrorBit,
-                                      vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-offset-02822"}));
+                                      std::vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-offset-02822"}));
 
     const auto break_vp_y = [&](CreatePipelineHelper &helper) {
         helper.vp_state_ci_.viewportCount = 1;
@@ -3550,7 +3550,7 @@ TEST_F(NegativePipeline, ViewportStateScissorOverflow) {
         helper.vp_state_ci_.pScissors = &scissor_y;
     };
     CreatePipelineHelper::OneshotTest(*this, break_vp_y, kErrorBit,
-                                      vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-offset-02823"}));
+                                      std::vector<std::string>({"VUID-VkPipelineViewportStateCreateInfo-offset-02823"}));
 }
 
 TEST_F(NegativePipeline, ViewportStateScissorNegative) {

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -14,6 +14,7 @@
  */
 
 #include "utils/cast_utils.h"
+#include "utils/convert_utils.h"
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/descriptor_helper.h"

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -13,6 +13,7 @@
 #include "../framework/shader_object_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
+#include "../framework/shader_templates.h"
 
 class NegativeShaderObject : public ShaderObjectTest {};
 

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -12,6 +12,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/shader_object_helper.h"
 #include "../framework/descriptor_helper.h"
+#include "../framework/shader_templates.h"
 
 void ShaderObjectTest::InitBasicShaderObject() {
     SetTargetApiVersion(VK_API_VERSION_1_1);

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -16,6 +16,7 @@
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
 #include "../framework/render_pass_helper.h"
+#include "utils/convert_utils.h"
 
 class NegativeSubpass : public VkLayerTest {};
 

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -17,6 +17,7 @@
 
 #include "../framework/layer_validation_tests.h"
 #include "../framework/pipeline_helper.h"
+#include "utils/convert_utils.h"
 
 class PositiveSubpass : public VkLayerTest {};
 

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -403,9 +403,9 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputAttributes) {
         helper.vi_ci_.vertexAttributeDescriptionCount = 1;
     };
     CreatePipelineHelper::OneshotTest(*this, set_attribute, kErrorBit,
-                                      vector<string>{"VUID-VkVertexInputAttributeDescription-location-00620",
-                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
-                                                     "VUID-VkVertexInputAttributeDescription-format-00623"});
+                                      std::vector<std::string>{"VUID-VkVertexInputAttributeDescription-location-00620",
+                                                               "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                                               "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
 TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputBindings) {
@@ -425,9 +425,9 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputBindings) {
         helper.vi_ci_.vertexAttributeDescriptionCount = 1;
     };
     CreatePipelineHelper::OneshotTest(*this, set_attribute, kErrorBit,
-                                      vector<string>{"VUID-VkVertexInputAttributeDescription-binding-00621",
-                                                     "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
-                                                     "VUID-VkVertexInputAttributeDescription-format-00623"});
+                                      std::vector<std::string>{"VUID-VkVertexInputAttributeDescription-binding-00621",
+                                                               "VUID-VkPipelineVertexInputStateCreateInfo-binding-00615",
+                                                               "VUID-VkVertexInputAttributeDescription-format-00623"});
 }
 
 TEST_F(NegativeVertexInput, AttributeDescriptionOffset) {


### PR DESCRIPTION
While in meeting, reducing the `#include` clustering in `./tests` so when I edit a util/framework file, I can rebuild slightly less than every test if not needed