### PR TITLE
layers: Update semaphore state tracking

### DIFF
--- a/layers/containers/custom_containers.h
+++ b/layers/containers/custom_containers.h
@@ -1069,6 +1069,23 @@ const Value *Find(const Container &container, const Key &key) {
     return (it != container.cend()) ? &it->second : nullptr;
 }
 
+//
+// auto& thing = vvl::FindExisting(map, key);
+//
+template <typename Container, typename Key = typename Container::key_type, typename Value = typename Container::mapped_type>
+Value &FindExisting(Container &container, const Key &key) {
+    auto it = container.find(key);
+    assert(it != container.end());
+    return it->second;
+}
+
+template <typename Container, typename Key = typename Container::key_type, typename Value = typename Container::mapped_type>
+const Value &FindExisting(const Container &container, const Key &key) {
+    auto it = container.find(key);
+    assert(it != container.end());
+    return it->second;
+}
+
 // EraseIf is not implemented as std::erase(std::remove_if(...), ...) for two reasons:
 //   1) Robin Hood containers don't support two-argument erase functions
 //   2) STL remove_if requires the predicate to be const w.r.t the value-type, and std::erase_if doesn't AFAICT

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -192,7 +192,7 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
     };
     submission.EndUse();
     for (auto &wait : submission.wait_semaphores) {
-        wait.semaphore->Retire(this, submission.loc.Get(), wait.payload);
+        wait.semaphore->RetireWait(this, wait.payload, submission.loc.Get(), true);
     }
     for (auto &cb_state : submission.cbs) {
         auto cb_guard = cb_state->WriteLock();
@@ -203,7 +203,7 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
         cb_state->Retire(submission.perf_submit_pass, is_query_updated_after);
     }
     for (auto &signal : submission.signal_semaphores) {
-        signal.semaphore->Retire(this, submission.loc.Get(), signal.payload);
+        signal.semaphore->RetireSignal(this, signal.payload, submission.loc.Get());
     }
     if (submission.fence) {
         submission.fence->Retire();

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -48,7 +48,7 @@ class Semaphore : public RefcountedStateObject {
     struct SemOp {
         OpType op_type;
         uint64_t payload;
-        SubmissionReference submit;
+        SubmissionReference submit;  // Used only by binary semaphores
         std::optional<Func> acquire_command;
 
         SemOp(OpType op_type, const SubmissionReference &submit, uint64_t payload)
@@ -63,6 +63,7 @@ class Semaphore : public RefcountedStateObject {
         std::optional<Func> acquire_command;
         std::promise<void> completed;
         std::shared_future<void> waiter;
+        bool pending_wait = false;  // WORKAROUND when wait can't see a signal (then signal has to see the wait)
 
         TimePoint() : completed(), waiter(completed.get_future()) {}
         bool HasSignaler() const { return signal_submit.has_value() || acquire_command.has_value(); }
@@ -84,11 +85,14 @@ class Semaphore : public RefcountedStateObject {
     // Enqueue binary semaphore signal from swapchain image acquire command
     void EnqueueAcquire(Func acquire_command);
 
-    // Helper for retiring timeline semaphores and then retiring all queues using the semaphore
-    void NotifyAndWait(const Location &loc, uint64_t payload);
+    // Process wait by retiring timeline timepoints up to the specified payload.
+    // If there is un-retired resolving signal then wait until another queue or a host retires timepoints instead.
+    // queue_thread determines if this function is called by a queue thread or by the validation object.
+    // (validation object has to use {Begin/End}BlockingOperation() when waiting for the timepoint)
+    void RetireWait(Queue *current_queue, uint64_t payload, const Location &loc, bool queue_thread = false);
 
-    // Remove completed operations and signal any waiters. This should only be called by Queue
-    void Retire(Queue *current_queue, const Location &loc, uint64_t payload);
+    // Process signal by retiring timeline timepoints up to the specified payload
+    void RetireSignal(Queue *current_queue, uint64_t payload, const Location &loc);
 
     // Look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(
@@ -101,7 +105,7 @@ class Semaphore : public RefcountedStateObject {
     std::optional<SubmissionReference> GetPendingBinaryWaitSubmission() const;
 
     // Current payload value.
-    // If a queue submission command is pending execution, then the returned value may immediately be out of date.
+    // If a queue submission command is pending execution, then the returned value may immediately be out of date
     uint64_t CurrentPayload() const;
 
     bool CanBinaryBeSignaled() const;
@@ -124,13 +128,20 @@ class Semaphore : public RefcountedStateObject {
     Semaphore(ValidationStateTracker &dev, VkSemaphore handle, const VkSemaphoreTypeCreateInfo *type_create_info,
               const VkSemaphoreCreateInfo *pCreateInfo);
 
-    // Signal queue(s) that need to retire because a wait on this payload has finished
-    void Notify(uint64_t payload);
-
-    std::shared_future<void> Wait(uint64_t payload);
-
     ReadLockGuard ReadLock() const { return ReadLockGuard(lock_); }
     WriteLockGuard WriteLock() { return WriteLockGuard(lock_); }
+
+    // Return true if timepoint has no dependencies and can be retired.
+    // If there is unresolved wait then notify signaling queue (if there is registered signal) and return false
+    bool CanRetireBinaryWait(TimePoint &timepoint) const;
+    bool CanRetireTimelineWait(const vvl::Queue *current_queue, uint64_t payload) const;
+
+    // Mark timepoints up to and including payload as completed (notify waiters) and remove them from timeline
+    void RetireTimePoint(uint64_t payload, OpType completed_op, SubmissionReference completed_submit);
+
+    // Waits for the waiter. Unblock parameter must be true if the caller is a validation object and false otherwise.
+    // (validation object has to use {Begin/End}BlockingOperation() when waiting for the timepoint)
+    void WaitTimePoint(std::shared_future<void> &&waiter, uint64_t payload, bool unblock_validation_object, const Location &loc);
 
   private:
     enum Scope scope_ { kInternal };

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -569,10 +569,6 @@ class ValidationStateTracker : public ValidationObject {
                                          const RecordObject& record_obj) override;
     void PreCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
                                       const RecordObject& record_obj) override;
-    void PostCallRecordSignalSemaphoreKHR(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
-                                          const RecordObject& record_obj) override;
-    void PostCallRecordSignalSemaphore(VkDevice device, const VkSemaphoreSignalInfo* pSignalInfo,
-                                       const RecordObject& record_obj) override;
 
     // Create/Destroy/Bind
     void PostCallRecordBindAccelerationStructureMemoryNV(VkDevice device, uint32_t bindInfoCount,

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -264,6 +264,12 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
             vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
             vk::ResetFences(device(), 1, &fence.handle());
         }
+        {
+            // We did not synchronize with the presentation request from the last iteration.
+            // Wait on the queue to ensure submit semaphore used by presentation request is not in use.
+            std::unique_lock<std::mutex> lock(queue_mutex);
+            m_default_queue->Wait();
+        }
     }
     thread.join();
 }


### PR DESCRIPTION
Broadly this fixes the following categories of issues:
* semaphore signal on one queue could initiate forward progress on a different queue and mark resources there as not in-use in the scenarios where the second queue is not synchronized with a host in any way.
* various combinations of timeline semaphore host signal/wait led to deadlock (timeout and internal vvl error).
* issues with timeline synchronization when signal and wait values are not equal (larger signals also resolve the waits).

The main observation that notifying timeline's timepoint should notify only resolving signals but not the waits (which can trigger forward progress on other queues even without host wait). The waits are naturally processed when forward progress on particular queue goes over submissions one by one.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7941
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8370
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8476
