### PR TITLE
gpu: Revert forcing of ray query

### DIFF
--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -193,31 +193,6 @@ void Validator::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const
             }
         }
     }
-
-    // Force rayQuery feature if available and needed
-    // ---
-    if (gpuav_settings.shader_instrumentation.ray_query) {
-        VkPhysicalDeviceRayQueryFeaturesKHR ray_query_feature_check = vku::InitStructHelper();
-        VkPhysicalDeviceFeatures2 features_2 = vku::InitStructHelper(&ray_query_feature_check);
-        DispatchGetPhysicalDeviceFeatures2(physicalDevice, &features_2);
-        if (ray_query_feature_check.rayQuery && IsExtensionAvailable(VK_KHR_RAY_QUERY_EXTENSION_NAME, available_extensions)) {
-            vku::AddExtension(*modified_create_info, VK_KHR_RAY_QUERY_EXTENSION_NAME);
-            if (auto *ray_query_feature = const_cast<VkPhysicalDeviceRayQueryFeaturesKHR *>(
-                    vku::FindStructInPNextChain<VkPhysicalDeviceRayQueryFeaturesKHR>(modified_create_info))) {
-                if (!ray_query_feature->rayQuery) {
-                    InternalWarning(device, record_obj.location,
-                                    "Forcing VkPhysicalDeviceRayQueryFeaturesKHR::rayQuery to VK_TRUE");
-                    ray_query_feature->rayQuery = VK_TRUE;
-                }
-            } else {
-                InternalWarning(device, record_obj.location,
-                                "Adding a VkPhysicalDeviceRayQueryFeaturesKHR to pNext with rayQuery set to VK_TRUE");
-                VkPhysicalDeviceRayQueryFeaturesKHR new_bda_features = vku::InitStructHelper();
-                new_bda_features.rayQuery = VK_TRUE;
-                vku::AddToPnext(*modified_create_info, new_bda_features);
-            }
-        }
-    }
 }
 
 // Perform initializations that can be done at Create Device time.
@@ -359,12 +334,15 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
 // At this point extensions/features may have been turned on by us in PreCallRecord.
 // Now that we have all the information, here is where we might disable GPU-AV settings that are missing requirements
 void Validator::InitSettings(const Location &loc) {
+    VkPhysicalDeviceFeatures supported_features{};
+    DispatchGetPhysicalDeviceFeatures(physical_device, &supported_features);
+
     GpuAVSettings::ShaderInstrumentation &shader_instrumentation = gpuav_settings.shader_instrumentation;
     if (shader_instrumentation.bindless_descriptor) {
         if (!enabled_features.bufferDeviceAddress) {
             shader_instrumentation.bindless_descriptor = false;
             InternalWarning(device, loc,
-                            "Descriptors Indexing Validation optin was enabled. but the bufferDeviceAddress was not supported "
+                            "Descriptors Indexing Validation optin was enabled. but the bufferDeviceAddress was not enabled "
                             "[Disabling gpuav_descriptor_checks]");
         }
     }
@@ -372,14 +350,13 @@ void Validator::InitSettings(const Location &loc) {
     if (shader_instrumentation.buffer_device_address) {
         const bool bda_validation_possible = ((IsExtEnabled(device_extensions.vk_ext_buffer_device_address) ||
                                                IsExtEnabled(device_extensions.vk_khr_buffer_device_address)) &&
-                                              enabled_features.shaderInt64 && enabled_features.bufferDeviceAddress);
+                                              supported_features.shaderInt64 && enabled_features.bufferDeviceAddress);
         if (!bda_validation_possible) {
             shader_instrumentation.buffer_device_address = false;
-            if (!enabled_features.shaderInt64) {
-                InternalWarning(
-                    device, loc,
-                    "Buffer device address validation option was enabled, but the shaderInt64 feature is not supported. "
-                    "[Disabling gpuav_buffer_address_oob].");
+            if (!supported_features.shaderInt64) {
+                InternalWarning(device, loc,
+                                "Buffer device address validation option was enabled, but the shaderInt64 feature is not enabled. "
+                                "[Disabling gpuav_buffer_address_oob].");
             } else {
                 InternalWarning(device, loc,
                                 "Buffer device address validation option was enabled, but required buffer device address extension "
@@ -392,7 +369,7 @@ void Validator::InitSettings(const Location &loc) {
         if (!enabled_features.rayQuery) {
             shader_instrumentation.ray_query = false;
             InternalWarning(device, loc,
-                            "Ray Query validation option was enabled, but the rayQuery feature is not supported. "
+                            "Ray Query validation option was enabled, but the rayQuery feature is not enabled. "
                             "[Disabling gpuav_validate_ray_query]");
         }
     }
@@ -402,7 +379,7 @@ void Validator::InitSettings(const Location &loc) {
         if (!enabled_features.uniformAndStorageBuffer8BitAccess) {
             gpuav_settings.validate_buffer_copies = false;
             InternalWarning(device, loc,
-                            "Buffer copies option was enabled, but the uniformAndStorageBuffer8BitAccess feature is not supported. "
+                            "Buffer copies option was enabled, but the uniformAndStorageBuffer8BitAccess feature is not enabled. "
                             "[Disabling gpuav_buffer_copies]");
         }
     }

--- a/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpu_shader_instrumentor.cpp
@@ -191,10 +191,6 @@ void GpuShaderInstrumentor::PreCallRecordCreateDevice(VkPhysicalDevice physicalD
                             "Forcing VkPhysicalDeviceFeatures::vertexPipelineStoresAndAtomics to VK_TRUE");
             enabled_features->vertexPipelineStoresAndAtomics = VK_TRUE;
         }
-        if (supported_features.shaderInt64 && !enabled_features->shaderInt64) {
-            InternalWarning(device, record_obj.location, "Forcing VkPhysicalDeviceFeatures::shaderInt64 to VK_TRUE");
-            enabled_features->shaderInt64 = VK_TRUE;
-        }
     }
 
     auto add_missing_features = [this, &record_obj, modified_create_info]() {

--- a/tests/unit/gpu_av.cpp
+++ b/tests/unit/gpu_av.cpp
@@ -967,8 +967,6 @@ TEST_F(NegativeGpuAV, ForceUniformAndStorageBuffer8BitAccess) {
         "Adding a VkPhysicalDevice8BitStorageFeatures to pNext with uniformAndStorageBuffer8BitAccess set to VK_TRUE");
 
     // noise
-    m_errorMonitor->SetAllowedFailureMsg("Adding a VkPhysicalDevice8BitStorageFeatures to pNext with shaderInt64 set to VK_TRUE");
-    m_errorMonitor->SetAllowedFailureMsg("Adding a VkPhysicalDeviceRayQueryFeaturesKHR to pNext with rayQuery set to VK_TRUE");
     m_errorMonitor->SetAllowedFailureMsg(
         "Adding a VkPhysicalDeviceTimelineSemaphoreFeatures to pNext with timelineSemaphore set to VK_TRUE");
     m_errorMonitor->SetAllowedFailureMsg(
@@ -980,8 +978,6 @@ TEST_F(NegativeGpuAV, ForceUniformAndStorageBuffer8BitAccess) {
     m_errorMonitor->SetAllowedFailureMsg(
         "vkGetDeviceProcAddr(): pName is trying to grab vkGetPhysicalDeviceCalibrateableTimeDomainsKHR which is an instance level "
         "function");
-    m_errorMonitor->SetAllowedFailureMsg(
-        "Internal Warning: Ray Query validation option was enabled, but the rayQuery feature is not supported.");
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->VerifyFound();
 }


### PR DESCRIPTION
This reverts commit c1f8ad1fb56dac845979536a4b082a1fa0b8bc51.

Self Validation Error: [ VUID-vkCreateDevice-ppEnabledExtensionNames-01387 ] 
Object 0: handle = 0x1ab3517f0e0, type = VK_OBJECT_TYPE_INSTANCE; | 
MessageID = 0x12537a2c | 
vkCreateDevice(): pCreateInfo->ppEnabledExtensionNames[1] Missing extension required by the device extension VK_KHR_ray_query: VK_KHR_acceleration_structure.
The Vulkan spec states: All required device extensions for each extension in the VkDeviceCreateInfo::ppEnabledExtensionNames list must also be present in that list (https://www.khronos.org/registry/vulkan/specs/1.3-extensions/html/vkspec.html#VUID-vkCreateDevice-ppEnabledExtensionNames-01387)

Not a priority now, so I am just reverting