### PR TITLE
printf: Don't allocate memory when not needed

### DIFF
--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -194,9 +194,9 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     template <typename SafeCreateInfo>
     void PreCallRecordPipelineCreationShaderInstrumentation(
         const VkAllocationCallbacks *pAllocator, vvl::Pipeline &pipeline_state, SafeCreateInfo &new_pipeline_ci,
-        const Location &loc, chassis::ShaderInstrumentationMetadata &shader_instrumentation_metadata);
+        const Location &loc, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);
     void PostCallRecordPipelineCreationShaderInstrumentation(
-        vvl::Pipeline &pipeline_state, chassis::ShaderInstrumentationMetadata &shader_instrumentation_metadata);
+        vvl::Pipeline &pipeline_state, std::vector<chassis::ShaderInstrumentationMetadata> &shader_instrumentation_metadata);
     void PostCallRecordPipelineCreationsRT(VkResult result, VkDeferredOperationKHR deferredOperation,
                                            const VkAllocationCallbacks *pAllocator,
                                            std::shared_ptr<chassis::CreateRayTracingPipelinesKHR> chassis_state);

--- a/layers/state_tracker/pipeline_state.h
+++ b/layers/state_tracker/pipeline_state.h
@@ -132,8 +132,15 @@ class Pipeline : public StateObject {
 
     mutable bool binary_data_released = false;
 
-    // We create a VkShaderModule that is instrumented and need to delete before leaving the pipeline call
-    std::vector<VkShaderModule> instrumented_shader_module;
+    // TODO - Because we have hack to create a pipeline at PreCallValidate time (for GPL) we have no proper way to create inherited
+    // state objects of the pipeline This is to make it clear that while currently everyone has to allocate this memory, it is only
+    // ment for GPU-AV
+    struct GPU {
+        // We create a VkShaderModule that is instrumented and need to delete before leaving the pipeline call
+        std::vector<VkShaderModule> instrumented_shader_module;
+        // TODO - For GPL, this doesn't get passed down from linked shaders
+        bool was_instrumented = false;
+    } gpu;
 
     // Executable or legacy pipeline
     Pipeline(const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo *pCreateInfo,

--- a/layers/state_tracker/shader_object_state.h
+++ b/layers/state_tracker/shader_object_state.h
@@ -49,6 +49,11 @@ struct ShaderObject : public StateObject {
     const PushConstantRangesId push_constant_ranges;
     const std::vector<PipelineLayoutCompatId> set_compat_ids;
 
+    // TOOD Create a shader object inherited class
+    struct GPU {
+        bool was_instrumented = false;
+    } gpu;
+
     VkShaderEXT VkHandle() const { return handle_.Cast<VkShaderEXT>(); }
     bool IsGraphicsShaderState() const { return create_info.stage != VK_SHADER_STAGE_COMPUTE_BIT; };
     VkPrimitiveTopology GetTopology() const;


### PR DESCRIPTION
This will now not waste internal allocation for DebugPrintf when the current draw/dispatch we know is not going to print anything (because it was never instrumented)