### PR TITLE
layers: Improve error message formatting

### DIFF
--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -629,11 +629,15 @@ bool DebugReport::LogMsg(VkFlags msg_flags, const LogObjectList &objects, const 
 
             // Add period at end if forgotten
             // This provides better seperation between error message and spec text
-            if (str_plus_spec_text.back() != '.') {
+            if (str_plus_spec_text.back() != '.' && str_plus_spec_text.back() != '\n') {
                 str_plus_spec_text.append(".");
             }
 
-            str_plus_spec_text.append(" The Vulkan spec states: ");
+            // Start Vulkan spec text with a new line to make it easier visually
+            if (str_plus_spec_text.back() != '\n') {
+                str_plus_spec_text.append("\n");
+            }
+            str_plus_spec_text.append("The Vulkan spec states: ");
             str_plus_spec_text.append(spec_text);
             if (0 == spec_type.compare("default")) {
                 str_plus_spec_text.append(" (https://github.com/KhronosGroup/Vulkan-Docs/search?q=)");


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8422

Makes sure that an error message is always

```
Some long Validation error message.
The Vulkan spec states ...
```