### PR TITLE
gpuav: Hash shaders from output, not input

### DIFF
--- a/layers/vulkan/generated/gpu_av_shader_hash.h
+++ b/layers/vulkan/generated/gpu_av_shader_hash.h
@@ -24,4 +24,4 @@
 
 #pragma once
 
-#define GPU_AV_SHADER_GIT_HASH "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+#define GPU_AV_SHADER_GIT_HASH "afacdc2997692feb9588043872345c3f8b8eaa3f"

--- a/scripts/generate_spirv.py
+++ b/scripts/generate_spirv.py
@@ -304,9 +304,13 @@ def main():
         words = compile(gpu_shaders_dir, shader, glslang, spirv_opt, args.targetenv)
         write(words, shader, args.api, args.outdir)
 
-    # Don't want to hash if just generating a single shader for testings
-    if (len(shaders_to_compile) > 1):
-        write_inst_hash(shaders_to_compile, args.outdir)
+    # Hash after we have generated the output
+    shaders_to_hash = []
+    generated_cpp = common_ci.RepoRelative('layers/vulkan/generated/')
+    for filename in os.listdir(generated_cpp):
+        if (filename.startswith('cmd_validation') or filename.startswith('instrumentation_')) and filename.split(".")[-1] == 'cpp':
+            shaders_to_hash.append(os.path.join(generated_cpp, filename))
+    write_inst_hash(shaders_to_hash, args.outdir)
 
 if __name__ == '__main__':
   main()


### PR DESCRIPTION
We were hashing the input GLSL which allowed a change like https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8620 to completely change how the shaders work (write to binding `1` not `0`) and the hash was not being updated