### PR TITLE
layers: Remove workaround for handling missing signals

### DIFF
--- a/layers/gpu/core/gpu_state_tracker.cpp
+++ b/layers/gpu/core/gpu_state_tracker.cpp
@@ -28,19 +28,7 @@ Queue::Queue(gpu::GpuShaderInstrumentor &shader_instrumentor, VkQueue q, uint32_
              VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties, bool timeline_khr)
     : vvl::Queue(shader_instrumentor, q, family_index, queue_index, flags, queueFamilyProperties),
       shader_instrumentor_(shader_instrumentor),
-      timeline_khr_(timeline_khr) {
-    VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
-    semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
-    semaphore_type_create_info.initialValue = 0;
-
-    VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
-
-    auto result = DispatchCreateSemaphore(shader_instrumentor_.device, &semaphore_create_info, nullptr, &barrier_sem_);
-    if (result != VK_SUCCESS) {
-        Location loc(vvl::Func::vkGetDeviceQueue);
-        shader_instrumentor_.InternalError(shader_instrumentor_.device, loc, "Unable to create barrier semaphore.");
-    }
-}
+      timeline_khr_(timeline_khr) {}
 
 Queue::~Queue() {
     if (barrier_command_buffer_) {
@@ -85,6 +73,21 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
             return;
         }
 
+        VkSemaphoreTypeCreateInfoKHR semaphore_type_create_info = vku::InitStructHelper();
+        semaphore_type_create_info.semaphoreType = VK_SEMAPHORE_TYPE_TIMELINE_KHR;
+        semaphore_type_create_info.initialValue = 0;
+
+        VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper(&semaphore_type_create_info);
+
+        result = DispatchCreateSemaphore(shader_instrumentor_.device, &semaphore_create_info, nullptr, &barrier_sem_);
+        if (result != VK_SUCCESS) {
+            shader_instrumentor_.InternalError(shader_instrumentor_.device, loc, "Unable to create barrier semaphore.");
+            DispatchDestroyCommandPool(shader_instrumentor_.device, barrier_command_pool_, nullptr);
+            barrier_command_pool_ = VK_NULL_HANDLE;
+            barrier_command_buffer_ = VK_NULL_HANDLE;
+            return;
+        }
+
         // Hook up command buffer dispatch
         shader_instrumentor_.vk_set_device_loader_data_(shader_instrumentor_.device, barrier_command_buffer_);
 
@@ -118,39 +121,44 @@ void Queue::SubmitBarrier(const Location &loc, uint64_t seq) {
     }
 }
 
-vvl::SubmitResult Queue::PostSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
-    assert(!submissions.empty());
-    auto &submission = submissions.back();
-    assert(submission.end_batch);
+vvl::PreSubmitResult Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
+    for (const auto &submission : submissions) {
+        auto loc = submission.loc.Get();
+        for (auto &cb : submission.cbs) {
+            auto gpu_cb = std::static_pointer_cast<CommandBuffer>(cb);
+            auto guard = gpu_cb->ReadLock();
+            gpu_cb->PreProcess(loc);
+            for (auto *secondary_cb : gpu_cb->linkedCommandBuffers) {
+                auto secondary_guard = secondary_cb->ReadLock();
+                auto *secondary_gpu_cb = static_cast<CommandBuffer *>(secondary_cb);
+                secondary_gpu_cb->PreProcess(loc);
+            }
+        }
+    }
+    return vvl::Queue::PreSubmit(std::move(submissions));
+}
 
-    auto loc = submission.loc.Get();
-    SubmitBarrier(loc, submission.seq);
-
-    return vvl::Queue::PostSubmit(std::move(submissions));
+void Queue::PostSubmit(vvl::QueueSubmission &submission) {
+    vvl::Queue::PostSubmit(submission);
+    if (submission.end_batch) {
+        auto loc = submission.loc.Get();
+        SubmitBarrier(loc, submission.seq);
+    }
 }
 
 void Queue::Retire(vvl::QueueSubmission &submission) {
-    auto wait_seq = submission.seq;
     vvl::Queue::Retire(submission);
     retiring_.emplace_back(submission.cbs);
     if (submission.end_batch) {
         VkSemaphoreWaitInfo wait_info = vku::InitStructHelper();
         wait_info.semaphoreCount = 1;
         wait_info.pSemaphores = &barrier_sem_;
-        wait_info.pValues = &wait_seq;
+        wait_info.pValues = &submission.seq;
 
-        VkResult result;
         if (timeline_khr_) {
-            result = DispatchWaitSemaphoresKHR(shader_instrumentor_.device, &wait_info, 1000000000);
+            DispatchWaitSemaphoresKHR(shader_instrumentor_.device, &wait_info, 1000000000);
         } else {
-            result = DispatchWaitSemaphores(shader_instrumentor_.device, &wait_info, 1000000000);
-        }
-        if (result != VK_SUCCESS) {
-            Location loc(timeline_khr_ ? vvl::Func::vkWaitSemaphoresKHR : vvl::Func::vkWaitSemaphores);
-            std::stringstream msg;
-            msg << "Error waiting on barrier_sem VkQueue: " << Handle() << " result: " << string_VkResult(result);
-            shader_instrumentor_.InternalError(shader_instrumentor_.device, loc, msg.str().c_str());
-            return;
+            DispatchWaitSemaphores(shader_instrumentor_.device, &wait_info, 1000000000);
         }
 
         for (auto &cbs : retiring_) {

--- a/layers/gpu/core/gpu_state_tracker.h
+++ b/layers/gpu/core/gpu_state_tracker.h
@@ -31,7 +31,8 @@ class Queue : public vvl::Queue {
     virtual ~Queue();
 
   protected:
-    vvl::SubmitResult PostSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
+    vvl::PreSubmitResult PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) override;
+    void PostSubmit(vvl::QueueSubmission &) override;
     void SubmitBarrier(const Location &loc, uint64_t seq);
     void Retire(vvl::QueueSubmission &) override;
 

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -881,60 +881,6 @@ void GpuShaderInstrumentor::PreCallRecordDestroyPipeline(VkDevice device, VkPipe
     BaseClass::PreCallRecordDestroyPipeline(device, pipeline, pAllocator, record_obj);
 }
 
-void GpuShaderInstrumentor::PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits,
-                                                     VkFence fence, const RecordObject &record_obj) {
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        Location loc = record_obj.location.dot(vvl::Field::pSubmits, submit_idx);
-        const VkSubmitInfo *submit = &pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit->commandBufferCount; i++) {
-            auto gpu_cb = Get<gpu_tracker::CommandBuffer>(submit->pCommandBuffers[i]);
-            gpu_cb->PreProcess(loc);
-            for (auto *secondary_cb : gpu_cb->linkedCommandBuffers) {
-                auto secondary_guard = secondary_cb->WriteLock();
-                auto *secondary_gpu_cb = static_cast<gpu_tracker::CommandBuffer *>(secondary_cb);
-                secondary_gpu_cb->PreProcess(loc);
-            }
-        }
-    }
-    BaseClass::PreCallRecordQueueSubmit(queue, submitCount, pSubmits, fence, record_obj);
-}
-
-void GpuShaderInstrumentor::PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits,
-                                                         VkFence fence, const RecordObject &record_obj) {
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        Location loc = record_obj.location.dot(vvl::Field::pSubmits, submit_idx);
-        const auto &submit = pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit.commandBufferInfoCount; i++) {
-            auto gpu_cb = Get<gpu_tracker::CommandBuffer>(submit.pCommandBufferInfos[i].commandBuffer);
-            gpu_cb->PreProcess(loc);
-            for (auto *secondary_cb : gpu_cb->linkedCommandBuffers) {
-                auto secondary_guard = secondary_cb->WriteLock();
-                auto *secondary_gpu_cb = static_cast<gpu_tracker::CommandBuffer *>(secondary_cb);
-                secondary_gpu_cb->PreProcess(loc);
-            }
-        }
-    }
-    BaseClass::PreCallRecordQueueSubmit2KHR(queue, submitCount, pSubmits, fence, record_obj);
-}
-
-void GpuShaderInstrumentor::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits,
-                                                      VkFence fence, const RecordObject &record_obj) {
-    for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        Location loc = record_obj.location.dot(vvl::Field::pSubmits, submit_idx);
-        const auto &submit = pSubmits[submit_idx];
-        for (uint32_t i = 0; i < submit.commandBufferInfoCount; i++) {
-            auto gpu_cb = Get<gpu_tracker::CommandBuffer>(submit.pCommandBufferInfos[i].commandBuffer);
-            gpu_cb->PreProcess(loc);
-            for (auto *secondary_cb : gpu_cb->linkedCommandBuffers) {
-                auto secondary_guard = secondary_cb->WriteLock();
-                auto *secondary_gpu_cb = static_cast<gpu_tracker::CommandBuffer *>(secondary_cb);
-                secondary_gpu_cb->PreProcess(loc);
-            }
-        }
-    }
-    BaseClass::PreCallRecordQueueSubmit2(queue, submitCount, pSubmits, fence, record_obj);
-}
-
 template <typename CreateInfo>
 VkShaderModule GetShaderModule(const CreateInfo &create_info, VkShaderStageFlagBits stage) {
     for (uint32_t i = 0; i < create_info.stageCount; ++i) {

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -167,13 +167,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
                                       const RecordObject &record_obj) override;
 
-    void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
-                                  const RecordObject &record_obj) override;
-    void PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits, VkFence fence,
-                                      const RecordObject &record_obj) override;
-    void PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2 *pSubmits, VkFence fence,
-                                   const RecordObject &record_obj) override;
-
     VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer) const;
 
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message, bool vma_fail = false) const;

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -49,16 +49,11 @@ void vvl::QueueSubmission::EndUse() {
     }
 }
 
-void vvl::Queue::SetupSubmissions(std::vector<vvl::QueueSubmission> &submissions) {
-    assert(!submissions.empty());
-    for (auto &s : submissions) {
-        s.seq = ++seq_;
+vvl::PreSubmitResult vvl::Queue::PreSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
+    if (!submissions.empty()) {
+        submissions.back().end_batch = true;
     }
-    submissions.back().end_batch = true;
-}
-
-vvl::SubmitResult vvl::Queue::PostSubmit(std::vector<vvl::QueueSubmission> &&submissions) {
-    SubmitResult result;
+    PreSubmitResult result;
     for (auto &submission : submissions) {
         for (auto &cb_state : submission.cbs) {
             auto cb_guard = cb_state->WriteLock();
@@ -69,7 +64,10 @@ vvl::SubmitResult vvl::Queue::PostSubmit(std::vector<vvl::QueueSubmission> &&sub
             cb_state->IncrementResources();
             cb_state->Submit(VkHandle(), submission.perf_submit_pass, submission.loc.Get());
         }
-        assert(submission.seq != 0);
+        // seq_ is atomic so we don't need a lock until updating the deque below.
+        // Note that this relies on the external synchonization requirements for the
+        // VkQueue
+        submission.seq = ++seq_;
         submission.BeginUse();
         for (auto &wait : submission.wait_semaphores) {
             wait.semaphore->EnqueueWait(SubmissionReference(this, submission.seq), wait.payload);
@@ -87,7 +85,6 @@ vvl::SubmitResult vvl::Queue::PostSubmit(std::vector<vvl::QueueSubmission> &&sub
         }
         {
             auto guard = Lock();
-            PostSubmit(submission);
             submissions_.emplace_back(std::move(submission));
             if (!thread_) {
                 thread_ = std::make_unique<std::thread>(&Queue::ThreadFunc, this);
@@ -150,6 +147,13 @@ void vvl::Queue::Destroy() {
         dead_thread.reset();
     }
     StateObject::Destroy();
+}
+
+void vvl::Queue::PostSubmit() {
+    auto guard = Lock();
+    if (!submissions_.empty()) {
+        PostSubmit(submissions_.back());
+    }
 }
 
 vvl::QueueSubmission *vvl::Queue::NextSubmission() {

--- a/layers/state_tracker/queue_state.cpp
+++ b/layers/state_tracker/queue_state.cpp
@@ -207,7 +207,7 @@ void vvl::Queue::Retire(QueueSubmission &submission) {
         cb_state->Retire(submission.perf_submit_pass, is_query_updated_after);
     }
     for (auto &signal : submission.signal_semaphores) {
-        signal.semaphore->RetireSignal(this, signal.payload, submission.loc.Get());
+        signal.semaphore->RetireSignal(signal.payload);
     }
     if (submission.fence) {
         submission.fence->Retire();

--- a/layers/state_tracker/queue_state.h
+++ b/layers/state_tracker/queue_state.h
@@ -76,7 +76,9 @@ static inline std::chrono::time_point<std::chrono::steady_clock> GetCondWaitTime
     return std::chrono::steady_clock::now() + std::chrono::seconds(10);
 }
 
-struct SubmitResult {
+struct PreSubmitResult {
+    uint64_t last_submission_seq = 0;
+
     bool has_external_fence = false;
     uint64_t submission_with_external_fence_seq = 0;
 };
@@ -97,10 +99,10 @@ class Queue : public StateObject {
 
     VkQueue VkHandle() const { return handle_.Cast<VkQueue>(); }
 
-    void SetupSubmissions(std::vector<QueueSubmission> &submissions);
-
+    // called from the various PreCallRecordQueueSubmit() methods
+    virtual PreSubmitResult PreSubmit(std::vector<QueueSubmission> &&submissions);
     // called from the various PostCallRecordQueueSubmit() methods
-    virtual SubmitResult PostSubmit(std::vector<QueueSubmission> &&submissions);
+    void PostSubmit();
 
     // Tell the queue thread that submissions up to and including the submission with
     // sequence number until_seq have finished. kU64Max means to finish all submissions.

--- a/layers/state_tracker/semaphore_state.h
+++ b/layers/state_tracker/semaphore_state.h
@@ -63,7 +63,6 @@ class Semaphore : public RefcountedStateObject {
         std::optional<Func> acquire_command;
         std::promise<void> completed;
         std::shared_future<void> waiter;
-        bool pending_wait = false;  // WORKAROUND when wait can't see a signal (then signal has to see the wait)
 
         TimePoint() : completed(), waiter(completed.get_future()) {}
         bool HasSignaler() const { return signal_submit.has_value() || acquire_command.has_value(); }
@@ -92,7 +91,7 @@ class Semaphore : public RefcountedStateObject {
     void RetireWait(Queue *current_queue, uint64_t payload, const Location &loc, bool queue_thread = false);
 
     // Process signal by retiring timeline timepoints up to the specified payload
-    void RetireSignal(Queue *current_queue, uint64_t payload, const Location &loc);
+    void RetireSignal(uint64_t payload);
 
     // Look for most recent / highest payload operation that matches
     std::optional<SemOp> LastOp(

--- a/layers/state_tracker/state_tracker.h
+++ b/layers/state_tracker/state_tracker.h
@@ -915,10 +915,14 @@ class ValidationStateTracker : public ValidationObject {
                                          const RecordObject& record_obj) override;
     void PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject& record_obj) override;
     void PostCallRecordEndCommandBuffer(VkCommandBuffer commandBuffer, const RecordObject& record_obj) override;
+    void PreCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
+                                      const RecordObject& record_obj) override;
     void PostCallRecordQueueBindSparse(VkQueue queue, uint32_t bindInfoCount, const VkBindSparseInfo* pBindInfo, VkFence fence,
                                        const RecordObject& record_obj) override;
     void PostCallRecordQueuePresentKHR(VkQueue queue, const VkPresentInfoKHR* pPresentInfo,
                                        const RecordObject& record_obj) override;
+    void PreCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
+                                  const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo* pSubmits, VkFence fence,
                                    const RecordObject& record_obj) override;
     void PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject& record_obj) override;
@@ -1602,6 +1606,10 @@ class ValidationStateTracker : public ValidationObject {
                                              uint32_t query, const RecordObject& record_obj) override;
     void PostCallRecordCmdWriteTimestamp2(VkCommandBuffer commandBuffer, VkPipelineStageFlags2 stage, VkQueryPool queryPool,
                                           uint32_t query, const RecordObject& record_obj) override;
+    void PreCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
+                                      const RecordObject& record_obj) override;
+    void PreCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,
+                                   const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR* pSubmits, VkFence fence,
                                        const RecordObject& record_obj) override;
     void PostCallRecordQueueSubmit2(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2* pSubmits, VkFence fence,


### PR DESCRIPTION
Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8461

Discussed with ~@jeremy-lunarg~ @jeremyg-lunarg  reverted commit.  PreRecord guarantees that any dependent PostRecord will see registered signals/waits in semaphore state object. There is a code that relies on this (when retiring non-external semaphore wait, there should be a signal).
