### PR TITLE
sync: Apply pending state during Validate phase

### DIFF
--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -59,6 +59,8 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
     std::vector<std::shared_ptr<QueueSyncState>> queue_sync_states_;
     QueueId queue_id_limit_ = 0;
 
+    mutable std::mutex queue_submit_mutex_;
+
     // Semaphore signal registry
     vvl::unordered_map<VkSemaphore, SignalInfo> binary_signals_;
     vvl::unordered_map<VkSemaphore, std::vector<SignalInfo>> timeline_signals_;
@@ -586,7 +588,7 @@ class SyncValidator : public ValidationStateTracker, public SyncStageAccess {
                              const ErrorObject &error_obj) const;
     bool PreCallValidateQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
                                     const ErrorObject &error_obj) const override;
-    void RecordQueueSubmit(VkQueue queue, VkFence fence, const RecordObject &record_obj);
+    void RecordQueueSubmit(VkQueue queue, VkFence fence, QueueSubmitCmdState *cmd_state);
     void PostCallRecordQueueSubmit(VkQueue queue, uint32_t submitCount, const VkSubmitInfo *pSubmits, VkFence fence,
                                    const RecordObject &record_obj) override;
     bool PreCallValidateQueueSubmit2KHR(VkQueue queue, uint32_t submitCount, const VkSubmitInfo2KHR *pSubmits, VkFence fence,


### PR DESCRIPTION
This fixes false-positives in Vulkan-Samples timeline_semaphore demo and in similar multi-threaded scenarios.

Two main changes: 
* Validate phase for QueueSubmit is protected by mutex
* Validate phase does both Validation and Updates state directly instead of using pending variables.

QueueSubmit calls in syncval (Present will be update later if necessary) computed state during Validate phase. It was stored in mutable variables and then is applied in the Record phase. Having this pending variables introduce additional complexity and with timeline semaphores synchronization becomes even more difficult. 

This change applies state directly at the end of the Validate phase instead of forwarding it through pending variables. The role of the pending variables was mostly to follow conventions of Validate/Record separation. With my current understanding setting state at first in Validate (pending variables) and then in Record (regular vairables) does not bring much to the table comparing to just setting state in Validate phase bypassing pending system, assuming Validate is thread safe. On the other hand pending variables introduce additional complications, since the code had to choose in different places which type of variables to use. With this change we can remove pending variables in the following PRs.