### PR TITLE
sync: Cleanup timeline signals after queue/device wait

### DIFF
--- a/layers/sync/sync_submit.cpp
+++ b/layers/sync/sync_submit.cpp
@@ -32,7 +32,7 @@ SignalInfo::SignalInfo(const std::shared_ptr<const vvl::Semaphore>& semaphore_st
       timeline_value(timeline_value) {}
 
 SignalInfo::SignalInfo(const std::shared_ptr<const vvl::Semaphore>& semaphore_state, uint64_t timeline_value)
-    : semaphore_state(semaphore_state), timeline_value(timeline_value) {}
+    : semaphore_state(semaphore_state), first_scope(kQueueIdInvalid, SyncExecScope{}), timeline_value(timeline_value) {}
 
 SignalInfo::SignalInfo(const std::shared_ptr<const vvl::Semaphore>& semaphore_state, const PresentedImage& presented,
                        ResourceUsageTag acquire_tag)

--- a/layers/sync/sync_submit.h
+++ b/layers/sync/sync_submit.h
@@ -60,10 +60,11 @@ struct SignalInfo {
     // Signaled semaphore. Not null.
     std::shared_ptr<const vvl::Semaphore> semaphore_state;
 
-    // Batch from the signal's first scope. Null if it's a host signal (SignalSemaphore).
+    // Batch from the signal's first scope. It is null for a host signal (vkSignalSemaphore)
     std::shared_ptr<QueueBatchContext> batch;
 
-    // Use the first_scope.valid_accesses for first access scope
+    // Use the first_scope.valid_accesses for the first access scope of non-host signals.
+    // first_scope.queue is kQueueIdInvalid for a host signal (vkSignalSemaphore)
     SemaphoreScope first_scope;
 
     // Value signaled by a timeline semaphore

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -654,3 +654,35 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
     }
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
+
+TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesAllSignals) {
+    TEST_DESCRIPTION("Test for manual inspection of registered signals (VK_SYNCVAL_SHOW_STATS can be used)");
+    RETURN_IF_SKIP(InitTimelineSemaphore());
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    const uint32_t N = 100;
+    for (uint32_t i = 1; i <= N; i++) {
+        m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, i);
+        // The maximum number of registered signals will be around 25
+        if (i % 25 == 0) {
+            m_default_queue->Wait();
+        }
+    }
+    m_device->Wait();
+}
+
+TEST_F(PositiveSyncValTimelineSemaphore, DeviceWaitIdleRemovesAllSignals) {
+    TEST_DESCRIPTION("Test for manual inspection of registered signals (VK_SYNCVAL_SHOW_STATS can be used)");
+    RETURN_IF_SKIP(InitTimelineSemaphore());
+
+    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
+    const uint32_t N = 100;
+    for (uint32_t i = 1; i <= N; i++) {
+        m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, i);
+        // The maximum number of registered signals will be around 50
+        if (i % 50 == 0) {
+            m_device->Wait();
+        }
+    }
+    m_device->Wait();
+}


### PR DESCRIPTION
Addresses signals cleanup for vkQueueWaitIdle/vkDeviceWaitIdle. Main timelines PR implemented this only for vkWaitSemaphores.