### PR TITLE
layers: Sending setting warning through debug callback

### DIFF
--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -484,7 +484,7 @@ void GpuShaderInstrumentor::PostCallRecordCreateShaderModule(VkDevice device, co
                                                              chassis::CreateShaderModule &chassis_state) {
     BaseClass::PostCallRecordCreateShaderModule(device, pCreateInfo, pAllocator, pShaderModule, record_obj, chassis_state);
 
-    // By default, we instrument everything, but if the setting is turned on, we only will instrument th{e shaders the app picks
+    // By default, we instrument everything, but if the setting is enabled, we only will instrument the shaders the app picks
     if (gpuav_settings.select_instrumented_shaders && IsSelectiveInstrumentationEnabled(pCreateInfo->pNext)) {
         // If this is being filled up, likely only a few shaders and the app scope is narrowed down, so no need to spend time
         // removing these later

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -651,7 +651,7 @@ struct Module {
     VulkanTypedHandle handle_;                            // Will be updated once its known its valid SPIR-V
     VulkanTypedHandle handle() const { return handle_; }  // matches normal convention to get handle
 
-    // Used for when modifying the SPIR-V (spirv-opt, GPU-AV instrumentation, etc) and need reparse it for VVL validaiton
+    // Used for when modifying the SPIR-V (spirv-opt, GPU-AV instrumentation, etc) and need reparse it for VVL validation
     Module(vvl::span<const uint32_t> code) : valid_spirv(true), words_(code.begin(), code.end()), static_data_(*this) {}
 
     // StatelessData is a pointer as we have cases were we don't need it and simpler to just null check the few cases that use it


### PR DESCRIPTION
Update to https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8564

found that warnings NEED to go through the callback or else they can easily be lost in the void....forever!!