### PR TITLE
layers: Fix multiple calls to CmdSetVertexInputEXT

### DIFF
--- a/layers/core_checks/cc_cmd_buffer_dynamic.cpp
+++ b/layers/core_checks/cc_cmd_buffer_dynamic.cpp
@@ -1018,8 +1018,8 @@ bool CoreChecks::ValidateDrawDynamicState(const LastBound& last_bound_state, con
                 continue;
             }
             bool location_provided = false;
-            for (const auto& binding_state : cb_state.dynamic_state_value.vertex_bindings) {
-                const auto* attrib = vvl::Find(binding_state.second.locations, variable_ptr->decorations.location);
+            for (const auto& vertex_binding : cb_state.dynamic_state_value.vertex_bindings) {
+                const auto* attrib = vvl::Find(vertex_binding.second.locations, variable_ptr->decorations.location);
                 if (!attrib) continue;
                 location_provided = true;
 

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -5255,14 +5255,14 @@ void ValidationStateTracker::PostCallRecordCmdSetVertexInputEXT(
     }
     auto &vertex_bindings = cb_state->dynamic_state_value.vertex_bindings;
     for (const auto [i, bd] : vvl::enumerate(pVertexBindingDescriptions, vertexBindingDescriptionCount)) {
-        vertex_bindings.emplace(bd->binding, VertexBindingState(i, bd));
+        vertex_bindings.insert_or_assign(bd->binding, VertexBindingState(i, bd));
 
         cb_state->current_vertex_buffer_binding_info[bd->binding].stride = bd->stride;
     }
 
     for (const auto [i, ad] : vvl::enumerate(pVertexAttributeDescriptions, vertexAttributeDescriptionCount)) {
         if (auto *binding_state = vvl::Find(vertex_bindings, ad->binding)) {
-            binding_state->locations.emplace(ad->location, VertexAttrState(i, ad));
+            binding_state->locations.insert_or_assign(ad->location, VertexAttrState(i, ad));
         }
     }
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8523

When we called `vkCmdSetVertexInputEXT` twice in the same command buffer, we were not actually updating the values since `emplace()` does not override the value in the `unordered_map`