### PR TITLE
scripts: Fix vkGetPipelineKeyKHR

### DIFF
--- a/layers/chassis/layer_chassis_dispatch_manual.cpp
+++ b/layers/chassis/layer_chassis_dispatch_manual.cpp
@@ -1638,3 +1638,21 @@ VkResult DispatchCreatePipelineBinariesKHR(VkDevice device, const VkPipelineBina
 
     return result;
 }
+
+VkResult DispatchGetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR *pPipelineCreateInfo,
+                                   VkPipelineBinaryKeyKHR *pPipelineKey) {
+    auto layer_data = GetLayerDataPtr(GetDispatchKey(device), layer_data_map);
+    if (!wrap_handles) return layer_data->device_dispatch_table.GetPipelineKeyKHR(device, pPipelineCreateInfo, pPipelineKey);
+    vku::safe_VkPipelineCreateInfoKHR var_local_pPipelineCreateInfo;
+    vku::safe_VkPipelineCreateInfoKHR *local_pPipelineCreateInfo = nullptr;
+    {
+        if (pPipelineCreateInfo) {
+            local_pPipelineCreateInfo = &var_local_pPipelineCreateInfo;
+            local_pPipelineCreateInfo->initialize(pPipelineCreateInfo);
+            UnwrapPnextChainHandles(layer_data, local_pPipelineCreateInfo->pNext);
+        }
+    }
+    VkResult result = layer_data->device_dispatch_table.GetPipelineKeyKHR(
+        device, (const VkPipelineCreateInfoKHR *)local_pPipelineCreateInfo, pPipelineKey);
+    return result;
+}

--- a/layers/vulkan/generated/layer_chassis_dispatch.cpp
+++ b/layers/vulkan/generated/layer_chassis_dispatch.cpp
@@ -37,6 +37,99 @@ void UnwrapPnextChainHandles(ValidationObject* layer_data, const void* pNext) {
         VkBaseOutStructure* header = reinterpret_cast<VkBaseOutStructure*>(cur_pnext);
 
         switch (header->sType) {
+            case VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO: {
+                auto* safe_struct = reinterpret_cast<vku::safe_VkComputePipelineCreateInfo*>(cur_pnext);
+
+                if (safe_struct->stage.module) {
+                    safe_struct->stage.module = layer_data->Unwrap(safe_struct->stage.module);
+                }
+                UnwrapPnextChainHandles(layer_data, safe_struct->stage.pNext);
+
+                if (safe_struct->layout) {
+                    safe_struct->layout = layer_data->Unwrap(safe_struct->layout);
+                }
+                if (safe_struct->basePipelineHandle) {
+                    safe_struct->basePipelineHandle = layer_data->Unwrap(safe_struct->basePipelineHandle);
+                }
+            } break;
+            case VK_STRUCTURE_TYPE_GRAPHICS_PIPELINE_CREATE_INFO: {
+                auto* safe_struct = reinterpret_cast<vku::safe_VkGraphicsPipelineCreateInfo*>(cur_pnext);
+                if (safe_struct->pStages) {
+                    for (uint32_t index0 = 0; index0 < safe_struct->stageCount; ++index0) {
+                        UnwrapPnextChainHandles(layer_data, safe_struct->pStages[index0].pNext);
+
+                        if (safe_struct->pStages[index0].module) {
+                            safe_struct->pStages[index0].module = layer_data->Unwrap(safe_struct->pStages[index0].module);
+                        }
+                    }
+                }
+
+                if (safe_struct->layout) {
+                    safe_struct->layout = layer_data->Unwrap(safe_struct->layout);
+                }
+                if (safe_struct->renderPass) {
+                    safe_struct->renderPass = layer_data->Unwrap(safe_struct->renderPass);
+                }
+                if (safe_struct->basePipelineHandle) {
+                    safe_struct->basePipelineHandle = layer_data->Unwrap(safe_struct->basePipelineHandle);
+                }
+            } break;
+            case VK_STRUCTURE_TYPE_RAY_TRACING_PIPELINE_CREATE_INFO_KHR: {
+                auto* safe_struct = reinterpret_cast<vku::safe_VkRayTracingPipelineCreateInfoKHR*>(cur_pnext);
+                if (safe_struct->pStages) {
+                    for (uint32_t index0 = 0; index0 < safe_struct->stageCount; ++index0) {
+                        UnwrapPnextChainHandles(layer_data, safe_struct->pStages[index0].pNext);
+
+                        if (safe_struct->pStages[index0].module) {
+                            safe_struct->pStages[index0].module = layer_data->Unwrap(safe_struct->pStages[index0].module);
+                        }
+                    }
+                }
+                if (safe_struct->pLibraryInfo) {
+                    if (safe_struct->pLibraryInfo->pLibraries) {
+                        for (uint32_t index1 = 0; index1 < safe_struct->pLibraryInfo->libraryCount; ++index1) {
+                            safe_struct->pLibraryInfo->pLibraries[index1] =
+                                layer_data->Unwrap(safe_struct->pLibraryInfo->pLibraries[index1]);
+                        }
+                    }
+                }
+
+                if (safe_struct->layout) {
+                    safe_struct->layout = layer_data->Unwrap(safe_struct->layout);
+                }
+                if (safe_struct->basePipelineHandle) {
+                    safe_struct->basePipelineHandle = layer_data->Unwrap(safe_struct->basePipelineHandle);
+                }
+            } break;
+#ifdef VK_ENABLE_BETA_EXTENSIONS
+            case VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX: {
+                auto* safe_struct = reinterpret_cast<vku::safe_VkExecutionGraphPipelineCreateInfoAMDX*>(cur_pnext);
+                if (safe_struct->pStages) {
+                    for (uint32_t index0 = 0; index0 < safe_struct->stageCount; ++index0) {
+                        UnwrapPnextChainHandles(layer_data, safe_struct->pStages[index0].pNext);
+
+                        if (safe_struct->pStages[index0].module) {
+                            safe_struct->pStages[index0].module = layer_data->Unwrap(safe_struct->pStages[index0].module);
+                        }
+                    }
+                }
+                if (safe_struct->pLibraryInfo) {
+                    if (safe_struct->pLibraryInfo->pLibraries) {
+                        for (uint32_t index1 = 0; index1 < safe_struct->pLibraryInfo->libraryCount; ++index1) {
+                            safe_struct->pLibraryInfo->pLibraries[index1] =
+                                layer_data->Unwrap(safe_struct->pLibraryInfo->pLibraries[index1]);
+                        }
+                    }
+                }
+
+                if (safe_struct->layout) {
+                    safe_struct->layout = layer_data->Unwrap(safe_struct->layout);
+                }
+                if (safe_struct->basePipelineHandle) {
+                    safe_struct->basePipelineHandle = layer_data->Unwrap(safe_struct->basePipelineHandle);
+                }
+            } break;
+#endif  // VK_ENABLE_BETA_EXTENSIONS
             case VK_STRUCTURE_TYPE_FRAME_BOUNDARY_EXT: {
                 auto* safe_struct = reinterpret_cast<vku::safe_VkFrameBoundaryEXT*>(cur_pnext);
                 if (safe_struct->pImages) {
@@ -5192,15 +5285,6 @@ void DispatchDestroyPipelineBinaryKHR(VkDevice device, VkPipelineBinaryKHR pipel
         pipelineBinary = (VkPipelineBinaryKHR)0;
     }
     layer_data->device_dispatch_table.DestroyPipelineBinaryKHR(device, pipelineBinary, pAllocator);
-}
-
-VkResult DispatchGetPipelineKeyKHR(VkDevice device, const VkPipelineCreateInfoKHR* pPipelineCreateInfo,
-                                   VkPipelineBinaryKeyKHR* pPipelineKey) {
-    auto layer_data = GetLayerDataPtr(GetDispatchKey(device), layer_data_map);
-
-    VkResult result = layer_data->device_dispatch_table.GetPipelineKeyKHR(device, pPipelineCreateInfo, pPipelineKey);
-
-    return result;
 }
 
 VkResult DispatchGetPipelineBinaryDataKHR(VkDevice device, const VkPipelineBinaryDataInfoKHR* pInfo,

--- a/scripts/generators/layer_chassis_dispatch_generator.py
+++ b/scripts/generators/layer_chassis_dispatch_generator.py
@@ -100,10 +100,17 @@ class LayerChassisDispatchOutputGenerator(BaseGenerator):
             'vkGetDisplayPlaneSupportedDisplaysKHR',
             # need to handle binaries in VkPipelineBinaryHandlesInfoKHR as output, not input.
             'vkCreatePipelineBinariesKHR',
+            'vkGetPipelineKeyKHR',
             ]
 
         # List of all extension structs strings containing handles
-        self.ndo_extension_structs = []
+        self.ndo_extension_structs = [
+            # These are added manually because vkGetPipelineKeyKHR needs to unwrap these (see VUID 09604)
+            "VkComputePipelineCreateInfo",
+            "VkGraphicsPipelineCreateInfo",
+            "VkRayTracingPipelineCreateInfoKHR",
+            "VkExecutionGraphPipelineCreateInfoAMDX",
+        ]
 
         # Dispatch functions that need special state tracking variables passed in
         self.custom_definition = {

--- a/tests/unit/pipeline_binary_positive.cpp
+++ b/tests/unit/pipeline_binary_positive.cpp
@@ -141,3 +141,32 @@ TEST_F(PositivePipelineBinary, CreateBinaryFromData) {
         vk::DestroyPipelineBinaryKHR(device(), pipeline_binary2, nullptr);
     }
 }
+
+TEST_F(PositivePipelineBinary, GetPipelineKey) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8540");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_PIPELINE_BINARY_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::pipelineBinaries);
+    RETURN_IF_SKIP(Init());
+
+    VkShaderObj cs(this, kMinimalShaderGlsl, VK_SHADER_STAGE_COMPUTE_BIT);
+
+    std::vector<VkDescriptorSetLayoutBinding> bindings(0);
+    const vkt::DescriptorSetLayout pipeline_dsl(*m_device, bindings);
+    const vkt::PipelineLayout pipeline_layout(*m_device, {&pipeline_dsl});
+
+    VkComputePipelineCreateInfo compute_create_info = vku::InitStructHelper();
+    compute_create_info.stage = cs.GetStageCreateInfo();
+    compute_create_info.layout = pipeline_layout.handle();
+
+    VkPipelineBinaryInfoKHR pipeline_binary_info = vku::InitStructHelper();
+    pipeline_binary_info.binaryCount = 0;
+
+    compute_create_info.pNext = &pipeline_binary_info;
+
+    VkPipelineCreateInfoKHR pipeline_create_info = vku::InitStructHelper(&compute_create_info);
+
+    VkPipelineBinaryKeyKHR pipeline_key = vku::InitStructHelper();
+
+    vk::GetPipelineKeyKHR(device(), &pipeline_create_info, &pipeline_key);
+}


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8540

Background:

- `VK_KHR_pipeline_binary` is already an exception to a lot of rules for code gen because we mix the way to do input/output from pNext (fun discussion here https://gitlab.khronos.org/vulkan/vulkan/-/issues/3880)
- 1.3.294 the `VK_KHR_pipeline_binary` extension came out and we added support (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8450) and it was all working
- 1.3.295 there was an XML change (https://github.com/KhronosGroup/Vulkan-Docs/commit/8e435deb15124bbf9a7e3340e6cc7975999ed5c5) that caused some strange code gen (https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8485/files#r1741222743) and it was now breaking thigns

This change basically reverts the original working code by just adding yet-another-exceptions™ to the code gen