### PR TITLE
gpu: Print internal shader ID in error message

### DIFF
--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -340,10 +340,10 @@ void Validator::AnalyzeAndGenerateMessage(VkCommandBuffer command_buffer, VkQueu
         }
 
         if (verbose) {
-            std::string debug_info_message =
-                GenerateDebugInfoMessage(command_buffer, instructions, debug_record->stage_id, debug_record->stage_info_0,
-                                         debug_record->stage_info_1, debug_record->stage_info_2, debug_record->instruction_position,
-                                         tracker_info, buffer_info.pipeline_bind_point, buffer_info.action_command_index);
+            std::string debug_info_message = GenerateDebugInfoMessage(
+                command_buffer, instructions, debug_record->stage_id, debug_record->stage_info_0, debug_record->stage_info_1,
+                debug_record->stage_info_2, debug_record->instruction_position, tracker_info, debug_record->shader_id,
+                buffer_info.pipeline_bind_point, buffer_info.action_command_index);
             if (use_stdout) {
                 std::cout << "WARNING-DEBUG-PRINTF " << shader_message.str() << '\n' << debug_info_message;
             } else {

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -1578,7 +1578,7 @@ static void GenerateStageMessage(std::ostringstream &ss, uint32_t stage_id, uint
 std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
     VkCommandBuffer commandBuffer, const std::vector<spirv::Instruction> &instructions, uint32_t stage_id, uint32_t stage_info_0,
     uint32_t stage_info_1, uint32_t stage_info_2, uint32_t instruction_position, const gpu::GpuAssistedShaderTracker *tracker_info,
-    VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const {
+    uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const {
     std::ostringstream ss;
     if (instructions.empty() || !tracker_info) {
         ss << "[Internal Error] - Can't get instructions from shader_map\n";
@@ -1616,15 +1616,16 @@ std::string GpuShaderInstrumentor::GenerateDebugInfoMessage(
 
         if (tracker_info->shader_module == VK_NULL_HANDLE) {
             ss << "Shader Object " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(tracker_info->shader_object)) << "("
-               << HandleToUint64(tracker_info->shader_object) << ")\n";
+               << HandleToUint64(tracker_info->shader_object) << ") (internal ID " << shader_id << ")\n";
         } else {
             ss << "Pipeline " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(tracker_info->pipeline)) << "("
-               << HandleToUint64(tracker_info->pipeline) << ")\n";
+               << HandleToUint64(tracker_info->pipeline) << ")";
             if (tracker_info->shader_module == gpu::kPipelineStageInfoHandle) {
-                ss << "Shader Module was passed in via VkPipelineShaderStageCreateInfo::pNext\n";
+                ss << " (internal ID " << shader_id
+                   << ")\nShader Module was passed in via VkPipelineShaderStageCreateInfo::pNext\n";
             } else {
-                ss << "Shader Module " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(tracker_info->shader_module))
-                   << "(" << HandleToUint64(tracker_info->shader_module) << ")\n";
+                ss << "\nShader Module " << LookupDebugUtilsNameNoLock(debug_report, HandleToUint64(tracker_info->shader_module))
+                   << "(" << HandleToUint64(tracker_info->shader_module) << ") (internal ID " << shader_id << ")\n";
             }
         }
     }

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.h
@@ -184,7 +184,8 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::vector<spirv::Instruction> &instructions,
                                          uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2,
                                          uint32_t instruction_position, const gpu::GpuAssistedShaderTracker *tracker_info,
-                                         VkPipelineBindPoint pipeline_bind_point, uint32_t operation_index) const;
+                                         uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point,
+                                         uint32_t operation_index) const;
 
   protected:
     std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -559,7 +559,7 @@ bool LogInstrumentationError(Validator &gpuav, VkCommandBuffer cmd_buffer, const
             cmd_buffer, instructions, error_record[gpuav::glsl::kHeaderStageIdOffset],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_0], error_record[gpuav::glsl::kHeaderStageInfoOffset_1],
             error_record[gpuav::glsl::kHeaderStageInfoOffset_2], error_record[gpuav::glsl::kHeaderInstructionIdOffset],
-            tracker_info, pipeline_bind_point, operation_index);
+            tracker_info, shader_id, pipeline_bind_point, operation_index);
 
         if (uses_robustness && oob_access) {
             if (gpuav.gpuav_settings.warn_on_robust_oob) {


### PR DESCRIPTION
now the error message will display

> Shader Module (4fac1c0000000032) (internal ID 1)

which is **SUPER** nice when you have large app and do a `VK_LAYER_GPUAV_DEBUG_DUMP_INSTRUMENTED_SHADERS` and need to line up which shader matches the error