### PR TITLE
gpu: Fix Descriptor Buffer GPU-AV crash

### DIFF
--- a/layers/gpu/core/gpu_settings.h
+++ b/layers/gpu/core/gpu_settings.h
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 #pragma once
+#include <cstdint>
 // Default values for those settings should match layers/VkLayer_khronos_validation.json.in
 
 struct GpuAVSettings {
@@ -50,6 +51,8 @@ struct GpuAVSettings {
     }
     // Also disables shader caching and select shader instrumentation
     void DisableShaderInstrumentationAndOptions() {
+        shader_instrumentation_enabled = false;
+
         shader_instrumentation.bindless_descriptor = false;
         shader_instrumentation.buffer_device_address = false;
         shader_instrumentation.ray_query = false;

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -278,7 +278,7 @@ void Validator::PreCallRecordCmdBindDescriptorBuffersEXT(VkCommandBuffer command
                                                          const VkDescriptorBufferBindingInfoEXT *pBindingInfos,
                                                          const RecordObject &record_obj) {
     BaseClass::PreCallRecordCmdBindDescriptorBuffersEXT(commandBuffer, bufferCount, pBindingInfos, record_obj);
-    gpuav_settings.shader_instrumentation.bindless_descriptor = false;
+    // TODO - Unsupported
 }
 
 void Validator::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(VkCommandBuffer commandBuffer,
@@ -286,7 +286,7 @@ void Validator::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(VkComman
                                                                         VkPipelineLayout layout, uint32_t set,
                                                                         const RecordObject &record_obj) {
     BaseClass::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplersEXT(commandBuffer, pipelineBindPoint, layout, set, record_obj);
-    gpuav_settings.shader_instrumentation.bindless_descriptor = false;
+    // TODO - Unsupported
 }
 
 void Validator::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(
@@ -294,7 +294,7 @@ void Validator::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(
     const RecordObject &record_obj) {
     BaseClass::PreCallRecordCmdBindDescriptorBufferEmbeddedSamplers2EXT(commandBuffer, pBindDescriptorBufferEmbeddedSamplersInfo,
                                                                         record_obj);
-    gpuav_settings.shader_instrumentation.bindless_descriptor = false;
+    // TODO - Unsupported
 }
 
 void Validator::PreCallRecordCmdDraw(VkCommandBuffer commandBuffer, uint32_t vertexCount, uint32_t instanceCount,

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -301,7 +301,10 @@ void Validator::InitSettings(const Location &loc) {
         InternalWarning(
             device, loc,
             "VK_EXT_descriptor_buffer is enabled, but GPU-AV does not currently support validation of descriptor buffers. "
-            "Use of descriptor buffers will result in no descriptor checking");
+            "[Disabling shader_instrumentation_enabled]");
+        // Because of VUs like VUID-VkPipelineLayoutCreateInfo-pSetLayouts-08008 we currently would need to rework the entire shader
+        // instrumentation logic
+        gpuav_settings.DisableShaderInstrumentationAndOptions();
     }
 
     if (gpuav_settings.IsBufferValidationEnabled()) {
@@ -312,6 +315,11 @@ void Validator::InitSettings(const Location &loc) {
                 "Device does not support the minimum range of push constants (32 bytes). No indirect buffer checking will be "
                 "attempted");
         }
+    }
+
+    // If we have turned off all the possible things to instrument, turn off everything fully
+    if (!gpuav_settings.IsShaderInstrumentationEnabled()) {
+        gpuav_settings.DisableShaderInstrumentationAndOptions();
     }
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ target_sources(vk_layer_validation_tests PRIVATE
     unit/gpu_av.cpp
     unit/gpu_av_buffer_device_address.cpp
     unit/gpu_av_buffer_device_address_positive.cpp
+    unit/gpu_av_descriptor_buffer_positive.cpp
     unit/gpu_av_descriptor_indexing.cpp
     unit/gpu_av_descriptor_indexing_positive.cpp
     unit/gpu_av_indirect_buffer.cpp

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+#include "../framework/layer_validation_tests.h"
+#include "../framework/pipeline_helper.h"
+#include "utils/vk_layer_utils.h"
+
+class PositiveGpuAVDescriptorBuffer : public GpuAVTest {};
+
+TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::descriptorBuffer);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitGpuAvFramework());
+    RETURN_IF_SKIP(InitState());
+    m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit);
+
+    VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
+    GetPhysicalDeviceProperties2(descriptor_buffer_properties);
+
+    vkt::Buffer buffer_data(*m_device, 16, 0, vkt::device_address);
+    uint32_t *data = (uint32_t *)buffer_data.memory().map();
+    data[0] = 8;
+    data[1] = 12;
+    data[2] = 1;
+    buffer_data.memory().unmap();
+
+    VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
+    vkt::DescriptorSetLayout ds_layout(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
+
+    VkPipelineLayoutCreateInfo pipe_layout_ci = vku::InitStructHelper();
+    pipe_layout_ci.setLayoutCount = 1;
+    pipe_layout_ci.pSetLayouts = &ds_layout.handle();
+    vkt::PipelineLayout pipeline_layout(*m_device, pipe_layout_ci);
+
+    VkDeviceSize ds_layout_size = 0;
+    vk::GetDescriptorSetLayoutSizeEXT(device(), ds_layout.handle(), &ds_layout_size);
+
+    ds_layout_size = Align(ds_layout_size, descriptor_buffer_properties.descriptorBufferOffsetAlignment);
+
+    vkt::Buffer descriptor_buffer(*m_device, ds_layout_size, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT,
+                                  vkt::device_address);
+
+    VkDescriptorAddressInfoEXT addr_info = vku::InitStructHelper();
+    addr_info.address = buffer_data.address();
+    addr_info.range = 16;
+    addr_info.format = VK_FORMAT_UNDEFINED;
+
+    VkDescriptorGetInfoEXT buffer_descriptor_info = vku::InitStructHelper();
+    buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+    buffer_descriptor_info.data.pStorageBuffer = &addr_info;
+
+    void *mapped_descriptor_data = descriptor_buffer.memory().map();
+    vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
+                         mapped_descriptor_data);
+    descriptor_buffer.memory().unmap();
+
+    char const *cs_source = R"glsl(
+        #version 450
+        layout (set = 0, binding = 0) buffer SSBO_0 {
+            uint a;
+            uint b;
+            uint c;
+        };
+
+        void main() {
+            c = a + b;
+        }
+    )glsl";
+
+    CreateComputePipelineHelper pipe(*this);
+    pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_2);
+    pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
+    pipe.cp_ci_.layout = pipeline_layout.handle();
+    pipe.CreateComputePipeline();
+
+    m_commandBuffer->begin();
+    vk::CmdBindPipeline(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
+
+    VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
+    descriptor_buffer_binding_info.address = descriptor_buffer.address();
+    descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
+    vk::CmdBindDescriptorBuffersEXT(m_commandBuffer->handle(), 1, &descriptor_buffer_binding_info);
+
+    uint32_t buffer_index = 0;
+    VkDeviceSize buffer_offset = 0;
+    vk::CmdSetDescriptorBufferOffsetsEXT(m_commandBuffer->handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
+                                         &buffer_index, &buffer_offset);
+    vk::CmdDispatch(m_commandBuffer->handle(), 1, 1, 1);
+    m_commandBuffer->end();
+
+    m_default_queue->Submit(*m_commandBuffer);
+    m_default_queue->Wait();
+
+    if (!IsPlatformMockICD()) {
+        data = (uint32_t *)buffer_data.memory().map();
+        ASSERT_TRUE(data[0] == 8);
+        ASSERT_TRUE(data[1] == 12);
+        ASSERT_TRUE(data[2] == 20);
+        buffer_data.memory().unmap();
+    }
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8492

We will have to redo the entire Shader Instrumentation Flow to handle Descriptor Buffers

For now make use of `shader_instrumentation_enabled` to prevent any shader instrumentation hooks to take place when turned off