### PR TITLE
layers: Update SPIRV-Tools

### DIFF
--- a/layers/vulkan/generated/spirv_grammar_helper.cpp
+++ b/layers/vulkan/generated/spirv_grammar_helper.cpp
@@ -939,6 +939,8 @@ const char* string_SpvOpcode(uint32_t opcode) {
             return "OpRayQueryGetIntersectionWorldToObjectKHR";
         case spv::OpAtomicFAddEXT:
             return "OpAtomicFAddEXT";
+        case spv::OpSubgroupBlockPrefetchINTEL:
+            return "OpSubgroupBlockPrefetchINTEL";
         case spv::OpGroupIMulKHR:
             return "OpGroupIMulKHR";
         case spv::OpGroupFMulKHR:
@@ -1199,10 +1201,10 @@ const char* string_SpvExecutionMode(uint32_t execution_mode) {
             return "OutputLinesEXT";
         case spv::ExecutionModeOutputPrimitivesEXT:
             return "OutputPrimitivesEXT";
-        case spv::ExecutionModeDerivativeGroupQuadsNV:
-            return "DerivativeGroupQuadsNV";
-        case spv::ExecutionModeDerivativeGroupLinearNV:
-            return "DerivativeGroupLinearNV";
+        case spv::ExecutionModeDerivativeGroupQuadsKHR:
+            return "DerivativeGroupQuadsKHR";
+        case spv::ExecutionModeDerivativeGroupLinearKHR:
+            return "DerivativeGroupLinearKHR";
         case spv::ExecutionModeOutputTrianglesEXT:
             return "OutputTrianglesEXT";
         case spv::ExecutionModePixelInterlockOrderedEXT:
@@ -2298,6 +2300,7 @@ const OperandInfo& GetOperandInfo(uint32_t opcode) {
         {spv::OpRayQueryGetIntersectionObjectToWorldKHR, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpRayQueryGetIntersectionWorldToObjectKHR, {{OperandKind::Id, OperandKind::Id}}},
         {spv::OpAtomicFAddEXT, {{OperandKind::Id, OperandKind::Id, OperandKind::Id, OperandKind::Id}}},
+        {spv::OpSubgroupBlockPrefetchINTEL, {{OperandKind::Id, OperandKind::Id, OperandKind::BitEnum}}},
         {spv::OpGroupIMulKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupFMulKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},
         {spv::OpGroupBitwiseAndKHR, {{OperandKind::Id, OperandKind::ValueEnum, OperandKind::Id}}},

--- a/layers/vulkan/generated/spirv_tools_commit_id.h
+++ b/layers/vulkan/generated/spirv_tools_commit_id.h
@@ -23,4 +23,4 @@
 
 #pragma once
 
-#define SPIRV_TOOLS_COMMIT_ID "b21dda0ee7a3ea4e0192a7b2b09db1df1de9d5e7"
+#define SPIRV_TOOLS_COMMIT_ID "05be5b2466b67317caaaed0d5369fd7f99af05a8"

--- a/layers/vulkan/generated/spirv_validation_helper.cpp
+++ b/layers/vulkan/generated/spirv_validation_helper.cpp
@@ -188,10 +188,8 @@ const std::unordered_multimap<uint32_t, RequiredSpirvInfo> &GetSpirvCapabilites(
         {spv::CapabilityRoundingModeRTZ, {0, nullptr, nullptr, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat64 & VK_TRUE) != 0"}},
         {spv::CapabilityComputeDerivativeGroupQuadsNV, {0, &DeviceFeatures::computeDerivativeGroupQuads, nullptr, ""}},
         {spv::CapabilityComputeDerivativeGroupLinearNV, {0, &DeviceFeatures::computeDerivativeGroupLinear, nullptr, ""}},
-        // Not found in current SPIR-V Headers
-        // {spv::CapabilityComputeDerivativeGroupQuadsKHR, {0, &DeviceFeatures::computeDerivativeGroupQuads, nullptr, ""}},
-        // Not found in current SPIR-V Headers
-        // {spv::CapabilityComputeDerivativeGroupLinearKHR, {0, &DeviceFeatures::computeDerivativeGroupLinear, nullptr, ""}},
+        {spv::CapabilityComputeDerivativeGroupQuadsKHR, {0, &DeviceFeatures::computeDerivativeGroupQuads, nullptr, ""}},
+        {spv::CapabilityComputeDerivativeGroupLinearKHR, {0, &DeviceFeatures::computeDerivativeGroupLinear, nullptr, ""}},
         {spv::CapabilityFragmentBarycentricNV, {0, &DeviceFeatures::fragmentShaderBarycentric, nullptr, ""}},
         {spv::CapabilityImageFootprintNV, {0, &DeviceFeatures::imageFootprint, nullptr, ""}},
         {spv::CapabilityShadingRateNV, {0, &DeviceFeatures::shadingRateImage, nullptr, ""}},
@@ -607,8 +605,8 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "MeshShadingEXT";
         case spv::CapabilityFragmentBarycentricKHR:
             return "FragmentBarycentricKHR";
-        case spv::CapabilityComputeDerivativeGroupQuadsNV:
-            return "ComputeDerivativeGroupQuadsNV";
+        case spv::CapabilityComputeDerivativeGroupQuadsKHR:
+            return "ComputeDerivativeGroupQuadsKHR";
         case spv::CapabilityFragmentDensityEXT:
             return "FragmentDensityEXT";
         case spv::CapabilityGroupNonUniformPartitionedNV:
@@ -649,8 +647,8 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "VulkanMemoryModelDeviceScope";
         case spv::CapabilityPhysicalStorageBufferAddresses:
             return "PhysicalStorageBufferAddresses";
-        case spv::CapabilityComputeDerivativeGroupLinearNV:
-            return "ComputeDerivativeGroupLinearNV";
+        case spv::CapabilityComputeDerivativeGroupLinearKHR:
+            return "ComputeDerivativeGroupLinearKHR";
         case spv::CapabilityRayTracingProvisionalKHR:
             return "RayTracingProvisionalKHR";
         case spv::CapabilityCooperativeMatrixNV:
@@ -719,6 +717,8 @@ static inline const char *string_SpvCapability(uint32_t input_value) {
             return "AtomicFloat64AddEXT";
         case spv::CapabilityAtomicFloat16AddEXT:
             return "AtomicFloat16AddEXT";
+        case spv::CapabilitySubgroupBufferPrefetchINTEL:
+            return "SubgroupBufferPrefetchINTEL";
         case spv::CapabilityGroupUniformArithmeticKHR:
             return "GroupUniformArithmeticKHR";
         default:
@@ -927,6 +927,8 @@ static inline const char* SpvCapabilityRequirements(uint32_t capability) {
     {spv::CapabilityRoundingModeRTZ, "(VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat16 == VK_TRUE) OR (VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat32 == VK_TRUE) OR (VkPhysicalDeviceVulkan12Properties::shaderRoundingModeRTZFloat64 == VK_TRUE)"},
     {spv::CapabilityComputeDerivativeGroupQuadsNV, "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupQuads"},
     {spv::CapabilityComputeDerivativeGroupLinearNV, "VkPhysicalDeviceComputeShaderDerivativesFeaturesNV::computeDerivativeGroupLinear"},
+    {spv::CapabilityComputeDerivativeGroupQuadsKHR, "VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR::computeDerivativeGroupQuads"},
+    {spv::CapabilityComputeDerivativeGroupLinearKHR, "VkPhysicalDeviceComputeShaderDerivativesFeaturesKHR::computeDerivativeGroupLinear"},
     {spv::CapabilityFragmentBarycentricNV, "VkPhysicalDeviceFragmentShaderBarycentricFeaturesNV::fragmentShaderBarycentric"},
     {spv::CapabilityImageFootprintNV, "VkPhysicalDeviceShaderImageFootprintFeaturesNV::imageFootprint"},
     {spv::CapabilityShadingRateNV, "VkPhysicalDeviceShadingRateImageFeaturesNV::shadingRateImage"},

--- a/scripts/known_good.json
+++ b/scripts/known_good.json
@@ -29,7 +29,7 @@
             "sub_dir": "SPIRV-Headers",
             "build_dir": "SPIRV-Headers/build",
             "install_dir": "SPIRV-Headers/build/install",
-            "commit": "69ab0f32dc6376d74b3f5b0b7161c6681478badd"
+            "commit": "2a9b6f951c7d6b04b6c21fe1bf3f475b68b84801"
         },
         {
             "name": "SPIRV-Tools",
@@ -43,7 +43,7 @@
                 "-DSPIRV_SKIP_TESTS=ON",
                 "-DSPIRV_SKIP_EXECUTABLES=OFF"
             ],
-            "commit": "b21dda0ee7a3ea4e0192a7b2b09db1df1de9d5e7"
+            "commit": "05be5b2466b67317caaaed0d5369fd7f99af05a8"
         },
         {
             "name": "robin-hood-hashing",


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8513

This grabs this change https://github.com/KhronosGroup/SPIRV-Tools/pull/5789 that fixes the comparison of `OpTypeImage` to not compare the `Depth` which was giving false positive 