### PR TITLE
Fix issues uncovered by SC downstream

### DIFF
--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -691,7 +691,7 @@ class CoreChecks : public ValidationStateTracker {
     bool PreCallValidateCreateShaderModule(VkDevice device, const VkShaderModuleCreateInfo* pCreateInfo,
                                            const VkAllocationCallbacks* pAllocator, VkShaderModule* pShaderModule,
                                            const ErrorObject& error_obj) const override;
-    bool ValidateShaderStage(const ShaderStageState& stage_state, const vvl::Pipeline* pipeline, const Location& loc) const;
+    virtual bool ValidateShaderStage(const ShaderStageState& stage_state, const vvl::Pipeline* pipeline, const Location& loc) const;
     bool ValidatePointSizeShaderState(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,
                                       const vvl::Pipeline& pipeline, VkShaderStageFlagBits stage, const Location& loc) const;
     bool ValidatePrimitiveRateShaderState(const spirv::Module& module_state, const spirv::EntryPoint& entrypoint,

--- a/layers/state_tracker/pipeline_sub_state.h
+++ b/layers/state_tracker/pipeline_sub_state.h
@@ -141,20 +141,20 @@ std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI
 std::unique_ptr<const vku::safe_VkPipelineShaderStageCreateInfo> ToShaderStageCI(const VkPipelineShaderStageCreateInfo &cbs);
 
 struct FragmentShaderState : public PipelineSubState {
-    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data, std::shared_ptr<const vvl::RenderPass> rp,
-                        uint32_t subpass, VkPipelineLayout layout);
+    FragmentShaderState(const vvl::Pipeline &pipeline_state, const ValidationStateTracker &dev_data,
+                        std::shared_ptr<const vvl::RenderPass> rp, uint32_t subpass, VkPipelineLayout layout);
 
     template <typename CreateInfo>
-    FragmentShaderState(const vvl::Pipeline &p, const ValidationStateTracker &dev_data, const CreateInfo &create_info,
+    FragmentShaderState(const vvl::Pipeline &pipeline_state, const ValidationStateTracker &dev_data, const CreateInfo &create_info,
                         std::shared_ptr<const vvl::RenderPass> rp, spirv::StatelessData *stateless_data)
-        : FragmentShaderState(p, dev_data, rp, create_info.subpass, create_info.layout) {
+        : FragmentShaderState(pipeline_state, dev_data, rp, create_info.subpass, create_info.layout) {
         if (create_info.pMultisampleState) {
             ms_state = ToSafeMultisampleState(*create_info.pMultisampleState);
         }
         if (create_info.pDepthStencilState) {
             ds_state = ToSafeDepthStencilState(*create_info.pDepthStencilState);
         }
-        FragmentShaderState::SetFragmentShaderInfo(*this, dev_data, create_info, stateless_data);
+        FragmentShaderState::SetFragmentShaderInfo(pipeline_state, *this, dev_data, create_info, stateless_data);
     }
 
     static inline VkShaderStageFlags ValidShaderStages() { return VK_SHADER_STAGE_FRAGMENT_BIT; }
@@ -172,10 +172,11 @@ struct FragmentShaderState : public PipelineSubState {
     std::shared_ptr<const spirv::EntryPoint> fragment_entry_point;
 
   private:
-    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
-                                      const VkGraphicsPipelineCreateInfo &create_info,
+    static void SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
+                                      const ValidationStateTracker &state_data, const VkGraphicsPipelineCreateInfo &create_info,
                                       spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
-    static void SetFragmentShaderInfo(FragmentShaderState &fs_state, const ValidationStateTracker &state_data,
+    static void SetFragmentShaderInfo(const vvl::Pipeline &pipeline_state, FragmentShaderState &fs_state,
+                                      const ValidationStateTracker &state_data,
                                       const vku::safe_VkGraphicsPipelineCreateInfo &create_info,
                                       spirv::StatelessData stateless_data[kCommonMaxGraphicsShaderStages]);
 };

--- a/scripts/generate_source.py
+++ b/scripts/generate_source.py
@@ -202,7 +202,7 @@ def RunGenerators(api: str, registry: str, grammar: str, directory: str, styleFi
         },
         'chassis.cpp' : {
             'generator' : LayerChassisOutputGenerator,
-            'genCombined': False,
+            'genCombined': True,
         },
         'chassis_dispatch_helper.h' : {
             'generator' : LayerChassisOutputGenerator,


### PR DESCRIPTION
- Use combined headers for `chassis.cpp`
- Re-add virtual qualifier lost during renaming
- Propagate code duplication of module query to all call sites
  - This last item is something which should likely be refactored, as it's currently subject to copy-paste mistakes. Obtaining the module of a ShaderStage should be factored out into "one source of truth".
  - We ran into this issue because a newly added test uncovered places previously uncovered. In some copies of the module obtaining query, the pipeline cache was interrogated for the module, but not in all copies, and the newly added test stumbled across such a codepath.