### PR TITLE
Add exceptions for copying compressed images

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -871,7 +871,7 @@ class CoreChecks : public ValidationStateTracker {
 
     bool CheckItgExtent(const LogObjectList& objlist, const VkExtent3D& extent, const VkOffset3D& offset,
                         const VkExtent3D& granularity, const VkExtent3D& subresource_extent, const VkImageType image_type,
-                        const Location& extent_loc, const char* vuid) const;
+                        const VkFormat format, const Location& extent_loc, const char* vuid) const;
 
     bool CheckItgOffset(const LogObjectList& objlist, const VkOffset3D& offset, const VkExtent3D& granularity,
                         const Location& offset_loc, const char* vuid) const;


### PR DESCRIPTION
Seen in #1946

This has been an open spec issue for a long time, and it doesn't seem like it will get resolved soon. We should add exceptions allowing copying from and to compressed images when `block.height > extent.height`.

Without this, it is impossible to copy the last mip level and there are also CTS tests covering this.