### PR TITLE
layers: Split long android error messages

### DIFF
--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -33,7 +33,6 @@
 
 #if defined __ANDROID__
 #include <android/log.h>
-#define LOGCONSOLE(...) ((void)__android_log_print(ANDROID_LOG_INFO, "VALIDATION", __VA_ARGS__))
 [[maybe_unused]] static const char *kForceDefaultCallbackKey = "debug.vvl.forcelayerlog";
 #endif
 

--- a/layers/vk_layer_config.cpp
+++ b/layers/vk_layer_config.cpp
@@ -502,7 +502,8 @@ void __attribute__((constructor)) CheckAndroidVersion() {
     }
 
     if (queried_version < target_android_api) {
-        LOGCONSOLE("ERROR - Android version is %d and needs to be 26 or above.", queried_version);
+        __android_log_print(ANDROID_LOG_FATAL, "VALIDATION", "ERROR - Android version is %d and needs to be 26 or above.",
+                            queried_version);
     }
 }
 


### PR DESCRIPTION
closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8430

now will print the full error message in logcat

```
I VALIDATION: VUID-vkCmdDraw-None-06479(ERROR / SPEC): msgNum: 1268585879 - Validation Error: [ VUID-vkCmdDraw-None-06479 ] Object 0: handle = 0xd5b26f0000000010, type = VK_OBJECT_TYPE_DESCRIPTOR_SET; Object 1: handle = 0xd897d90000000016, type = VK_OBJECT_TYPE_IMAGE_VIEW; | MessageID = 0x4b9d1597 | vkCmdDraw():  the descriptor VkDescriptorSet 0xd5b26f0000000010[] [Set 0, Binding 1, Index 0, variable "tex"] has VkImageView 0xd897d90000000016[] with format of VK_FORMAT_R4G4_UNORM_PACK8 which doesn't support VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT.
I VALIDATION: (supported features: VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT|VK_FORMAT_FEATURE_2_BLIT_SRC_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_LINEAR_BIT|VK_FORMAT_FEATURE_2_TRANSFER_SRC_BIT|VK_FORMAT_FEATURE_2_TRANSFER_DST_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_FILTER_MINMAX_BIT|VK_FORMAT_FEATURE_2_MIDPOINT_CHROMA_SAMPLES_BIT|VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT).
I VALIDATION: The Vulkan spec states: If a VkImageView is sampled with depth comparison, the i
I VALIDATION: age view's format features must contain VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCmdDraw-None-06479)
I VALIDATION:     Objects: 2
I VALIDATION:         [0] 0xd5b26f0000000010, type: 23, name: NULL
I VALIDATION:         [1] 0xd897d90000000016, type: 14, name: NULL
```