### PR TITLE
layers: Fix vkGetPipelineKeyKHR with null createinfo

### DIFF
--- a/layers/core_checks/cc_pipeline.cpp
+++ b/layers/core_checks/cc_pipeline.cpp
@@ -716,6 +716,9 @@ bool CoreChecks::PreCallValidateGetPipelineKeyKHR(VkDevice device, const VkPipel
                                                   VkPipelineBinaryKeyKHR *pPipelineKey, const ErrorObject &error_obj) const {
     bool skip = false;
 
+    // Used when getting global key
+    if (!pPipelineCreateInfo) return skip;
+
     const VkBaseOutStructure *pipeline_create_info = reinterpret_cast<const VkBaseOutStructure *>(pPipelineCreateInfo->pNext);
     if (pipeline_create_info) {
         if (pipeline_create_info->sType != VK_STRUCTURE_TYPE_EXECUTION_GRAPH_PIPELINE_CREATE_INFO_AMDX &&

--- a/tests/unit/pipeline_binary_positive.cpp
+++ b/tests/unit/pipeline_binary_positive.cpp
@@ -168,5 +168,15 @@ TEST_F(PositivePipelineBinary, GetPipelineKey) {
 
     VkPipelineBinaryKeyKHR pipeline_key = vku::InitStructHelper();
 
-    vk::GetPipelineKeyKHR(device(), &pipeline_create_info, &pipeline_key);
+    ASSERT_EQ(VK_SUCCESS, vk::GetPipelineKeyKHR(device(), &pipeline_create_info, &pipeline_key));
+}
+
+TEST_F(PositivePipelineBinary, GetPipelineKeyGlobal) {
+    TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8544");
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_PIPELINE_BINARY_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::pipelineBinaries);
+    RETURN_IF_SKIP(Init());
+    VkPipelineBinaryKeyKHR pipeline_key = vku::InitStructHelper();
+    ASSERT_EQ(VK_SUCCESS, vk::GetPipelineKeyKHR(device(), nullptr, &pipeline_key));
 }


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8544