### PR TITLE
Improve enum extension error message

### DIFF
--- a/layers/stateless/stateless_validation.h
+++ b/layers/stateless/stateless_validation.h
@@ -407,7 +407,8 @@ class StatelessValidation : public ValidationObject {
         } else if (result == ValidValue::NoExtension && device != VK_NULL_HANDLE) {
             // If called from an instance function, there is no device to base extension support off of
             auto extensions = GetEnumExtensions(value);
-            skip |= LogError(vuid, device, loc, "(%" PRIu32 ") requires the extensions %s.", value, String(extensions).c_str());
+            skip |=
+                LogError(vuid, device, loc, "(%s) requires the extensions %s.", DescribeEnum(value), String(extensions).c_str());
         }
 
         return skip;
@@ -455,8 +456,8 @@ class StatelessValidation : public ValidationObject {
                 } else if (result == ValidValue::NoExtension && device != VK_NULL_HANDLE) {
                     // If called from an instance function, there is no device to base extension support off of
                     auto extensions = GetEnumExtensions(array[i]);
-                    skip |= LogError(array_required_vuid, device, array_loc.dot(i), "(%" PRIu32 ") requires the extensions %s.",
-                                     array[i], String(extensions).c_str());
+                    skip |= LogError(array_required_vuid, device, array_loc.dot(i), "(%s) requires the extensions %s.",
+                                     DescribeEnum(array[i]), String(extensions).c_str());
                 }
             }
         }
@@ -489,6 +490,8 @@ class StatelessValidation : public ValidationObject {
     ValidValue IsValidEnumValue(T value) const;
     template <typename T>
     vvl::Extensions GetEnumExtensions(T value) const;
+    template <typename T>
+    const char *DescribeEnum(T value) const;
 
     // VkFlags values don't have a way overload, so need to use vvl::FlagBitmask
     vvl::Extensions IsValidFlagValue(vvl::FlagBitmask flag_bitmask, VkFlags value, const DeviceExtensions &device_extensions) const;
@@ -594,8 +597,8 @@ class StatelessValidation : public ValidationObject {
                                                     const ErrorObject &error_obj) const;
 
     bool ValidatePipelineShaderStageCreateInfoCommon(const VkPipelineShaderStageCreateInfo &create_info, const Location &loc) const;
-    bool ValidatePipelineBinaryInfo(const void *next, VkPipelineCreateFlags flags,
-                                    VkPipelineCache pipelineCache, const Location &loc) const;
+    bool ValidatePipelineBinaryInfo(const void *next, VkPipelineCreateFlags flags, VkPipelineCache pipelineCache,
+                                    const Location &loc) const;
     bool ValidatePipelineRenderingCreateInfo(const VkPipelineRenderingCreateInfo &rendering_struct, const Location &loc) const;
     bool ValidateCreateGraphicsPipelinesFlags(const VkPipelineCreateFlags2KHR flags, const Location &flags_loc) const;
     bool manual_PreCallValidateCreateGraphicsPipelines(VkDevice device, VkPipelineCache pipelineCache, uint32_t createInfoCount,

--- a/layers/vulkan/generated/valid_enum_values.cpp
+++ b/layers/vulkan/generated/valid_enum_values.cpp
@@ -23,6 +23,7 @@
 // NOLINTBEGIN
 
 #include "stateless/stateless_validation.h"
+#include <vulkan/vk_enum_string_helper.h>
 
 //  Checking for values is a 2 part process
 //    1. Check if is valid at all
@@ -2030,6 +2031,10 @@ template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPipelineCacheHeaderVersion value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPipelineCacheHeaderVersion value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageLayout value) const {
@@ -2068,6 +2073,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageLayout value) cons
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkImageLayout value) const {
+    return string_VkImageLayout(value);
 }
 
 template <>
@@ -2124,6 +2133,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkObjectType value) const
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkObjectType value) const {
+    return string_VkObjectType(value);
 }
 
 template <>
@@ -2205,6 +2218,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkFormat value) const {
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkFormat value) const {
+    return string_VkFormat(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageTiling value) const {
@@ -2215,10 +2232,18 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageTiling value) cons
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkImageTiling value) const {
+    return string_VkImageTiling(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageType value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkImageType value) const {
+    return nullptr;
 }
 
 template <>
@@ -2253,25 +2278,45 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkQueryType value) const 
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkQueryType value) const {
+    return string_VkQueryType(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSharingMode value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkSharingMode value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkComponentSwizzle value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkComponentSwizzle value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkImageViewType value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkImageViewType value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkBlendFactor value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkBlendFactor value) const {
+    return nullptr;
 }
 
 template <>
@@ -2328,10 +2373,18 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkBlendOp value) const {
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkBlendOp value) const {
+    return string_VkBlendOp(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCompareOp value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCompareOp value) const {
+    return nullptr;
 }
 
 template <>
@@ -2418,20 +2471,36 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkDynamicState value) con
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDynamicState value) const {
+    return string_VkDynamicState(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFrontFace value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkFrontFace value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkVertexInputRate value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkVertexInputRate value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPrimitiveTopology value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkPrimitiveTopology value) const {
+    return nullptr;
 }
 
 template <>
@@ -2443,15 +2512,27 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkPolygonMode value) cons
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPolygonMode value) const {
+    return string_VkPolygonMode(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkStencilOp value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkStencilOp value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkLogicOp value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkLogicOp value) const {
+    return nullptr;
 }
 
 template <>
@@ -2464,6 +2545,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkBorderColor value) cons
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkBorderColor value) const {
+    return string_VkBorderColor(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFilter value) const {
@@ -2473,6 +2558,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkFilter value) const {
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkFilter value) const {
+    return string_VkFilter(value);
 }
 
 template <>
@@ -2484,10 +2573,18 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerAddressMode valu
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkSamplerAddressMode value) const {
+    return string_VkSamplerAddressMode(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerMipmapMode value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkSamplerMipmapMode value) const {
+    return nullptr;
 }
 
 template <>
@@ -2508,6 +2605,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkDescriptorType value) c
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDescriptorType value) const {
+    return string_VkDescriptorType(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAttachmentLoadOp value) const {
@@ -2517,6 +2618,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkAttachmentLoadOp value)
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkAttachmentLoadOp value) const {
+    return string_VkAttachmentLoadOp(value);
 }
 
 template <>
@@ -2528,6 +2633,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkAttachmentStoreOp value
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkAttachmentStoreOp value) const {
+    return string_VkAttachmentStoreOp(value);
 }
 
 template <>
@@ -2543,10 +2652,18 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkPipelineBindPoint value
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPipelineBindPoint value) const {
+    return string_VkPipelineBindPoint(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCommandBufferLevel value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCommandBufferLevel value) const {
+    return nullptr;
 }
 
 template <>
@@ -2560,6 +2677,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkIndexType value) const 
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkIndexType value) const {
+    return string_VkIndexType(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSubpassContents value) const {
@@ -2570,25 +2691,45 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkSubpassContents value) 
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkSubpassContents value) const {
+    return string_VkSubpassContents(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkTessellationDomainOrigin value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkTessellationDomainOrigin value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerYcbcrModelConversion value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkSamplerYcbcrModelConversion value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerYcbcrRange value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkSamplerYcbcrRange value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkChromaLocation value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkChromaLocation value) const {
+    return nullptr;
 }
 
 template <>
@@ -2600,6 +2741,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkDescriptorUpdateTemplat
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDescriptorUpdateTemplateType value) const {
+    return string_VkDescriptorUpdateTemplateType(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerReductionMode value) const {
@@ -2610,10 +2755,18 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkSamplerReductionMode va
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkSamplerReductionMode value) const {
+    return string_VkSamplerReductionMode(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkSemaphoreType value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkSemaphoreType value) const {
+    return nullptr;
 }
 
 template <>
@@ -2625,6 +2778,10 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkPresentModeKHR value) c
         default:
             return {};
     };
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkPresentModeKHR value) const {
+    return string_VkPresentModeKHR(value);
 }
 
 template <>
@@ -2651,30 +2808,54 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkColorSpaceKHR value) co
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkColorSpaceKHR value) const {
+    return string_VkColorSpaceKHR(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkQueueGlobalPriorityKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkQueueGlobalPriorityKHR value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFragmentShadingRateCombinerOpKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkFragmentShadingRateCombinerOpKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkVideoEncodeTuningModeKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkVideoEncodeTuningModeKHR value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkLineRasterizationModeKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkLineRasterizationModeKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkTimeDomainKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkTimeDomainKHR value) const {
+    return nullptr;
 }
 
 template <>
@@ -2700,156 +2881,280 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkDebugReportObjectTypeEX
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDebugReportObjectTypeEXT value) const {
+    return string_VkDebugReportObjectTypeEXT(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkRasterizationOrderAMD value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkRasterizationOrderAMD value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkShaderInfoTypeAMD value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkShaderInfoTypeAMD value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkValidationCheckEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkValidationCheckEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPipelineRobustnessBufferBehaviorEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPipelineRobustnessBufferBehaviorEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPipelineRobustnessImageBehaviorEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkPipelineRobustnessImageBehaviorEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDisplayPowerStateEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDisplayPowerStateEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDeviceEventTypeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkDeviceEventTypeEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDisplayEventTypeEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDisplayEventTypeEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkViewportCoordinateSwizzleNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkViewportCoordinateSwizzleNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDiscardRectangleModeEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDiscardRectangleModeEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkConservativeRasterizationModeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkConservativeRasterizationModeEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkBlendOverlapEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkBlendOverlapEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCoverageModulationModeNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCoverageModulationModeNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkShadingRatePaletteEntryNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkShadingRatePaletteEntryNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCoarseSampleOrderTypeNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCoarseSampleOrderTypeNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkRayTracingShaderGroupTypeKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkRayTracingShaderGroupTypeKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkGeometryTypeKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkGeometryTypeKHR value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAccelerationStructureTypeKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkAccelerationStructureTypeKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCopyAccelerationStructureModeKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCopyAccelerationStructureModeKHR value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAccelerationStructureMemoryRequirementsTypeNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkAccelerationStructureMemoryRequirementsTypeNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkMemoryOverallocationBehaviorAMD value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkMemoryOverallocationBehaviorAMD value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPerformanceConfigurationTypeINTEL value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPerformanceConfigurationTypeINTEL value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkQueryPoolSamplingModeINTEL value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkQueryPoolSamplingModeINTEL value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPerformanceOverrideTypeINTEL value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkPerformanceOverrideTypeINTEL value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkPerformanceParameterTypeINTEL value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkPerformanceParameterTypeINTEL value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkValidationFeatureEnableEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkValidationFeatureEnableEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkValidationFeatureDisableEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkValidationFeatureDisableEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCoverageReductionModeNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkCoverageReductionModeNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkProvokingVertexModeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkProvokingVertexModeEXT value) const {
+    return nullptr;
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFullScreenExclusiveEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkFullScreenExclusiveEXT value) const {
+    return nullptr;
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
@@ -2865,40 +3170,72 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkIndirectCommandsTokenTy
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkIndirectCommandsTokenTypeNV value) const {
+    return string_VkIndirectCommandsTokenTypeNV(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDepthBiasRepresentationEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkDepthBiasRepresentationEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFragmentShadingRateTypeNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkFragmentShadingRateTypeNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkFragmentShadingRateNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkFragmentShadingRateNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAccelerationStructureMotionInstanceTypeNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkAccelerationStructureMotionInstanceTypeNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDeviceFaultAddressTypeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkDeviceFaultAddressTypeEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDeviceFaultVendorBinaryHeaderVersionEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkDeviceFaultVendorBinaryHeaderVersionEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDeviceAddressBindingTypeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkDeviceAddressBindingTypeEXT value) const {
+    return nullptr;
 }
 
 template <>
@@ -2910,90 +3247,162 @@ vvl::Extensions StatelessValidation::GetEnumExtensions(VkMicromapTypeEXT value) 
             return {};
     };
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkMicromapTypeEXT value) const {
+    return string_VkMicromapTypeEXT(value);
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkBuildMicromapModeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkBuildMicromapModeEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCopyMicromapModeEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkCopyMicromapModeEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAccelerationStructureCompatibilityKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkAccelerationStructureCompatibilityKHR value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAccelerationStructureBuildTypeKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkAccelerationStructureBuildTypeKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkDirectDriverLoadingModeLUNARG value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkDirectDriverLoadingModeLUNARG value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkOpticalFlowPerformanceLevelNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkOpticalFlowPerformanceLevelNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkOpticalFlowSessionBindingPointNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkOpticalFlowSessionBindingPointNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAntiLagModeAMD value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkAntiLagModeAMD value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkAntiLagStageAMD value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkAntiLagStageAMD value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkShaderCodeTypeEXT value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkShaderCodeTypeEXT value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkLayerSettingTypeEXT value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkLayerSettingTypeEXT value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkLatencyMarkerNV value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkLatencyMarkerNV value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkOutOfBandQueueTypeNV value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkOutOfBandQueueTypeNV value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkBlockMatchWindowCompareModeQCOM value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkBlockMatchWindowCompareModeQCOM value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkCubicFilterWeightsQCOM value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkCubicFilterWeightsQCOM value) const {
+    return nullptr;
 }
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkBuildAccelerationStructureModeKHR value) const {
     return {};
 }
+template <>
+const char* StatelessValidation::DescribeEnum(VkBuildAccelerationStructureModeKHR value) const {
+    return nullptr;
+}
 
 template <>
 vvl::Extensions StatelessValidation::GetEnumExtensions(VkShaderGroupShaderKHR value) const {
     return {};
+}
+template <>
+const char* StatelessValidation::DescribeEnum(VkShaderGroupShaderKHR value) const {
+    return nullptr;
 }
 
 // NOLINTEND

--- a/layers/vulkan/generated/valid_flag_values.cpp
+++ b/layers/vulkan/generated/valid_flag_values.cpp
@@ -23,6 +23,7 @@
 // NOLINTBEGIN
 
 #include "stateless/stateless_validation.h"
+#include <vulkan/vk_enum_string_helper.h>
 
 // For flags, we can't use the VkFlag as it can't be templated (since it all resolves to a int).
 // It is simpler for the caller to already check for both

--- a/scripts/generators/valid_enum_values_generator.py
+++ b/scripts/generators/valid_enum_values_generator.py
@@ -76,6 +76,7 @@ class ValidEnumValuesOutputGenerator(BaseGenerator):
         out = []
         out.append('''
             #include "stateless/stateless_validation.h"
+            #include <vulkan/vk_enum_string_helper.h>
 
             //  Checking for values is a 2 part process
             //    1. Check if is valid at all
@@ -132,6 +133,7 @@ class ValidEnumValuesOutputGenerator(BaseGenerator):
             # Need empty functions to resolve all template variations
             if len(enum.fieldExtensions) <= len(enum.extensions):
                 out.append(f'template<> vvl::Extensions StatelessValidation::GetEnumExtensions({enum.name} value) const {{ return {{}}; }}\n')
+                out.append(f'template<> const char* StatelessValidation::DescribeEnum({enum.name} value) const {{ return nullptr; }}\n')
                 out.extend(guard_helper.add_guard(None, extra_newline=True))
                 continue
 
@@ -158,6 +160,10 @@ class ValidEnumValuesOutputGenerator(BaseGenerator):
                         };
                     }
                 ''')
+
+            out.append(f'template<> const char* StatelessValidation::DescribeEnum({enum.name} value) const {{\n')
+            out.append(f'   return string_{enum.name}(value);\n')
+            out.append('}\n')
             out.extend(guard_helper.add_guard(None, extra_newline=True))
 
         self.write(''.join(out))

--- a/scripts/generators/valid_flag_values_generator.py
+++ b/scripts/generators/valid_flag_values_generator.py
@@ -67,6 +67,7 @@ class ValidFlagValuesOutputGenerator(BaseGenerator):
         out = []
         out.append('''
             #include "stateless/stateless_validation.h"
+            #include <vulkan/vk_enum_string_helper.h>
 
             // For flags, we can't use the VkFlag as it can't be templated (since it all resolves to a int).
             // It is simpler for the caller to already check for both

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -2275,3 +2275,10 @@ TEST_F(VkLayerTest, PhysicalDeviceLayeredApiVulkanPropertiesKHR) {
     vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
     m_errorMonitor->VerifyFound();
 }
+
+TEST_F(VkLayerTest, UnrecognizedEnumExtension) {
+    RETURN_IF_SKIP(Init());
+    m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-format-parameter");
+    vkt::Image image(*m_device, 4, 4, 1, VK_FORMAT_A4B4G4R4_UNORM_PACK16, VK_IMAGE_USAGE_SAMPLED_BIT);
+    m_errorMonitor->VerifyFound();
+}


### PR DESCRIPTION
similar to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8534 but for the enums

old message

> [ VUID-VkImageCreateInfo-format-parameter ] | vkCreateImage(): pCreateInfo->format (1000340001) requires the extensions VK_EXT_4444_formats.

now

> [ VUID-VkImageCreateInfo-format-parameter ] | vkCreateImage(): pCreateInfo->format (VK_FORMAT_A4B4G4R4_UNORM_PACK16) requires the extensions VK_EXT_4444_formats.

