### PR TITLE
layers: Early exit on VUID 09006 violation

### DIFF
--- a/layers/core_checks/cc_descriptor.cpp
+++ b/layers/core_checks/cc_descriptor.cpp
@@ -2161,6 +2161,7 @@ bool CoreChecks::ValidateCmdSetDescriptorBufferOffsets(const vvl::CommandBuffer 
                              "Descriptor set layout (%s) for set %" PRIu32
                              " was created without VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT flag set.",
                              FormatHandle(set_layout->Handle()).c_str(), firstSet + i);
+            continue;
         }
 
         if (bufferIndex < cb_state.descriptor_buffer_binding_info.size()) {


### PR DESCRIPTION
@spencer-lunarg I'd like your opinion on this one. Currently the test for `VUID-vkCmdSetDescriptorBufferOffsetsEXT-firstSet-09006` correctly detects that the VUID is violated, but then continues on trying to do further validation and ends up calling `vkGetDescriptorSetLayoutSizeEXT` which is invalid because the layout was created without `VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT`

Ultimately this results in the following misleading error message in the current tests:

````
[ RUN      ] NegativeDescriptorBuffer.CmdSetDescriptorBufferOffsets
/home/SERILOCAL/r.potter/dev/Vulkan-ValidationLayers/tests/framework/error_monitor.cpp:252: Failure
Failed
Validation Error: [ VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063 ] Object 0: handle = 0x5590ad0504c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x22ff52a9 | vkCmdSetDescriptorBufferOffsetsEXT(): pOffsets[0] 0 must be small enough such that any descriptor binding referenced by layout without the VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT flag computes a valid address inside the underlying VkBuffer. The Vulkan spec states: The offsets in pOffsets must be small enough such that any descriptor binding referenced by layout without the VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT flag computes a valid address inside the underlying VkBuffer (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063)

/home/SERILOCAL/r.potter/dev/Vulkan-ValidationLayers/tests/framework/error_monitor.cpp:252: Failure
Failed
Validation Error: [ VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063 ] Object 0: handle = 0x5590ad0504c0, type = VK_OBJECT_TYPE_COMMAND_BUFFER; | MessageID = 0x22ff52a9 | vkCmdSetDescriptorBufferOffsetsEXT(): pOffsets[1] 0 must be small enough such that any descriptor binding referenced by layout without the VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT flag computes a valid address inside the underlying VkBuffer. The Vulkan spec states: The offsets in pOffsets must be small enough such that any descriptor binding referenced by layout without the VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT flag computes a valid address inside the underlying VkBuffer (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdSetDescriptorBufferOffsetsEXT-pOffsets-08063)

[  FAILED  ] NegativeDescriptorBuffer.CmdSetDescriptorBufferOffsets (37 ms)
````

This change simply early exits on the initial failure, which prevents the spurious error message. The alternative would be to put additional conditional guards on the call to `vkGetDescriptorSetLayoutSizeEXT` but that seemed like additional complexity when we know the root cause is a missing flag.