### PR TITLE
gpuav: Handle VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT

### DIFF
--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -294,6 +294,13 @@ void PreCallSetupShaderInstrumentationResources(Validator &gpuav, CommandBuffer 
     if (last_bound.pipeline_state && !last_bound.pipeline_state->PreRasterPipelineLayoutState()->Destroyed()) {
         inst_binding_pipe_layout_state = last_bound.pipeline_state->PreRasterPipelineLayoutState();
         inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundPipeline;
+
+        // One exception when using GPL is we need to look out for INDEPENDENT_SETS_BIT which will have null sets inside them.
+        // We have a fake merged_graphics_layout to mimic the complete layout, but the app must bind it to descriptor set
+        if (inst_binding_pipe_layout_state->create_flags & VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT) {
+            inst_binding_pipe_layout_state = gpuav.Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
+            inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundDescriptorSet;
+        }
     } else if (last_bound.desc_set_pipeline_layout) {
         inst_binding_pipe_layout_state = gpuav.Get<vvl::PipelineLayout>(last_bound.desc_set_pipeline_layout);
         inst_binding_pipe_layout_src = PipelineLayoutSource::LastBoundDescriptorSet;


### PR DESCRIPTION
I missed this in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8565 and luckily there was a DebugPrintf test that caught this when I was merging things

The issue is based on having this

```
vkt::PipelineLayout pipeline_layout_vs(device, {&vertex_set.layout_, nullptr              }, {}, VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
vkt::PipelineLayout pipeline_layout_fs(device, {nullptr,             &fragment_set.layout_}, {}, VK_PIPELINE_LAYOUT_CREATE_INDEPENDENT_SETS_BIT_EXT);
vkt::PipelineLayout pipeline_layout   (device, {&vertex_set.layout_, &fragment_set.layout_}, {},
```

and before we were grabbing the `pipeline_layout_vs` which ended up having a null set inside causing self validation error (and crashing on drivers as well in CI)