### PR TITLE
layers: Fix assert_and_continue

### DIFF
--- a/layers/utils/vk_layer_utils.h
+++ b/layers/utils/vk_layer_utils.h
@@ -72,12 +72,10 @@
     } while (0)
 
 #define ASSERT_AND_CONTINUE(cond) \
-    do {                          \
-        if (!(cond)) {            \
-            assert(false);        \
-            continue;             \
-        }                         \
-    } while (0)
+    if (!(cond)) {                \
+        assert(false);            \
+        continue;                 \
+    }
 
 static inline VkExtent3D CastTo3D(const VkExtent2D &d2) {
     VkExtent3D d3 = {d2.width, d2.height, 1};


### PR DESCRIPTION
The `continue;` was affecting the `while (0)` loop, not the intended parent loop