### PR TITLE
printf: Improve the debugprintf settings

### DIFF
--- a/layers/VkLayer_khronos_validation.json.in
+++ b/layers/VkLayer_khronos_validation.json.in
@@ -137,6 +137,14 @@
                             "value": [
                                 "error"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": true
                         }
                     ]
                 },
@@ -211,6 +219,14 @@
                             "value": [
                                 "error"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": true
                         }
                     ]
                 },
@@ -288,6 +304,14 @@
                                 "warn",
                                 "perf"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": true
                         }
                     ]
                 },
@@ -363,6 +387,14 @@
                             "value": [
                                 "error"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": true
                         }
                     ]
                 },
@@ -440,6 +472,14 @@
                             "value": [
                                 "error"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": "VK_DBG_LAYER_ACTION_LOG_MSG"
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": true
                         }
                     ]
                 },
@@ -511,8 +551,17 @@
                         {
                             "key": "report_flags",
                             "value": [
-                                "error"
+                                "error",
+                                "info"
                             ]
+                        },
+                        {
+                            "key": "debug_action",
+                            "value": ""
+                        },
+                        {
+                            "key": "enable_message_limit",
+                            "value": false
                         }
                     ]
                 }
@@ -819,7 +868,7 @@
                                         {
                                             "key": "printf_verbose",
                                             "label": "Printf verbose",
-                                            "description": "Set the verbosity of debug printf messages",
+                                            "description": "Will print out handles, instruction location, position in command buffer, and more",
                                             "type": "BOOL",
                                             "default": false,
                                             "platforms": [
@@ -839,7 +888,7 @@
                                         {
                                             "key": "printf_buffer_size",
                                             "label": "Printf buffer size",
-                                            "description": "Set the size in bytes of the buffer used by debug printf",
+                                            "description": "Set the size in bytes of the buffer per draw/dispatch/traceRays to hold the messages",
                                             "type": "INT",
                                             "default": 1024,
                                             "range": {

--- a/layers/error_message/logging.cpp
+++ b/layers/error_message/logging.cpp
@@ -731,7 +731,9 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerLogCallback(VkDebugUtilsMessageSeverityF
 
     msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
                << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << '\n';
-    msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
+    if (callback_data->objectCount > 0) {
+        msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
+    }
     for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
         msg_buffer << "        [" << obj << "] " << std::hex << std::showbase
                    << HandleToUint64(callback_data->pObjects[obj].objectHandle) << ", type: " << std::dec << std::noshowbase
@@ -777,7 +779,9 @@ VKAPI_ATTR VkBool32 VKAPI_CALL MessengerWin32DebugOutputMsg(VkDebugUtilsMessageS
 
     msg_buffer << callback_data->pMessageIdName << "(" << msg_severity << " / " << msg_type
                << "): msgNum: " << callback_data->messageIdNumber << " - " << callback_data->pMessage << '\n';
-    msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
+    if (callback_data->objectCount > 0) {
+        msg_buffer << "    Objects: " << callback_data->objectCount << '\n';
+    }
 
     for (uint32_t obj = 0; obj < callback_data->objectCount; ++obj) {
         msg_buffer << "       [" << obj << "]  " << std::hex << std::showbase

--- a/layers/error_message/logging.h
+++ b/layers/error_message/logging.h
@@ -190,7 +190,7 @@ class DebugReport {
     // This mutex is defined as mutable since the normal usage for a debug report object is as 'const'. The mutable keyword allows
     // the layers to continue this pattern, but also allows them to use/change this specific member for synchronization purposes.
     mutable std::mutex debug_output_mutex;
-    uint32_t duplicate_message_limit = 0;
+    uint32_t duplicate_message_limit = 0;  // zero will keep printing forever
     const void *instance_pnext_chain{};
     bool force_default_log_callback{false};
     uint32_t device_created = 0;

--- a/layers/gpu/core/gpu_settings.h
+++ b/layers/gpu/core/gpu_settings.h
@@ -70,10 +70,8 @@ struct GpuAVSettings {
         validate_indirect_trace_rays_buffers = enabled;
         validate_buffer_copies = enabled;
     }
-};
 
-struct DebugPrintfSettings {
-    bool to_stdout = false;
-    bool verbose = false;
-    uint32_t buffer_size = 1024;
+    bool debug_printf_to_stdout = false;
+    bool debug_printf_verbose = false;
+    uint32_t debug_printf_buffer_size = 1024;
 };

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -342,7 +342,7 @@ void Validator::InitSettings(const Location &loc) {
         if (!enabled_features.bufferDeviceAddress) {
             shader_instrumentation.bindless_descriptor = false;
             InternalWarning(device, loc,
-                            "Descriptors Indexing validaiton optin was enabled. but the bufferDeviceAddress was not enabled "
+                            "Descriptors Indexing Validation optin was enabled. but the bufferDeviceAddress was not enabled "
                             "[Disabling gpuav_descriptor_checks]");
         }
     }

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -153,9 +153,5 @@ class Validator : public gpu::GpuShaderInstrumentor {
 
     std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer cb, const VkCommandBufferAllocateInfo* create_info,
                                                              const vvl::CommandPool* pool) final;
-
-  private:
-    bool verbose = false;
-    bool use_stdout = false;
 };
 }  // namespace debug_printf

--- a/layers/layer_options.h
+++ b/layers/layer_options.h
@@ -87,7 +87,6 @@ struct GlobalSettings {
 
 class DebugReport;
 struct GpuAVSettings;
-struct DebugPrintfSettings;
 struct SyncValSettings;
 struct MessageFormatSettings;
 struct ConfigAndEnvSettings {
@@ -108,7 +107,6 @@ struct ConfigAndEnvSettings {
 
     // Individual settings for different internal layers
     GpuAVSettings *gpuav_settings;
-    DebugPrintfSettings *printf_settings;
     SyncValSettings *syncval_settings;
 };
 const std::vector<std::string> &GetDisableFlagNameHelper();

--- a/layers/vulkan/generated/chassis.cpp
+++ b/layers/vulkan/generated/chassis.cpp
@@ -498,12 +498,11 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     CHECK_DISABLED local_disables{};
     GlobalSettings local_global_settings = {};
     GpuAVSettings local_gpuav_settings = {};
-    DebugPrintfSettings local_printf_settings = {};
     SyncValSettings local_syncval_settings = {};
-    ConfigAndEnvSettings config_and_env_settings_data{
-        OBJECT_LAYER_DESCRIPTION, pCreateInfo, local_enables, local_disables, debug_report,
-        // All settings for various internal layers
-        &local_global_settings, &local_gpuav_settings, &local_printf_settings, &local_syncval_settings};
+    ConfigAndEnvSettings config_and_env_settings_data{OBJECT_LAYER_DESCRIPTION, pCreateInfo, local_enables, local_disables,
+                                                      debug_report,
+                                                      // All settings for various internal layers
+                                                      &local_global_settings, &local_gpuav_settings, &local_syncval_settings};
     ProcessConfigAndEnvSettings(&config_and_env_settings_data);
 
     // Create temporary dispatch vector for pre-calls until instance is created
@@ -562,7 +561,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
     framework->enabled = local_enables;
     framework->global_settings = local_global_settings;
     framework->gpuav_settings = local_gpuav_settings;
-    framework->printf_settings = local_printf_settings;
     framework->syncval_settings = local_syncval_settings;
 
     framework->instance = *pInstance;
@@ -583,7 +581,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateInstance(const VkInstanceCreateInfo* pCreat
         intercept->disabled = framework->disabled;
         intercept->global_settings = framework->global_settings;
         intercept->gpuav_settings = framework->gpuav_settings;
-        intercept->printf_settings = framework->printf_settings;
         intercept->syncval_settings = framework->syncval_settings;
         intercept->instance = *pInstance;
     }
@@ -735,7 +732,6 @@ VKAPI_ATTR VkResult VKAPI_CALL CreateDevice(VkPhysicalDevice gpu, const VkDevice
         object->enabled = instance_interceptor->enabled;
         object->global_settings = instance_interceptor->global_settings;
         object->gpuav_settings = instance_interceptor->gpuav_settings;
-        object->printf_settings = instance_interceptor->printf_settings;
         object->syncval_settings = instance_interceptor->syncval_settings;
         object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
         object->instance_extensions = instance_interceptor->instance_extensions;

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2247,7 +2247,6 @@ class ValidationObject {
     CHECK_ENABLED enabled = {};
     GlobalSettings global_settings = {};
     GpuAVSettings gpuav_settings = {};
-    DebugPrintfSettings printf_settings = {};
     SyncValSettings syncval_settings = {};
 
     VkInstance instance = VK_NULL_HANDLE;

--- a/scripts/generators/layer_chassis_generator.py
+++ b/scripts/generators/layer_chassis_generator.py
@@ -432,7 +432,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_ENABLED enabled = {};
                 GlobalSettings global_settings = {};
                 GpuAVSettings gpuav_settings = {};
-                DebugPrintfSettings printf_settings = {};
                 SyncValSettings syncval_settings = {};
 
                 VkInstance instance = VK_NULL_HANDLE;
@@ -1106,12 +1105,11 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 CHECK_DISABLED local_disables{};
                 GlobalSettings local_global_settings = {};
                 GpuAVSettings local_gpuav_settings = {};
-                DebugPrintfSettings local_printf_settings = {};
                 SyncValSettings local_syncval_settings = {};
                 ConfigAndEnvSettings config_and_env_settings_data{
                     OBJECT_LAYER_DESCRIPTION, pCreateInfo, local_enables, local_disables, debug_report,
                     // All settings for various internal layers
-                    &local_global_settings, &local_gpuav_settings, &local_printf_settings, &local_syncval_settings};
+                    &local_global_settings, &local_gpuav_settings, &local_syncval_settings};
                 ProcessConfigAndEnvSettings(&config_and_env_settings_data);
 
                 // Create temporary dispatch vector for pre-calls until instance is created
@@ -1170,7 +1168,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                 framework->enabled = local_enables;
                 framework->global_settings = local_global_settings;
                 framework->gpuav_settings = local_gpuav_settings;
-                framework->printf_settings = local_printf_settings;
                 framework->syncval_settings = local_syncval_settings;
 
                 framework->instance = *pInstance;
@@ -1191,7 +1188,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     intercept->disabled = framework->disabled;
                     intercept->global_settings = framework->global_settings;
                     intercept->gpuav_settings = framework->gpuav_settings;
-                    intercept->printf_settings = framework->printf_settings;
                     intercept->syncval_settings = framework->syncval_settings;
                     intercept->instance = *pInstance;
                 }
@@ -1342,7 +1338,6 @@ class LayerChassisOutputGenerator(BaseGenerator):
                     object->enabled = instance_interceptor->enabled;
                     object->global_settings = instance_interceptor->global_settings;
                     object->gpuav_settings = instance_interceptor->gpuav_settings;
-                    object->printf_settings = instance_interceptor->printf_settings;
                     object->syncval_settings = instance_interceptor->syncval_settings;
                     object->instance_dispatch_table = instance_interceptor->instance_dispatch_table;
                     object->instance_extensions = instance_interceptor->instance_extensions;


### PR DESCRIPTION
Does 2 main things

1. Move the settings together (from https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8561)
2. Add **much** nicer error messages on what is going on with very common mistakes one would get trying to use debugprintf