### PR TITLE
tests: Add video queues to test framework

### DIFF
--- a/tests/framework/binding.cpp
+++ b/tests/framework/binding.cpp
@@ -300,10 +300,19 @@ void Device::InitQueues(const VkDeviceCreateInfo &info) {
             if (queue_family_prop.queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
                 queues_[SPARSE].push_back(queue_storage.back().get());
             }
+
+            if (queue_family_prop.queueFlags & VK_QUEUE_VIDEO_DECODE_BIT_KHR) {
+                queues_[VIDEO_DECODE].push_back(queue_storage.back().get());
+            }
+
+            if (queue_family_prop.queueFlags & VK_QUEUE_VIDEO_ENCODE_BIT_KHR) {
+                queues_[VIDEO_ENCODE].push_back(queue_storage.back().get());
+            }
         }
     }
 
-    ASSERT_TRUE(!queues_[GRAPHICS].empty() || !queues_[COMPUTE].empty() || !queues_[TRANSFER].empty() || !queues_[SPARSE].empty());
+    ASSERT_TRUE(!queues_[GRAPHICS].empty() || !queues_[COMPUTE].empty() || !queues_[TRANSFER].empty() || !queues_[SPARSE].empty() ||
+                !queues_[VIDEO_DECODE].empty() || !queues_[VIDEO_ENCODE].empty());
 }
 
 const Device::QueueFamilyQueues &Device::QueuesFromFamily(uint32_t queue_family) const {

--- a/tests/framework/binding.h
+++ b/tests/framework/binding.h
@@ -315,7 +315,9 @@ class Device : public internal::Handle<VkDevice> {
         COMPUTE = 1,
         TRANSFER = 2,
         SPARSE = 3,
-        QUEUE_CAPABILITY_COUNT = 4,
+        VIDEO_DECODE = 4,
+        VIDEO_ENCODE = 5,
+        QUEUE_CAPABILITY_COUNT = 6,
     };
 
     void InitQueues(const VkDeviceCreateInfo &info);


### PR DESCRIPTION
On a device which has queue families that only have queueFlags `VK_QUEUE_VIDEO_DECODE_BIT_KHR` or `VK_QUEUE_VIDEO_ENCODE_BIT_KHR` and none of the others some tests would assert, for example `NegativeWsi.SwapchainNotSupported`