### PR TITLE
Descriptor Buffer cleanup

### DIFF
--- a/layers/core_checks/cc_buffer_address.h
+++ b/layers/core_checks/cc_buffer_address.h
@@ -192,7 +192,7 @@ bool BufferAddressValidation<ChecksCount>::LogInvalidBuffers(const CoreChecks& c
         error_msg_beginning += address_string;
         error_msg_beginning +=
             ") has no buffer(s) associated to it such that valid usage passes. "
-            "At least one buffer associated to this device address must be valid. ";
+            "At least one buffer associated to this device address must be valid.\n";
     }
 
     // For each buffer, and for each violated VUID, build an error message

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -651,6 +651,8 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
 
     const bool has_host_only_pool_flag = (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_EXT) != 0;
     const bool has_update_after_bind_flag = (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT) != 0;
+    const bool has_embedded_immutable_sampler_flag =
+        (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT) != 0;
 
     if (has_push_descriptor_flag && has_host_only_pool_flag) {
         skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-04590", device, create_info_loc.dot(Field::flags), "is %s.",
@@ -666,7 +668,7 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
                          string_VkDescriptorSetLayoutCreateFlags(create_info.flags).c_str());
     }
 
-    if ((create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT) && !has_descriptor_buffer_flag) {
+    if (has_embedded_immutable_sampler_flag && !has_descriptor_buffer_flag) {
         skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08001", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(create_info.flags).c_str());
     }
@@ -676,7 +678,7 @@ bool StatelessValidation::ValidateDescriptorSetLayoutCreateInfo(const VkDescript
                          string_VkDescriptorSetLayoutCreateFlags(create_info.flags).c_str());
     }
 
-    if (has_descriptor_buffer_flag && (create_info.flags & VK_DESCRIPTOR_SET_LAYOUT_CREATE_HOST_ONLY_POOL_BIT_VALVE)) {
+    if (has_descriptor_buffer_flag && has_host_only_pool_flag) {
         skip |= LogError("VUID-VkDescriptorSetLayoutCreateInfo-flags-08003", device, create_info_loc.dot(Field::flags), "is %s.",
                          string_VkDescriptorSetLayoutCreateFlags(create_info.flags).c_str());
     }

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -987,6 +987,14 @@ class DescriptorSetLayout : public internal::NonDispHandle<VkDescriptorSetLayout
         info.pBindings = descriptor_set_bindings.data();
         init(dev, info);
     }
+    DescriptorSetLayout(const Device &dev, const VkDescriptorSetLayoutBinding &descriptor_set_binding,
+                        VkDescriptorSetLayoutCreateFlags flags = 0, void *pNext = nullptr) {
+        VkDescriptorSetLayoutCreateInfo info = vku::InitStructHelper(pNext);
+        info.flags = flags;
+        info.bindingCount = 1;
+        info.pBindings = &descriptor_set_binding;
+        init(dev, info);
+    }
 
     ~DescriptorSetLayout() noexcept;
     void destroy() noexcept;

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -100,12 +100,8 @@ TEST_F(NegativeDescriptorBuffer, SetLayout) {
 
     {
         const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-        const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-        const auto dslci1 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, 1U, &binding);
-        vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
-
-        const auto dslci2 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, 0U, 1U, &binding);
-        vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
+        vkt::DescriptorSetLayout dsl1(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+        vkt::DescriptorSetLayout dsl2(*m_device, binding, 0);
 
         VkPipelineLayout pipeline_layout;
         const std::array<VkDescriptorSetLayout, 2> set_layouts{dsl1.handle(), dsl2.handle()};
@@ -120,9 +116,7 @@ TEST_F(NegativeDescriptorBuffer, SetLayout) {
 
     {
         const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
-        const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
-        const auto dslci1 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, 1U, &binding);
-        vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
+        vkt::DescriptorSetLayout dsl1(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 
         VkDescriptorPoolSize pool_size = {binding.descriptorType, binding.descriptorCount};
         const auto dspci =
@@ -196,10 +190,7 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     TEST_DESCRIPTION("Tests for when descriptor buffer is not enabled");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
-    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddDisabledFeature(vkt::Feature::descriptorBuffer);
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
@@ -208,15 +199,9 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
 
     const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
-    const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;
-    const auto dslci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, 1U, &binding);
-    vkt::DescriptorSetLayout dsl(*m_device, dslci);
-
-    VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
-    plci.setLayoutCount = 1;
-    plci.pSetLayouts = &dsl.handle();
-    vkt::PipelineLayout pipeline_layout(*m_device, plci);
+    vkt::DescriptorSetLayout dsl(*m_device, binding,
+                                 VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                                     VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT);
 
     {
         VkDeviceSize size;
@@ -246,6 +231,11 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
     }
 
     {
+        VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
+        plci.setLayoutCount = 1;
+        plci.pSetLayouts = &dsl.handle();
+        vkt::PipelineLayout pipeline_layout(*m_device, plci);
+
         m_commandBuffer->begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-None-08068");
         vk::CmdBindDescriptorBufferEmbeddedSamplersEXT(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
@@ -254,123 +244,198 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
 
         m_commandBuffer->end();
     }
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledBufferDeviceAddress) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddDisabledFeature(vkt::Feature::descriptorBuffer);
+    RETURN_IF_SKIP(Init());
+
+    vkt::Buffer d_buffer(*m_device, 4096,
+                         VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT,
+                         vkt::device_address);
+
+    VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
+    dbbi.address = d_buffer.address();
+    dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    d_buffer.memory().destroy();
+
+    m_commandBuffer->begin();
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBuffersEXT-None-08047");
+    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1, &dbbi);
+    m_errorMonitor->VerifyFound();
+
+    m_commandBuffer->end();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledGetBufferOpaqueCaptureDescriptorDataEXT) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    uint8_t data[256];
+    vkt::Buffer temp_buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+
+    VkBufferCaptureDescriptorDataInfoEXT bcddi = vku::InitStructHelper();
+    bcddi.buffer = temp_buffer.handle();
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-None-08072");
+    m_errorMonitor->SetDesiredError("VUID-VkBufferCaptureDescriptorDataInfoEXT-buffer-08075");
+    vk::GetBufferOpaqueCaptureDescriptorDataEXT(device(), &bcddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledGetImageOpaqueCaptureDescriptorDataEXT) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    uint8_t data[256];
+
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.extent.width = 128;
+    image_create_info.extent.height = 128;
+    image_create_info.extent.depth = 1;
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_create_info.format = VK_FORMAT_D32_SFLOAT;
+    image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    vkt::Image image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    VkImageCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
+    icddi.image = image.handle();
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetImageOpaqueCaptureDescriptorDataEXT-None-08076");
+    m_errorMonitor->SetDesiredError("VUID-VkImageCaptureDescriptorDataInfoEXT-image-08079");
+    vk::GetImageOpaqueCaptureDescriptorDataEXT(device(), &icddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledGetImageViewOpaqueCaptureDescriptorDataEXT) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+    uint8_t data[256];
+
+    VkImageCreateInfo image_create_info = vku::InitStructHelper();
+    image_create_info.imageType = VK_IMAGE_TYPE_2D;
+    image_create_info.extent.width = 128;
+    image_create_info.extent.height = 128;
+    image_create_info.extent.depth = 1;
+    image_create_info.mipLevels = 1;
+    image_create_info.arrayLayers = 1;
+    image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
+    image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
+    image_create_info.format = VK_FORMAT_D32_SFLOAT;
+    image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+    vkt::Image image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+
+    // missing VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+    vkt::ImageView dsv = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
+
+    VkImageViewCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
+    icddi.imageView = dsv.handle();
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetImageViewOpaqueCaptureDescriptorDataEXT-None-08080");
+    m_errorMonitor->SetDesiredError("VUID-VkImageViewCaptureDescriptorDataInfoEXT-imageView-08083");
+    vk::GetImageViewOpaqueCaptureDescriptorDataEXT(device(), &icddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledGetSamplerOpaqueCaptureDescriptorDataEXT) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    uint8_t data[256];
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+    VkSamplerCaptureDescriptorDataInfoEXT scddi = vku::InitStructHelper();
+    scddi.sampler = sampler.handle();
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetSamplerOpaqueCaptureDescriptorDataEXT-None-08084");
+    m_errorMonitor->SetDesiredError("VUID-VkSamplerCaptureDescriptorDataInfoEXT-sampler-08087");
+    vk::GetSamplerOpaqueCaptureDescriptorDataEXT(device(), &scddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledGetAccelerationStructureOpaqueCaptureDescriptorDataEXT) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    auto blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
+    blas->Build();
+
+    uint8_t data[256];
+
+    VkAccelerationStructureCaptureDescriptorDataInfoEXT ascddi = vku::InitStructHelper();
+    ascddi.accelerationStructure = blas->handle();
+
+    m_errorMonitor->SetDesiredError("VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-None-08088");
+    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructure-08091");
+    vk::GetAccelerationStructureOpaqueCaptureDescriptorDataEXT(device(), &ascddi, &data);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplay) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddDisabledFeature(vkt::Feature::descriptorBuffer);
+    AddDisabledFeature(vkt::Feature::descriptorBufferPushDescriptors);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
+
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(descriptor_buffer_properties);
+
+    uint32_t data[128];
+    const auto ocddci = vku::InitStruct<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(nullptr, &data);
 
     {
-        uint32_t data[128];
-        const auto ocddci = vku::InitStruct<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(nullptr, &data);
+        VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+        buffer_ci.size = 4096;
+        buffer_ci.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
-        {
-            VkBufferCreateInfo buffCI = vku::InitStructHelper();
-            buffCI.size = 4096;
-            buffCI.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+        buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-flags-08099");
 
-            buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-flags-08099");
+        buffer_ci.flags = 0;
 
-            buffCI.flags = 0;
-
-            if (descriptor_buffer_properties.bufferlessPushDescriptors) {
-                m_errorMonitor->SetDesiredError("VUID-VkBufferCreateInfo-usage-08102");
-            }
-            buffCI.usage =
-                VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-usage-08101");
-
-            buffCI.pNext = &ocddci;
-            buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-            CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-pNext-08100");
+        if (descriptor_buffer_properties.bufferlessPushDescriptors) {
+            m_errorMonitor->SetDesiredError("VUID-VkBufferCreateInfo-usage-08102");
         }
+        buffer_ci.usage =
+            VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-usage-08101");
 
-        {
-            VkImageCreateInfo image_create_info = vku::InitStructHelper();
-            image_create_info.flags |= VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            image_create_info.imageType = VK_IMAGE_TYPE_2D;
-            image_create_info.extent.width = 128;
-            image_create_info.extent.height = 128;
-            image_create_info.extent.depth = 1;
-            image_create_info.mipLevels = 1;
-            image_create_info.arrayLayers = 1;
-            image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-            image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-            image_create_info.format = VK_FORMAT_D32_SFLOAT;
-            image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-            image_create_info.pNext = &ocddci;
-            CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-08104");
-
-            image_create_info.pNext = &ocddci;
-            image_create_info.flags &= ~VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-08105");
-        }
-
-        {
-            vkt::Image temp_image(*m_device, 64, 64, 1, VK_FORMAT_D32_SFLOAT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
-
-            VkImageViewCreateInfo dsvci = vku::InitStructHelper();
-            dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            dsvci.image = temp_image.handle();
-            dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
-            dsvci.format = VK_FORMAT_D32_SFLOAT;
-            dsvci.subresourceRange.layerCount = 1;
-            dsvci.subresourceRange.baseMipLevel = 0;
-            dsvci.subresourceRange.levelCount = 1;
-            dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-            CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-flags-08106");
-
-            dsvci.pNext = &ocddci;
-            dsvci.flags &= ~VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-pNext-08107");
-        }
-
-        {
-            vkt::Buffer as_buffer(*m_device, 4096, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
-                                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-
-            VkAccelerationStructureKHR as;
-            VkAccelerationStructureCreateInfoKHR asci = vku::InitStructHelper();
-            asci.createFlags = VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            asci.buffer = as_buffer.handle();
-
-            m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108");
-            vk::CreateAccelerationStructureKHR(device(), &asci, NULL, &as);
-            m_errorMonitor->VerifyFound();
-
-            asci.pNext = &ocddci;
-            asci.createFlags &= ~VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109");
-            vk::CreateAccelerationStructureKHR(device(), &asci, NULL, &as);
-            m_errorMonitor->VerifyFound();
-        }
-
-        {
-            auto sampler_ci = SafeSaneSamplerCreateInfo();
-            sampler_ci.flags |= VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-
-            CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-flags-08110");
-
-            sampler_ci.pNext = &ocddci;
-            sampler_ci.flags &= ~VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-            CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-pNext-08111");
-        }
+        buffer_ci.pNext = &ocddci;
+        buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+        CreateBufferTest(*this, &buffer_ci, "VUID-VkBufferCreateInfo-pNext-08100");
     }
 
     {
-        uint8_t data[256];
-        vkt::Buffer temp_buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-
-        VkBufferCaptureDescriptorDataInfoEXT bcddi = vku::InitStructHelper();
-        bcddi.buffer = temp_buffer.handle();
-
-        m_errorMonitor->SetDesiredError("VUID-vkGetBufferOpaqueCaptureDescriptorDataEXT-None-08072");
-        m_errorMonitor->SetDesiredError("VUID-VkBufferCaptureDescriptorDataInfoEXT-buffer-08075");
-        vk::GetBufferOpaqueCaptureDescriptorDataEXT(device(), &bcddi, &data);
-        m_errorMonitor->VerifyFound();
-    }
-
-    {
-        uint8_t data[256];
-
         VkImageCreateInfo image_create_info = vku::InitStructHelper();
+        image_create_info.flags |= VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
         image_create_info.extent.width = 128;
         image_create_info.extent.height = 128;
@@ -381,101 +446,83 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         image_create_info.format = VK_FORMAT_D32_SFLOAT;
         image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
+        image_create_info.pNext = &ocddci;
+        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-08104");
 
-        vkt::Image temp_image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-
-        VkImageCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
-        icddi.image = temp_image.handle();
-
-        m_errorMonitor->SetDesiredError("VUID-vkGetImageOpaqueCaptureDescriptorDataEXT-None-08076");
-        m_errorMonitor->SetDesiredError("VUID-VkImageCaptureDescriptorDataInfoEXT-image-08079");
-        vk::GetImageOpaqueCaptureDescriptorDataEXT(device(), &icddi, &data);
-        m_errorMonitor->VerifyFound();
+        image_create_info.pNext = &ocddci;
+        image_create_info.flags &= ~VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-pNext-08105");
     }
 
     {
-        uint8_t data[256];
+        vkt::Image temp_image(*m_device, 64, 64, 1, VK_FORMAT_D32_SFLOAT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
-        VkImageCreateInfo image_create_info = vku::InitStructHelper();
-        image_create_info.imageType = VK_IMAGE_TYPE_2D;
-        image_create_info.extent.width = 128;
-        image_create_info.extent.height = 128;
-        image_create_info.extent.depth = 1;
-        image_create_info.mipLevels = 1;
-        image_create_info.arrayLayers = 1;
-        image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
-        image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
-        image_create_info.format = VK_FORMAT_D32_SFLOAT;
-        image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
-        vkt::Image temp_image(*m_device, image_create_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        VkImageViewCreateInfo dsvci = vku::InitStructHelper();
+        dsvci.flags |= VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        dsvci.image = temp_image.handle();
+        dsvci.viewType = VK_IMAGE_VIEW_TYPE_2D;
+        dsvci.format = VK_FORMAT_D32_SFLOAT;
+        dsvci.subresourceRange.layerCount = 1;
+        dsvci.subresourceRange.baseMipLevel = 0;
+        dsvci.subresourceRange.levelCount = 1;
+        dsvci.subresourceRange.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+        CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-flags-08106");
 
-        // missing VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-        vkt::ImageView dsv = temp_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
-
-        VkImageViewCaptureDescriptorDataInfoEXT icddi = vku::InitStructHelper();
-        icddi.imageView = dsv.handle();
-
-        m_errorMonitor->SetDesiredError("VUID-vkGetImageViewOpaqueCaptureDescriptorDataEXT-None-08080");
-        m_errorMonitor->SetDesiredError("VUID-VkImageViewCaptureDescriptorDataInfoEXT-imageView-08083");
-        vk::GetImageViewOpaqueCaptureDescriptorDataEXT(device(), &icddi, &data);
-        m_errorMonitor->VerifyFound();
+        dsvci.pNext = &ocddci;
+        dsvci.flags &= ~VK_IMAGE_VIEW_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        CreateImageViewTest(*this, &dsvci, "VUID-VkImageViewCreateInfo-pNext-08107");
     }
 
     {
-        uint8_t data[256];
+        auto sampler_ci = SafeSaneSamplerCreateInfo();
+        sampler_ci.flags |= VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
 
-        VkSamplerCaptureDescriptorDataInfoEXT scddi = vku::InitStructHelper();
-        scddi.sampler = sampler.handle();
+        CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-flags-08110");
 
-        m_errorMonitor->SetDesiredError("VUID-vkGetSamplerOpaqueCaptureDescriptorDataEXT-None-08084");
-        m_errorMonitor->SetDesiredError("VUID-VkSamplerCaptureDescriptorDataInfoEXT-sampler-08087");
-        vk::GetSamplerOpaqueCaptureDescriptorDataEXT(device(), &scddi, &data);
-        m_errorMonitor->VerifyFound();
+        sampler_ci.pNext = &ocddci;
+        sampler_ci.flags &= ~VK_SAMPLER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        CreateSamplerTest(*this, &sampler_ci, "VUID-VkSamplerCreateInfo-pNext-08111");
     }
+}
 
-    {
-        auto blas = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096);
-        blas->Build();
+TEST_F(NegativeDescriptorBuffer, NotEnabledDescriptorBufferCaptureReplayAS) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_ACCELERATION_STRUCTURE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddDisabledFeature(vkt::Feature::descriptorBuffer);
+    AddDisabledFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(Init());
 
-        uint8_t data[256];
+    uint32_t data[128];
+    const auto ocddci = vku::InitStruct<VkOpaqueCaptureDescriptorDataCreateInfoEXT>(nullptr, &data);
 
-        VkAccelerationStructureCaptureDescriptorDataInfoEXT ascddi = vku::InitStructHelper();
-        ascddi.accelerationStructure = blas->handle();
+    vkt::Buffer as_buffer(*m_device, 4096, VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR,
+                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
-        m_errorMonitor->SetDesiredError("VUID-vkGetAccelerationStructureOpaqueCaptureDescriptorDataEXT-None-08088");
-        m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCaptureDescriptorDataInfoEXT-accelerationStructure-08091");
-        vk::GetAccelerationStructureOpaqueCaptureDescriptorDataEXT(device(), &ascddi, &data);
-        m_errorMonitor->VerifyFound();
-    }
+    VkAccelerationStructureKHR as;
+    VkAccelerationStructureCreateInfoKHR asci = vku::InitStructHelper();
+    asci.createFlags = VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+    asci.buffer = as_buffer.handle();
 
-    {
-        vkt::Buffer d_buffer(*m_device, 4096,
-                             VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT,
-                             vkt::device_address);
+    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCreateInfoKHR-createFlags-08108");
+    vk::CreateAccelerationStructureKHR(device(), &asci, NULL, &as);
+    m_errorMonitor->VerifyFound();
 
-        VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-        dbbi.address = d_buffer.address();
-        dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
-
-        d_buffer.memory().destroy();
-
-        m_commandBuffer->begin();
-        m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBuffersEXT-None-08047");
-        vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1, &dbbi);
-        m_errorMonitor->VerifyFound();
-
-        m_commandBuffer->end();
-    }
+    asci.pNext = &ocddci;
+    asci.createFlags &= ~VK_ACCELERATION_STRUCTURE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+    m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureCreateInfoKHR-pNext-08109");
+    vk::CreateAccelerationStructureKHR(device(), &asci, NULL, &as);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptorsOff) {
     TEST_DESCRIPTION("When bufferlessPushDescriptors is not supported.");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
     AddRequiredFeature(vkt::Feature::descriptorBufferPushDescriptors);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -511,12 +558,9 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptorsOff) {
 }
 
 TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptors) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
     AddRequiredFeature(vkt::Feature::descriptorBufferPushDescriptors);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -557,11 +601,8 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptors) {
 }
 
 TEST_F(NegativeDescriptorBuffer, DescriptorBufferOffsetAlignment) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -585,12 +626,9 @@ TEST_F(NegativeDescriptorBuffer, DescriptorBufferOffsetAlignment) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeDescriptorBuffer, DescriptorBufferBindingInfoUsage) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+TEST_F(NegativeDescriptorBuffer, BindingInfoUsage) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -624,32 +662,43 @@ TEST_F(NegativeDescriptorBuffer, DescriptorBufferBindingInfoUsage) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeDescriptorBuffer, CmdBindDescriptorBufferEmbeddedSamplers) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+TEST_F(NegativeDescriptorBuffer, BindingInfoUsageMultiBuffers) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     m_commandBuffer->begin();
 
+    vkt::Buffer buffer_good1(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+    vkt::Buffer buffer_good2(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
+    vkt::Buffer buffer_bad(*m_device, 4096, 0, vkt::device_address);
+
+    VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
+    dbbi.address = buffer_bad.address();
+    dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
+
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-usage-08122");
+    m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBuffersEXT-pBindingInfos-08055");
+    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1, &dbbi);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDescriptorBuffer, CmdBindDescriptorBufferEmbeddedSamplers) {
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+
+    m_commandBuffer->begin();
+
+    VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+    vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-
-    const VkDescriptorSetLayoutBinding bindings[] = {
-        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
-    };
-    const auto dslci1 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(
-        nullptr, static_cast<VkDescriptorSetLayoutCreateFlags>(VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT),
-        size32(bindings), bindings);
-    vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
-
-    const VkDescriptorSetLayoutBinding bindings2[] = {
-        {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
-    };
-    const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;
-    const auto dslci2 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, size32(bindings2), bindings2);
-    vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
+    VkDescriptorSetLayoutBinding binding2 = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
+    vkt::DescriptorSetLayout dsl2(*m_device, binding2,
+                                  VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT);
 
     const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
     VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
@@ -668,34 +717,22 @@ TEST_F(NegativeDescriptorBuffer, CmdBindDescriptorBufferEmbeddedSamplers) {
 }
 
 TEST_F(NegativeDescriptorBuffer, CmdSetDescriptorBufferOffsets) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     m_commandBuffer->begin();
 
+    VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+    vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-
-    const VkDescriptorSetLayoutBinding bindings[] = {
-        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
-    };
-    const auto dslci1 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(
-        nullptr, static_cast<VkDescriptorSetLayoutCreateFlags>(VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT),
-        size32(bindings), bindings);
-    vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
-
-    const VkDescriptorSetLayoutBinding bindings2[] = {
-        {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
-    };
-    const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;
-    const auto dslci2 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, size32(bindings2), bindings2);
-    vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
+    VkDescriptorSetLayoutBinding binding2 = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
+    vkt::DescriptorSetLayout dsl2(*m_device, binding2,
+                                  VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT);
 
     const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
     VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
@@ -777,33 +814,22 @@ TEST_F(NegativeDescriptorBuffer, CmdSetDescriptorBufferOffsets) {
 
 TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     TEST_DESCRIPTION("Test mapping from address to buffers when validating buffer offsets");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     m_commandBuffer->begin();
 
+    VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+    vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-
-    const VkDescriptorSetLayoutBinding bindings[] = {
-        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
-    };
-    const auto dslci1 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(
-        nullptr, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT, size32(bindings), bindings);
-    vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
-
-    const VkDescriptorSetLayoutBinding bindings2[] = {
-        {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()},
-    };
-    const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;
-    const auto dslci2 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, size32(bindings2), bindings2);
-    vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
+    VkDescriptorSetLayoutBinding binding2 = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
+    vkt::DescriptorSetLayout dsl2(*m_device, binding2,
+                                  VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT);
 
     const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
     VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
@@ -901,7 +927,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
     CreateComputePipelineHelper pipe(*this);
-    ASSERT_EQ(VK_SUCCESS, pipe.CreateComputePipeline());
+    pipe.CreateComputePipeline();
 
     m_commandBuffer->begin();
     vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
@@ -984,22 +1010,14 @@ TEST_F(NegativeDescriptorBuffer, BindPoint) {
 
     vkt::PipelineLayout pipeline_layout;
     {
-        const VkDescriptorSetLayoutBinding bindings[] = {
-            {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr},
-        };
-        const VkDescriptorSetLayoutCreateInfo dslci1 = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr,
-                                                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT, size32(bindings),
-                                                        bindings};
-        vkt::DescriptorSetLayout dsl1(*m_device, dslci1);
+        VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
+        vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
 
         vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-
-        const VkDescriptorSetLayoutBinding binding2 = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                                       &sampler.handle()};
-        const VkDescriptorSetLayoutCreateFlags flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
-                                                       VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT;
-        const auto dslci2 = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, flags, 1u, &binding2);
-        vkt::DescriptorSetLayout dsl2(*m_device, dslci2);
+        VkDescriptorSetLayoutBinding binding2 = {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
+        vkt::DescriptorSetLayout dsl2(*m_device, binding2,
+                                      VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT |
+                                          VK_DESCRIPTOR_SET_LAYOUT_CREATE_EMBEDDED_IMMUTABLE_SAMPLERS_BIT_EXT);
 
         const VkDescriptorSetLayout set_layouts[2] = {dsl1.handle(), dsl2.handle()};
         VkPipelineLayoutCreateInfo plci = vku::InitStructHelper();
@@ -1180,23 +1198,6 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAS) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoRtxNV) {
-    TEST_DESCRIPTION("Descriptor buffer vkDescriptorGetInfo() for NV_ray_tracing.");
-    AddRequiredExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
-    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
-
-    uint8_t buffer[128];
-    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
-    GetPhysicalDeviceProperties2(descriptor_buffer_properties);
-
-    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
-    dgi.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
-    dgi.data.accelerationStructure = 0;
-    m_errorMonitor->SetDesiredError("VUID-VkDescriptorDataEXT-type-08042");
-    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.accelerationStructureDescriptorSize, &buffer);
-    m_errorMonitor->VerifyFound();
-}
-
 TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     TEST_DESCRIPTION("Descriptor buffer vkDescriptorGetInfo() with VkDescriptorAddressInfoEXT.");
     AddRequiredExtensions(VK_KHR_BUFFER_DEVICE_ADDRESS_EXTENSION_NAME);
@@ -1207,10 +1208,10 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    VkBufferCreateInfo buffCI = vku::InitStructHelper();
-    buffCI.size = 4096;
-    buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-    vkt::Buffer d_buffer(*m_device, buffCI, vkt::no_mem);
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    vkt::Buffer d_buffer(*m_device, buffer_ci, vkt::no_mem);
 
     VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
     VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
@@ -1238,7 +1239,7 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     d_buffer.bind_memory(mem, 0);
 
     dai.address = d_buffer.address();
-    dai.range = 4096 * buffCI.size;
+    dai.range = 4096 * buffer_ci.size;
     dai.format = VK_FORMAT_R8_UINT;
 
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-range-08045");
@@ -1294,125 +1295,40 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
     m_errorMonitor->VerifyFound();
 }
 
-TEST_F(NegativeDescriptorBuffer, Various) {
-    TEST_DESCRIPTION("Descriptor buffer various tests.");
-    AddOptionalExtensions(VK_EXT_MUTABLE_DESCRIPTOR_TYPE_EXTENSION_NAME);
-    AddOptionalExtensions(VK_EXT_INLINE_UNIFORM_BLOCK_EXTENSION_NAME);
-    AddOptionalExtensions(VK_NV_RAY_TRACING_EXTENSION_NAME);
+TEST_F(NegativeDescriptorBuffer, LayoutFlags) {
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
-    const bool nv_ray_tracing = IsExtensionsEnabled(VK_NV_RAY_TRACING_EXTENSION_NAME);
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
-    {
-        VkSampler invalid_sampler = CastToHandle<VkSampler, uintptr_t>(0xbaadbeef);
-        VkImageView invalid_imageview = CastToHandle<VkImageView, uintptr_t>(0xbaadbeef);
-        VkDeviceAddress invalid_buffer = CastToHandle<VkDeviceAddress, uintptr_t>(0xbaadbeef);
+    const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, &sampler.handle()};
+    vkt::DescriptorSetLayout dsl(*m_device, binding);
 
-        uint8_t buffer[128];
-        VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
+    VkDeviceSize size;
 
-        const VkDescriptorImageInfo dii = {invalid_sampler, invalid_imageview, VK_IMAGE_LAYOUT_GENERAL};
+    m_errorMonitor->SetDesiredError("VUID-vkGetDescriptorSetLayoutSizeEXT-layout-08012");
+    vk::GetDescriptorSetLayoutSizeEXT(device(), dsl.handle(), &size);
+    m_errorMonitor->VerifyFound();
 
-        dgi.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        dgi.data.pCombinedImageSampler = &dii;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08019");
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08020");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.combinedImageSamplerDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
+    VkDeviceSize offset;
 
-        dgi.type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
-        dgi.data.pInputAttachmentImage = &dii;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08021");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.inputAttachmentDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
+    m_errorMonitor->SetDesiredError("VUID-vkGetDescriptorSetLayoutBindingOffsetEXT-layout-08014");
+    vk::GetDescriptorSetLayoutBindingOffsetEXT(device(), dsl.handle(), 0, &offset);
+    m_errorMonitor->VerifyFound();
+}
 
-        dgi.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
-        dgi.data.pSampledImage = &dii;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08022");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.sampledImageDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
-        dgi.data.pStorageImage = &dii;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08023");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageImageDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
-        dai.address = invalid_buffer;
-        dai.range = 64;
-        dai.format = VK_FORMAT_R8_UINT;
-
-        dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
-        dgi.data.pUniformTexelBuffer = &dai;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08024");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.uniformTexelBufferDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
-        dgi.data.pStorageTexelBuffer = &dai;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08025");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageTexelBufferDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        dgi.data.pUniformTexelBuffer = &dai;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08026");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.uniformBufferDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        dgi.data.pStorageTexelBuffer = &dai;
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
-        m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08027");
-        vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageBufferDescriptorSize, &buffer);
-        m_errorMonitor->VerifyFound();
-
-        if (nv_ray_tracing) {
-            dgi.type = VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_NV;
-            dgi.data.pStorageTexelBuffer = &dai;
-            m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08029");
-            vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageBufferDescriptorSize, &buffer);
-            m_errorMonitor->VerifyFound();
-        }
-    }
+TEST_F(NegativeDescriptorBuffer, DescriptorBufferCaptureReplay) {
+    AddRequiredFeature(vkt::Feature::descriptorBufferCaptureReplay);
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     {
-        const VkDescriptorSetLayoutBinding binding{0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT,
-                                                   &sampler.handle()};
-        const auto dslci = vku::InitStruct<VkDescriptorSetLayoutCreateInfo>(nullptr, 0U, 1U, &binding);
-        vkt::DescriptorSetLayout dsl(*m_device, dslci);
+        VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+        buffer_ci.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
+        buffer_ci.size = 4096;
+        buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
-        {
-            VkDeviceSize size;
-
-            m_errorMonitor->SetDesiredError("VUID-vkGetDescriptorSetLayoutSizeEXT-layout-08012");
-            vk::GetDescriptorSetLayoutSizeEXT(device(), dsl.handle(), &size);
-            m_errorMonitor->VerifyFound();
-
-            VkDeviceSize offset;
-
-            m_errorMonitor->SetDesiredError("VUID-vkGetDescriptorSetLayoutBindingOffsetEXT-layout-08014");
-            vk::GetDescriptorSetLayoutBindingOffsetEXT(device(), dsl.handle(), 0, &offset);
-            m_errorMonitor->VerifyFound();
-        }
-    }
-
-    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features = vku::InitStructHelper();
-    GetPhysicalDeviceFeatures2(descriptor_buffer_features);
-    if (descriptor_buffer_features.descriptorBufferCaptureReplay) {
-        VkBufferCreateInfo buffCI = vku::InitStructHelper();
-        buffCI.flags = VK_BUFFER_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
-        buffCI.size = 4096;
-        buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-
-        vkt::Buffer d_buffer(*m_device, buffCI, vkt::no_mem);
+        vkt::Buffer d_buffer(*m_device, buffer_ci, vkt::no_mem);
 
         VkMemoryRequirements mem_reqs;
         vk::GetBufferMemoryRequirements(device(), d_buffer.handle(), &mem_reqs);
@@ -1428,7 +1344,7 @@ TEST_F(NegativeDescriptorBuffer, Various) {
         m_errorMonitor->VerifyFound();
     }
 
-    if (descriptor_buffer_features.descriptorBufferCaptureReplay) {
+    {
         VkImageCreateInfo image_create_info = vku::InitStructHelper();
         image_create_info.flags = VK_IMAGE_CREATE_DESCRIPTOR_BUFFER_CAPTURE_REPLAY_BIT_EXT;
         image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -1455,6 +1371,82 @@ TEST_F(NegativeDescriptorBuffer, Various) {
         vk::BindImageMemory(device(), temp_image.handle(), mem.handle(), 0);
         m_errorMonitor->VerifyFound();
     }
+}
+
+TEST_F(NegativeDescriptorBuffer, DescriptorGetInfo) {
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
+
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(descriptor_buffer_properties);
+
+    vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
+
+    VkSampler invalid_sampler = CastToHandle<VkSampler, uintptr_t>(0xbaadbeef);
+    VkImageView invalid_imageview = CastToHandle<VkImageView, uintptr_t>(0xbaadbeef);
+    VkDeviceAddress invalid_buffer = CastToHandle<VkDeviceAddress, uintptr_t>(0xbaadbeef);
+
+    uint8_t buffer[128];
+    VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
+
+    const VkDescriptorImageInfo dii = {invalid_sampler, invalid_imageview, VK_IMAGE_LAYOUT_GENERAL};
+
+    dgi.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    dgi.data.pCombinedImageSampler = &dii;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08019");
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08020");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.combinedImageSamplerDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT;
+    dgi.data.pInputAttachmentImage = &dii;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08021");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.inputAttachmentDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
+    dgi.data.pSampledImage = &dii;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08022");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.sampledImageDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_IMAGE;
+    dgi.data.pStorageImage = &dii;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08023");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageImageDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
+    dai.address = invalid_buffer;
+    dai.range = 64;
+    dai.format = VK_FORMAT_R8_UINT;
+
+    dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER;
+    dgi.data.pUniformTexelBuffer = &dai;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08024");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.uniformTexelBufferDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER;
+    dgi.data.pStorageTexelBuffer = &dai;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08025");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageTexelBufferDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+    dgi.data.pUniformTexelBuffer = &dai;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08026");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.uniformBufferDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
+
+    dgi.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    dgi.data.pStorageTexelBuffer = &dai;
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorAddressInfoEXT-None-08044");
+    m_errorMonitor->SetDesiredError("VUID-VkDescriptorGetInfoEXT-type-08027");
+    vk::GetDescriptorEXT(device(), &dgi, descriptor_buffer_properties.storageBufferDescriptorSize, &buffer);
+    m_errorMonitor->VerifyFound();
 }
 
 TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
@@ -1488,10 +1480,10 @@ TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
 
     dbf.descriptorBuffer = true;
 
-    VkDevice testDevice;
+    VkDevice test_device;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-None-08095");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+    vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1547,12 +1539,9 @@ TEST_F(NegativeDescriptorBuffer, NullHandle) {
 }
 
 TEST_F(NegativeDescriptorBuffer, NullCombinedImageSampler) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_ROBUSTNESS_2_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::nullDescriptor);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -1596,12 +1585,9 @@ TEST_F(NegativeDescriptorBuffer, BufferUsage) {
 }
 
 TEST_F(NegativeDescriptorBuffer, Binding) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_MAINTENANCE_6_EXTENSION_NAME);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance6);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     // TODO - try to get 08010 removed from spec as no possible way to create descriptor with the invalid flag
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkDescriptorSetAllocateInfo-pSetLayouts-08009");
@@ -1641,38 +1627,35 @@ TEST_F(NegativeDescriptorBuffer, InvalidDescriptorBufferUsage) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(Init());
 
-    VkBufferCreateInfo buffCI = vku::InitStructHelper();
-    buffCI.size = 4096;
-    buffCI.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
-                   VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+    VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
+    buffer_ci.size = 4096;
+    buffer_ci.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
+                      VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
     VkMemoryAllocateFlagsInfo allocate_flag_info = vku::InitStructHelper();
     allocate_flag_info.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT;
-    vkt::Buffer d_buffer(*m_device, buffCI, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
+    vkt::Buffer d_buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
-    VkDescriptorBufferBindingInfoEXT bindingInfo = vku::InitStructHelper();
-    bindingInfo.address = d_buffer.address();
-    bindingInfo.usage = buffCI.usage | 0x80000000;
+    VkDescriptorBufferBindingInfoEXT binding_info = vku::InitStructHelper();
+    binding_info.address = d_buffer.address();
+    binding_info.usage = buffer_ci.usage | 0x80000000;
 
     m_commandBuffer->begin();
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-None-09499");
-    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1u, &bindingInfo);
+    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1u, &binding_info);
     m_errorMonitor->VerifyFound();
 
-    bindingInfo.usage = 0u;
+    binding_info.usage = 0u;
 
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-None-09500");
-    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1u, &bindingInfo);
+    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1u, &binding_info);
     m_errorMonitor->VerifyFound();
     m_commandBuffer->end();
 }
 
 TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
     TEST_DESCRIPTION("texel buffers must be less than maxTexelBufferElements.");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
@@ -1702,11 +1685,8 @@ TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
 }
 
 TEST_F(NegativeDescriptorBuffer, TexelBufferFormat) {
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::descriptorBuffer);
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    RETURN_IF_SKIP(Init());
+    RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);


### PR DESCRIPTION
- Improves some error messages
- Uses newer coding conventions
- Splits up large tests
- Use framework more for tests