### PR TITLE
sync: Cleanup signals that are never/rarely waited on

### DIFF
--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -135,6 +135,11 @@ void SyncValidator::ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchCo
             ++it;
         }
     }
+
+    // Enforce max signals limit in case timeline is signaled multiple times and never/rarely is waited on.
+    // This does not introduce errors/false-positives (check EnsureTimelineSignalsLimit documentation)
+    const uint32_t kMaxTimelineSignalsPerQueue = 100;
+    EnsureTimelineSignalsLimit(kMaxTimelineSignalsPerQueue);
 }
 
 void SyncValidator::ApplyTaggedWait(QueueId queue_id, ResourceUsageTag tag) {

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -71,6 +71,17 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     uint32_t debug_reset_count = 1;
     std::string debug_cmdbuf_pattern;
 
+    // Ensures that the number of signals per timeline per queue does not exceed the specified limit.
+    // If `queue` parameter is specified, then only that queue is checked (used by vkQueueWaitIdle).
+    // If the number of signals exceeds the limit, then signals with the smallest values are removed.
+    //
+    // Note, removing registered signals can't introduce errors/false-positives assuming at least
+    // a single signal per timeline is left. That's because if there are more than one matching signal
+    // to resolve a wait then the specification defines that only one signal is selected, which one is
+    // unspecified. In the current implementation we keep multiple signals per timeline to have additional
+    // options of validation, but, for example, keeping only the last signal is sufficient.
+    void EnsureTimelineSignalsLimit(uint32_t signals_per_queue_limit, QueueId queue = kQueueIdInvalid);
+
     // Applies information from update object to binary_signals_/timeline_signals_.
     // The update object is mutable to be able to std::move SignalInfo from it.
     void ApplySignalsUpdate(SignalsUpdate &update, const QueueBatchContext::Ptr &last_batch);

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -655,7 +655,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
 
-TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesAllSignals) {
+TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesSignals) {
     TEST_DESCRIPTION("Test for manual inspection of registered signals (VK_SYNCVAL_SHOW_STATS can be used)");
     RETURN_IF_SKIP(InitTimelineSemaphore());
 
@@ -671,7 +671,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesAllSignals) {
     m_device->Wait();
 }
 
-TEST_F(PositiveSyncValTimelineSemaphore, DeviceWaitIdleRemovesAllSignals) {
+TEST_F(PositiveSyncValTimelineSemaphore, DeviceWaitIdleRemovesignals) {
     TEST_DESCRIPTION("Test for manual inspection of registered signals (VK_SYNCVAL_SHOW_STATS can be used)");
     RETURN_IF_SKIP(InitTimelineSemaphore());
 


### PR DESCRIPTION
In contrast to binary semaphores, timeline can be signaled arbitrary amount of times without waits. Ensure resource usage does not grow unboundeadly in this case.

Also unify code that cleanups signals, so it's shared with QueueWaitIdle/DeviceWaitIdle.
