### PR TITLE
gpu: Fix crash in `Pass::ConvertTo32()`

### DIFF
--- a/layers/gpu/spirv/pass.cpp
+++ b/layers/gpu/spirv/pass.cpp
@@ -357,7 +357,9 @@ uint32_t Pass::ConvertTo32(uint32_t id, BasicBlock& block, InstructionIt* inst_i
         type = &constant->type_;
     } else {
         const Instruction* inst = block.function_.FindInstruction(id);
-        type = module_.type_manager_.FindTypeById(inst->TypeId());
+        if (inst) {
+            type = module_.type_manager_.FindTypeById(inst->TypeId());
+        }
     }
     if (!type) {
         return id;


### PR DESCRIPTION
Fixed a crash in `Pass::ConvertTo32()`.

Reproduce: https://github.com/corporateshark/lightweightvk/blob/master/samples/004_YUV.cpp