### PR TITLE
layers: Fix a crash in `vvl::DescriptorSet::UpdateDrawState()`

### DIFF
--- a/layers/state_tracker/descriptor_sets.cpp
+++ b/layers/state_tracker/descriptor_sets.cpp
@@ -691,6 +691,9 @@ void vvl::DescriptorSet::UpdateDrawState(ValidationStateTracker *device_data, vv
     for (const auto &binding_req_pair : binding_req_map) {
         auto *binding = GetBinding(binding_req_pair.first);
         ASSERT_AND_CONTINUE(binding);
+        if (!binding) {
+            continue;
+        }
 
         // core validation doesn't handle descriptor indexing, that is only done by GPU-AV
         if (SkipBinding(*binding, binding_req_pair.second.variable->is_dynamic_accessed)) {


### PR DESCRIPTION
Fixed a crash in `vvl::DescriptorSet::UpdateDrawState()`.

**P.S.** The issue is actually much bigger. The macro `ASSERT_AND_CONTINUE()` isn't doing what it appears to do because there's a `do-while` loop inside it.