### PR TITLE
tests: Update test functions to use consistent naming

### DIFF
--- a/tests/framework/android_hardware_buffer.h
+++ b/tests/framework/android_hardware_buffer.h
@@ -1,6 +1,6 @@
 /*
- * Copyright (c) 2023 Valve Corporation
- * Copyright (c) 2023 LunarG, Inc.
+ * Copyright (c) 2023-2024 Valve Corporation
+ * Copyright (c) 2023-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ inline bool SetAllocationInfoImportAHB(vkt::Device *device, VkAndroidHardwareBuf
     // Set index to match one of the bits in ahb_props that is also only Device Local
     // Android implemenetations "should have" a DEVICE_LOCAL only index designed for AHB
     VkMemoryPropertyFlagBits property = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
-    VkPhysicalDeviceMemoryProperties mem_props = device->phy().memory_properties_;
+    VkPhysicalDeviceMemoryProperties mem_props = device->Physical().memory_properties_;
     // AHB object hold the real allocationSize needed
     info.allocationSize = ahb_props.allocationSize;
     info.memoryTypeIndex = mem_props.memoryTypeCount + 1;

--- a/tests/framework/barrier_queue_family.cpp
+++ b/tests/framework/barrier_queue_family.cpp
@@ -58,7 +58,7 @@ void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool im
         image_.init(*device_obj, image_ci, 0);
         image_.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     } else {
-        image_.init_no_mem(*device_obj, image_ci);
+        image_.InitNoMemory(*device_obj, image_ci);
     }
 
     image_barrier_ = image_.ImageMemoryBarrier(VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_TRANSFER_READ_BIT, image_.Layout(),
@@ -69,7 +69,7 @@ void BarrierQueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool im
     if (buffer_memory) {
         buffer_.init(*device_obj, buffer_ci, mem_prop);
     } else {
-        buffer_.init_no_mem(*device_obj, buffer_ci);
+        buffer_.InitNoMemory(*device_obj, buffer_ci);
     }
     ASSERT_TRUE(buffer_.initialized());
     buffer_barrier_ = buffer_.BufferMemoryBarrier(VK_ACCESS_TRANSFER_READ_BIT, VK_ACCESS_TRANSFER_READ_BIT, 0, VK_WHOLE_SIZE);
@@ -84,7 +84,7 @@ void Barrier2QueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool i
         image_.init(*device_obj, image_ci, 0);
         image_.SetLayout(VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     } else {
-        image_.init_no_mem(*device_obj, image_ci);
+        image_.InitNoMemory(*device_obj, image_ci);
     }
 
     image_barrier_ = image_.ImageMemoryBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -96,7 +96,7 @@ void Barrier2QueueFamilyTestHelper::Init(std::vector<uint32_t> *families, bool i
     if (buffer_memory) {
         buffer_.init(*device_obj, buffer_ci, mem_prop);
     } else {
-        buffer_.init_no_mem(*device_obj, buffer_ci);
+        buffer_.InitNoMemory(*device_obj, buffer_ci);
     }
     ASSERT_TRUE(buffer_.initialized());
     buffer_barrier_ = buffer_.BufferMemoryBarrier(VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
@@ -133,12 +133,12 @@ void BarrierQueueFamilyTestHelper::operator()(const std::string &img_err, const 
 
     vkt::CommandBuffer *command_buffer = qf->command_buffer;
     for (int cb_repeat = 0; cb_repeat < (mod == Modifier::DOUBLE_COMMAND_BUFFER ? 2 : 1); cb_repeat++) {
-        command_buffer->begin();
+        command_buffer->Begin();
         for (int repeat = 0; repeat < (mod == Modifier::DOUBLE_RECORD ? 2 : 1); repeat++) {
             vk::CmdPipelineBarrier(command_buffer->handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
                                    VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 1, &buffer_barrier_, 1, &image_barrier_);
         }
-        command_buffer->end();
+        command_buffer->End();
         command_buffer = qf->command_buffer2;  // Second pass (if any) goes to the secondary command_buffer.
     }
 
@@ -187,11 +187,11 @@ void Barrier2QueueFamilyTestHelper::operator()(const std::string &img_err, const
 
     vkt::CommandBuffer *command_buffer = qf->command_buffer;
     for (int cb_repeat = 0; cb_repeat < (mod == Modifier::DOUBLE_COMMAND_BUFFER ? 2 : 1); cb_repeat++) {
-        command_buffer->begin();
+        command_buffer->Begin();
         for (int repeat = 0; repeat < (mod == Modifier::DOUBLE_RECORD ? 2 : 1); repeat++) {
             vk::CmdPipelineBarrier2KHR(command_buffer->handle(), &dep_info);
         }
-        command_buffer->end();
+        command_buffer->End();
         command_buffer = qf->command_buffer2;  // Second pass (if any) goes to the secondary command_buffer.
     }
 

--- a/tests/framework/buffer_helper.h
+++ b/tests/framework/buffer_helper.h
@@ -26,9 +26,9 @@ template <typename VertexT>
 Buffer VertexBuffer(const Device &dev, const std::vector<float> &vertices) {
     vkt::Buffer vertex_buffer(dev, vertices.size() * sizeof(VertexT), VK_BUFFER_USAGE_VERTEX_BUFFER_BIT,
                               VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    auto *vertex_buffer_ptr = static_cast<VertexT *>(vertex_buffer.memory().map());
+    auto *vertex_buffer_ptr = static_cast<VertexT *>(vertex_buffer.Memory().Map());
     std::copy(vertices.data(), vertices.data() + vertices.size(), vertex_buffer_ptr);
-    vertex_buffer.memory().unmap();
+    vertex_buffer.Memory().Unmap();
     return vertex_buffer;
 }
 
@@ -36,9 +36,9 @@ template <typename IndexT>
 Buffer IndexBuffer(const Device &dev, const std::vector<IndexT> &indices) {
     vkt::Buffer index_buffer(dev, indices.size() * sizeof(IndexT), VK_BUFFER_USAGE_INDEX_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    auto *index_buffer_ptr = static_cast<IndexT *>(index_buffer.memory().map());
+    auto *index_buffer_ptr = static_cast<IndexT *>(index_buffer.Memory().Map());
     std::copy(indices.data(), indices.data() + indices.size(), index_buffer_ptr);
-    index_buffer.memory().unmap();
+    index_buffer.Memory().Unmap();
     return index_buffer;
 }
 

--- a/tests/framework/layer_validation_tests.cpp
+++ b/tests/framework/layer_validation_tests.cpp
@@ -405,18 +405,18 @@ void VkLayerTest::SetTargetApiVersion(APIVersion target_api_version) {
 
 APIVersion VkLayerTest::DeviceValidationVersion() const {
     // The validation layers assume the version we are validating to is the apiVersion unless the device apiVersion is lower
-    return std::min(m_target_api_version, APIVersion(physDevProps().apiVersion));
+    return std::min(m_target_api_version, APIVersion(PhysicalDeviceProps().apiVersion));
 }
 
 template <>
 VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDeviceFeatures2 &features2) {
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
-        vk::GetPhysicalDeviceFeatures2(gpu(), &features2);
+        vk::GetPhysicalDeviceFeatures2(Gpu(), &features2);
     } else {
         auto vkGetPhysicalDeviceFeatures2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceFeatures2KHR>(
             vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceFeatures2KHR"));
         assert(vkGetPhysicalDeviceFeatures2KHR);
-        vkGetPhysicalDeviceFeatures2KHR(gpu(), &features2);
+        vkGetPhysicalDeviceFeatures2KHR(Gpu(), &features2);
     }
     return features2;
 }
@@ -424,12 +424,12 @@ VkPhysicalDeviceFeatures2 VkLayerTest::GetPhysicalDeviceFeatures2(VkPhysicalDevi
 template <>
 VkPhysicalDeviceProperties2 VkLayerTest::GetPhysicalDeviceProperties2(VkPhysicalDeviceProperties2 &props2) {
     if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
-        vk::GetPhysicalDeviceProperties2(gpu(), &props2);
+        vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
     } else {
         auto vkGetPhysicalDeviceProperties2KHR = reinterpret_cast<PFN_vkGetPhysicalDeviceProperties2KHR>(
             vk::GetInstanceProcAddr(instance(), "vkGetPhysicalDeviceProperties2KHR"));
         assert(vkGetPhysicalDeviceProperties2KHR);
-        vkGetPhysicalDeviceProperties2KHR(gpu(), &props2);
+        vkGetPhysicalDeviceProperties2KHR(Gpu(), &props2);
     }
     return props2;
 }
@@ -549,7 +549,7 @@ bool VkLayerTest::LoadDeviceProfileLayer(PFN_VkSetPhysicalDeviceProperties2EXT &
     return true;
 }
 
-void print_android(const char *c) {
+void PrintAndroid(const char *c) {
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
     __android_log_print(ANDROID_LOG_INFO, "VulkanLayerValidationTests", "%s", c);
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/framework/layer_validation_tests.h
+++ b/tests/framework/layer_validation_tests.h
@@ -448,4 +448,4 @@ void CreateBufferViewTest(VkLayerTest &test, const VkBufferViewCreateInfo *pCrea
 
 void CreateImageViewTest(VkLayerTest &test, const VkImageViewCreateInfo *pCreateInfo, const std::string &code = "");
 
-void print_android(const char *c);
+void PrintAndroid(const char *c);

--- a/tests/framework/pipeline_helper.cpp
+++ b/tests/framework/pipeline_helper.cpp
@@ -110,7 +110,7 @@ CreatePipelineHelper::CreatePipelineHelper(VkLayerTest &test, void *pNext) : lay
     gp_ci_.pDepthStencilState = nullptr;
     gp_ci_.pColorBlendState = &cb_ci_;
     gp_ci_.pDynamicState = nullptr;
-    gp_ci_.renderPass = layer_test_.renderPass();
+    gp_ci_.renderPass = layer_test_.RenderPass();
 }
 
 CreatePipelineHelper::~CreatePipelineHelper() { Destroy(); }
@@ -169,7 +169,7 @@ void CreatePipelineHelper::InitPreRasterLibInfo(const VkPipelineShaderStageCreat
 
     // If using Dynamic Rendering, will need to be set to null
     // otherwise needs to be shared across libraries in the same executable pipeline
-    gp_ci_.renderPass = layer_test_.renderPass();
+    gp_ci_.renderPass = layer_test_.RenderPass();
     gp_ci_.subpass = 0;
 
     gp_ci_.stageCount = 1;  // default is just the Vertex shader
@@ -187,7 +187,7 @@ void CreatePipelineHelper::InitFragmentLibInfo(const VkPipelineShaderStageCreate
 
     // If using Dynamic Rendering, will need to be set to null
     // otherwise needs to be shared across libraries in the same executable pipeline
-    gp_ci_.renderPass = layer_test_.renderPass();
+    gp_ci_.renderPass = layer_test_.RenderPass();
     gp_ci_.subpass = 0;
 
     // TODO if renderPass is null, MS info is not needed
@@ -209,7 +209,7 @@ void CreatePipelineHelper::InitFragmentOutputLibInfo(void *p_next) {
 
     // If using Dynamic Rendering, will need to be set to null
     // otherwise needs to be shared across libraries in the same executable pipeline
-    gp_ci_.renderPass = layer_test_.renderPass();
+    gp_ci_.renderPass = layer_test_.RenderPass();
     gp_ci_.subpass = 0;
 
     gp_ci_.stageCount = 0;
@@ -229,7 +229,7 @@ void CreatePipelineHelper::InitShaderLibInfo(std::vector<VkPipelineShaderStageCr
 
     // If using Dynamic Rendering, will need to be set to null
     // otherwise needs to be shared across libraries in the same executable pipeline
-    gp_ci_.renderPass = layer_test_.renderPass();
+    gp_ci_.renderPass = layer_test_.RenderPass();
     gp_ci_.subpass = 0;
 
     gp_ci_.pMultisampleState = &ms_ci_;

--- a/tests/framework/queue_submit_context.cpp
+++ b/tests/framework/queue_submit_context.cpp
@@ -92,7 +92,7 @@ void QSTestContext::Begin(vkt::CommandBuffer& cb) {
 }
 
 void QSTestContext::End() {
-    current_cb->end();
+    current_cb->End();
     current_cb = nullptr;
 }
 
@@ -178,8 +178,8 @@ void QSTestContext::SubmitX(VkQueue q, vkt::CommandBuffer& cb, VkSemaphore wait,
 
 void QSTestContext::WaitEventBufferTransfer(vkt::Buffer& buffer, VkPipelineStageFlags src_mask, VkPipelineStageFlags dst_mask) {
     std::vector<VkBufferMemoryBarrier> buffer_barriers(1, InitBufferBarrierWAR(buffer));
-    event.cmd_wait(*current_cb, src_mask, dst_mask, std::vector<VkMemoryBarrier>(), buffer_barriers,
-                   std::vector<VkImageMemoryBarrier>());
+    event.CmdWait(*current_cb, src_mask, dst_mask, std::vector<VkMemoryBarrier>(), buffer_barriers,
+                  std::vector<VkImageMemoryBarrier>());
 }
 
 void QSTestContext::RecordCopy(vkt::CommandBuffer& cb, vkt::Buffer& from, vkt::Buffer& to, const VkBufferCopy& copy_region) {

--- a/tests/framework/queue_submit_context.h
+++ b/tests/framework/queue_submit_context.h
@@ -102,10 +102,10 @@ struct QSTestContext {
     void Submit1Signal(vkt::CommandBuffer& cb, VkPipelineStageFlags signal_mask) {
         Submit1(cb, VK_NULL_HANDLE, 0U, semaphore.handle());
     }
-    void SetEvent(VkPipelineStageFlags src_mask) { event.cmd_set(*current_cb, src_mask); }
+    void SetEvent(VkPipelineStageFlags src_mask) { event.CmdSet(*current_cb, src_mask); }
     void WaitEventBufferTransfer(vkt::Buffer& buffer, VkPipelineStageFlags src_mask, VkPipelineStageFlags dst_mask);
 
-    void ResetEvent(VkPipelineStageFlags src_mask) { event.cmd_reset(*current_cb, src_mask); }
+    void ResetEvent(VkPipelineStageFlags src_mask) { event.CmdReset(*current_cb, src_mask); }
 
     void QueueWait(VkQueue q) { vk::QueueWaitIdle(q); }
     void QueueWait0() { QueueWait(q0); }

--- a/tests/framework/ray_tracing_helper_nv.cpp
+++ b/tests/framework/ray_tracing_helper_nv.cpp
@@ -214,13 +214,13 @@ void GetSimpleGeometryForAccelerationStructureTests(const vkt::Device &device, v
     constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
     constexpr std::array<uint32_t, 3> indicies = {{0, 1, 2}};
 
-    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo->memory().map();
+    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo->Memory().Map();
     std::memcpy(mapped_vbo_buffer_data + offset, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
-    vbo->memory().unmap();
+    vbo->Memory().Unmap();
 
-    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo->memory().map();
+    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo->Memory().Map();
     std::memcpy(mapped_ibo_buffer_data + offset, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
-    ibo->memory().unmap();
+    ibo->Memory().Unmap();
 
     *geometry = {};
     geometry->sType = VK_STRUCTURE_TYPE_GEOMETRY_NV;

--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -86,7 +86,7 @@ GeometryKHR &GeometryKHR::SetTrianglesDeviceVertexBuffer(vkt::Buffer &&vertex_bu
                                                          VkDeviceSize stride /*= 3 * sizeof(float)*/) {
     triangles_.device_vertex_buffer = std::move(vertex_buffer);
     vk_obj_.geometry.triangles.vertexFormat = vertex_format;
-    vk_obj_.geometry.triangles.vertexData.deviceAddress = triangles_.device_vertex_buffer.address();
+    vk_obj_.geometry.triangles.vertexData.deviceAddress = triangles_.device_vertex_buffer.Address();
     vk_obj_.geometry.triangles.maxVertex = max_vertex;
     vk_obj_.geometry.triangles.vertexStride = stride;
     return *this;
@@ -106,7 +106,7 @@ GeometryKHR &GeometryKHR::SetTrianglesDeviceIndexBuffer(vkt::Buffer &&index_buff
                                                         VkIndexType index_type /*= VK_INDEX_TYPE_UINT32*/) {
     triangles_.device_index_buffer = std::move(index_buffer);
     vk_obj_.geometry.triangles.indexType = index_type;
-    vk_obj_.geometry.triangles.indexData.deviceAddress = triangles_.device_index_buffer.address();
+    vk_obj_.geometry.triangles.indexData.deviceAddress = triangles_.device_index_buffer.Address();
     return *this;
 }
 
@@ -134,7 +134,7 @@ GeometryKHR &GeometryKHR::SetTrianglesMaxVertex(uint32_t max_vertex) {
 
 GeometryKHR &GeometryKHR::SetTrianglesTransformBuffer(vkt::Buffer &&transform_buffer) {
     triangles_.device_transform_buffer = std::move(transform_buffer);
-    vk_obj_.geometry.triangles.transformData.deviceAddress = triangles_.device_transform_buffer.address();
+    vk_obj_.geometry.triangles.transformData.deviceAddress = triangles_.device_transform_buffer.Address();
     return *this;
 }
 
@@ -155,7 +155,7 @@ GeometryKHR &GeometryKHR::SetTrianglesIndexBufferDeviceAddress(VkDeviceAddress a
 
 GeometryKHR &GeometryKHR::SetAABBsDeviceBuffer(vkt::Buffer &&buffer, VkDeviceSize stride /*= sizeof(VkAabbPositionsKHR)*/) {
     aabbs_.device_buffer = std::move(buffer);
-    vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.address();
+    vk_obj_.geometry.aabbs.data.deviceAddress = aabbs_.device_buffer.Address();
     vk_obj_.geometry.aabbs.stride = stride;
     return *this;
 }
@@ -216,14 +216,14 @@ GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &dev
         VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
 
-    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instance_.buffer.memory().map());
+    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instance_.buffer.Memory().Map());
     for (size_t vk_instance_i = 0; vk_instance_i < instance_.vk_instances.size(); ++vk_instance_i) {
         instance_buffer_ptr[vk_instance_i] = instance_.vk_instances[vk_instance_i];
     }
-    instance_.buffer.memory().unmap();
+    instance_.buffer.Memory().Unmap();
 
     vk_obj_.geometry.instances.arrayOfPointers = VK_FALSE;
-    vk_obj_.geometry.instances.data.deviceAddress = instance_.buffer.address();
+    vk_obj_.geometry.instances.data.deviceAddress = instance_.buffer.Address();
     return *this;
 }
 
@@ -305,8 +305,8 @@ AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferMemoryPropert
     return *this;
 }
 
-AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferInitNoMem(bool buffer_init_no_mem) {
-    buffer_init_no_mem_ = buffer_init_no_mem;
+AccelerationStructureKHR &AccelerationStructureKHR::SetDeviceBufferInitNoMem(bool buffer_InitNoMemory) {
+    buffer_InitNoMemory_ = buffer_InitNoMemory;
     return *this;
 }
 
@@ -319,7 +319,7 @@ VkDeviceAddress AccelerationStructureKHR::GetBufferDeviceAddress() const {
     assert(initialized());
     assert(device_buffer_.initialized());
     assert(device_buffer_.CreateInfo().size > 0);
-    return device_buffer_.address();
+    return device_buffer_.Address();
 }
 
 VkDeviceAddress AccelerationStructureKHR::GetAccelerationStructureDeviceAddress() const {
@@ -339,8 +339,8 @@ void AccelerationStructureKHR::Build() {
         VkBufferCreateInfo ci = vku::InitStructHelper();
         ci.size = vk_info_.size;
         ci.usage = buffer_usage_flags_;
-        if (buffer_init_no_mem_) {
-            device_buffer_.init_no_mem(*device_, ci);
+        if (buffer_InitNoMemory_) {
+            device_buffer_.InitNoMemory(*device_, ci);
         } else {
             device_buffer_.init(*device_, ci, buffer_memory_property_flags_, &alloc_flags);
         }
@@ -555,7 +555,7 @@ void BuildGeometryInfoKHR::SetupBuild(bool is_on_device_build, bool use_ppGeomet
             // Get minAccelerationStructureScratchOffsetAlignment
             VkPhysicalDeviceAccelerationStructurePropertiesKHR as_props = vku::InitStructHelper();
             VkPhysicalDeviceProperties2 phys_dev_props = vku::InitStructHelper(&as_props);
-            vk::GetPhysicalDeviceProperties2(device_->phy(), &phys_dev_props);
+            vk::GetPhysicalDeviceProperties2(device_->Physical(), &phys_dev_props);
 
             assert(device_scratch_);  // So far null pointers are not supported
             if (!device_scratch_->initialized()) {
@@ -570,7 +570,7 @@ void BuildGeometryInfoKHR::SetupBuild(bool is_on_device_build, bool use_ppGeomet
             }
             if (device_scratch_->CreateInfo().size != 0 &&
                 device_scratch_->CreateInfo().usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
-                const VkDeviceAddress scratch_address = device_scratch_->address();
+                const VkDeviceAddress scratch_address = device_scratch_->Address();
                 const auto aligned_scratch_address =
                     Align<VkDeviceAddress>(scratch_address, as_props.minAccelerationStructureScratchOffsetAlignment);
                 assert(aligned_scratch_address >= scratch_address);
@@ -651,7 +651,7 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                            VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
 
-    auto *ranges_info = static_cast<VkAccelerationStructureBuildRangeInfoKHR *>(indirect_buffer_->memory().map());
+    auto *ranges_info = static_cast<VkAccelerationStructureBuildRangeInfoKHR *>(indirect_buffer_->Memory().Map());
 
     // fill vk_info_ with geometry data, and get build ranges
     std::vector<const VkAccelerationStructureGeometryKHR *> pGeometries(geometries_.size());
@@ -667,12 +667,12 @@ void BuildGeometryInfoKHR::VkCmdBuildAccelerationStructuresIndirectKHR(VkCommand
     } else {
         vk_info_.ppGeometries = pGeometries.data();
     }
-    indirect_buffer_->memory().unmap();
+    indirect_buffer_->Memory().Unmap();
 
     std::vector<uint32_t> p_max_primitive_counts(vk_info_.geometryCount, 1);
     const uint32_t *pp_max_primitive_counts = p_max_primitive_counts.data();
 
-    const VkDeviceAddress indirect_address = indirect_buffer_address_ ? *indirect_buffer_address_ : indirect_buffer_->address();
+    const VkDeviceAddress indirect_address = indirect_buffer_address_ ? *indirect_buffer_address_ : indirect_buffer_->Address();
 
     vk::CmdBuildAccelerationStructuresIndirectKHR(cmd_buffer, vk_info_count_, &vk_info_, &indirect_address, &indirect_stride_,
                                                   &pp_max_primitive_counts);
@@ -911,13 +911,13 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, size_t
         indices[3 * triangle_i + 2] = 2;
     }
 
-    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.memory().map());
+    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.Memory().Map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
-    vertex_buffer.memory().unmap();
+    vertex_buffer.Memory().Unmap();
 
-    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.memory().map());
+    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
-    index_buffer.memory().unmap();
+    index_buffer.Memory().Unmap();
 
     // clang-format off
     VkTransformMatrixKHR transform_matrix = {{
@@ -927,9 +927,9 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, size_t
     }};
     // clang-format on
 
-    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.memory().map());
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.Memory().Map());
     std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
-    transform_buffer.memory().unmap();
+    transform_buffer.Memory().Unmap();
 
     // Assign vertex and index buffers to out geometry
     triangle_geometry.SetTrianglesDeviceVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3));
@@ -985,9 +985,9 @@ GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device &device) {
 
     // Fill buffer with one AABB
     aabb_geometry.SetPrimitiveCount(static_cast<uint32_t>(aabbs.size()));
-    auto mapped_aabb_buffer_data = static_cast<VkAabbPositionsKHR *>(aabb_buffer.memory().map());
+    auto mapped_aabb_buffer_data = static_cast<VkAabbPositionsKHR *>(aabb_buffer.Memory().Map());
     std::copy(aabbs.begin(), aabbs.end(), mapped_aabb_buffer_data);
-    aabb_buffer.memory().unmap();
+    aabb_buffer.Memory().Unmap();
 
     aabb_geometry.SetAABBsDeviceBuffer(std::move(aabb_buffer));
 
@@ -1446,7 +1446,7 @@ void Pipeline::BuildSbt() {
     std::cout << "SBT buffer fill:\n";
 #endif
 
-    void *const sbt_buffer_base_ptr = sbt_buffer_.memory().map();
+    void *const sbt_buffer_base_ptr = sbt_buffer_.Memory().Map();
     void *sbt_buffer_ptr = sbt_buffer_base_ptr;
     (void)sbt_buffer_base_ptr;
     size_t sbt_buffer_space_left = static_cast<size_t>(sbt_buffer_info.size);
@@ -1496,7 +1496,7 @@ void Pipeline::BuildSbt() {
     sbt_buffer_space_left -= closest_hit_shaders_.size() * handle_size_aligned;
     sbt_host_storage_ptr += closest_hit_shaders_.size() * rt_pipeline_props.shaderGroupHandleSize;
 
-    sbt_buffer_.memory().unmap();
+    sbt_buffer_.Memory().Unmap();
 }
 
 void Pipeline::DeferBuild() {
@@ -1511,12 +1511,12 @@ void Pipeline::DeferBuild() {
 vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt() {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&rt_pipeline_props);
-    vk::GetPhysicalDeviceProperties2(device_->phy(), &props2);
+    vk::GetPhysicalDeviceProperties2(device_->Physical(), &props2);
 
     const uint32_t handle_size_aligned =
         Align(rt_pipeline_props.shaderGroupHandleSize, rt_pipeline_props.shaderGroupHandleAlignment);
 
-    const VkDeviceAddress sbt_base_address = sbt_buffer_.address();
+    const VkDeviceAddress sbt_base_address = sbt_buffer_.Address();
     VkDeviceAddress sbt_address = sbt_base_address;
 
     assert(sbt_address == Align<VkDeviceAddress>(sbt_address, rt_pipeline_props.shaderGroupBaseAlignment));

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -128,7 +128,7 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     AccelerationStructureKHR& SetDeviceBuffer(vkt::Buffer&& buffer);
     AccelerationStructureKHR& SetDeviceBufferMemoryAllocateFlags(VkMemoryAllocateFlags memory_allocate_flags);
     AccelerationStructureKHR& SetDeviceBufferMemoryPropertyFlags(VkMemoryAllocateFlags memory_property_flags);
-    AccelerationStructureKHR& SetDeviceBufferInitNoMem(bool buffer_init_no_mem);
+    AccelerationStructureKHR& SetDeviceBufferInitNoMem(bool buffer_InitNoMemory);
     // Set it to 0 to skip buffer initialization at Build() step
     AccelerationStructureKHR& SetBufferUsageFlags(VkBufferUsageFlags usage_flags);
 
@@ -152,7 +152,7 @@ class AccelerationStructureKHR : public vkt::internal::NonDispHandle<VkAccelerat
     VkMemoryAllocateFlags buffer_memory_allocate_flags_{};
     VkMemoryPropertyFlags buffer_memory_property_flags_{};
     VkBufferUsageFlags buffer_usage_flags_{};
-    bool buffer_init_no_mem_ = false;
+    bool buffer_InitNoMemory_ = false;
 };
 
 class BuildGeometryInfoKHR {

--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -66,12 +66,12 @@ VkRenderFramework::~VkRenderFramework() {
     m_errorMonitor->Finish();
 }
 
-VkPhysicalDevice VkRenderFramework::gpu() const {
+VkPhysicalDevice VkRenderFramework::Gpu() const {
     EXPECT_NE((VkInstance)0, instance_);  // Invalid to request gpu before instance exists
     return gpu_;
 }
 
-const VkPhysicalDeviceProperties &VkRenderFramework::physDevProps() const {
+const VkPhysicalDeviceProperties &VkRenderFramework::PhysicalDeviceProps() const {
     EXPECT_NE((VkPhysicalDevice)0, gpu_);  // Invalid to request physical device properties before gpu
     return physDevProps_;
 }
@@ -438,7 +438,7 @@ bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
         return true;
     }
 
-    if (!DeviceExtensionSupported(gpu(), nullptr, dev_ext_name)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, dev_ext_name)) {
         return false;
     }
     m_device_extension_names.push_back(dev_ext_name);
@@ -453,7 +453,7 @@ bool VkRenderFramework::AddRequestedDeviceExtensions(const char *dev_ext_name) {
 }
 
 bool VkRenderFramework::IsPromotedDeviceExtension(const char *dev_ext_name) const {
-    auto device_version = std::min(m_target_api_version, APIVersion(physDevProps().apiVersion));
+    auto device_version = std::min(m_target_api_version, APIVersion(PhysicalDeviceProps().apiVersion));
     if (!device_version.Valid()) return false;
 
     const auto promotion_info_map = GetDevicePromotionInfoMap();
@@ -525,7 +525,7 @@ void VkRenderFramework::ShutdownFramework() {
 ErrorMonitor &VkRenderFramework::Monitor() { return monitor_; }
 
 void VkRenderFramework::GetPhysicalDeviceFeatures(VkPhysicalDeviceFeatures *features) {
-    vk::GetPhysicalDeviceFeatures(gpu(), features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), features);
 }
 
 // static
@@ -541,7 +541,7 @@ bool VkRenderFramework::IsPlatformMockICD() {
     if (VkRenderFramework::IgnoreDisableChecks()) {
         return false;
     } else {
-        return 0 == mock_icd_device_name.compare(physDevProps().deviceName);
+        return 0 == mock_icd_device_name.compare(PhysicalDeviceProps().deviceName);
     }
 }
 
@@ -614,9 +614,9 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
     if (!features) {
         if (feature_requirements_.HasFeatures2()) {
             if (vk::GetPhysicalDeviceFeatures2KHR) {
-                vk::GetPhysicalDeviceFeatures2KHR(gpu(), feature_requirements_.GetFeatures2());
+                vk::GetPhysicalDeviceFeatures2KHR(Gpu(), feature_requirements_.GetFeatures2());
             } else {
-                vk::GetPhysicalDeviceFeatures2(gpu(), feature_requirements_.GetFeatures2());
+                vk::GetPhysicalDeviceFeatures2(Gpu(), feature_requirements_.GetFeatures2());
             }
         } else {
             GetPhysicalDeviceFeatures(feature_requirements_.GetFeatures());
@@ -665,11 +665,11 @@ void VkRenderFramework::InitState(VkPhysicalDeviceFeatures *features, void *crea
     m_default_queue = queues[0];
     if (queues.size() > 1) {
         m_second_queue = queues[1];
-        m_second_queue_caps = m_device->phy().queue_properties_[m_second_queue->family_index].queueFlags;
+        m_second_queue_caps = m_device->Physical().queue_properties_[m_second_queue->family_index].queueFlags;
     }
     if (queues.size() > 2) {
         m_third_queue = queues[2];
-        m_third_queue_caps = m_device->phy().queue_properties_[m_third_queue->family_index].queueFlags;
+        m_third_queue_caps = m_device->Physical().queue_properties_[m_third_queue->family_index].queueFlags;
     }
 
     m_depthStencil = new vkt::Image();
@@ -828,7 +828,7 @@ void VkRenderFramework::InitSwapchainInfo() {
 // Makes query to get information about swapchain needed to create a valid swapchain object each test creating a swapchain will
 // need
 SurfaceInformation VkRenderFramework::GetSwapchainInfo(const VkSurfaceKHR surface) {
-    const VkPhysicalDevice physicalDevice = gpu();
+    const VkPhysicalDevice physicalDevice = Gpu();
 
     assert(surface != VK_NULL_HANDLE);
 
@@ -880,7 +880,7 @@ bool VkRenderFramework::CreateSwapchain(VkSurfaceKHR &surface, VkImageUsageFlags
                                         VkSurfaceTransformFlagBitsKHR preTransform, VkSwapchainKHR &swapchain,
                                         VkSwapchainKHR oldSwapchain) {
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, surface, &supported);
     if (!supported) {
         // Graphics queue does not support present
         return false;
@@ -975,7 +975,7 @@ void VkRenderFramework::InitRenderTarget(uint32_t targets, const VkImageView *ds
         m_renderPassClearValues.push_back(clear);
 
         VkFormatProperties props;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), m_render_target_fmt, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), m_render_target_fmt, &props);
 
         VkImageTiling tiling = VK_IMAGE_TILING_OPTIMAL;
         if (props.linearTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) {

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -65,15 +65,19 @@ class VkRenderFramework : public VkTestFramework {
     VkInstance instance() const { return instance_; }
     VkDevice device() const { return m_device->handle(); }
     vkt::Device *DeviceObj() const { return m_device; }
-    VkPhysicalDevice gpu() const;
-    VkRenderPass renderPass() const { return m_renderPass; }
-    VkFramebuffer framebuffer() const { return m_framebuffer->handle(); }
+    VkPhysicalDevice Gpu() const;
+    // Deprecated, use Gpu()
+    VkPhysicalDevice gpu() const { return Gpu(); }
+    VkRenderPass RenderPass() const { return m_renderPass; }
+    VkFramebuffer Framebuffer() const { return m_framebuffer->handle(); }
 
     vkt::Queue *DefaultQueue() const { return m_default_queue; }
     vkt::Queue *SecondQueue() const { return m_second_queue; }
 
     ErrorMonitor &Monitor();
-    const VkPhysicalDeviceProperties &physDevProps() const;
+    const VkPhysicalDeviceProperties &PhysicalDeviceProps() const;
+    // Deprecated, use PhysicalDeviceProps()
+    const VkPhysicalDeviceProperties &physDevProps() const { return PhysicalDeviceProps(); }
 
     bool InstanceLayerSupported(const char *layer_name, uint32_t spec_version = 0, uint32_t impl_version = 0);
     bool InstanceExtensionSupported(const char *extension_name, uint32_t spec_version = 0);
@@ -154,7 +158,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const GLSLContainer &code,
                                     const spv_target_env env = SPV_ENV_VULKAN_1_0) {
         std::vector<uint32_t> spv;
-        GLSLtoSPV(&m_device->phy().limits_, stage, code, spv, env);
+        GLSLtoSPV(&m_device->Physical().limits_, stage, code, spv, env);
         return spv;
     }
 

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -1,7 +1,7 @@
 /*
- * Copyright (c) 2015-2023 The Khronos Group Inc.
- * Copyright (c) 2015-2023 Valve Corporation
- * Copyright (c) 2015-2023 LunarG, Inc.
+ * Copyright (c) 2015-2024 The Khronos Group Inc.
+ * Copyright (c) 2015-2024 Valve Corporation
+ * Copyright (c) 2015-2024 LunarG, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -775,7 +775,7 @@ VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkSha
 
 bool VkShaderObj::InitFromGLSL(const void *pNext) {
     std::vector<uint32_t> spv;
-    m_framework.GLSLtoSPV(&m_device.phy().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
+    m_framework.GLSLtoSPV(&m_device.Physical().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.pNext = pNext;
@@ -794,14 +794,14 @@ VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device *custom_device) {
     std::vector<uint32_t> spv;
     // 99% of tests just use the framework's VkDevice, but this allows for tests to use custom device object
     // Can't set at contructor time since all reference members need to be initialized then.
-    VkPhysicalDeviceLimits limits = (custom_device) ? custom_device->phy().limits_ : m_device.phy().limits_;
+    VkPhysicalDeviceLimits limits = (custom_device) ? custom_device->Physical().limits_ : m_device.Physical().limits_;
     m_framework.GLSLtoSPV(&limits, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
-    const auto result = init_try(((custom_device) ? *custom_device : m_device), moduleCreateInfo);
+    const auto result = InitTry(((custom_device) ? *custom_device : m_device), moduleCreateInfo);
     m_stage_info.module = handle();
     return result;
 }
@@ -827,7 +827,7 @@ VkResult VkShaderObj::InitFromASMTry() {
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
     moduleCreateInfo.pCode = spv.data();
 
-    const auto result = init_try(m_device, moduleCreateInfo);
+    const auto result = InitTry(m_device, moduleCreateInfo);
     m_stage_info.module = handle();
     return result;
 }

--- a/tests/unit/amd_best_practices.cpp
+++ b/tests/unit/amd_best_practices.cpp
@@ -132,12 +132,12 @@ TEST_F(VkAmdBestPracticesLayerTest, UsageConcurentRT) {
 
     InitRenderTarget();
 
-    if (m_device->phy().queue_properties_.size() < 2) {
+    if (m_device->Physical().queue_properties_.size() < 2) {
         GTEST_SKIP() << "Test not supported by a single queue family device";
     }
 
-    std::vector<uint32_t> queueFamilies(m_device->phy().queue_properties_.size());
-    for (size_t i = 0; i < m_device->phy().queue_properties_.size(); i++) {
+    std::vector<uint32_t> queueFamilies(m_device->Physical().queue_properties_.size());
+    for (size_t i = 0; i < m_device->Physical().queue_properties_.size(); i++) {
         queueFamilies[i] = i;
     }
 
@@ -382,7 +382,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       VK_IMAGE_LAYOUT_UNDEFINED};
         vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         image_1D.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
         VkClearColorValue clear_value = {{0.0f, 0.0f, 0.0f, 0.0f}};
@@ -397,7 +397,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                &image_range);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     vk::ResetCommandPool(device(), m_command_pool.handle(), 0);
@@ -421,7 +421,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
         m_errorMonitor->SetAllowedFailureMsg("VUID-VkImageCreateInfo-imageCreateMaxMipLevels-02251");
         vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         image_1D.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
                            VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
@@ -437,7 +437,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ClearImage) {
                                       &clear_value, 1, &image_range);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -470,7 +470,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
         GTEST_SKIP() << "Could not initilize Linear image, skipping image to image copy test";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     image1D_1.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-AMD-vkImage-AvoidImageToImageCopy");
@@ -483,7 +483,7 @@ TEST_F(VkAmdBestPracticesLayerTest, ImageToImageCopy) {
     vk::CmdCopyImage(m_command_buffer.handle(), image1D_1.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image_1D_2.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkAmdBestPracticesLayerTest, GeneralLayout) {
@@ -537,7 +537,7 @@ TEST_F(VkAmdBestPracticesLayerTest, RobustAccessOn) {
     device_ci.pEnabledFeatures = &features;
 
     VkDevice test_device;
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
 
     m_errorMonitor->VerifyFound();
 }
@@ -565,7 +565,7 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
         VK_IMAGE_LAYOUT_UNDEFINED};
     vkt::Image image_1D(*m_device, img_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // check for read-to-read barrier
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-PipelineBarrier-readToReadBarrier");
     image_1D.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
@@ -586,7 +586,7 @@ TEST_F(VkAmdBestPracticesLayerTest, Barriers) {
     image_1D.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkAmdBestPracticesLayerTest, NumberOfSubmissions) {
@@ -701,7 +701,7 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
     binfo.pInheritanceInfo = &iinfo;
     binfo.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     // record a secondary command buffer
-    secondary_cmd_buf.begin(&binfo);
+    secondary_cmd_buf.Begin(&binfo);
 
     vk::CmdBindPipeline(secondary_cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offset = 0;
@@ -722,9 +722,9 @@ TEST_F(VkAmdBestPracticesLayerTest, SecondaryCmdBuffer) {
 
     vk::CmdClearAttachments(secondary_cmd_buf.handle(), 1, &color_attachment, 1, &clear_rect);
 
-    secondary_cmd_buf.end();
+    secondary_cmd_buf.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-DrawState-ClearCmdBeforeDraw");
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-AMD-VkCommandBuffer-AvoidSecondaryCmdBuffers");

--- a/tests/unit/android_external_resolve.cpp
+++ b/tests/unit/android_external_resolve.cpp
@@ -458,11 +458,11 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebuffer) {
     render_pass_bi.clearValueCount = 1;
     render_pass_bi.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-09354");
     m_command_buffer.BeginRenderPass(render_pass_bi);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
@@ -580,11 +580,11 @@ TEST_F(NegativeAndroidExternalResolve, ImagelessFramebufferFormat) {
     render_pass_bi.clearValueCount = 1;
     render_pass_bi.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-09353");
     m_command_buffer.BeginRenderPass(render_pass_bi);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, DynamicRendering) {
@@ -661,7 +661,7 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRendering) {
     begin_rendering_info.pDepthAttachment = &ds_attachment;
     begin_rendering_info.pStencilAttachment = &ds_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     // One for depth and stencil attachment
@@ -751,7 +751,7 @@ TEST_F(NegativeAndroidExternalResolve, DynamicRenderingResolveModeNonNullColor) 
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     color_attachment.resolveImageView = resolve_view.handle();
     color_attachment.imageView = VK_NULL_HANDLE;
@@ -907,7 +907,7 @@ TEST_F(NegativeAndroidExternalResolve, MissingImageUsage) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-colorAttachmentCount-09476");
@@ -983,7 +983,7 @@ TEST_F(NegativeAndroidExternalResolve, ClearAttachment) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -997,7 +997,7 @@ TEST_F(NegativeAndroidExternalResolve, ClearAttachment) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
@@ -1080,7 +1080,7 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -1094,7 +1094,7 @@ TEST_F(NegativeAndroidExternalResolve, DrawDynamicRasterizationSamples) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
@@ -1162,7 +1162,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier2 barrier = vku::InitStructHelper();
     barrier.srcStageMask = VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1191,7 +1191,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrier) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
@@ -1269,7 +1269,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle());
 
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
@@ -1289,7 +1289,7 @@ TEST_F(NegativeAndroidExternalResolve, PipelineBarrierUnused) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAndroidExternalResolve, RenderPassAndFramebuffer) {

--- a/tests/unit/android_external_resolve_positive.cpp
+++ b/tests/unit/android_external_resolve_positive.cpp
@@ -227,10 +227,10 @@ TEST_F(PositiveAndroidExternalResolve, ImagelessFramebuffer) {
     render_pass_bi.clearValueCount = 1;
     render_pass_bi.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass_bi);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveAndroidExternalResolve, DynamicRendering) {
@@ -301,12 +301,12 @@ TEST_F(PositiveAndroidExternalResolve, DynamicRendering) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
@@ -385,7 +385,7 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle());
 
     VkImageMemoryBarrier image_barrier = vku::InitStructHelper();
@@ -403,7 +403,7 @@ TEST_F(PositiveAndroidExternalResolve, PipelineBarrier) {
                            &image_barrier);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 #endif  // VK_USE_PLATFORM_ANDROID_KHR

--- a/tests/unit/android_hardware_buffer.cpp
+++ b/tests/unit/android_hardware_buffer.cpp
@@ -740,7 +740,7 @@ TEST_F(NegativeAndroidHardwareBuffer, PhysDevImageFormatProp2) {
 
     // AHB_usage chained to input without a matching external image format struc chained to output
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties2-pNext-01868");
-    vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &pdifi, &ifp);
+    vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &pdifi, &ifp);
     m_errorMonitor->VerifyFound();
 
     // output struct chained, but does not include VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID usage
@@ -748,7 +748,7 @@ TEST_F(NegativeAndroidHardwareBuffer, PhysDevImageFormatProp2) {
     pdeifi.handleType = VK_EXTERNAL_MEMORY_HANDLE_TYPE_HOST_ALLOCATION_BIT_EXT;
     pdifi.pNext = &pdeifi;
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties2-pNext-01868");
-    vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &pdifi, &ifp);
+    vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &pdifi, &ifp);
     m_errorMonitor->VerifyFound();
 }
 
@@ -986,7 +986,8 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportBufferAllocationSize) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper(&export_memory_info);
     memory_info.allocationSize = 0;
 
-    bool has_memtype = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    bool has_memtype =
+        m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
         GTEST_SKIP() << "No valid memory type index could be found";
     }
@@ -1035,7 +1036,7 @@ TEST_F(NegativeAndroidHardwareBuffer, ExportImageNonBound) {
     memory_info.allocationSize = 0;
 
     // Use any DEVICE_LOCAL memory found
-    bool has_memtype = m_device->phy().SetMemoryType(0xFFFFFFFF, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    bool has_memtype = m_device->Physical().SetMemoryType(0xFFFFFFFF, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
         GTEST_SKIP() << "No valid memory type index could be found";
     }
@@ -1303,7 +1304,7 @@ TEST_F(NegativeAndroidHardwareBuffer, NullAHBImport) {
     // Android implemenetations "should have" a DEVICE_LOCAL only index designed for AHB
     VkMemoryPropertyFlagBits property = VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT;
     VkPhysicalDeviceMemoryProperties gpu_memory_props;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &gpu_memory_props);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &gpu_memory_props);
     memory_allocate_info.memoryTypeIndex = gpu_memory_props.memoryTypeCount + 1;
     for (uint32_t i = 0; i < gpu_memory_props.memoryTypeCount; i++) {
         if ((ahb_props.memoryTypeBits & (1 << i)) && ((gpu_memory_props.memoryTypes[i].propertyFlags & property) == property)) {

--- a/tests/unit/android_hardware_buffer_positive.cpp
+++ b/tests/unit/android_hardware_buffer_positive.cpp
@@ -180,7 +180,8 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportBuffer) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper(&export_memory_info);
     memory_info.allocationSize = mem_reqs.size;
 
-    bool has_memtype = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    bool has_memtype =
+        m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
         GTEST_SKIP() << "No valid memory type index could be found";
     }
@@ -238,7 +239,7 @@ TEST_F(PositiveAndroidHardwareBuffer, ExportImage) {
     memory_info.allocationSize = 0;
 
     // Use any DEVICE_LOCAL memory found
-    bool has_memtype = m_device->phy().SetMemoryType(0xFFFFFFFF, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    bool has_memtype = m_device->Physical().SetMemoryType(0xFFFFFFFF, &memory_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (!has_memtype) {
         GTEST_SKIP() << "No valid memory type index could be found";
     }

--- a/tests/unit/arm_best_practices.cpp
+++ b/tests/unit/arm_best_practices.cpp
@@ -33,9 +33,9 @@ class VkConstantBufferObj : public vkt::Buffer {
         VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         init(*device, CreateInfo(size, usage), reqs);
 
-        void* pData = memory().map();
+        void* pData = Memory().Map();
         memcpy(pData, data, static_cast<size_t>(size));
-        memory().unmap();
+        Memory().Unmap();
     }
 };
 
@@ -265,7 +265,7 @@ TEST_F(VkArmBestPracticesLayerTest, AttachmentNeedsReadback) {
 
     // NOTE: VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT should be set for all tests in this file because
     // otherwise BestPractices-vkBeginCommandBuffer-one-time-submit will be triggered.
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
     m_errorMonitor->VerifyFound();
@@ -296,7 +296,7 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     pipe.ms_ci_ = pipe_ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -309,7 +309,7 @@ TEST_F(VkArmBestPracticesLayerTest, ManySmallIndexedDrawcalls) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkArmBestPracticesLayerTest, SuboptimalDescriptorReuseTest) {
@@ -444,14 +444,14 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
         pr_pipe.CreateGraphicsPipeline();
 
         vk::ResetCommandPool(device(), m_command_pool.handle(), 0);
-        m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+        m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdBindIndexBuffer(m_command_buffer.handle(), ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
         // the validation layer will only be able to analyse mapped memory, it's too expensive otherwise to do in the layer itself
-        ibo.memory().map();
+        ibo.Memory().Map();
         if (expect_error) {
             m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-Arm-vkCmdDrawIndexed-sparse-index-buffer");
         }
@@ -460,7 +460,7 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
             m_errorMonitor->VerifyFound();
         } else {
         }
-        ibo.memory().unmap();
+        ibo.Memory().Unmap();
 
         if (expect_error) {
             m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-Arm-vkCmdDrawIndexed-sparse-index-buffer");
@@ -468,15 +468,15 @@ TEST_F(VkArmBestPracticesLayerTest, SparseIndexBufferTest) {
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pr_pipe.Handle());
         vk::CmdBindIndexBuffer(m_command_buffer.handle(), ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
-        ibo.memory().map();
+        ibo.Memory().Map();
         vk::CmdDrawIndexed(m_command_buffer.handle(), index_count, 0, 0, 0, 0);
         if (expect_error) {
             m_errorMonitor->VerifyFound();
         }
-        ibo.memory().unmap();
+        ibo.Memory().Unmap();
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->Reset();
     };
@@ -507,7 +507,7 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -537,21 +537,21 @@ TEST_F(VkArmBestPracticesLayerTest, PostTransformVertexCacheThrashingIndicesTest
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), worst_ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
     // the validation layer will only be able to analyse mapped memory, it's too expensive otherwise to do in the layer itself
-    worst_ibo.memory().map();
+    worst_ibo.Memory().Map();
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit,
                                          "BestPractices-Arm-vkCmdDrawIndexed-post-transform-cache-thrashing");
     vk::CmdDrawIndexed(m_command_buffer.handle(), worst_indices.size(), 0, 0, 0, 0);
     m_errorMonitor->VerifyFound();
-    worst_ibo.memory().unmap();
+    worst_ibo.Memory().Unmap();
 
     // make sure that the best-case indices don't throw a warning
     VkConstantBufferObj best_ibo(m_device, best_indices.size() * sizeof(uint16_t), best_indices.data(),
                                  VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), best_ibo.handle(), static_cast<VkDeviceSize>(0), VK_INDEX_TYPE_UINT16);
 
-    best_ibo.memory().map();
+    best_ibo.Memory().Map();
     vk::CmdDrawIndexed(m_command_buffer.handle(), best_indices.size(), 0, 0, 0, 0);
-    best_ibo.memory().unmap();
+    best_ibo.Memory().Unmap();
 }
 
 TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
@@ -564,7 +564,7 @@ TEST_F(VkArmBestPracticesLayerTest, PresentModeTest) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present, skipping test";
     }
@@ -656,13 +656,13 @@ TEST_F(VkArmBestPracticesLayerTest, RobustBufferAccessTest) {
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     VkPhysicalDeviceFeatures supported_features;
-    vk::GetPhysicalDeviceFeatures(this->gpu(), &supported_features);
+    vk::GetPhysicalDeviceFeatures(this->Gpu(), &supported_features);
     if (supported_features.robustBufferAccess) {
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkCreateDevice-RobustBufferAccess");
         VkPhysicalDeviceFeatures device_features = {};
         device_features.robustBufferAccess = VK_TRUE;
         dev_info.pEnabledFeatures = &device_features;
-        vk::CreateDevice(this->gpu(), &dev_info, nullptr, &local_device);
+        vk::CreateDevice(this->Gpu(), &dev_info, nullptr, &local_device);
         m_errorMonitor->VerifyFound();
     } else {
         GTEST_SKIP() << "robustBufferAccess is not available, skipping test";
@@ -673,7 +673,7 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableArmValidation));
     RETURN_IF_SKIP(InitState());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -723,7 +723,7 @@ TEST_F(VkArmBestPracticesLayerTest, DepthPrePassUsage) {
 
     VkConstantBufferObj ibo(m_device, sizeof(uint32_t) * indices.size(), indices.data(), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), ibo.handle(), 0, VK_INDEX_TYPE_UINT32);
 
     // record a command buffer which doesn't use enough depth pre-passes or geometry to matter
@@ -790,7 +790,7 @@ TEST_F(VkArmBestPracticesLayerTest, ComputeShaderBadWorkGroupThreadAlignmentTest
         m_errorMonitor->VerifyFound();
     }
 
-    if (m_device->phy().limits_.maxComputeWorkGroupInvocations > 128) {
+    if (m_device->Physical().limits_.maxComputeWorkGroupInvocations > 128) {
         char const* csSource = R"glsl(
             #version 450
             layout(local_size_x = 16, local_size_y = 9, local_size_z = 1) in;
@@ -973,11 +973,11 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassStore) {
 
     const auto execute_work = [&](const std::function<void(vkt::CommandBuffer & command_buffer)>& work) {
         vk::ResetCommandPool(device(), m_command_pool.handle(), 0);
-        m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+        m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
         work(m_command_buffer);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
@@ -1061,7 +1061,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
     VkClearValue clear_values[3];
     memset(clear_values, 0, sizeof(clear_values));
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     VkClearColorValue clear_color_value = {};
     VkImageSubresourceRange subresource_range = {};
@@ -1086,7 +1086,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantRenderPassClear) {
 
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1155,7 +1155,7 @@ TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
     VkClearValue clear_values[3];
     memset(clear_values, 0, sizeof(clear_values));
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     VkClearColorValue clear_color_value = {};
     VkImageSubresourceRange subresource_range = {};
@@ -1180,7 +1180,7 @@ TEST_F(VkArmBestPracticesLayerTest, InefficientRenderPassClear) {
 
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1290,7 +1290,7 @@ TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
     VkClearValue clear_values[3];
     memset(clear_values, 0, sizeof(clear_values));
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     VkClearColorValue clear_color_value = {};
     VkImageSubresourceRange subresource_range = {};
@@ -1335,7 +1335,7 @@ TEST_F(VkArmBestPracticesLayerTest, DescriptorTracking) {
     }
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1356,7 +1356,7 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     // On tiled renderers, this can also trigger a warning about LOAD_OP_LOAD causing a readback
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdBeginRenderPass-attachment-needs-readback");
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCmdEndRenderPass-redundant-attachment-on-tile");
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     const VkFormat FMT = VK_FORMAT_R8G8B8A8_UNORM;
     const uint32_t WIDTH = 512, HEIGHT = 512;
@@ -1446,7 +1446,7 @@ TEST_F(VkArmBestPracticesLayerTest, BlitImageLoadOpLoad) {
     // subtest 1: bind in the wrong subpass
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), WIDTH, HEIGHT);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -1463,10 +1463,10 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
     // One of these formats must be supported.
     VkFormat ds_format = VK_FORMAT_D24_UNORM_S8_UINT;
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), ds_format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), ds_format, &format_props);
     if ((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
         ds_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
-        vk::GetPhysicalDeviceFormatProperties(gpu(), ds_format, &format_props);
+        vk::GetPhysicalDeviceFormatProperties(Gpu(), ds_format, &format_props);
         ASSERT_TRUE((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0);
     }
 
@@ -1504,7 +1504,7 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
     pipe_stencil.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe_stencil.CreateGraphicsPipeline();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
 
     // Nothing is redundant.
     {
@@ -1565,5 +1565,5 @@ TEST_F(VkArmBestPracticesLayerTest, RedundantAttachment) {
         m_command_buffer.EndRenderPass();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -366,7 +366,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
@@ -374,7 +374,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime64) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-SampledType-04471");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
@@ -416,7 +416,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
@@ -424,7 +424,7 @@ TEST_F(NegativeAtomic, ImageInt64Drawtime32) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-SampledType-04470");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
@@ -485,14 +485,14 @@ TEST_F(NegativeAtomic, ImageInt64DrawtimeSparse) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-sparseImageInt64Atomics-04474");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAtomic, ImageInt64Mesh32) {
@@ -552,7 +552,7 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -561,7 +561,7 @@ TEST_F(NegativeAtomic, ImageInt64Mesh32) {
     vk::CmdDrawMeshTasksEXT(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAtomic, Float) {
@@ -1267,14 +1267,14 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
                                                        // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, image_format, usage);
 
-    if (ImageFormatIsSupported(instance(), gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
+    if (ImageFormatIsSupported(instance(), Gpu(), image_ci, VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT not supported.";
     }
 
     VkFormat buffer_view_format =
         VK_FORMAT_R8_UNORM;  // The format doesn't support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT to
                              // cause DesiredFailure. VK_FORMAT_R32_UINT is right format.
-    if (BufferFormatAndFeaturesSupported(gpu(), buffer_view_format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
+    if (BufferFormatAndFeaturesSupported(Gpu(), buffer_view_format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT)) {
         GTEST_SKIP() << "Cannot make VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_ATOMIC_BIT not supported.";
     }
     m_errorMonitor->SetUnexpectedError("VUID-VkBufferViewCreateInfo-format-08779");
@@ -1330,7 +1330,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
     g_pipe.descriptor_set_->WriteDescriptorBufferView(0, buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 1);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1342,7 +1342,7 @@ TEST_F(NegativeAtomic, InvalidStorageOperation) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeAtomic, ImageFloat16Vector) {

--- a/tests/unit/atomics_positive.cpp
+++ b/tests/unit/atomics_positive.cpp
@@ -129,12 +129,12 @@ TEST_F(PositiveAtomic, ImageInt64DrawtimeSparse) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveAtomic, Float) {
@@ -819,10 +819,10 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
     }
 
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), format, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT;
     formatProps.optimalTilingFeatures &= ~VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), format, formatProps);
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, format, VK_IMAGE_USAGE_STORAGE_BIT);
     vkt::Image image(*m_device, image_ci, vkt::set_layout);
@@ -863,12 +863,12 @@ TEST_F(PositiveAtomic, OpImageTexelPointerWithNoAtomic) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveAtomic, ImageFloat16Vector) {

--- a/tests/unit/best_practices.cpp
+++ b/tests/unit/best_practices.cpp
@@ -56,11 +56,12 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     image_format_info.type = VK_IMAGE_TYPE_3D;
     image_format_info.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
 
-    VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+    VkResult result =
+        vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
     // Only run this test if this super-wierd format is not supported
     if (VK_SUCCESS != result) {
         m_errorMonitor->SetDesiredWarning("BestPractices-Error-Result");
-        vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+        vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
         m_errorMonitor->VerifyFound();
     }
 
@@ -71,7 +72,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     // Force a non-success success code by only asking for a subset of query results
     uint32_t format_count;
     std::vector<VkSurfaceFormatKHR> formats;
-    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, NULL);
+    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &format_count, NULL);
     if (result != VK_SUCCESS || format_count <= 1) {
         GTEST_SKIP() << "test requires 2 or more extensions available";
     }
@@ -79,7 +80,7 @@ TEST_F(VkBestPracticesLayerTest, ReturnCodes) {
     formats.resize(format_count);
 
     m_errorMonitor->SetDesiredFailureMsg(kVerboseBit, "BestPractices-Verbose-Success-Logging");
-    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, formats.data());
+    result = vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &format_count, formats.data());
     ASSERT_TRUE(result > VK_SUCCESS);
     m_errorMonitor->VerifyFound();
 }
@@ -157,7 +158,7 @@ TEST_F(VkBestPracticesLayerTest, UseDeprecatedDeviceExtensions) {
     // One for VK_KHR_buffer_device_address
     // One for the dependency extension VK_KHR_device_group
     m_errorMonitor->SetDesiredWarning("BestPractices-deprecated-extension", 2);
-    vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
+    vk::CreateDevice(this->Gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -186,7 +187,7 @@ TEST_F(VkBestPracticesLayerTest, SpecialUseExtensions) {
     dev_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     m_errorMonitor->SetDesiredWarning("BestPractices-specialuse-extension");
-    vk::CreateDevice(this->gpu(), &dev_info, NULL, &local_device);
+    vk::CreateDevice(this->Gpu(), &dev_info, NULL, &local_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -197,7 +198,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTest) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Main thing we care about for this test is that the VkImage obj we're
@@ -226,7 +227,7 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::CommandBuffer secondary_full_clear(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     vkt::CommandBuffer secondary_small_clear(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
@@ -264,12 +265,12 @@ TEST_F(VkBestPracticesLayerTest, CmdClearAttachmentTestSecondary) {
     }
     m_command_buffer.EndRenderPass();
 
-    secondary_small_clear.begin(&begin_info);
-    secondary_full_clear.begin(&begin_info);
+    secondary_small_clear.Begin(&begin_info);
+    secondary_full_clear.Begin(&begin_info);
     vk::CmdClearAttachments(secondary_small_clear.handle(), 1, &color_attachment, 1, &clear_rect_small);
     vk::CmdClearAttachments(secondary_full_clear.handle(), 1, &color_attachment, 1, &clear_rect);
-    secondary_small_clear.end();
-    secondary_full_clear.end();
+    secondary_small_clear.End();
+    secondary_full_clear.End();
 
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     {
@@ -313,7 +314,7 @@ TEST_F(VkBestPracticesLayerTest, CmdResolveImageTypeMismatch) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Need memory barrier to VK_IMAGE_LAYOUT_GENERAL for source and dest?
     // VK_IMAGE_LAYOUT_UNDEFINED = 0,
     // VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -328,7 +329,7 @@ TEST_F(VkBestPracticesLayerTest, CmdResolveImageTypeMismatch) {
     vk::CmdResolveImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, ZeroSizeBlitRegion) {
@@ -350,13 +351,13 @@ TEST_F(VkBestPracticesLayerTest, ZeroSizeBlitRegion) {
     blit_region.dstOffsets[0] = {0, 128, 0};
     blit_region.dstOffsets[1] = {128, 128, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredWarning("BestPractices-DrawState-InvalidExtents-src");
     m_errorMonitor->SetDesiredWarning("BestPractices-DrawState-InvalidExtents-dst");
     vk::CmdBlitImage(m_command_buffer.handle(), image_src.handle(), image_src.Layout(), image_dst.handle(), image_dst.Layout(), 1,
                      &blit_region, VK_FILTER_LINEAR);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
@@ -371,7 +372,7 @@ TEST_F(VkBestPracticesLayerTest, VtxBufferBadIndex) {
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-vkEndCommandBuffer-VtxIndexOutOfBounds");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // VBO idx 1, but no VBO in PSO
@@ -407,11 +408,11 @@ TEST_F(VkBestPracticesLayerTest, SecondaryCommandBuffer) {
     RETURN_IF_SKIP(InitState());
 
     uint32_t queue_family_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
 
     std::vector<VkQueueFamilyProperties> queue_family_props;
     queue_family_props.resize(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_family_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_family_props.data());
 
     uint32_t queue_family_index = VK_QUEUE_FAMILY_IGNORED;
     const VkQueueFlags sec_cmd_buf_queue_flags = VK_QUEUE_GRAPHICS_BIT | VK_QUEUE_COMPUTE_BIT | VK_QUEUE_TRANSFER_BIT;
@@ -471,7 +472,7 @@ TEST_F(VkBestPracticesLayerTest, SmallAllocation) {
 
     // Find appropriate memory type for given reqs
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-    VkPhysicalDeviceMemoryProperties dev_mem_props = m_device->phy().memory_properties_;
+    VkPhysicalDeviceMemoryProperties dev_mem_props = m_device->Physical().memory_properties_;
 
     uint32_t mem_type_index = 0;
     for (mem_type_index = 0; mem_type_index < dev_mem_props.memoryTypeCount; ++mem_type_index) {
@@ -509,7 +510,7 @@ TEST_F(VkBestPracticesLayerTest, SmallDedicatedAllocation) {
 
     vkt::DeviceMemory mem;
     mem.init(*m_device,
-             vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
+             vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT));
     vk::BindImageMemory(device(), image.handle(), mem.handle(), 0);
 
     m_errorMonitor->VerifyFound();
@@ -665,7 +666,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoad) {
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-redundant-clear");
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-RenderPass-inefficient-clear");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), m_width, m_height);
 
     VkClearAttachment color_attachment;
@@ -716,7 +717,7 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     pipe_writes.cb_attachments_.colorWriteMask = 0xf;
     pipe_writes.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -776,9 +777,9 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     vkt::CommandBuffer secondary_draw_masked(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     vkt::CommandBuffer secondary_draw_write(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    secondary_clear.begin(&begin_info);
-    secondary_draw_masked.begin(&begin_info);
-    secondary_draw_write.begin(&begin_info);
+    secondary_clear.Begin(&begin_info);
+    secondary_draw_masked.Begin(&begin_info);
+    secondary_draw_write.Begin(&begin_info);
 
     vk::CmdClearAttachments(secondary_clear.handle(), 1, &color_attachment, 1, &clear_rect);
 
@@ -788,9 +789,9 @@ TEST_F(VkBestPracticesLayerTest, ClearAttachmentsAfterLoadSecondary) {
     vk::CmdBindPipeline(secondary_draw_write.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_writes.Handle());
     vk::CmdDraw(secondary_draw_write.handle(), 1, 0, 0, 0);
 
-    secondary_clear.end();
-    secondary_draw_masked.end();
-    secondary_draw_write.end();
+    secondary_clear.End();
+    secondary_draw_masked.End();
+    secondary_draw_write.End();
 
     // Plain clear after load.
     m_command_buffer.BeginRenderPass(render_pass_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
@@ -833,7 +834,7 @@ TEST_F(VkBestPracticesLayerTest, TripleBufferingTest) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -912,13 +913,13 @@ TEST_F(VkBestPracticesLayerTest, SwapchainCreationTest) {
     // Test for successful swapchain creation when GetPhysicalDeviceSurfaceCapabilitiesKHR() and
     // GetPhysicalDeviceSurfaceFormatsKHR() are queried as expected and GetPhysicalDeviceSurfacePresentModesKHR() is not called but
     // the present mode is VK_PRESENT_MODE_FIFO_KHR
-    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &m_surface_capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(Gpu(), m_surface, &m_surface_capabilities);
 
     uint32_t format_count;
-    vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, nullptr);
+    vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &format_count, nullptr);
     if (format_count != 0) {
         m_surface_formats.resize(format_count);
-        vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, m_surface_formats.data());
+        vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &format_count, m_surface_formats.data());
     }
 
     swapchain_create_info.imageFormat = m_surface_formats[0].format;
@@ -1006,8 +1007,8 @@ TEST_F(VkBestPracticesLayerTest, MissingQueryDetails) {
     vkt::QueueCreateInfoArray queue_info(phys_device_obj.queue_properties_, true);
     // Only request creation with queuefamilies that have at least one queue
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t j = 0; j < queue_info.size(); ++j) {
+    auto qci = queue_info.Data();
+    for (uint32_t j = 0; j < queue_info.Size(); ++j) {
         if (qci[j].queueCount) {
             create_queue_infos.push_back(qci[j]);
         }
@@ -1044,7 +1045,7 @@ TEST_F(VkBestPracticesLayerTest, DepthBiasNoAttachment) {
     pipe.rs_state_ci_.depthBiasConstantFactor = 1.0f;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1053,7 +1054,7 @@ TEST_F(VkBestPracticesLayerTest, DepthBiasNoAttachment) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, CreatePipelineVsFsTypeMismatchArraySize) {
@@ -1244,7 +1245,7 @@ TEST_F(VkBestPracticesLayerTest, TransitionFromUndefinedToReadOnly) {
     img_barrier.subresourceRange.layerCount = 1;
     img_barrier.subresourceRange.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &color_clear_value, 1, &clear_range);
 
@@ -1254,7 +1255,7 @@ TEST_F(VkBestPracticesLayerTest, TransitionFromUndefinedToReadOnly) {
                            nullptr, 0, nullptr, 1, &img_barrier);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SemaphoreSetWhenCountIsZero) {
@@ -1372,7 +1373,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     vkt::RenderPass rp(*m_device, rp_info);
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), w, h);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Create a useless VkClearValue
     VkClearValue cv{};
@@ -1391,7 +1392,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearWithoutLoadOpClear) {
     m_command_buffer.BeginRenderPass(begin_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCount) {
@@ -1438,7 +1439,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCo
     vkt::RenderPass rp(*m_device, rp_info);
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &image_view.handle(), w, h);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Create two VkClearValues
     VkClearValue cv[2];
@@ -1464,7 +1465,7 @@ TEST_F(VkBestPracticesLayerTest, RenderPassClearValueCountHigherThanAttachmentCo
     m_command_buffer.BeginRenderPass(begin_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
@@ -1517,7 +1518,7 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
     vkt::RenderPass rp2(*m_device, rp_info);
     vkt::Framebuffer fb(*m_device, rp1.handle(), 1, &image_view.handle(), w, h);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // All white
     VkClearValue cv;
@@ -1534,7 +1535,7 @@ TEST_F(VkBestPracticesLayerTest, DontCareThenLoad) {
 
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredWarning("BestPractices-StoreOpDontCareThenLoadOpLoad");
     m_default_queue->Submit(m_command_buffer);
@@ -1573,7 +1574,7 @@ TEST_F(VkBestPracticesLayerTest, LoadDeprecatedExtension) {
     m_errorMonitor->SetAllowedFailureMsg("BestPractices-vkCreateDevice-API-version-mismatch");
 
     VkDevice device = VK_NULL_HANDLE;
-    vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
+    vk::CreateDevice(Gpu(), &dev_info, nullptr, &device);
 
     if (DeviceValidationVersion() >= VK_API_VERSION_1_3) {
         m_errorMonitor->VerifyFound();
@@ -1685,19 +1686,19 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     // Record command buffers without queue transition
 
     // Record graphics command buffer
-    graphics_buffer.begin();
+    graphics_buffer.Begin();
 
     graphics_buffer.BeginRenderPass(begin_info);
 
     graphics_buffer.EndRenderPass();
 
-    graphics_buffer.end();
+    graphics_buffer.End();
 
     graphics_queue->Submit(graphics_buffer);
     graphics_queue->Wait();
 
     // Record compute command buffer
-    compute_buffer.begin();
+    compute_buffer.Begin();
 
     vk::CmdBindPipeline(compute_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
@@ -1706,7 +1707,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     vk::CmdDispatch(compute_buffer.handle(), w, h, 1);
 
-    compute_buffer.end();
+    compute_buffer.End();
 
     // Warning should trigger as we are potentially accessing undefined resources
     m_errorMonitor->SetDesiredWarning("BestPractices-ConcurrentUsageOfExclusiveImage");
@@ -1733,7 +1734,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     barrier.subresourceRange.layerCount = VK_REMAINING_ARRAY_LAYERS;
 
     // Record graphics command buffer
-    graphics_buffer.begin();
+    graphics_buffer.Begin();
 
     graphics_buffer.BeginRenderPass(begin_info);
 
@@ -1742,12 +1743,12 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
     vk::CmdPipelineBarrier(graphics_buffer.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
 
-    graphics_buffer.end();
+    graphics_buffer.End();
     graphics_queue->Submit(graphics_buffer);
     graphics_queue->Wait();
 
     // Record compute command buffer
-    compute_buffer.begin();
+    compute_buffer.Begin();
 
     vk::CmdPipelineBarrier(compute_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
                            VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
@@ -1759,7 +1760,7 @@ TEST_F(VkBestPracticesLayerTest, ExclusiveImageMultiQueueUsage) {
 
     vk::CmdDispatch(compute_buffer.handle(), w, h, 1);
 
-    compute_buffer.end();
+    compute_buffer.End();
 
     // Warning shouldn't trigger
     m_errorMonitor->SetDesiredWarning("BestPractices-ConcurrentUsageOfExclusiveImage");
@@ -1801,7 +1802,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
     img_barrier.subresourceRange.layerCount = 1;
     img_barrier.subresourceRange.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &color_clear_value, 1, &clear_range);
 
@@ -1870,7 +1871,7 @@ TEST_F(VkBestPracticesLayerTest, ImageMemoryBarrierAccessLayoutCombinations) {
         img_barrier2.dstAccessMask = 0;
         vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -1880,8 +1881,8 @@ TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    secondary.begin();
-    secondary.end();
+    secondary.Begin();
+    secondary.End();
 
     VkCommandBufferBeginInfo cbbi = {
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO,
@@ -1890,11 +1891,11 @@ TEST_F(VkBestPracticesLayerTest, NonSimultaneousSecondaryMarksPrimary) {
         nullptr,
     };
 
-    m_command_buffer.begin(&cbbi);
+    m_command_buffer.Begin(&cbbi);
     m_errorMonitor->SetDesiredWarning("BestPractices-vkCmdExecuteCommands-CommandBufferSimultaneousUse");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, NoCreateSwapchainPresentModes) {
@@ -1938,9 +1939,9 @@ TEST_F(VkBestPracticesLayerTest, GetQueryPoolResultsWithoutBegin) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0u, 1u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -1963,7 +1964,7 @@ TEST_F(VkBestPracticesLayerTest, NonOptimalResolveFormat) {
 
     VkSubpassResolvePerformanceQueryEXT performance_query = vku::InitStructHelper();
     VkFormatProperties2 format_properties2 = vku::InitStructHelper(&performance_query);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &format_properties2);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_properties2);
     if (performance_query.optimal == VK_TRUE) {
         GTEST_SKIP() << "VkSubpassResolvePerformanceQueryEXT::optimal required to be VK_FALSE.";
     }
@@ -2036,7 +2037,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(uint32_t),
@@ -2051,7 +2052,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetEnd) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
@@ -2084,7 +2085,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, {push_constant_range});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(uint32_t),
@@ -2097,7 +2098,7 @@ TEST_F(VkBestPracticesLayerTest, PartialPushConstantSetMiddle) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/7495
@@ -2139,11 +2140,11 @@ TEST_F(VkBestPracticesLayerTest, IgnoreResolveImageView) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredWarning("BestPractices-VkRenderingInfo-ResolveModeNone");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SetSignaledEvent) {
@@ -2152,12 +2153,12 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEvent) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SetSignaledEvent2) {
@@ -2176,12 +2177,12 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEvent2) {
     dep_info.memoryBarrierCount = 1;
     dep_info.pMemoryBarriers = &barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent2(m_command_buffer.handle(), event, &dep_info);
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     vk::CmdSetEvent2(m_command_buffer.handle(), event, &dep_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SetEventSignaledByHost) {
@@ -2191,9 +2192,9 @@ TEST_F(VkBestPracticesLayerTest, SetEventSignaledByHost) {
     vkt::Event event(*m_device);
     vk::SetEvent(*m_device, event);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
@@ -2205,15 +2206,15 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     cb2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb2.end();
+    cb2.End();
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_default_queue->Submit(cb2);
     m_errorMonitor->VerifyFound();
@@ -2228,15 +2229,15 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventMultipleSubmits2) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit2(m_command_buffer);
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     cb2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb2.end();
+    cb2.End();
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_default_queue->Submit2(cb2);
     m_errorMonitor->VerifyFound();
@@ -2250,16 +2251,16 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary) {
     vkt::Event event(*m_device);
 
     vkt::CommandBuffer secondary_cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary_cb.begin();
+    secondary_cb.Begin();
     secondary_cb.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    secondary_cb.end();
+    secondary_cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_command_buffer.ExecuteCommands(secondary_cb);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary2) {
@@ -2275,16 +2276,16 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary2) {
     VkCommandBufferBeginInfo cb_begin_info = vku::InitStructHelper();
     cb_begin_info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
     cb_begin_info.pInheritanceInfo = &inheritanc_info;
-    cb.begin(&cb_begin_info);
+    cb.Begin(&cb_begin_info);
     cb.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb.end();
+    cb.End();
     const VkCommandBuffer secondary_cbs[2] = {cb.handle(), cb.handle()};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 2, secondary_cbs);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary3) {
@@ -2294,19 +2295,19 @@ TEST_F(VkBestPracticesLayerTest, SetSignaledEventSecondary3) {
     vkt::Event event(*m_device);
 
     vkt::CommandBuffer secondary_cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary_cb.begin();
+    secondary_cb.Begin();
     secondary_cb.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    secondary_cb.end();
+    secondary_cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.ExecuteCommands(secondary_cb);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     cb2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb2.end();
+    cb2.End();
     m_errorMonitor->SetDesiredWarning("BestPractices-Event-SignalSignaledEvent");
     m_default_queue->Submit(cb2);
     m_errorMonitor->VerifyFound();

--- a/tests/unit/best_practices_positive.cpp
+++ b/tests/unit/best_practices_positive.cpp
@@ -118,7 +118,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DrawingWithUnboundUnusedSet) {
     OneOffDescriptorSet empty_ds(m_device, {});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&empty_ds.layout_, &empty_ds.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 1, 1,
                               &empty_ds.set_, 0, nullptr);
@@ -132,7 +132,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, DrawingWithUnboundUnusedSet) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
@@ -167,9 +167,9 @@ TEST_F(VkPositiveBestPracticesLayerTest, DynStateIgnoreAttachments) {
     pipe.cb_ci_.pAttachments = nullptr;
     pipe.gp_ci_.pDynamicState = &dynamic_create_info;
     pipe.CreateGraphicsPipeline();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, PipelineLibraryNoRendering) {
@@ -231,14 +231,14 @@ TEST_F(VkPositiveBestPracticesLayerTest, PushConstantSet) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {}, push_constant_ranges);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0, 16, data);
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_FRAGMENT_BIT, 16, 4, data);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
@@ -268,7 +268,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     m_errorMonitor->ExpectSuccess(kErrorBit | kWarningBit | kPerformanceWarningBit);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
 
@@ -278,7 +278,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, VertexBufferNotForAllDraws) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe1.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, SetDifferentEvents) {
@@ -289,10 +289,10 @@ TEST_F(VkPositiveBestPracticesLayerTest, SetDifferentEvents) {
     vkt::Event event(*m_device);
     vkt::Event event2(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_command_buffer.SetEvent(event2, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSet) {
@@ -302,11 +302,11 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSet) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits) {
@@ -316,16 +316,16 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_command_buffer.ResetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     cb2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb2.end();
+    cb2.End();
     m_default_queue->Submit(cb2);
     m_default_queue->Wait();
 }
@@ -337,15 +337,15 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventBeforeSetMultipleSubmits2) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     cb2.ResetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     cb2.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    cb2.end();
+    cb2.End();
 
     VkSubmitInfo submits[2];
     submits[0] = vku::InitStructHelper();
@@ -367,15 +367,15 @@ TEST_F(VkPositiveBestPracticesLayerTest, ResetEventFromSecondary) {
     vkt::Event event(*m_device);
 
     vkt::CommandBuffer secondary_cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary_cb.begin();
+    secondary_cb.Begin();
     secondary_cb.ResetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    secondary_cb.end();
+    secondary_cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
     m_command_buffer.ExecuteCommands(secondary_cb);
     m_command_buffer.SetEvent(event, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
@@ -388,7 +388,7 @@ TEST_F(VkPositiveBestPracticesLayerTest, CreateFifoRelaxedSwapchain) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }

--- a/tests/unit/buffer.cpp
+++ b/tests/unit/buffer.cpp
@@ -24,7 +24,7 @@ TEST_F(NegativeBuffer, UpdateBufferAlignment) {
     RETURN_IF_SKIP(Init());
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Introduce failure by using dstOffset that is not multiple of 4
     m_errorMonitor->SetDesiredError(" is not a multiple of 4");
     vk::CmdUpdateBuffer(m_command_buffer.handle(), buffer.handle(), 1, 4, updateData);
@@ -45,7 +45,7 @@ TEST_F(NegativeBuffer, UpdateBufferAlignment) {
     vk::CmdUpdateBuffer(m_command_buffer.handle(), buffer.handle(), 0, (VkDeviceSize)80000, updateData);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, FillBufferAlignmentAndSize) {
@@ -53,7 +53,7 @@ TEST_F(NegativeBuffer, FillBufferAlignmentAndSize) {
 
     RETURN_IF_SKIP(Init());
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Introduce failure by using dstOffset greater than bufferSize
     m_errorMonitor->SetDesiredError("VUID-vkCmdFillBuffer-dstOffset-00024");
@@ -80,7 +80,7 @@ TEST_F(NegativeBuffer, FillBufferAlignmentAndSize) {
     vk::CmdFillBuffer(m_command_buffer.handle(), buffer.handle(), 0, 0, 0x11111111);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, BufferViewObject) {
@@ -154,7 +154,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     AddOptionalExtensions(VK_EXT_TEXEL_BUFFER_ALIGNMENT_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     const VkDeviceSize minTexelBufferOffsetAlignment = dev_limits.minTexelBufferOffsetAlignment;
     if (minTexelBufferOffsetAlignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
@@ -163,7 +163,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
     const VkFormat format_with_uniform_texel_support = VK_FORMAT_R8G8B8A8_UNORM;
     const VkFormat format_without_texel_support = VK_FORMAT_R8G8B8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format_with_uniform_texel_support, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format_with_uniform_texel_support, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
@@ -231,7 +231,7 @@ TEST_F(NegativeBuffer, BufferViewCreateInfoEntries) {
         CreateBufferViewTest(*this, &buff_view_ci, {"VUID-VkBufferViewCreateInfo-range-04059"});
     }
 
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format_without_texel_support, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format_without_texel_support, &format_properties);
     if ((format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT) ||
         (format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP()
@@ -262,13 +262,13 @@ TEST_F(NegativeBuffer, TexelBufferAlignmentIn12) {
         GTEST_SKIP() << "Vulkan version 1.2 or less is required";
     }
 
-    const VkDeviceSize minTexelBufferOffsetAlignment = m_device->phy().limits_.minTexelBufferOffsetAlignment;
+    const VkDeviceSize minTexelBufferOffsetAlignment = m_device->Physical().limits_.minTexelBufferOffsetAlignment;
     if (minTexelBufferOffsetAlignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
     }
 
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
@@ -333,7 +333,7 @@ TEST_F(NegativeBuffer, TexelBufferAlignment) {
 
     // Test a 3-component format
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R32G32B32_SFLOAT, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R32G32B32_SFLOAT, &format_properties);
     if (format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT) {
         buffer_info.usage = VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT;
         vkt::Buffer buffer2;
@@ -367,7 +367,7 @@ TEST_F(NegativeBuffer, FillBufferWithinRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkMemoryPropertyFlags reqs = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT;
@@ -378,7 +378,7 @@ TEST_F(NegativeBuffer, FillBufferWithinRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, UpdateBufferWithinRenderPass) {
@@ -388,7 +388,7 @@ TEST_F(NegativeBuffer, UpdateBufferWithinRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vkt::Buffer dst_buffer(*m_device, 1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
@@ -401,14 +401,14 @@ TEST_F(NegativeBuffer, UpdateBufferWithinRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, IdxBufferAlignmentError) {
     // Bind a BeginRenderPass within an active RenderPass
     RETURN_IF_SKIP(Init());
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer-offset-08783");
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), buffer.handle(), 7, VK_INDEX_TYPE_UINT16);
     m_errorMonitor->VerifyFound();
@@ -436,7 +436,7 @@ TEST_F(NegativeBuffer, BindNull) {
     vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
-    m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     vkt::DeviceMemory memory(*m_device, buffer_alloc_info);
 
     vk::DestroyBuffer(device(), buffer, nullptr);
@@ -450,10 +450,10 @@ TEST_F(NegativeBuffer, VertexBufferOffset) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    const uint32_t maxVertexInputBindings = m_device->phy().limits_.maxVertexInputBindings;
+    const uint32_t maxVertexInputBindings = m_device->Physical().limits_.maxVertexInputBindings;
     const VkDeviceSize vbo_size = 3 * sizeof(float);
     vkt::Buffer vbo(*m_device, vbo_size, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers-pOffsets-00626");
@@ -473,7 +473,7 @@ TEST_F(NegativeBuffer, VertexBufferOffset) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, IndexBufferOffset) {
@@ -484,7 +484,7 @@ TEST_F(NegativeBuffer, IndexBufferOffset) {
     InitRenderTarget();
     const uint32_t buffer_size = 32;
     vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Set offset over buffer size
@@ -503,7 +503,7 @@ TEST_F(NegativeBuffer, IndexBufferOffset) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, IndexBuffer2Offset) {
@@ -517,7 +517,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Offset) {
     InitRenderTarget();
     const uint32_t buffer_size = 32;
     vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Set offset over buffer size
@@ -536,7 +536,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Offset) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, IndexBuffer2Size) {
@@ -551,7 +551,7 @@ TEST_F(NegativeBuffer, IndexBuffer2Size) {
     vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &mem_reqs);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer2KHR-size-08767");
@@ -563,13 +563,13 @@ TEST_F(NegativeBuffer, IndexBuffer2Size) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, IndexBufferNull) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer-None-09493");
@@ -583,7 +583,7 @@ TEST_F(NegativeBuffer, IndexBufferNullOffset) {
     AddRequiredFeature(vkt::Feature::maintenance6);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer-buffer-09494");
@@ -684,11 +684,11 @@ TEST_F(NegativeBuffer, FillBufferCmdPoolUnsupported) {
     vkt::CommandPool pool(*m_device, transfer_family.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer cb(*m_device, pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    cb.begin();
+    cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdFillBuffer-apiVersion-07894");
     vk::CmdFillBuffer(cb.handle(), buffer.handle(), 0, 12, 0x11111111);
     m_errorMonitor->VerifyFound();
-    cb.end();
+    cb.End();
 }
 
 TEST_F(NegativeBuffer, ConditionalRenderingBufferUsage) {
@@ -700,11 +700,11 @@ TEST_F(NegativeBuffer, ConditionalRenderingBufferUsage) {
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = vku::InitStructHelper();
     conditional_rendering_begin.buffer = buffer.handle();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkConditionalRenderingBeginInfoEXT-buffer-01982");
     vk::CmdBeginConditionalRenderingEXT(m_command_buffer.handle(), &conditional_rendering_begin);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, ConditionalRenderingOffset) {
@@ -719,7 +719,7 @@ TEST_F(NegativeBuffer, ConditionalRenderingOffset) {
     conditional_rendering_begin.buffer = buffer.handle();
     conditional_rendering_begin.offset = 3;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkConditionalRenderingBeginInfoEXT-offset-01984");
     vk::CmdBeginConditionalRenderingEXT(m_command_buffer.handle(), &conditional_rendering_begin);
@@ -730,7 +730,7 @@ TEST_F(NegativeBuffer, ConditionalRenderingOffset) {
     vk::CmdBeginConditionalRenderingEXT(m_command_buffer.handle(), &conditional_rendering_begin);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, BeginConditionalRendering) {
@@ -742,13 +742,13 @@ TEST_F(NegativeBuffer, BeginConditionalRendering) {
     VkConditionalRenderingBeginInfoEXT conditional_rendering_begin = vku::InitStructHelper();
     conditional_rendering_begin.buffer = buffer.handle();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginConditionalRenderingEXT(m_command_buffer.handle(), &conditional_rendering_begin);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginConditionalRenderingEXT-None-01980");
     vk::CmdBeginConditionalRenderingEXT(m_command_buffer.handle(), &conditional_rendering_begin);
     m_errorMonitor->VerifyFound();
     vk::CmdEndConditionalRenderingEXT(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeBuffer, MaxBufferSize) {

--- a/tests/unit/buffer_positive.cpp
+++ b/tests/unit/buffer_positive.cpp
@@ -56,13 +56,13 @@ TEST_F(PositiveBuffer, TexelBufferAlignmentIn13) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
 
-    const VkDeviceSize minTexelBufferOffsetAlignment = m_device->phy().limits_.minTexelBufferOffsetAlignment;
+    const VkDeviceSize minTexelBufferOffsetAlignment = m_device->Physical().limits_.minTexelBufferOffsetAlignment;
     if (minTexelBufferOffsetAlignment == 1) {
         GTEST_SKIP() << "Test requires minTexelOffsetAlignment to not be equal to 1";
     }
 
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
@@ -118,9 +118,9 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressWorstCase) {
     for (size_t i = 0; i < N; ++i) {
         vkt::Buffer &buffer = buffers[i];
         buffer_ci.size = (i + 1) * 4096;
-        buffer.init_no_mem(*m_device, buffer_ci);
+        buffer.InitNoMemory(*m_device, buffer_ci);
         vk::BindBufferMemory(device(), buffer.handle(), buffer_memory.handle(), 0);
-        VkDeviceAddress addr = buffer.address();
+        VkDeviceAddress addr = buffer.Address();
         if (ref_address == 0) {
             ref_address = addr;
         }
@@ -157,10 +157,10 @@ TEST_F(PositiveBuffer, DISABLED_PerfGetBufferAddressGoodCase) {
 
     for (size_t i = 0; i < N; ++i) {
         vkt::Buffer &buffer = buffers[i];
-        buffer.init_no_mem(*m_device, buffer_ci);
+        buffer.InitNoMemory(*m_device, buffer_ci);
         // Consecutive offsets
         vk::BindBufferMemory(device(), buffer.handle(), buffer_memory.handle(), i * buffer_ci.size);
-        (void)buffer.address();
+        (void)buffer.Address();
     }
 }
 
@@ -174,7 +174,7 @@ TEST_F(PositiveBuffer, IndexBuffer2Size) {
 
     const uint32_t buffer_size = 32;
     vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindIndexBuffer2KHR(m_command_buffer.handle(), buffer.handle(), 4, 8, VK_INDEX_TYPE_UINT32);
@@ -182,7 +182,7 @@ TEST_F(PositiveBuffer, IndexBuffer2Size) {
     vk::CmdBindIndexBuffer2KHR(m_command_buffer.handle(), buffer.handle(), 0, buffer_size, VK_INDEX_TYPE_UINT32);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveBuffer, IndexBufferNull) {
@@ -195,7 +195,7 @@ TEST_F(PositiveBuffer, IndexBufferNull) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndexed(m_command_buffer.handle(), 0, 1, 0, 0, 0);
@@ -203,7 +203,7 @@ TEST_F(PositiveBuffer, IndexBufferNull) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), VK_NULL_HANDLE, 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexed(m_command_buffer.handle(), 0, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveBuffer, BufferViewUsageBasic) {

--- a/tests/unit/command.cpp
+++ b/tests/unit/command.cpp
@@ -53,7 +53,7 @@ TEST_F(NegativeCommand, IndexBufferNotBound) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -72,7 +72,7 @@ TEST_F(NegativeCommand, IndexBufferDestroyed) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
@@ -92,7 +92,7 @@ TEST_F(NegativeCommand, IndexBufferSizeOffset) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -129,7 +129,7 @@ TEST_F(NegativeCommand, MissingClearAttachment) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -156,7 +156,7 @@ TEST_F(NegativeCommand, MissingClearAttachment2) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
@@ -174,7 +174,7 @@ TEST_F(NegativeCommand, ClearAttachment64Bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_R64G64B64A64_SFLOAT format not supported";
     }
@@ -189,7 +189,7 @@ TEST_F(NegativeCommand, ClearAttachment64Bit) {
     rp.CreateRenderPass();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &image_view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
     VkClearAttachment attachment;
@@ -212,8 +212,8 @@ TEST_F(NegativeCommand, CommandBufferTwoSubmits) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-    m_command_buffer.end();
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.End();
 
     // Bypass framework since it does the waits automatically
     m_default_queue->Submit(m_command_buffer);
@@ -236,8 +236,8 @@ TEST_F(NegativeCommand, Sync2CommandBufferTwoSubmits) {
     m_errorMonitor->SetDesiredError("UNASSIGNED-DrawState-CommandBufferSingleSubmitViolation");
     InitRenderTarget();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
-    m_command_buffer.end();
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT);
+    m_command_buffer.End();
 
     // Bypass framework since it does the waits automatically
     VkCommandBufferSubmitInfoKHR cb_info = vku::InitStructHelper();
@@ -276,7 +276,7 @@ TEST_F(NegativeCommand, PushConstants) {
         char const *msg;
     };
 
-    const uint32_t too_big = m_device->phy().limits_.maxPushConstantsSize + 0x4;
+    const uint32_t too_big = m_device->Physical().limits_.maxPushConstantsSize + 0x4;
     const std::array<PipelineLayoutTestCase, 10> range_tests = {{
         {{VK_SHADER_STAGE_VERTEX_BIT, 0, 0}, "VUID-VkPushConstantRange-size-00296"},
         {{VK_SHADER_STAGE_VERTEX_BIT, 0, 1}, "VUID-VkPushConstantRange-size-00297"},
@@ -369,7 +369,7 @@ TEST_F(NegativeCommand, PushConstants) {
 
     const uint8_t dummy_values[100] = {};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Check for invalid stage flag
@@ -412,7 +412,7 @@ TEST_F(NegativeCommand, PushConstants) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, PushConstant2PipelineLayoutCreateInfo) {
@@ -430,11 +430,11 @@ TEST_F(NegativeCommand, PushConstant2PipelineLayoutCreateInfo) {
     pc_info.pValues = data;
     pc_info.layout = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkPushConstantsInfoKHR-None-09495");
     vk::CmdPushConstants2KHR(m_command_buffer.handle(), &pc_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, NoBeginCommandBuffer) {
@@ -510,7 +510,7 @@ TEST_F(NegativeCommand, ClearColorAttachmentsOutsideRenderPass) {
     InitRenderTarget();
 
     // Start no RenderPass
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -533,7 +533,7 @@ TEST_F(NegativeCommand, ClearColorAttachmentsZeroLayercount) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
@@ -555,7 +555,7 @@ TEST_F(NegativeCommand, ClearColorAttachmentsZeroExtent) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
@@ -587,7 +587,7 @@ TEST_F(NegativeCommand, ClearAttachmentsAspectMasks) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
@@ -629,7 +629,7 @@ TEST_F(NegativeCommand, ClearAttachmentsImplicitCheck) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment color_attachment;
@@ -659,7 +659,7 @@ TEST_F(NegativeCommand, ClearAttachmentsDepth) {
     TEST_DESCRIPTION("Call CmdClearAttachments with invalid depth aspect masks.");
 
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedStencilOnlyFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedStencilOnlyFormat(Gpu());
     if (m_depth_stencil_fmt == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -669,7 +669,7 @@ TEST_F(NegativeCommand, ClearAttachmentsDepth) {
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
@@ -694,13 +694,13 @@ TEST_F(NegativeCommand, ClearAttachmentsStencil) {
     TEST_DESCRIPTION("Call CmdClearAttachments with invalid stencil aspect masks.");
 
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedDepthOnlyFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthOnlyFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
@@ -726,7 +726,7 @@ TEST_F(NegativeCommand, ClearAttachmentsOutsideRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkClearAttachment attachment;
     attachment.colorAttachment = 0;
     VkClearRect clear_rect = {};
@@ -748,7 +748,7 @@ TEST_F(NegativeCommand, DrawOutsideRenderPass) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-renderpass");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
@@ -767,7 +767,7 @@ TEST_F(NegativeCommand, MultiDrawDrawOutsideRenderPass) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMultiEXT-renderpass");
     vk::CmdDrawMultiEXT(m_command_buffer.handle(), 3, multi_draws, 1, 0, sizeof(VkMultiDrawInfoEXT));
@@ -782,10 +782,10 @@ TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
 
     // An empty primary command buffer
     vkt::CommandBuffer cb(*m_device, m_command_pool);
-    cb.begin();
-    cb.end();
+    cb.Begin();
+    cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     VkCommandBuffer handle = cb.handle();
 
@@ -796,7 +796,7 @@ TEST_F(NegativeCommand, ExecuteCommandsPrimaryCB) {
     m_errorMonitor->SetUnexpectedError("All elements of pCommandBuffers must not be in the pending state");
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, SimultaneousUseOneShot) {
@@ -877,7 +877,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipeline) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -890,7 +890,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineFunction) {
@@ -931,7 +931,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineFunction) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -944,7 +944,7 @@ TEST_F(NegativeCommand, DrawTimeImageViewTypeMismatchWithPipelineFunction) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
@@ -982,7 +982,7 @@ TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -994,7 +994,7 @@ TEST_F(NegativeCommand, DrawTimeImageComponentTypeMismatchWithPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ResolveImageLowSampleCount) {
@@ -1002,7 +1002,7 @@ TEST_F(NegativeCommand, ResolveImageLowSampleCount) {
 
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1013,7 +1013,7 @@ TEST_F(NegativeCommand, ResolveImageLowSampleCount) {
     vkt::Image srcImage(*m_device, image_create_info, vkt::set_layout);
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageResolve resolveRegion;
     resolveRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     resolveRegion.srcOffset = {0, 0, 0};
@@ -1022,7 +1022,7 @@ TEST_F(NegativeCommand, ResolveImageLowSampleCount) {
     resolveRegion.extent = {1, 1, 1};
     vk::CmdResolveImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1032,7 +1032,7 @@ TEST_F(NegativeCommand, ResolveImageHighSampleCount) {
 
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1058,7 +1058,7 @@ TEST_F(NegativeCommand, ResolveImageHighSampleCount) {
     vkt::Image srcImage(*m_device, image_create_info, vkt::set_layout);
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Need memory barrier to VK_IMAGE_LAYOUT_GENERAL for source and dest?
     // VK_IMAGE_LAYOUT_UNDEFINED = 0,
     // VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -1070,7 +1070,7 @@ TEST_F(NegativeCommand, ResolveImageHighSampleCount) {
     resolveRegion.extent = {1, 1, 1};
     vk::CmdResolveImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1080,7 +1080,7 @@ TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
 
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1109,7 +1109,7 @@ TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Need memory barrier to VK_IMAGE_LAYOUT_GENERAL for source and dest?
     // VK_IMAGE_LAYOUT_UNDEFINED = 0,
     // VK_IMAGE_LAYOUT_GENERAL = 1,
@@ -1121,7 +1121,7 @@ TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
     resolveRegion.extent = {1, 1, 1};
     vk::CmdResolveImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1129,7 +1129,7 @@ TEST_F(NegativeCommand, ResolveImageFormatMismatch) {
 TEST_F(NegativeCommand, ResolveImageLayoutMismatch) {
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1156,7 +1156,7 @@ TEST_F(NegativeCommand, ResolveImageLayoutMismatch) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // source image must have valid contents before resolve
     VkClearColorValue clear_color = {{0, 0, 0, 0}};
     VkImageSubresourceRange subresource = {};
@@ -1185,7 +1185,7 @@ TEST_F(NegativeCommand, ResolveImageLayoutMismatch) {
     vk::CmdResolveImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dstImage.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1, &resolveRegion);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ResolveInvalidSubresource) {
@@ -1193,7 +1193,7 @@ TEST_F(NegativeCommand, ResolveInvalidSubresource) {
     RETURN_IF_SKIP(Init());
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1220,7 +1220,7 @@ TEST_F(NegativeCommand, ResolveInvalidSubresource) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     vkt::Image dstImage(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // source image must have valid contents before resolve
     VkClearColorValue clear_color = {{0, 0, 0, 0}};
     VkImageSubresourceRange subresource = {};
@@ -1361,13 +1361,13 @@ TEST_F(NegativeCommand, ResolveInvalidSubresource) {
 
     resolveRegion.dstSubresource.baseArrayLayer = 0;
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ResolveImageImageType) {
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1400,7 +1400,7 @@ TEST_F(NegativeCommand, ResolveImageImageType) {
     image_create_info.arrayLayers = 1;
     vkt::Image dstImage3D(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageResolve resolveRegion;
     resolveRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -1438,14 +1438,14 @@ TEST_F(NegativeCommand, ResolveImageImageType) {
     m_errorMonitor->VerifyFound();
     resolveRegion.extent.depth = 1;
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ResolveImageSizeExceeded) {
     TEST_DESCRIPTION("Resolve Image with subresource region greater than size of src/dst image");
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1471,7 +1471,7 @@ TEST_F(NegativeCommand, ResolveImageSizeExceeded) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     vkt::Image dstImage2D(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageResolve resolveRegion = {};
     resolveRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -1532,7 +1532,7 @@ TEST_F(NegativeCommand, ResolveImageSizeExceeded) {
     m_errorMonitor->VerifyFound();
     resolveRegion.dstOffset.z = 0;
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearImage) {
@@ -1541,7 +1541,7 @@ TEST_F(NegativeCommand, ClearImage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Color image
     VkClearColorValue clear_color;
@@ -1609,14 +1609,14 @@ TEST_F(NegativeCommand, ClearColor64Bit) {
     TEST_DESCRIPTION("Clear with a 64-bit format");
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_R64G64B64A64_SFLOAT format not supported";
     }
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R64G64B64A64_SFLOAT, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
     VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearColorImage-image-09678");
@@ -1640,7 +1640,7 @@ TEST_F(NegativeCommand, CommandQueueFlags) {
 
     // Setup command buffer on pool
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     // Issue a graphics only command
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-commandBuffer-cmdpool");
@@ -1670,7 +1670,7 @@ TEST_F(NegativeCommand, MultiDraw) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1748,7 +1748,7 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1787,7 +1787,7 @@ TEST_F(NegativeCommand, MultiDrawWholeSizeMaintenance5) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1820,7 +1820,7 @@ TEST_F(NegativeCommand, MultiDrawMaintenance5Mixed) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1856,7 +1856,7 @@ TEST_F(NegativeCommand, MultiDrawFeatures) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMultiEXT-None-04933");
@@ -1879,7 +1879,7 @@ TEST_F(NegativeCommand, IndirectDraw) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1908,7 +1908,7 @@ TEST_F(NegativeCommand, IndirectDraw) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
@@ -1917,12 +1917,12 @@ TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.multiDrawIndirect = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxDrawIndirectCount < 2) {
+    if (m_device->Physical().limits_.maxDrawIndirectCount < 2) {
         GTEST_SKIP() << "maxDrawIndirectCount is too low";
     }
 
@@ -1934,7 +1934,7 @@ TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
@@ -1946,7 +1946,7 @@ TEST_F(NegativeCommand, MultiDrawIndirectFeature) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, StrideMultiDrawIndirect) {
@@ -1962,7 +1962,7 @@ TEST_F(NegativeCommand, StrideMultiDrawIndirect) {
     CreatePipelineHelper helper(*this);
     helper.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     auto BufferMemoryBarrier = buffer.BufferMemoryBarrier(
         VK_ACCESS_TRANSFER_WRITE_BIT, VK_ACCESS_INDIRECT_COMMAND_READ_BIT | VK_ACCESS_INDEX_READ_BIT, 0, VK_WHOLE_SIZE);
@@ -1986,7 +1986,7 @@ TEST_F(NegativeCommand, StrideMultiDrawIndirect) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), buffer.handle(), 0, 100, 2);
     m_errorMonitor->VerifyFound();
 
-    auto draw_count = m_device->phy().limits_.maxDrawIndirectCount;
+    auto draw_count = m_device->Physical().limits_.maxDrawIndirectCount;
     if (draw_count != vvl::kU32Max) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirect-drawCount-02719");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirect-drawCount-00476");
@@ -2006,7 +2006,7 @@ TEST_F(NegativeCommand, StrideMultiDrawIndirect) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), buffer.handle(), 0, 2, 24);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DrawIndirectCountKHR) {
@@ -2019,7 +2019,7 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2080,7 +2080,7 @@ TEST_F(NegativeCommand, DrawIndirectCountKHR) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
@@ -2093,7 +2093,7 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2166,7 +2166,7 @@ TEST_F(NegativeCommand, DrawIndexedIndirectCountKHR) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DrawIndirectCountFeature) {
@@ -2190,7 +2190,7 @@ TEST_F(NegativeCommand, DrawIndirectCountFeature) {
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands but without the drawIndirectCount feature set
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2208,7 +2208,7 @@ TEST_F(NegativeCommand, DrawIndirectCountFeature) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ExclusiveScissorNV) {
@@ -2226,7 +2226,7 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxViewports <= 1) {
+    if (m_device->Physical().limits_.maxViewports <= 1) {
         GTEST_SKIP() << "Device doesn't support multiple viewports";
     }
 
@@ -2293,7 +2293,7 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
         const VkRect2D scissor = {{0, 0}, {16, 16}};
         const VkRect2D scissors[] = {scissor, scissor};
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetExclusiveScissorNV-firstExclusiveScissor-02035");
         vk::CmdSetExclusiveScissorNV(m_command_buffer.handle(), 1, 1, scissors);
@@ -2342,7 +2342,7 @@ TEST_F(NegativeCommand, ExclusiveScissorNV) {
             m_errorMonitor->VerifyFound();
         }
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -2430,7 +2430,7 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
     pipe_dynamic.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_W_SCALING_NV);
     pipe_dynamic.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Bind pipeline without dynamic w scaling enabled
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2438,7 +2438,7 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
     // Bind pipeline that has dynamic w-scaling enabled
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_dynamic.Handle());
 
-    const auto max_vps = m_device->phy().limits_.maxViewports;
+    const auto max_vps = m_device->Physical().limits_.maxViewports;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewportWScalingNV-firstViewport-01324");
     vk::CmdSetViewportWScalingNV(m_command_buffer.handle(), 1, max_vps, scale.data());
@@ -2446,7 +2446,7 @@ TEST_F(NegativeCommand, ViewportWScalingNV) {
 
     vk::CmdSetViewportWScalingNV(m_command_buffer.handle(), 0, vp_count, scale.data());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
@@ -2461,7 +2461,7 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), format, &format_props);
     if ((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT) == 0) {
         GTEST_SKIP() << "SAMPLED_IMAGE_FILTER_CUBIC_BIT for format is not supported.";
     }
@@ -2481,7 +2481,7 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     VkFilterCubicImageViewImageFormatPropertiesEXT filter_cubic_props = vku::InitStructHelper();
     VkImageFormatProperties2 image_format_properties = vku::InitStructHelper(&filter_cubic_props);
 
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
 
     if (filter_cubic_props.filterCubic || filter_cubic_props.filterCubicMinmax) {
         GTEST_SKIP() << "Image and ImageView supports filter cubic ; skipped.";
@@ -2511,7 +2511,7 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler_reduction.handle());
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -2522,13 +2522,13 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    m_command_buffer.reset();
+    m_command_buffer.End();
+    m_command_buffer.Reset();
 
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler.handle());
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -2539,7 +2539,7 @@ TEST_F(NegativeCommand, FilterCubicSamplerInCmdDraw) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
@@ -2549,7 +2549,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_EXT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -2595,7 +2595,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, imageView, sampler.handle());
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -2606,7 +2606,7 @@ TEST_F(NegativeCommand, ImageFilterCubicSamplerInCmdDraw) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, CmdUpdateBufferSize) {
@@ -2619,9 +2619,9 @@ TEST_F(NegativeCommand, CmdUpdateBufferSize) {
     vkt::Buffer buffer(*m_device, dataSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-dataSize-00033");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdUpdateBuffer(m_command_buffer.handle(), buffer.handle(), sizeof(uint32_t), dataSize, (void *)update_data);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -2635,9 +2635,9 @@ TEST_F(NegativeCommand, CmdUpdateBufferDstOffset) {
     vkt::Buffer buffer(*m_device, dataSize, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdUpdateBuffer-dstOffset-00032");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdUpdateBuffer(m_command_buffer.handle(), buffer.handle(), sizeof(uint32_t) * 8, dataSize, (void *)update_data);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -2660,7 +2660,7 @@ TEST_F(NegativeCommand, DescriptorSetPipelineBindPoint) {
 
     vkt::CommandPool command_pool(*m_device, compute_qfi.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pipelineBindPoint-00361");
     vk::CmdBindDescriptorSets(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -2687,7 +2687,7 @@ TEST_F(NegativeCommand, DescriptorSetPipelineBindPointMaintenance6) {
 
     vkt::CommandPool command_pool(*m_device, compute_qfi.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     VkBindDescriptorSetsInfoKHR bind_ds_info = vku::InitStructHelper();
     bind_ds_info.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT;
@@ -2723,11 +2723,11 @@ TEST_F(NegativeCommand, CmdClearColorImageNullColor) {
     isr.layerCount = 1;
     isr.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearColorImage-pColor-04961");
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, nullptr, 1, &isr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, EndCommandBufferWithConditionalRendering) {
@@ -2767,7 +2767,7 @@ TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
 
     // Set format features from being found
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), render_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), render_format, &formatProps);
     if ((formatProps.linearTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) == 0) {
         GTEST_SKIP() << "Required linear tiling features not supported";
     }
@@ -2776,7 +2776,7 @@ TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
     // will be caught at draw time that feature for optimal image is not set
     // InitRenderTarget() should be setting color attachment as VK_IMAGE_TILING_LINEAR
     formatProps.linearTilingFeatures &= ~VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), render_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), render_format, formatProps);
 
     InitRenderTarget();
 
@@ -2784,7 +2784,7 @@ TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
     pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -2793,7 +2793,7 @@ TEST_F(NegativeCommand, DrawBlendEnabledFormatFeatures) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, EndConditionalRendering) {
@@ -2854,7 +2854,7 @@ TEST_F(NegativeCommand, EndConditionalRendering) {
     rpbi.clearValueCount = 1;
     rpbi.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndConditionalRenderingEXT-None-01985");
     vk::CmdEndConditionalRenderingEXT(m_command_buffer.handle());
@@ -2882,7 +2882,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
     TEST_DESCRIPTION("Resolve image with missing usage flags.");
 
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }
@@ -2897,12 +2897,12 @@ TEST_F(NegativeCommand, ResolveUsage) {
     VkFormat dst_format = VK_FORMAT_R8_SNORM;
 
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), src_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), src_format, &formatProps);
     formatProps.optimalTilingFeatures &= ~VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), src_format, formatProps);
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), dst_format, &formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), src_format, formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), dst_format, &formatProps);
     formatProps.optimalTilingFeatures &= ~VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), dst_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), dst_format, formatProps);
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -2923,7 +2923,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
     // Some implementations don't support multisampling, check that image format is valid
     VkImageFormatProperties image_format_props{};
     VkResult result =
-        vk::GetPhysicalDeviceImageFormatProperties(gpu(), dst_format, image_create_info.imageType, image_create_info.tiling,
+        vk::GetPhysicalDeviceImageFormatProperties(Gpu(), dst_format, image_create_info.imageType, image_create_info.tiling,
                                                    image_create_info.usage, image_create_info.flags, &image_format_props);
     bool src_image_2_tests_valid = false;
     vkt::Image srcImage2;
@@ -2957,7 +2957,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
     image_create_info.format = dst_format;
     vkt::Image invalidDstImage2(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageResolve resolveRegion;
     resolveRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     resolveRegion.srcOffset = {0, 0, 0};
@@ -2987,7 +2987,7 @@ TEST_F(NegativeCommand, ResolveUsage) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
@@ -2995,7 +2995,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
 
     RETURN_IF_SKIP(Init());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image ds_image(*m_device, 32, 32, 1, ds_format,
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     ds_image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -3050,7 +3050,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
 
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &image_view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, depth_pipe.Handle());
@@ -3078,7 +3078,7 @@ TEST_F(NegativeCommand, DepthStencilStateForReadOnlyLayout) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearColorImageWithRange) {
@@ -3092,7 +3092,7 @@ TEST_F(NegativeCommand, ClearColorImageWithRange) {
 
     const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const auto cb_handle = m_command_buffer.handle();
 
     // Try baseMipLevel >= image.mipLevels with VK_REMAINING_MIP_LEVELS
@@ -3168,7 +3168,7 @@ TEST_F(NegativeCommand, ClearDepthStencilWithAspect) {
     AddOptionalExtensions(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     const bool separate_stencil_usage_supported = IsExtensionsEnabled(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
-    const auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    const auto depth_format = FindSupportedDepthStencilFormat(Gpu());
     InitRenderTarget();
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
@@ -3185,7 +3185,7 @@ TEST_F(NegativeCommand, ClearDepthStencilWithAspect) {
     const VkClearDepthStencilValue clear_value = {};
     VkImageSubresourceRange range = {VK_IMAGE_ASPECT_STENCIL_BIT, 0, 1, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     if (!separate_stencil_usage_supported) {
         printf("VK_EXT_separate_stencil_usage Extension not supported, skipping part of test\n");
@@ -3224,7 +3224,7 @@ TEST_F(NegativeCommand, ClearDepthStencilWithAspect) {
     m_errorMonitor->VerifyFound();
 
     // Using stencil aspect when format only have depth
-    const VkFormat depth_only_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat depth_only_format = FindSupportedDepthOnlyFormat(Gpu());
     if (depth_only_format != VK_FORMAT_UNDEFINED) {
         image_create_info.format = depth_only_format;
         image_create_info.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
@@ -3236,7 +3236,7 @@ TEST_F(NegativeCommand, ClearDepthStencilWithAspect) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearDepthStencilWithRange) {
@@ -3245,14 +3245,14 @@ TEST_F(NegativeCommand, ClearDepthStencilWithRange) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    const auto depth_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     const VkImageAspectFlags ds_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     image.SetLayout(ds_aspect, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const VkClearDepthStencilValue clear_value = {};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const auto cb_handle = m_command_buffer.handle();
 
     // Try baseMipLevel >= image.mipLevels with VK_REMAINING_MIP_LEVELS
@@ -3329,7 +3329,7 @@ TEST_F(NegativeCommand, ClearColorImageWithinRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkClearColorValue clear_color;
@@ -3357,7 +3357,7 @@ TEST_F(NegativeCommand, ClearColorImageWithinRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearDepthStencilImage) {
@@ -3368,7 +3368,7 @@ TEST_F(NegativeCommand, ClearDepthStencilImage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkClearDepthStencilValue clear_value = {0};
     VkImageCreateInfo image_create_info = vkt::Image::CreateInfo();
@@ -3382,7 +3382,7 @@ TEST_F(NegativeCommand, ClearDepthStencilImage) {
     vkt::Image dst_image_bad_usage(*m_device, image_create_info, vkt::set_layout);
     const VkImageSubresourceRange range = vkt::Image::SubresourceRange(image_create_info, VK_IMAGE_ASPECT_DEPTH_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // need to handle since an element of pRanges includes VK_IMAGE_ASPECT_DEPTH_BIT without VkImageCreateInfo::usage having
     // VK_IMAGE_USAGE_TRANSFER_DST_BIT being set
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearDepthStencilImage-pRanges-02660");
@@ -3402,7 +3402,7 @@ TEST_F(NegativeCommand, ClearDepthStencilImage) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearDepthRangeUnrestricted) {
@@ -3412,7 +3412,7 @@ TEST_F(NegativeCommand, ClearDepthRangeUnrestricted) {
     RETURN_IF_SKIP(Init());
 
     // Need to set format framework uses for InitRenderTarget
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     int depth_attachment_index = 1;
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
@@ -3421,7 +3421,7 @@ TEST_F(NegativeCommand, ClearDepthRangeUnrestricted) {
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(&depth_image_view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkClearDepthStencilValue-depth-00022");
     const VkImageSubresourceRange range = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 1, 0, 1};
@@ -3449,7 +3449,7 @@ TEST_F(NegativeCommand, ClearDepthRangeUnrestricted) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearColorImageImageLayout) {
@@ -3476,7 +3476,7 @@ TEST_F(NegativeCommand, ClearColorImageImageLayout) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     image_create_info.flags = 0;
     vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkClearColorValue color_clear_value = {};
     VkImageSubresourceRange clear_range;
@@ -3500,9 +3500,9 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     InitRenderTarget();
 
     VkImageFormatProperties image_format_properties{};
-    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), m_renderTargets[0]->format(),
-                                                                 VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                                                                 m_renderTargets[0]->usage(), 0, &image_format_properties));
+    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), m_renderTargets[0]->Format(),
+                                                                     VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+                                                                     m_renderTargets[0]->Usage(), 0, &image_format_properties));
     if (image_format_properties.maxArrayLayers < 4) {
         GTEST_SKIP() << "Test needs to create image 2D array of 4 image view, but VkImageFormatProperties::maxArrayLayers is < 4. "
                         "Skipping test.";
@@ -3512,14 +3512,14 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     // to make sure that considered layer count is the one coming from frame buffer
     // (test would not fail if layer count used to do validation was 4)
     assert(!m_renderTargets.empty());
-    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->width(), m_renderTargets[0]->height(),
+    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->Width(), m_renderTargets[0]->Height(),
                                                                 m_renderTargets[0]->CreateInfo().mipLevels, 4,
-                                                                m_renderTargets[0]->format(), m_renderTargets[0]->usage());
+                                                                m_renderTargets[0]->Format(), m_renderTargets[0]->Usage());
     vkt::Image render_target(*m_device, render_target_ci, vkt::set_layout);
     vkt::ImageView render_target_view =
         render_target.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, render_target_ci.arrayLayers);
     VkFramebufferCreateInfo fb_info = vku::InitStructHelper();
-    fb_info.renderPass = renderPass();
+    fb_info.renderPass = RenderPass();
     fb_info.layers = 2;
     fb_info.attachmentCount = 1;
     fb_info.pAttachments = &render_target_view.handle();
@@ -3586,11 +3586,11 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     };
 
     // Register clear commands to secondary command buffer
-    secondary_cmd_buffer.begin(&secondary_cmd_buffer_begin_info);
+    secondary_cmd_buffer.Begin(&secondary_cmd_buffer_begin_info);
     clear_cmds(secondary_cmd_buffer.handle(), clear_rect);
-    secondary_cmd_buffer.end();
+    secondary_cmd_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Execute secondary command buffer
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
@@ -3604,7 +3604,7 @@ TEST_F(NegativeCommand, CmdClearAttachmentTests) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, BindVertexIndexBufferUsage) {
@@ -3613,7 +3613,7 @@ TEST_F(NegativeCommand, BindVertexIndexBufferUsage) {
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer-buffer-08784");
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
@@ -3624,19 +3624,19 @@ TEST_F(NegativeCommand, BindVertexIndexBufferUsage) {
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer.handle(), &offsets);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, BindIndexBufferHandles) {
     TEST_DESCRIPTION("call vkCmdBindIndexBuffer with bad Handles");
     RETURN_IF_SKIP(Init());
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBuffer bad_buffer = CastToHandle<VkBuffer, uintptr_t>(0xbaadbeef);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindIndexBuffer-buffer-parameter");
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), bad_buffer, 0, VK_INDEX_TYPE_UINT32);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearImageAspectMask) {
@@ -3651,11 +3651,11 @@ TEST_F(NegativeCommand, ClearImageAspectMask) {
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearColorImage-aspectMask-02498");
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &color_range);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, RenderPassContinueNotSupportedByCommandPool) {
@@ -3685,7 +3685,7 @@ TEST_F(NegativeCommand, ClearDepthStencilImageWithInvalidAspect) {
 
     RETURN_IF_SKIP(Init());
 
-    VkFormat format = FindSupportedDepthStencilFormat(m_device->phy().handle());
+    VkFormat format = FindSupportedDepthStencilFormat(m_device->Physical().handle());
     vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
@@ -3697,11 +3697,11 @@ TEST_F(NegativeCommand, ClearDepthStencilImageWithInvalidAspect) {
     range.baseArrayLayer = 0u;
     range.levelCount = 1u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearDepthStencilImage-aspectMask-02824");
     vk::CmdClearDepthStencilImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &clear_value, 1u, &range);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearColorImageWithMissingFeature) {
@@ -3719,9 +3719,9 @@ TEST_F(NegativeCommand, ClearColorImageWithMissingFeature) {
     VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), format, &formatProps);
     formatProps.optimalTilingFeatures &= ~VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), format, formatProps);
 
     vkt::Image image(*m_device, 32, 32, 1, format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -3735,11 +3735,11 @@ TEST_F(NegativeCommand, ClearColorImageWithMissingFeature) {
 
     VkClearColorValue clear_value = {{0, 0, 0, 0}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearColorImage-image-01993");
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &clear_value, 1u, &range);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
@@ -3749,8 +3749,8 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
 
     for (uint32_t i = 0; i < 2; ++i) {
         bool missing_depth = i == 0;
-        auto format = missing_depth ? FindSupportedStencilOnlyFormat(m_device->phy().handle())
-                                    : FindSupportedDepthOnlyFormat(m_device->phy().handle());
+        auto format = missing_depth ? FindSupportedStencilOnlyFormat(m_device->Physical().handle())
+                                    : FindSupportedDepthOnlyFormat(m_device->Physical().handle());
         if (format == VK_FORMAT_UNDEFINED) {
             continue;
         }
@@ -3781,7 +3781,7 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         clear_rect.baseArrayLayer = 0u;
         clear_rect.layerCount = 1u;
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
         if (missing_depth) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-aspectMask-07884");
@@ -3791,6 +3791,6 @@ TEST_F(NegativeCommand, ClearDsImageWithInvalidAspect) {
         vk::CmdClearAttachments(m_command_buffer.handle(), 1u, &clear_attachment, 1u, &clear_rect);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }

--- a/tests/unit/command_positive.cpp
+++ b/tests/unit/command_positive.cpp
@@ -44,7 +44,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirectCountKHR(m_command_buffer.handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
@@ -53,7 +53,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature) {
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
@@ -81,7 +81,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirectCount(m_command_buffer.handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
@@ -90,7 +90,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithoutFeature12) {
     vk::CmdDrawIndexedIndirectCount(m_command_buffer.handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                     sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
@@ -124,7 +124,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
     pipe.CreateGraphicsPipeline();
 
     // Make calls to valid commands
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirectCount(m_command_buffer.handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
@@ -133,7 +133,7 @@ TEST_F(PositiveCommand, DrawIndirectCountWithFeature) {
     vk::CmdDrawIndexedIndirectCount(m_command_buffer.handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                     sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCommand, CommandBufferSimultaneousUseSync) {
@@ -143,8 +143,8 @@ TEST_F(PositiveCommand, CommandBufferSimultaneousUseSync) {
     // simultaneously.
     VkCommandBufferBeginInfo cbbi = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                      VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT, nullptr};
-    m_command_buffer.begin(&cbbi);
-    m_command_buffer.end();
+    m_command_buffer.Begin(&cbbi);
+    m_command_buffer.End();
 
     VkFenceCreateInfo fci = {VK_STRUCTURE_TYPE_FENCE_CREATE_INFO, nullptr, 0};
     VkFence fence;
@@ -285,16 +285,16 @@ TEST_F(PositiveCommand, DISABLED_ClearRectWith2DArray) {
         rpbi.clearValueCount = 1;
         rpbi.pClearValues = &clearValue;
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rpbi);
 
         VkClearRect clear_rect = {{{0, 0}, {image_ci.extent.width, image_ci.extent.height}}, 0, image_ci.extent.depth};
         vk::CmdClearAttachments(m_command_buffer.handle(), 1, &color_attachment, 1, &clear_rect);
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 }
 
@@ -347,7 +347,7 @@ TEST_F(PositiveCommand, ClearAttachmentsDepthStencil) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
 
     VkClearAttachment attachment;
@@ -380,7 +380,7 @@ TEST_F(PositiveCommand, ClearColorImageWithValidRange) {
 
     const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const auto cb_handle = m_command_buffer.handle();
 
     // Try good case
@@ -405,14 +405,14 @@ TEST_F(PositiveCommand, ClearDepthStencilWithValidRange) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     const VkImageAspectFlags ds_aspect = VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT;
     image.SetLayout(ds_aspect, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
     const VkClearDepthStencilValue clear_value = {};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const auto cb_handle = m_command_buffer.handle();
 
     // Try good case
@@ -435,13 +435,13 @@ TEST_F(PositiveCommand, ClearColor64Bit) {
     TEST_DESCRIPTION("Clear with a 64-bit format");
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R64_UINT, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R64_UINT, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_R64_UINT format not supported";
     }
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R64_UINT, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
     VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), image.Layout(), &clear_color, 1, &range);
@@ -464,9 +464,9 @@ TEST_F(PositiveCommand, FillBufferCmdPoolTransferQueue) {
     vkt::CommandBuffer cb(*m_device, pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
     vkt::Buffer buffer(*m_device, 20, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
 
-    cb.begin();
+    cb.Begin();
     vk::CmdFillBuffer(cb.handle(), buffer.handle(), 0, 12, 0x11111111);
-    cb.end();
+    cb.End();
 }
 
 TEST_F(PositiveCommand, MultiDrawMaintenance5) {
@@ -484,7 +484,7 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -525,7 +525,7 @@ TEST_F(PositiveCommand, MultiDrawMaintenance5Mixed) {
     pipe.CreateGraphicsPipeline();
 
     // Try existing VUID checks
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -599,7 +599,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchWithZeroExtend) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
@@ -607,7 +607,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchWithZeroExtend) {
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
@@ -668,7 +668,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
                                                    VK_IMAGE_LAYOUT_GENERAL);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
@@ -676,7 +676,7 @@ TEST_F(PositiveCommand, ImageFormatTypeMismatchRedundantExtend) {
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCommand, DeviceLost) {
@@ -691,9 +691,9 @@ TEST_F(PositiveCommand, DeviceLost) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Destroying should not throw VUID-vkDestroyFence-fence-01120
     vkt::Fence fence(*m_device);
@@ -725,6 +725,6 @@ TEST_F(PositiveCommand, CommandBufferInheritanceInfoIgnoredPointer) {
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.pInheritanceInfo = reinterpret_cast<const VkCommandBufferInheritanceInfo *>(undereferencable_pointer);
-    m_command_buffer.begin(&begin_info);
-    m_command_buffer.end();
+    m_command_buffer.Begin(&begin_info);
+    m_command_buffer.End();
 }

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
 
     // Bail if any dimension of transfer granularity is 0.
     auto index = m_device->graphics_queue_node_index_;
-    auto queue_family_properties = m_device->phy().queue_properties_;
+    auto queue_family_properties = m_device->Physical().queue_properties_;
     if ((queue_family_properties[index].minImageTransferGranularity.depth == 0) ||
         (queue_family_properties[index].minImageTransferGranularity.width == 0) ||
         (queue_family_properties[index].minImageTransferGranularity.height == 0)) {
@@ -51,7 +51,7 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
     // Verify R8G8B8A8_UINT format is supported for transfer
     bool missing_rgba_support = false;
     VkFormatProperties props = {0, 0, 0};
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_R8G8B8A8_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_R8G8B8A8_UINT, &props);
     missing_rgba_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_rgba_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_rgba_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
@@ -68,19 +68,19 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
 
     // Verify all needed Depth/Stencil formats are supported
     bool missing_ds_support = false;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D32_SFLOAT_S8_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D32_SFLOAT_S8_UINT, &props);
     missing_ds_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D24_UNORM_S8_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D24_UNORM_S8_UINT, &props);
     missing_ds_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D16_UNORM, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D16_UNORM, &props);
     missing_ds_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_S8_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_S8_UINT, &props);
     missing_ds_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_ds_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
@@ -142,7 +142,7 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
         printf("R8G8B8A8_UINT transfer unsupported - skipping RGBA tests.\n");
 
         // start recording for future tests
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
     } else {
         // attempt copies before putting command buffer in recording state
         m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-commandBuffer-recording");
@@ -156,7 +156,7 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
         m_errorMonitor->VerifyFound();
 
         // start recording
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         // successful copies
         vk::CmdCopyImageToBuffer(m_command_buffer.handle(), image_16k.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer_16k.handle(), 1,
@@ -422,17 +422,17 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
         bool missing_astc_support = false;
         bool missing_compression_support = false;
 
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_BC3_SRGB_BLOCK, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_BC3_SRGB_BLOCK, &props);
         missing_bc_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
         missing_bc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
         missing_bc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
 
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_ETC2_R8G8B8A8_UNORM_BLOCK, &props);
         missing_etc_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
         missing_etc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
         missing_etc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
 
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_ASTC_4x4_UNORM_BLOCK, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_ASTC_4x4_UNORM_BLOCK, &props);
         missing_astc_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
         missing_astc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
         missing_astc_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
@@ -547,7 +547,7 @@ TEST_F(NegativeCopyBufferImage, ImageBufferCopy) {
         // Try to use G8_B8R8_2PLANE_420_UNORM because need 2-plane format for some tests and likely supported due to copy support
         // being required with samplerYcbcrConversion feature
         bool missing_mp_support = false;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, &props);
         missing_mp_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
         missing_mp_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
         missing_mp_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
@@ -613,7 +613,7 @@ TEST_F(NegativeCopyBufferImage, ImageLayerCountMismatch) {
 
     VkFormat image_format = VK_FORMAT_B8G8R8A8_UNORM;
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_format, &format_props);
     if ((format_props.optimalTilingFeatures & (VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) == 0) {
         GTEST_SKIP() << "Transfer for format is not supported";
     }
@@ -635,7 +635,7 @@ TEST_F(NegativeCopyBufferImage, ImageLayerCountMismatch) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     copyRegion.srcOffset = {0, 0, 0};
@@ -702,7 +702,7 @@ TEST_F(NegativeCopyBufferImage, CompressedImageMip) {
     region.bufferOffset = 0;
 
     // start recording
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkMemoryBarrier mem_barriers[3];
     mem_barriers[0] = vku::InitStructHelper();
@@ -880,10 +880,10 @@ TEST_F(NegativeCopyBufferImage, MiscImageLayer) {
 
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R16G16B16A16_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R16G16B16A16_UINT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R16G16B16A16_UINT features not supported";
-    } else if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    } else if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R8G8_UNORM features not supported";
     }
@@ -904,7 +904,7 @@ TEST_F(NegativeCopyBufferImage, MiscImageLayer) {
     vkt::Image image2(*m_device, 128, 128, 1, VK_FORMAT_R8G8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);  // 16bpp
     image2.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::Buffer buffer2(*m_device, 128 * 128 * 2, VK_BUFFER_USAGE_TRANSFER_SRC_BIT, 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Image must have offset.z of 0 and extent.depth of 1
     // Introduce failure by setting imageExtent.depth to 0
@@ -999,7 +999,7 @@ TEST_F(NegativeCopyBufferImage, ImageTypeExtentMismatch) {
     ci.arrayLayers = 8;
     vkt::Image image_2D_array(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {32, 1, 1};
@@ -1210,7 +1210,7 @@ TEST_F(NegativeCopyBufferImage, ImageTypeExtentMismatch) {
     m_errorMonitor->VerifyFound();
     copy_region.srcSubresource.baseArrayLayer = 0;
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageTypeExtentMismatchMaintenance1) {
@@ -1255,7 +1255,7 @@ TEST_F(NegativeCopyBufferImage, ImageTypeExtentMismatchMaintenance1) {
     ci.arrayLayers = 8;
     vkt::Image image_2D_array_2(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {32, 1, 1};
@@ -1318,7 +1318,7 @@ TEST_F(NegativeCopyBufferImage, ImageTypeExtentMismatchMaintenance1) {
     m_errorMonitor->VerifyFound();
     copy_region.extent = {32, 1, 1};
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageCompressedBlockAlignment) {
@@ -1350,7 +1350,7 @@ TEST_F(NegativeCopyBufferImage, ImageCompressedBlockAlignment) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
 
     VkImageFormatProperties img_prop = {};
-    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), ci.format, ci.imageType, ci.tiling,
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), ci.format, ci.imageType, ci.tiling,
                                                                  ci.usage, ci.flags, &img_prop)) {
         GTEST_SKIP() << "No compressed formats supported - CopyImageCompressedBlockAlignment skipped";
     }
@@ -1360,7 +1360,7 @@ TEST_F(NegativeCopyBufferImage, ImageCompressedBlockAlignment) {
     ci.extent = {62, 62, 1};  // slightly smaller and not divisible by block size
     vkt::Image image_2(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {48, 48, 1};
@@ -1442,7 +1442,7 @@ TEST_F(NegativeCopyBufferImage, ImageCompressedBlockAlignment) {
     // "VUID-vkCmdCopyImage-dstImage-01734"
     //       There are currently no supported compressed formats with a block depth other than 1,
     //       so impossible to create a 'not a multiple' condition for depth.
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageSrcSizeExceeded) {
@@ -1468,7 +1468,7 @@ TEST_F(NegativeCopyBufferImage, ImageSrcSizeExceeded) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image dst_image(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {32, 32, 8};
@@ -1513,7 +1513,7 @@ TEST_F(NegativeCopyBufferImage, ImageSrcSizeExceeded) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageDstSizeExceeded) {
@@ -1539,7 +1539,7 @@ TEST_F(NegativeCopyBufferImage, ImageDstSizeExceeded) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     vkt::Image src_image(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {32, 32, 8};
@@ -1582,7 +1582,7 @@ TEST_F(NegativeCopyBufferImage, ImageDstSizeExceeded) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageZeroSize) {
@@ -1608,7 +1608,7 @@ TEST_F(NegativeCopyBufferImage, ImageZeroSize) {
     // large enough for image
     vkt::Buffer buffer(*m_device, 16384, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -1660,7 +1660,7 @@ TEST_F(NegativeCopyBufferImage, ImageZeroSize) {
                              &buffer_image_copy);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageMultiPlaneSizeExceeded) {
@@ -1672,7 +1672,7 @@ TEST_F(NegativeCopyBufferImage, ImageMultiPlaneSizeExceeded) {
     // copy support being required with samplerYcbcrConversion feature
     VkFormatProperties props = {0, 0, 0};
     bool missing_format_support = false;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, &props);
     missing_format_support |= (props.bufferFeatures == 0 && props.linearTilingFeatures == 0 && props.optimalTilingFeatures == 0);
     missing_format_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0;
     missing_format_support |= (props.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0;
@@ -1695,7 +1695,7 @@ TEST_F(NegativeCopyBufferImage, ImageMultiPlaneSizeExceeded) {
     copy_region.dstOffset = {0, 0, 0};
     VkImageCopy original_region = copy_region;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Should be able to do a 64x64 copy from plane 1 -> Plane 1
     vk::CmdCopyImage(m_command_buffer.handle(), src_image.handle(), VK_IMAGE_LAYOUT_GENERAL, dst_image.handle(),
@@ -1770,7 +1770,7 @@ TEST_F(NegativeCopyBufferImage, ImageMultiPlaneSizeExceeded) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
@@ -1782,10 +1782,10 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R8_UNORM features not supported";
-    } else if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8_UINT, VK_IMAGE_TILING_OPTIMAL,
+    } else if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R8_UINT features not supported";
     }
@@ -1809,12 +1809,12 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
     vkt::Image image_8b_uint(*m_device, image_create_info, vkt::set_layout);
 
     // First try to test two single plane mismatch
-    if (FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                    VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         image_create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
         vkt::Image image_32b_unorm(*m_device, image_create_info, vkt::set_layout);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         VkImageCopy copyRegion;
         copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         copyRegion.srcOffset = {0, 0, 0};
@@ -1837,7 +1837,7 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
                          VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     // DstImage is a mismatched plane of a multi-planar format
@@ -1848,7 +1848,7 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
         image_create_info.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
         vkt::Image image_8b_16b_420_unorm(*m_device, image_create_info, vkt::set_layout);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         VkImageCopy copyRegion;
         copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
         copyRegion.srcOffset = {0, 0, 0};
@@ -1902,16 +1902,16 @@ TEST_F(NegativeCopyBufferImage, ImageFormatSizeMismatch) {
                          image_8b_unorm.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
 TEST_F(NegativeCopyBufferImage, ImageDepthStencilFormatMismatch) {
     RETURN_IF_SKIP(Init());
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkFormatProperties properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D32_SFLOAT, &properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D32_SFLOAT, &properties);
     if (properties.optimalTilingFeatures == 0) {
         GTEST_SKIP() << "Image format not supported";
     }
@@ -1923,7 +1923,7 @@ TEST_F(NegativeCopyBufferImage, ImageDepthStencilFormatMismatch) {
 
     // Create two images of different types and try to copy between them
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_DEPTH_BIT, 0, 0, 1};
     copyRegion.srcOffset = {0, 0, 0};
@@ -1934,7 +1934,7 @@ TEST_F(NegativeCopyBufferImage, ImageDepthStencilFormatMismatch) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcImage-01548");
     vk::CmdCopyImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, dstImage.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1945,7 +1945,7 @@ TEST_F(NegativeCopyBufferImage, ImageSampleCountMismatch) {
     RETURN_IF_SKIP(Init());
 
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT, 0,
                                                &image_format_properties);
 
@@ -1973,7 +1973,7 @@ TEST_F(NegativeCopyBufferImage, ImageSampleCountMismatch) {
     ci.samples = VK_SAMPLE_COUNT_4_BIT;
     vkt::Image image4(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -2004,7 +2004,7 @@ TEST_F(NegativeCopyBufferImage, ImageSampleCountMismatch) {
                      1, &copyRegion);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageLayerCount) {
@@ -2024,7 +2024,7 @@ TEST_F(NegativeCopyBufferImage, ImageLayerCount) {
     ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     vkt::Image image(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 0};
@@ -2047,7 +2047,7 @@ TEST_F(NegativeCopyBufferImage, ImageLayerCount) {
                      &copyRegion);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, ImageAspectMismatch) {
@@ -2058,16 +2058,16 @@ TEST_F(NegativeCopyBufferImage, ImageAspectMismatch) {
     AddRequiredExtensions(VK_EXT_IMAGE_DRM_FORMAT_MODIFIER_EXTENSION_NAME);
     AddOptionalExtensions(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    auto ds_format = FindSupportedDepthStencilFormat(gpu());
+    auto ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     // Add Transfer support for all used formats
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_R32_SFLOAT features not supported";
-    } else if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_D32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
+    } else if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_D32_SFLOAT, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required VK_FORMAT_D32_SFLOAT features not supported";
-    } else if (!FormatFeaturesAreSupported(gpu(), ds_format, VK_IMAGE_TILING_OPTIMAL,
+    } else if (!FormatFeaturesAreSupported(Gpu(), ds_format, VK_IMAGE_TILING_OPTIMAL,
                                            VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT)) {
         GTEST_SKIP() << "Required Depth/Stencil Format features not supported";
     }
@@ -2094,7 +2094,7 @@ TEST_F(NegativeCopyBufferImage, ImageAspectMismatch) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Src and dest aspect masks don't match
     copyRegion.dstSubresource.aspectMask = VK_IMAGE_ASPECT_STENCIL_BIT;
@@ -2181,7 +2181,7 @@ TEST_F(NegativeCopyBufferImage, ImageAspectMismatch) {
     vk::CmdCopyImage(m_command_buffer.handle(), depth_image.handle(), VK_IMAGE_LAYOUT_GENERAL, depth_image.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copyRegion);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, DepthStencilImageCopyNoGraphicsQueueFlags) {
@@ -2197,7 +2197,7 @@ TEST_F(NegativeCopyBufferImage, DepthStencilImageCopyNoGraphicsQueueFlags) {
     }
 
     // Create Depth image
-    const VkFormat ds_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthOnlyFormat(Gpu());
     vkt::Image ds_image(*m_device, 64, 64, 1, ds_format,
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     ds_image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -2219,7 +2219,7 @@ TEST_F(NegativeCopyBufferImage, DepthStencilImageCopyNoGraphicsQueueFlags) {
 
     // Setup command buffer on pool
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-commandBuffer-07739");
     vk::CmdCopyBufferToImage(command_buffer.handle(), buffer.handle(), ds_image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
@@ -2260,7 +2260,7 @@ TEST_F(NegativeCopyBufferImage, ImageTransferQueueFlags) {
 
     // Setup command buffer on pool
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-dstImage-07975");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-commandBuffer-07737");
@@ -2297,7 +2297,7 @@ TEST_F(NegativeCopyBufferImage, CopyCommands2V13) {
     copy_image_info.dstImageLayout = VK_IMAGE_LAYOUT_GENERAL;
     copy_image_info.regionCount = 1;
     copy_image_info.pRegions = &copy_region;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-aspect-06663");
     vk::CmdCopyImage2(m_command_buffer.handle(), &copy_image_info);
     m_errorMonitor->VerifyFound();
@@ -2386,15 +2386,15 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemory) {
     vkt::Buffer buffer(*m_device,
                        vkt::Buffer::CreateInfo(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
                        vkt::no_mem);
-    const auto buffer_memory_requirements = buffer.memory_requirements();
+    const auto buffer_memory_requirements = buffer.MemoryRequirements();
 
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
-    const auto image_memory_requirements = image.memory_requirements();
+    const auto image_memory_requirements = image.MemoryRequirements();
 
     vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = (std::max)(buffer_memory_requirements.size, image_memory_requirements.size);
-    bool has_memtype = m_device->phy().SetMemoryType(
+    bool has_memtype = m_device->Physical().SetMemoryType(
         buffer_memory_requirements.memoryTypeBits & image_memory_requirements.memoryTypeBits, &alloc_info, 0);
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
@@ -2412,7 +2412,7 @@ TEST_F(NegativeCopyBufferImage, DISABLED_ImageOverlappingMemory) {
     region.bufferOffset = 0;
 
     region.imageExtent = {32, 32, 1};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImageToBuffer-pRegions-00184");
     vk::CmdCopyImageToBuffer(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer.handle(), 1, &region);
     m_errorMonitor->VerifyFound();
@@ -2475,7 +2475,7 @@ TEST_F(NegativeCopyBufferImage, ImageRemainingLayers) {
     ASSERT_TRUE(image_a.initialized());
     ASSERT_TRUE(image_b.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     image_a.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     image_b.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
@@ -2514,7 +2514,7 @@ TEST_F(NegativeCopyBufferImage, ImageRemainingLayers) {
                              &buffer_copy);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, DifferentFormatTexelBlockExtent) {
@@ -2527,11 +2527,11 @@ TEST_F(NegativeCopyBufferImage, DifferentFormatTexelBlockExtent) {
     VkFormat dst_format = VK_FORMAT_ASTC_10x8_SFLOAT_BLOCK;
 
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), src_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), src_format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0) {
         GTEST_SKIP() << "Src transfer for format is not supported";
     }
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), dst_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), dst_format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
         GTEST_SKIP() << "Dst transfer for format is not supported";
     }
@@ -2548,12 +2548,12 @@ TEST_F(NegativeCopyBufferImage, DifferentFormatTexelBlockExtent) {
     region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region.srcOffset = {0, 0, 0};
     region.dstOffset = {0, 0, 0};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcImage-09247");
     vk::CmdCopyImage(m_command_buffer.handle(), src_image.handle(), VK_IMAGE_LAYOUT_GENERAL, dst_image.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1u, &region);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, BufferToCompressedImage) {
@@ -2561,7 +2561,7 @@ TEST_F(NegativeCopyBufferImage, BufferToCompressedImage) {
     RETURN_IF_SKIP(Init());
 
     // Verify format support
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -2581,7 +2581,7 @@ TEST_F(NegativeCopyBufferImage, BufferToCompressedImage) {
     if (!width_image.initialized() || (!height_image.initialized())) {
         GTEST_SKIP() << "Unable to initialize surfaces";
     }
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-imageSubresource-07971");
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer.handle(), width_image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
@@ -2617,7 +2617,7 @@ TEST_F(NegativeCopyBufferImage, BufferToCompressedImage) {
     mem_alloc.memoryTypeIndex = 1;
     vk::GetImageMemoryRequirements(device(), depth_image, &mem_reqs);
     mem_alloc.allocationSize = mem_reqs.size;
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
     err = vk::AllocateMemory(device(), &mem_alloc, NULL, &mem1);
     ASSERT_EQ(VK_SUCCESS, err);
@@ -2629,7 +2629,7 @@ TEST_F(NegativeCopyBufferImage, BufferToCompressedImage) {
 
     vk::DestroyImage(device(), depth_image, NULL);
     vk::FreeMemory(device(), mem1, NULL);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, SameImage) {
@@ -2651,7 +2651,7 @@ TEST_F(NegativeCopyBufferImage, SameImage) {
     image_create_info.flags = 0;
     vkt::Image src_image(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageCopy copy_region;
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -2689,7 +2689,7 @@ TEST_F(NegativeCopyBufferImage, ImageRemainingArrayLayers) {
     copy_region.dstOffset = {4, 4, 0};
     copy_region.extent = {1, 1, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcImage-08794");
     vk::CmdCopyImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
                      &copy_region);
@@ -2726,7 +2726,7 @@ TEST_F(NegativeCopyBufferImage, ImageMemory) {
     copy_region.extent.height = 4;
     copy_region.extent.depth = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-srcImage-07966");
     vk::CmdCopyImage(m_command_buffer.handle(), image_no_mem.handle(), VK_IMAGE_LAYOUT_GENERAL, image.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
@@ -2772,7 +2772,7 @@ TEST_F(NegativeCopyBufferImage, ImageMissingUsage) {
     AddRequiredExtensions(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    auto format = FindSupportedDepthStencilFormat(gpu());
+    auto format = FindSupportedDepthStencilFormat(Gpu());
     VkImageStencilUsageCreateInfo stencil_usage_ci = vku::InitStructHelper();
     stencil_usage_ci.stencilUsage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
@@ -2808,7 +2808,7 @@ TEST_F(NegativeCopyBufferImage, ImageMissingUsage) {
     region.dstOffset = {0, 0, 0};
     region.extent = {32, 32, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyImage-aspect-06662");
     vk::CmdCopyImage(m_command_buffer.handle(), sampled_image.handle(), VK_IMAGE_LAYOUT_GENERAL, transfer_image.handle(),
@@ -2830,7 +2830,7 @@ TEST_F(NegativeCopyBufferImage, ImageMissingUsage) {
                      separate_stencil_sampled_image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, OverlappingImage) {
@@ -2842,7 +2842,7 @@ TEST_F(NegativeCopyBufferImage, OverlappingImage) {
                      VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy image_copy{};
     image_copy.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2855,14 +2855,14 @@ TEST_F(NegativeCopyBufferImage, OverlappingImage) {
     vk::CmdCopyImage(m_command_buffer.handle(), image, VK_IMAGE_LAYOUT_GENERAL, image, VK_IMAGE_LAYOUT_GENERAL, 1, &image_copy);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, MinImageTransferGranularity) {
     TEST_DESCRIPTION("Tests for validation of Queue Family property minImageTransferGranularity.");
     RETURN_IF_SKIP(Init());
 
-    auto queue_family_properties = m_device->phy().queue_properties_;
+    auto queue_family_properties = m_device->Physical().queue_properties_;
     auto large_granularity_family =
         std::find_if(queue_family_properties.begin(), queue_family_properties.end(), [](VkQueueFamilyProperties family_properties) {
             VkExtent3D family_granularity = family_properties.minImageTransferGranularity;
@@ -2898,7 +2898,7 @@ TEST_F(NegativeCopyBufferImage, MinImageTransferGranularity) {
     vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
 
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -2953,7 +2953,7 @@ TEST_F(NegativeCopyBufferImage, MinImageTransferGranularity) {
     vk::CmdCopyBufferToImage(command_buffer.handle(), buffer.handle(), dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
     m_errorMonitor->VerifyFound();
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, Extents) {
@@ -2968,7 +2968,7 @@ TEST_F(NegativeCopyBufferImage, Extents) {
 
     VkBufferCopy copy_info = {4096, 256, 256};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBuffer-srcOffset-00113");
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_one.handle(), buffer_two.handle(), 1, &copy_info);
@@ -3043,7 +3043,7 @@ TEST_F(NegativeCopyBufferImage, Extents) {
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_two.handle(), buffer_two.handle(), 1, &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeCopyBufferImage, CompletelyOverlappingBuffer) {
@@ -3057,9 +3057,9 @@ TEST_F(NegativeCopyBufferImage, CompletelyOverlappingBuffer) {
     vkt::Buffer buffer(*m_device, copy_info.size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
     vkt::Buffer buffer_shared_memory(*m_device, buffer.CreateInfo(), vkt::no_mem);
-    buffer_shared_memory.BindMemory(buffer.memory(), 0u);
+    buffer_shared_memory.BindMemory(buffer.Memory(), 0u);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBuffer-pRegions-00117");
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer.handle(), buffer.handle(), 1, &copy_info);
@@ -3067,7 +3067,7 @@ TEST_F(NegativeCopyBufferImage, CompletelyOverlappingBuffer) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBuffer-pRegions-00117");
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer.handle(), buffer_shared_memory.handle(), 1, &copy_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3093,9 +3093,9 @@ TEST_F(NegativeCopyBufferImage, InterleavedRegions) {
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, 0);
 
     vkt::Buffer buffer_shared_memory(*m_device, buffer.CreateInfo(), vkt::no_mem);
-    buffer_shared_memory.BindMemory(buffer.memory(), 0u);
+    buffer_shared_memory.BindMemory(buffer.Memory(), 0u);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer.handle(), buffer.handle(), 4, copy_infos);
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer.handle(), buffer_shared_memory.handle(), 4, copy_infos);
@@ -3108,5 +3108,5 @@ TEST_F(NegativeCopyBufferImage, InterleavedRegions) {
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer.handle(), buffer_shared_memory.handle(), 4, copy_infos);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/copy_buffer_image_positive.cpp
+++ b/tests/unit/copy_buffer_image_positive.cpp
@@ -41,7 +41,7 @@ TEST_F(PositiveCopyBufferImage, ImageRemainingLayersMaintenance5) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     vkt::Image image_b(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     image_a.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL);
     image_b.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
@@ -59,7 +59,7 @@ TEST_F(PositiveCopyBufferImage, ImageRemainingLayersMaintenance5) {
     copy_region.dstSubresource.layerCount = 6;
     vk::CmdCopyImage(m_command_buffer.handle(), image_a.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, image_b.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, ImageTypeExtentMismatchMaintenance5) {
@@ -95,10 +95,10 @@ TEST_F(PositiveCopyBufferImage, ImageTypeExtentMismatchMaintenance5) {
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyImage(m_command_buffer.handle(), image_1D.handle(), VK_IMAGE_LAYOUT_GENERAL, image_2D.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, ImageLayerCount) {
@@ -111,7 +111,7 @@ TEST_F(PositiveCopyBufferImage, ImageLayerCount) {
 
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_R8G8B8A8_UNORM,
                      VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copyRegion;
     copyRegion.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, VK_REMAINING_ARRAY_LAYERS};
@@ -121,7 +121,7 @@ TEST_F(PositiveCopyBufferImage, ImageLayerCount) {
     copyRegion.extent = {16, 16, 1};
     vk::CmdCopyImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
                      &copyRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, BufferToRemaingImageLayers) {
@@ -153,9 +153,9 @@ TEST_F(PositiveCopyBufferImage, BufferToRemaingImageLayers) {
     copy_buffer_to_image.regionCount = 1u;
     copy_buffer_to_image.pRegions = &region;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBufferToImage2KHR(m_command_buffer.handle(), &copy_buffer_to_image);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
@@ -171,15 +171,15 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     vkt::Buffer buffer(*m_device,
                        vkt::Buffer::CreateInfo(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
                        vkt::no_mem);
-    auto buffer_memory_requirements = buffer.memory_requirements();
+    auto buffer_memory_requirements = buffer.MemoryRequirements();
 
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
-    auto image_memory_requirements = image.memory_requirements();
+    auto image_memory_requirements = image.MemoryRequirements();
 
     vkt::DeviceMemory mem;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_memory_requirements.size + image_memory_requirements.size;
-    bool has_memtype = m_device->phy().SetMemoryType(
+    bool has_memtype = m_device->Physical().SetMemoryType(
         buffer_memory_requirements.memoryTypeBits & image_memory_requirements.memoryTypeBits, &alloc_info, 0);
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
@@ -197,16 +197,16 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     region.bufferOffset = 0;
 
     region.imageExtent = {32, 32, 1};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyImageToBuffer(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer.handle(), 1, &region);
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     auto compressed_image2_ci =
         vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_BC7_UNORM_BLOCK,
                                       VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_BC7_UNORM_BLOCK, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_BC7_UNORM_BLOCK, &format_properties);
     if (((format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_SRC_BIT) == 0) ||
         ((format_properties.linearTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0)) {
         printf("VK_FORMAT_BC7_UNORM_BLOCK with linear tiling not supported - skipping compressed format test.\n");
@@ -217,15 +217,15 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     vkt::Buffer buffer2(*m_device,
                         vkt::Buffer::CreateInfo(buff_size, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT),
                         vkt::no_mem);
-    buffer_memory_requirements = buffer.memory_requirements();
+    buffer_memory_requirements = buffer.MemoryRequirements();
 
     vkt::Image image2(*m_device, compressed_image2_ci, vkt::no_mem);
-    image_memory_requirements = image2.memory_requirements();
+    image_memory_requirements = image2.MemoryRequirements();
 
     vkt::DeviceMemory mem2;
     alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = buffer_memory_requirements.size + image_memory_requirements.size;
-    has_memtype = m_device->phy().SetMemoryType(
+    has_memtype = m_device->Physical().SetMemoryType(
         buffer_memory_requirements.memoryTypeBits & image_memory_requirements.memoryTypeBits, &alloc_info, 0);
     if (!has_memtype) {
         GTEST_SKIP() << "Failed to find a memory type for both a buffer and an image";
@@ -236,10 +236,10 @@ TEST_F(PositiveCopyBufferImage, ImageOverlappingMemory) {
     buffer2.BindMemory(mem2, 0);
     image2.BindMemory(mem2, buffer_memory_requirements.size);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyImageToBuffer(m_command_buffer.handle(), image2.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer2.handle(), 1, &region);
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer2.handle(), image2.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, UncompressedToCompressedImage) {
@@ -248,9 +248,9 @@ TEST_F(PositiveCopyBufferImage, UncompressedToCompressedImage) {
 
     // Verify format support
     // Size-compatible (64-bit) formats. Uncompressed is 64 bits per texel, compressed is 64 bits per 4x4 block (or 4bpt).
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R16G16B16A16_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R16G16B16A16_UINT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR) ||
-        !FormatFeaturesAreSupported(gpu(), VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_TILING_OPTIMAL,
+        !FormatFeaturesAreSupported(Gpu(), VK_FORMAT_BC1_RGBA_SRGB_BLOCK, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_TRANSFER_SRC_BIT_KHR | VK_FORMAT_FEATURE_TRANSFER_DST_BIT_KHR)) {
         GTEST_SKIP() << "Required formats/features not supported - UncompressedToCompressedImageCopy";
     }
@@ -274,7 +274,7 @@ TEST_F(PositiveCopyBufferImage, UncompressedToCompressedImage) {
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Copy from uncompressed to compressed
     copy_region.extent = {10, 10, 1};  // Dimensions in (uncompressed) texels
@@ -297,7 +297,7 @@ TEST_F(PositiveCopyBufferImage, UncompressedToCompressedImage) {
     vk::CmdCopyImage(m_command_buffer.handle(), comp_10x10b_40x40t_image.handle(), VK_IMAGE_LAYOUT_GENERAL,
                      uncomp_10x10t_image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveCopyBufferImage, ImageSubresource) {
@@ -319,7 +319,7 @@ TEST_F(PositiveCopyBufferImage, ImageSubresource) {
     auto dst_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     auto final_layout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     auto cb = m_command_buffer.handle();
 
@@ -338,12 +338,12 @@ TEST_F(PositiveCopyBufferImage, ImageSubresource) {
                            image_barriers);
     VkClearColorValue clear_color{};
     vk::CmdClearColorImage(cb, image.handle(), dst_layout, &clear_color, 1, &src_range);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     image_barriers[0].oldLayout = dst_layout;
     image_barriers[0].newLayout = src_layout;
@@ -368,7 +368,7 @@ TEST_F(PositiveCopyBufferImage, ImageSubresource) {
     image_barriers[1].newLayout = final_layout;
     vk::CmdPipelineBarrier(cb, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0, nullptr, 2,
                            image_barriers);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -419,9 +419,9 @@ TEST_F(PositiveCopyBufferImage, BufferCopiesStressTest) {
         copy_info_list[i + 4] = copy_info_list[i % 4];
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdCopyBuffer(m_command_buffer, src_buffer.handle(), dst_buffer.handle(), size32(copy_info_list), copy_info_list.data());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/debug_extensions.cpp
+++ b/tests/unit/debug_extensions.cpp
@@ -379,7 +379,7 @@ TEST_F(NegativeDebugExtensions, SetDebugUtilsObjectSecondDevice) {
         GTEST_SKIP() << "Skipping object naming test with MockICD.";
     }
 
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     vkt::Device second_device(gpu_, m_device_extension_names, &features, nullptr);
 
     DebugUtilsLabelCheckData callback_data;
@@ -457,9 +457,9 @@ TEST_F(NegativeDebugExtensions, DebugLabelPrimaryCommandBuffer) {
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912");
     m_default_queue->Submit(m_command_buffer);
@@ -475,16 +475,16 @@ TEST_F(NegativeDebugExtensions, DebugLabelPrimaryCommandBuffer2) {
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "regionA";
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
-    cb0.end();
+    cb0.End();
     m_default_queue->Submit(cb0);
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
     vk::CmdEndDebugUtilsLabelEXT(cb1);
-    cb1.end();
+    cb1.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912");
     m_default_queue->Submit(cb1);
     m_errorMonitor->VerifyFound();
@@ -499,18 +499,18 @@ TEST_F(NegativeDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "regionA";
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
     vk::CmdEndDebugUtilsLabelEXT(cb0);
-    cb0.end();
+    cb0.End();
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
     label.pLabelName = "regionB";
-    cb1.begin();
+    cb1.Begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb1, &label);
     vk::CmdEndDebugUtilsLabelEXT(cb1);
     vk::CmdEndDebugUtilsLabelEXT(cb1);
-    cb1.end();
+    cb1.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01912");
     std::array cbs = {&cb0, &cb1};
     m_default_queue->Submit(cbs);
@@ -524,11 +524,11 @@ TEST_F(NegativeDebugExtensions, DebugLabelSecondaryCommandBuffer) {
     RETURN_IF_SKIP(Init());
 
     vkt::CommandBuffer cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    cb.begin();
+    cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndDebugUtilsLabelEXT-commandBuffer-01913");
     vk::CmdEndDebugUtilsLabelEXT(cb);
     m_errorMonitor->VerifyFound();
-    cb.end();
+    cb.End();
 }
 
 TEST_F(NegativeDebugExtensions, SwapchainImagesDebugMarker) {

--- a/tests/unit/debug_extensions_positive.cpp
+++ b/tests/unit/debug_extensions_positive.cpp
@@ -91,12 +91,12 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer) {
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
     vk::CmdBeginDebugUtilsLabelEXT(m_command_buffer, &label);
     vk::CmdEndDebugUtilsLabelEXT(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -110,15 +110,15 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer2) {
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
-    cb0.end();
+    cb0.End();
     m_default_queue->Submit(cb0);
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
-    cb1.end();
+    cb1.End();
     m_default_queue->Submit(cb1);
 
     m_default_queue->Wait();
@@ -132,14 +132,14 @@ TEST_F(PositiveDebugExtensions, DebugLabelPrimaryCommandBuffer3) {
     VkDebugUtilsLabelEXT label = vku::InitStructHelper();
     label.pLabelName = "test";
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBeginDebugUtilsLabelEXT(cb0, &label);
-    cb0.end();
+    cb0.End();
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdEndDebugUtilsLabelEXT(cb1);
-    cb1.end();
+    cb1.End();
 
     std::array cbs = {&cb0, &cb1};
     m_default_queue->Submit(cbs);
@@ -150,14 +150,14 @@ TEST_F(PositiveDebugExtensions, DebugLabelSecondaryCommandBuffer) {
     AddRequiredExtensions(VK_EXT_DEBUG_UTILS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     vkt::CommandBuffer cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    cb.begin();
+    cb.Begin();
     {
         VkDebugUtilsLabelEXT label = vku::InitStructHelper();
         label.pLabelName = "test";
         vk::CmdBeginDebugUtilsLabelEXT(cb, &label);
         vk::CmdEndDebugUtilsLabelEXT(cb);
     }
-    cb.end();
+    cb.End();
 }
 
 TEST_F(PositiveDebugExtensions, SwapchainImagesDebugMarker) {

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -55,10 +55,10 @@ void NegativeDebugPrintf::BasicComputeTest(const char *shader, const char *messa
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, message);
     m_default_queue->Submit(m_command_buffer);
@@ -743,10 +743,10 @@ TEST_F(NegativeDebugPrintf, Empty) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "First printf with a % and no value");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Second printf with a value -135");
@@ -789,10 +789,10 @@ TEST_F(NegativeDebugPrintf, MultipleFunctions) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "START");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "fn1 [0]");
@@ -829,12 +829,12 @@ TEST_F(NegativeDebugPrintf, Fragment) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_FragCoord.xy 10.50, 10.50");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_FragCoord.xy 10.50, 11.50");
@@ -910,10 +910,10 @@ TEST_F(NegativeDebugPrintf, HLSL) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "launchIndex 2, 0");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "launchIndex 3, 0");
@@ -973,18 +973,18 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     multi_draws[0].vertexCount = multi_draws[1].vertexCount = multi_draws[2].vertexCount = 3;
     VkMultiDrawIndexedInfoEXT multi_draw_indices[3] = {};
     multi_draw_indices[0].indexCount = multi_draw_indices[1].indexCount = multi_draw_indices[2].indexCount = 3;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDrawMultiEXT(m_command_buffer.handle(), 3, multi_draws, 1, 0, sizeof(VkMultiDrawInfoEXT));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.memory().map();
+    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 0;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here are two float values 1.000000, 3.141500");
     }
@@ -993,12 +993,12 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.memory().map());
+    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
-    buffer.memory().unmap();
-    m_command_buffer.begin();
+    buffer.Memory().Unmap();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1006,11 +1006,11 @@ TEST_F(NegativeDebugPrintf, MultiDraw) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_INDEX_TYPE_UINT16);
     vk::CmdDrawMultiIndexedEXT(m_command_buffer.handle(), 3, multi_draw_indices, 1, 0, sizeof(VkMultiDrawIndexedInfoEXT), 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    data = (VkDeviceAddress *)buffer_in.memory().map();
+    data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 1;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here's a smaller float value 3.14");
     }
@@ -1073,12 +1073,12 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaders) {
     pipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawMeshTasksNV(m_command_buffer.handle(), 1, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
@@ -1160,14 +1160,14 @@ TEST_F(NegativeDebugPrintf, GPL) {
 
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), shader_source);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     std::vector<char const *> messages;
     messages.emplace_back("Here are two float values 1.000000, 3.141500");
@@ -1184,9 +1184,9 @@ TEST_F(NegativeDebugPrintf, GPL) {
     messages.emplace_back("First printf with a % and no value");
     messages.emplace_back("Second printf with a value -135");
     for (uint32_t i = 0; i < messages.size(); i++) {
-        VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.memory().map();
+        VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
         data[0] = i;
-        buffer_in.memory().unmap();
+        buffer_in.Memory().Unmap();
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, messages[i]);
         if (10 == i) {
             m_errorMonitor->SetDesiredFailureMsg(kInformationBit, messages[i + 1]);
@@ -1247,18 +1247,18 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     multi_draws[0].vertexCount = multi_draws[1].vertexCount = multi_draws[2].vertexCount = 3;
     VkMultiDrawIndexedInfoEXT multi_draw_indices[3] = {};
     multi_draw_indices[0].indexCount = multi_draw_indices[1].indexCount = multi_draw_indices[2].indexCount = 3;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDrawMultiEXT(m_command_buffer.handle(), 3, multi_draws, 1, 0, sizeof(VkMultiDrawInfoEXT));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.memory().map();
+    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 0;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here are two float values 1.000000, 3.141500");
     }
@@ -1267,12 +1267,12 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.memory().map());
+    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
-    buffer.memory().unmap();
-    m_command_buffer.begin();
+    buffer.Memory().Unmap();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1280,11 +1280,11 @@ TEST_F(NegativeDebugPrintf, GPLMultiDraw) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_INDEX_TYPE_UINT16);
     vk::CmdDrawMultiIndexedEXT(m_command_buffer.handle(), 3, multi_draw_indices, 1, 0, sizeof(VkMultiDrawIndexedInfoEXT), 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    data = (VkDeviceAddress *)buffer_in.memory().map();
+    data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 1;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here's a smaller float value 3.14");
     }
@@ -1298,7 +1298,7 @@ TEST_F(NegativeDebugPrintf, GPLInt64) {
     AddRequiredFeature(vkt::Feature::graphicsPipelineLibrary);
     RETURN_IF_SKIP(InitDebugPrintfFramework());
     RETURN_IF_SKIP(InitState());
-    if (!m_device->phy().Features().shaderInt64) {
+    if (!m_device->Physical().Features().shaderInt64) {
         GTEST_SKIP() << "shaderInt64 not supported";
     }
     InitRenderTarget();
@@ -1339,35 +1339,35 @@ TEST_F(NegativeDebugPrintf, GPLInt64) {
 
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), shader_source_int64);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.memory().map();
+    VkDeviceAddress *data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 0;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here's an unsigned long 0x2000000000000001");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (VkDeviceAddress *)buffer_in.memory().map();
+    data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 1;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     m_errorMonitor->SetDesiredFailureMsg(
         kInformationBit, "Here's a vector of ul 2000000000000001, 2000000000000001, 2000000000000001, 2000000000000001");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (VkDeviceAddress *)buffer_in.memory().map();
+    data = (VkDeviceAddress *)buffer_in.Memory().Map();
     data[0] = 2;
-    buffer_in.memory().unmap();
+    buffer_in.Memory().Unmap();
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit,
                                          "Unsigned long as decimal 2305843009213693953 and as hex 0x2000000000000001");
     m_default_queue->Submit(m_command_buffer);
@@ -1398,20 +1398,20 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : vert_data) {
             v = 0x01030507;
         }
-        vs_buffer.memory().unmap();
+        vs_buffer.Memory().Unmap();
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : frag_data) {
             v = 0x02040608;
         }
-        fs_buffer.memory().unmap();
+        fs_buffer.Memory().Unmap();
     }
 
     const std::array<VkDescriptorSet, 2> desc_sets = {vertex_set.set_, fragment_set.set_};
@@ -1448,14 +1448,14 @@ TEST_F(NegativeDebugPrintf, GPLFragment) {
 
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vert_shader, frag_shader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
@@ -1496,20 +1496,20 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : vert_data) {
             v = 0x01030507;
         }
-        vs_buffer.memory().unmap();
+        vs_buffer.Memory().Unmap();
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : frag_data) {
             v = 0x02040608;
         }
-        fs_buffer.memory().unmap();
+        fs_buffer.Memory().Unmap();
     }
 
     const std::array<VkDescriptorSet, 2> desc_sets = {vertex_set.set_, fragment_set.set_};
@@ -1584,14 +1584,14 @@ TEST_F(NegativeDebugPrintf, GPLFragmentIndependentSets) {
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     vkt::Pipeline pipe(*m_device, exe_pipe_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex shader 0, 0x1030507");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Fragment shader 0x2040608");
@@ -1620,7 +1620,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsGraphics) {
     )glsl";
     const vkt::Shader vs(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, shader_source));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
@@ -1630,7 +1630,7 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsGraphics) {
     SetDefaultDynamicStatesAll(m_command_buffer.handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "vertex 0 with value 3.141500");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "vertex 1 with value 3.141500");
@@ -1670,11 +1670,11 @@ TEST_F(NegativeDebugPrintf, ShaderObjects) {
     )glsl";
     const vkt::Shader cs(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, shader_source));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1, stages, &cs.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here are two float values 1.000000, 3.141500");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here's a smaller float value 3.14");
@@ -1712,11 +1712,11 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsInt64) {
     )glsl";
     const vkt::Shader cs(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, shader_source));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1, stages, &cs.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here's an unsigned long 0x2000000000000001");
     m_errorMonitor->SetDesiredFailureMsg(
@@ -1763,13 +1763,13 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     multi_draws[0].vertexCount = multi_draws[1].vertexCount = multi_draws[2].vertexCount = 3;
     VkMultiDrawIndexedInfoEXT multi_draw_indices[3] = {};
     multi_draw_indices[0].indexCount = multi_draw_indices[1].indexCount = multi_draw_indices[2].indexCount = 3;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     SetDefaultDynamicStatesAll(m_command_buffer.handle());
     vk::CmdDrawMultiEXT(m_command_buffer.handle(), 3, multi_draws, 1, 0, sizeof(VkMultiDrawInfoEXT));
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here are two float values 1.000000, 3.141500");
@@ -1779,19 +1779,19 @@ TEST_F(NegativeDebugPrintf, ShaderObjectsMultiDraw) {
     m_errorMonitor->VerifyFound();
 
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint16_t *ptr = static_cast<uint16_t *>(buffer.memory().map());
+    uint16_t *ptr = static_cast<uint16_t *>(buffer.Memory().Map());
     ptr[0] = 0;
     ptr[1] = 1;
     ptr[2] = 2;
-    buffer.memory().unmap();
-    m_command_buffer.begin();
+    buffer.Memory().Unmap();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     SetDefaultDynamicStatesAll(m_command_buffer.handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_INDEX_TYPE_UINT16);
     vk::CmdDrawMultiIndexedEXT(m_command_buffer.handle(), 3, multi_draw_indices, 1, 0, sizeof(VkMultiDrawIndexedInfoEXT), 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Here are two float values 1.000000, 3.141500");
@@ -1854,7 +1854,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
     const vkt::Shader ms(*m_device, VK_SHADER_STAGE_MESH_BIT_EXT,
                          GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, meshShaderText, SPV_ENV_VULKAN_1_3));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT,
@@ -1871,7 +1871,7 @@ TEST_F(NegativeDebugPrintf, MeshTaskShaderObjects) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 7u, stages, shaders);
     vk::CmdDrawMeshTasksEXT(m_command_buffer.handle(), 1, 1, 1);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from task shader");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "hello from mesh shader");
@@ -1916,12 +1916,12 @@ TEST_F(NegativeDebugPrintf, VertexFragmentSeparateShader) {
     pipe.vp_state_ci_.pScissors = &scissor;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex value is 4");
@@ -2029,12 +2029,12 @@ TEST_F(NegativeDebugPrintf, VertexFragmentMultiEntrypoint) {
     pipe.vp_state_ci_.pScissors = &scissor;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (auto i = 0; i < 3; i++) {
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Vertex value is 4");
@@ -2072,13 +2072,13 @@ TEST_F(NegativeDebugPrintf, ShaderObjectFragment) {
     renderingInfo.layerCount = 1;
     renderingInfo.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vert_shader, frag_shader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -2102,10 +2102,10 @@ TEST_F(NegativeDebugPrintf, ShaderObjectCompute) {
     )glsl";
     const vkt::Shader comp_shader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, cs_source));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BindCompShader(comp_shader);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -2154,10 +2154,10 @@ TEST_F(NegativeDebugPrintf, SetupErrorVersion) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -2235,10 +2235,10 @@ TEST_F(NegativeDebugPrintf, LocalSizeId) {
                                              &specialization_info);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 32, 32, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "TEST");
     m_default_queue->Submit(m_command_buffer);
@@ -2264,7 +2264,7 @@ TEST_F(NegativeDebugPrintf, Maintenance5) {
     )glsl";
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_COMPUTE_BIT, shader_source, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, shader_source, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();
@@ -2281,10 +2281,10 @@ TEST_F(NegativeDebugPrintf, Maintenance5) {
     pipe.cp_ci_.layout = layout.handle();
     pipe.CreateComputePipeline(false);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -2308,7 +2308,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
     )glsl";
 
     // Add one to use the descriptor slot we tried to reserve
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets + 1;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets + 1;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     // First try to use too many sets in the pipeline layout
     {
@@ -2327,10 +2327,10 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
         pipe.cp_ci_.layout = pipe_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2350,10 +2350,10 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineReserved) {
         pipe.cp_ci_.layout = pipe_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_default_queue->Submit(m_command_buffer);
@@ -2377,7 +2377,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
         }
     )glsl";
 
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     // First try to use too many sets in the pipeline layout
     {
@@ -2396,10 +2396,10 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
         pipe.cp_ci_.layout = pipe_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2419,10 +2419,10 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineNotReserved) {
         pipe.cp_ci_.layout = pipe_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_default_queue->Submit(m_command_buffer);
@@ -2448,7 +2448,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
     )glsl";
     VkShaderObj vs(this, shader_source, VK_SHADER_STAGE_VERTEX_BIT);
 
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     // First try to use too many sets in the pipeline layout
     {
@@ -2467,12 +2467,12 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
         pipe.gp_ci_.layout = pipe_layout.handle();
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2492,12 +2492,12 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGraphics) {
         pipe.gp_ci_.layout = pipe_layout.handle();
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
@@ -2526,7 +2526,7 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
         }
     )glsl";
 
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     // First try to use too many sets in the pipeline layout
     {
@@ -2542,12 +2542,12 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
 
         vkt::SimpleGPL pipe(*this, pipe_layout.handle(), shader_source);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2563,12 +2563,12 @@ TEST_F(NegativeDebugPrintf, UseAllDescriptorSlotsPipelineGPL) {
         vkt::PipelineLayout pipe_layout(*m_device, layouts);
         vkt::SimpleGPL pipe(*this, pipe_layout.handle(), shader_source);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
@@ -2599,7 +2599,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectReserved) 
     auto cs_spirv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, shader_source);
 
     // Add one to use the descriptor slot we tried to reserve
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets + 1;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets + 1;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     std::vector<VkDescriptorSetLayout> layouts;
     for (uint32_t i = 0; i < set_limit; i++) {
@@ -2616,10 +2616,10 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectReserved) 
                                       ShaderCreateInfo(cs_spirv, VK_SHADER_STAGE_COMPUTE_BIT, set_limit, layouts.data()));
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BindCompShader(comp_shader);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2631,10 +2631,10 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectReserved) 
         const vkt::Shader comp_shader(*m_device,
                                       ShaderCreateInfo(cs_spirv, VK_SHADER_STAGE_COMPUTE_BIT, set_limit - 1, layouts.data()));
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BindCompShader(comp_shader);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_default_queue->Submit(m_command_buffer);
@@ -2662,7 +2662,7 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectNotReserve
     )glsl";
     auto cs_spirv = GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, shader_source);
 
-    const uint32_t set_limit = m_device->phy().limits_.maxBoundDescriptorSets;
+    const uint32_t set_limit = m_device->Physical().limits_.maxBoundDescriptorSets;
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     std::vector<VkDescriptorSetLayout> layouts;
     for (uint32_t i = 0; i < set_limit; i++) {
@@ -2679,10 +2679,10 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectNotReserve
                                       ShaderCreateInfo(cs_spirv, VK_SHADER_STAGE_COMPUTE_BIT, set_limit, layouts.data()));
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BindCompShader(comp_shader);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Will not print out because no slot was possible to put output buffer
         m_default_queue->Submit(m_command_buffer);
@@ -2694,10 +2694,10 @@ TEST_F(NegativeDebugPrintf, DISABLED_UseAllDescriptorSlotsShaderObjectNotReserve
         const vkt::Shader comp_shader(*m_device,
                                       ShaderCreateInfo(cs_spirv, VK_SHADER_STAGE_COMPUTE_BIT, set_limit - 1, layouts.data()));
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BindCompShader(comp_shader);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
         m_default_queue->Submit(m_command_buffer);
@@ -2741,14 +2741,14 @@ TEST_F(NegativeDebugPrintf, DISABLED_ShaderObjectMultiCreate) {
     renderingInfo.layerCount = 1;
     renderingInfo.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT});
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_FRAGMENT_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 2, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -2778,10 +2778,10 @@ TEST_F(NegativeDebugPrintf, OverflowBuffer) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 4, 4, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredWarning(
         "Debug Printf message was truncated due to a buffer size (1024) being too small for the messages");
@@ -2810,10 +2810,10 @@ TEST_F(NegativeDebugPrintf, OverflowBufferLoop) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 4, 4, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredWarning(
         "Debug Printf message was truncated due to a buffer size (1024) being too small for the messages");
@@ -3165,12 +3165,12 @@ TEST_F(NegativeDebugPrintf, ValidationAbort) {
     }
 
     VkPhysicalDeviceFeatures features = {};
-    fpvkGetOriginalPhysicalDeviceFeaturesEXT(gpu(), &features);
+    fpvkGetOriginalPhysicalDeviceFeaturesEXT(Gpu(), &features);
 
     // Disable features so initialization aborts
     features.vertexPipelineStoresAndAtomics = false;
     features.fragmentStoresAndAtomics = false;
-    fpvkSetPhysicalDeviceFeaturesEXT(gpu(), features);
+    fpvkSetPhysicalDeviceFeaturesEXT(Gpu(), features);
     m_errorMonitor->SetDesiredError("DebugPrintf is being disabled");
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->VerifyFound();
@@ -3181,10 +3181,10 @@ TEST_F(NegativeDebugPrintf, ValidationAbort) {
     CreateComputePipelineHelper pipe(*this);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -3210,7 +3210,7 @@ TEST_F(NegativeDebugPrintf, DualPipelines) {
     CreateComputePipelineHelper pipe_normal(*this);
     pipe_normal.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_normal.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);  // no print
 
@@ -3223,7 +3223,7 @@ TEST_F(NegativeDebugPrintf, DualPipelines) {
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_debug.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);  // print
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
@@ -3257,15 +3257,15 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferHalfPrint) {
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBindPipeline(cb0.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_normal.Handle());
     vk::CmdDispatch(cb0.handle(), 1, 1, 1);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdBindPipeline(cb1.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_debug.Handle());
     vk::CmdDispatch(cb1.handle(), 1, 1, 1);
-    cb1.end();
+    cb1.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
 
@@ -3306,18 +3306,18 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferBothPrint) {
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
 
     uint32_t data = 4;
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPushConstants(cb0.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &data);
     vk::CmdBindPipeline(cb0.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(cb0.handle(), 1, 1, 1);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     data = 8;
     vk::CmdPushConstants(cb1.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &data);
     vk::CmdBindPipeline(cb1.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(cb1.handle(), 1, 1, 1);
-    cb1.end();
+    cb1.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "int == 4");  // cb0
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "int == 8");  // cb1
@@ -3356,16 +3356,16 @@ TEST_F(NegativeDebugPrintf, DualCommandBufferEmpty) {
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
 
     // Empty to make sure nothing breaks
-    cb0.begin();
-    cb0.end();
+    cb0.Begin();
+    cb0.End();
 
-    cb2.begin();
-    cb2.end();
+    cb2.Begin();
+    cb2.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdBindPipeline(cb1.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_debug.Handle());
     vk::CmdDispatch(cb1.handle(), 1, 1, 1);
-    cb1.end();
+    cb1.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
 
@@ -3393,20 +3393,20 @@ TEST_F(NegativeDebugPrintf, DispatchIndirect) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto indirect_command = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.memory().map());
+    auto indirect_command = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
     indirect_command->x = 1;
     indirect_command->y = 1;
     indirect_command->z = 1;
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
     CreateComputePipelineHelper pipe(*this);
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -3432,10 +3432,10 @@ TEST_F(NegativeDebugPrintf, DispatchBase) {
     pipe.cp_ci_.flags = VK_PIPELINE_CREATE_DISPATCH_BASE;
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatchBase(m_command_buffer.handle(), 1, 1, 1, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "float == 3.141500");
     m_default_queue->Submit(m_command_buffer);
@@ -3480,13 +3480,13 @@ TEST_F(NegativeDebugPrintf, DrawIndexed) {
 
     vkt::Buffer index_buffer = vkt::IndexBuffer<uint32_t>(*m_device, {0, 1, 2});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexed(m_command_buffer.handle(), 3, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_VertexIndex 0");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_VertexIndex 1");
@@ -3524,21 +3524,21 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirect) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.memory().map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
     indirect_command->vertexOffset = 1;
     indirect_command->firstInstance = 1;
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 0, 1, sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Hit Fragment");
     m_default_queue->Submit(m_command_buffer);
@@ -3573,27 +3573,27 @@ TEST_F(NegativeDebugPrintf, DrawIndirectCount) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.memory().map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
     indirect_command->vertexOffset = 1;
     indirect_command->firstInstance = 1;
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirectCount(m_command_buffer.handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                              sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Hit Fragment");
     m_default_queue->Submit(m_command_buffer);
@@ -3630,28 +3630,28 @@ TEST_F(NegativeDebugPrintf, DrawIndexedIndirectCount) {
 
     vkt::Buffer indirect_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.memory().map());
+    auto indirect_command = static_cast<VkDrawIndexedIndirectCommand *>(indirect_buffer.Memory().Map());
     indirect_command->indexCount = 3;
     indirect_command->instanceCount = 1;
     indirect_command->firstIndex = 1;
     indirect_command->vertexOffset = 1;
     indirect_command->firstInstance = 1;
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexedIndirectCount(m_command_buffer.handle(), indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                     sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Hit Fragment");
     m_default_queue->Submit(m_command_buffer);
@@ -3725,27 +3725,27 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsCompute) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.memory().map();
+    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.Memory().Map();
     block_buffer_ptr->x = 2;
     block_buffer_ptr->y = 1;
     block_buffer_ptr->z = 1;
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     VkGeneratedCommandsInfoEXT generated_commands_info = vku::InitStructHelper(&pipeline_info);
     generated_commands_info.shaderStages = VK_SHADER_STAGE_COMPUTE_BIT;
     generated_commands_info.indirectExecutionSet = VK_NULL_HANDLE;
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = sizeof(VkDispatchIndirectCommand);
-    generated_commands_info.indirectAddress = block_buffer.address();
-    generated_commands_info.preprocessAddress = pre_process_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
+    generated_commands_info.preprocessAddress = pre_process_buffer.Address();
     generated_commands_info.preprocessSize = pre_process_size;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxSequenceCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_NumWorkGroups 2, 1, 1");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_NumWorkGroups 2, 1, 1");
@@ -3823,28 +3823,28 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsGraphics) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDrawIndirectCommand *block_buffer_ptr = (VkDrawIndirectCommand *)block_buffer.memory().map();
+    VkDrawIndirectCommand *block_buffer_ptr = (VkDrawIndirectCommand *)block_buffer.Memory().Map();
     block_buffer_ptr->vertexCount = 3;
     block_buffer_ptr->instanceCount = 1;
     block_buffer_ptr->firstVertex = 0;
     block_buffer_ptr->firstInstance = 0;
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     VkGeneratedCommandsInfoEXT generated_commands_info = vku::InitStructHelper(&pipeline_info);
     generated_commands_info.shaderStages = VK_SHADER_STAGE_VERTEX_BIT;
     generated_commands_info.indirectExecutionSet = VK_NULL_HANDLE;
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = sizeof(VkDrawIndirectCommand);
-    generated_commands_info.indirectAddress = block_buffer.address();
-    generated_commands_info.preprocessAddress = pre_process_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
+    generated_commands_info.preprocessAddress = pre_process_buffer.Address();
     generated_commands_info.preprocessSize = pre_process_size;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxSequenceCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_VertexIndex 0");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "gl_VertexIndex 1");
@@ -3955,29 +3955,29 @@ TEST_F(NegativeDebugPrintf, DeviceGeneratedCommandsIES) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.memory().map();
+    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.Memory().Map();
     block_buffer_ptr[0] = 2;  // pick pipeline 2
     VkDispatchIndirectCommand *indirect_command_ptr = (VkDispatchIndirectCommand *)(block_buffer_ptr + 1);
     indirect_command_ptr->x = 1;
     indirect_command_ptr->y = 1;
     indirect_command_ptr->z = 1;
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     VkGeneratedCommandsInfoEXT generated_commands_info = vku::InitStructHelper();
     generated_commands_info.shaderStages = VK_SHADER_STAGE_COMPUTE_BIT;
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = sizeof(uint32_t) + sizeof(VkDispatchIndirectCommand);
-    generated_commands_info.indirectAddress = block_buffer.address();
-    generated_commands_info.preprocessAddress = pre_process_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
+    generated_commands_info.preprocessAddress = pre_process_buffer.Address();
     generated_commands_info.preprocessSize = pre_process_size;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxSequenceCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, init_pipe.Handle());
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "IndirectExecutionSet Pipeline 2");
     m_default_queue->Submit(m_command_buffer);

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -41,7 +41,7 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
         #extension GL_EXT_debug_printf : enable
         layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
         layout(location = 0) rayPayloadEXT vec3 hit;
-       
+
         void main() {
             debugPrintfEXT("In Raygen\n");
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
@@ -60,14 +60,14 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
 
     pipeline.Build();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "In Raygen");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -92,18 +92,18 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
 
     // Build Bottom Level Acceleration Structure
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     // Build Top Level Acceleration Structure
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -111,9 +111,9 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     // Buffer used to count invocations for the 3 shader types
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -130,7 +130,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         };
 
         layout(location = 0) rayPayloadEXT vec3 hit;
-       
+
         void main() {
             debugPrintfEXT("In Raygen\n");
             atomicAdd(debug_buffer[0], 1);
@@ -138,21 +138,21 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
             vec3 ray_origin = vec3(0,0,-50);
             vec3 ray_direction = vec3(0,0,1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
+
             // Will miss
             ray_origin = vec3(0,0,-50);
             ray_direction = vec3(0,0,-1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
+
             // Will miss
             ray_origin = vec3(0,0,50);
             ray_direction = vec3(0,0,1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
+
             ray_origin = vec3(0,0,50);
             ray_direction = vec3(0,0,-1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
+
             // Will miss
             ray_origin = vec3(0,0,0);
             ray_direction = vec3(0,0,1);
@@ -216,7 +216,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
 
     uint32_t frames_count = 250;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -225,7 +225,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
                             &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->SetDesiredInfo("In Raygen");
         m_errorMonitor->SetDesiredInfo("In Miss", 3);
         m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
@@ -234,9 +234,9 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     }
     m_errorMonitor->VerifyFound();
 
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
     ASSERT_EQ(debug_buffer_ptr[0], frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
-    debug_buffer.memory().unmap();
+    debug_buffer.Memory().Unmap();
 }

--- a/tests/unit/debug_printf_shader_debug_info.cpp
+++ b/tests/unit/debug_printf_shader_debug_info.cpp
@@ -48,10 +48,10 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, PipelineHandle) {
     name_info.pObjectName = object_name;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Pipeline (bad_pipeline)");
     m_default_queue->Submit(m_command_buffer);
@@ -86,10 +86,10 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, ShaderObjectHandle) {
     name_info.pObjectName = object_name;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1, shader_stages, &comp_shader.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Shader Object (bad_shader_object)");
     m_default_queue->Submit(m_command_buffer);
@@ -144,10 +144,10 @@ void main() {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_ASM);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(
         kInformationBit,
@@ -178,7 +178,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndex) {
     CreateComputePipelineHelper empty_pipe(*this);
     empty_pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, empty_pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
@@ -186,7 +186,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndex) {
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Compute Dispatch Index 3");
     m_default_queue->Submit(m_command_buffer);
@@ -225,7 +225,7 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndexMulti) {
 
     uint32_t skip = 0;
     uint32_t good = 4;
-    cb0.begin();
+    cb0.Begin();
     vk::CmdBindPipeline(cb0.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdPushConstants(cb0.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &skip);
     vk::CmdDispatch(cb0.handle(), 1, 1, 1);
@@ -235,15 +235,15 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, CommandBufferCommandIndexMulti) {
     vk::CmdDispatch(cb0.handle(), 1, 1, 1);
     vk::CmdPushConstants(cb0.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &skip);
     vk::CmdDispatch(cb0.handle(), 1, 1, 1);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdBindPipeline(cb1.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdPushConstants(cb1.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &good);
     vk::CmdDispatch(cb1.handle(), 1, 1, 1);
     vk::CmdPushConstants(cb1.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t), &skip);
     vk::CmdDispatch(cb1.handle(), 1, 1, 1);
-    cb1.end();
+    cb1.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Compute Dispatch Index 3");  // cb0
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Compute Dispatch Index 0");  // cb1
@@ -280,10 +280,10 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, StageInfo) {
     CreateComputePipelineHelper empty_pipe(*this);
     empty_pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 4, 4, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Global invocation ID (x, y, z) = (3, 1, 0)");
     m_default_queue->Submit(m_command_buffer);
@@ -316,12 +316,12 @@ TEST_F(NegativeDebugPrintfShaderDebugInfo, Fragment) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Stage = Fragment.  Fragment coord (x,y) = (10.5, 10.5)");
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "Stage = Fragment.  Fragment coord (x,y) = (10.5, 11.5)");

--- a/tests/unit/descriptor_buffer.cpp
+++ b/tests/unit/descriptor_buffer.cpp
@@ -236,13 +236,13 @@ TEST_F(NegativeDescriptorBuffer, NotEnabled) {
         plci.pSetLayouts = &dsl.handle();
         vkt::PipelineLayout pipeline_layout(*m_device, plci);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-None-08068");
         vk::CmdBindDescriptorBufferEmbeddedSamplersEXT(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
                                                        pipeline_layout.handle(), 0);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -259,17 +259,17 @@ TEST_F(NegativeDescriptorBuffer, NotEnabledBufferDeviceAddress) {
                          vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = d_buffer.address();
+    dbbi.address = d_buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
-    d_buffer.memory().destroy();
+    d_buffer.Memory().destroy();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBuffersEXT-None-08047");
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &dbbi);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorBuffer, NotEnabledGetBufferOpaqueCaptureDescriptorDataEXT) {
@@ -530,7 +530,7 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptorsOff) {
         GTEST_SKIP() << "bufferlessPushDescriptors is supported";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer d_buffer(*m_device, 4096,
                          VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
@@ -538,7 +538,7 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptorsOff) {
                          vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = d_buffer.address();
+    dbbi.address = d_buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_PUSH_DESCRIPTORS_DESCRIPTOR_BUFFER_BIT_EXT;
 
@@ -568,7 +568,7 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptors) {
         GTEST_SKIP() << "bufferlessPushDescriptors is not supported";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer d_buffer(*m_device, 4096,
                          VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT,
@@ -578,7 +578,7 @@ TEST_F(NegativeDescriptorBuffer, BufferlessPushDescriptors) {
     dbbpdbh.buffer = d_buffer.handle();
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper(&dbbpdbh);
-    dbbi.address = d_buffer.address();
+    dbbi.address = d_buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
@@ -610,14 +610,14 @@ TEST_F(NegativeDescriptorBuffer, DescriptorBufferOffsetAlignment) {
         GTEST_SKIP() << "descriptorBufferOffsetAlignment is 1";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer d_buffer(*m_device, 4096,
                          VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT,
                          vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = d_buffer.address() + 1;  // make alignment bad
+    dbbi.address = d_buffer.Address() + 1;  // make alignment bad
     dbbi.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT | VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT |
                  VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
 
@@ -633,12 +633,12 @@ TEST_F(NegativeDescriptorBuffer, BindingInfoUsage) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer buffer(*m_device, 4096, 0, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = buffer.address();
+    dbbi.address = buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-usage-08122");
@@ -669,14 +669,14 @@ TEST_F(NegativeDescriptorBuffer, BindingInfoUsageMultiBuffers) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer buffer_good1(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
     vkt::Buffer buffer_good2(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
     vkt::Buffer buffer_bad(*m_device, 4096, 0, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = buffer_bad.address();
+    dbbi.address = buffer_bad.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-usage-08122");
@@ -689,7 +689,7 @@ TEST_F(NegativeDescriptorBuffer, CmdBindDescriptorBufferEmbeddedSamplers) {
     AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
     RETURN_IF_SKIP(InitBasicDescriptorBuffer());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
     vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -723,7 +723,7 @@ TEST_F(NegativeDescriptorBuffer, CmdSetDescriptorBufferOffsets) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
     vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -743,7 +743,7 @@ TEST_F(NegativeDescriptorBuffer, CmdSetDescriptorBufferOffsets) {
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = buffer.address();
+    dbbi.address = buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &dbbi);
 
@@ -784,14 +784,14 @@ TEST_F(NegativeDescriptorBuffer, CmdSetDescriptorBufferOffsets) {
         index = 0;
         offset = 0;
 
-        command_buffer.begin();
+        command_buffer.Begin();
         vk::CmdBindDescriptorBuffersEXT(command_buffer.handle(), 1, &dbbi);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetDescriptorBufferOffsetsEXT-pipelineBindPoint-08067");
         vk::CmdSetDescriptorBufferOffsetsEXT(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                                              1, &index, &offset);
         m_errorMonitor->VerifyFound();
-        command_buffer.end();
+        command_buffer.End();
     }
 
     {
@@ -820,7 +820,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkDescriptorSetLayoutBinding binding1 = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
     vkt::DescriptorSetLayout dsl1(*m_device, binding1, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -859,7 +859,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
     alloc_info.allocationSize = buffer_mem_reqs.size;
-    m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &alloc_info, 0);
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &alloc_info, 0);
     vkt::DeviceMemory buffer_memory(*m_device, alloc_info);
 
     // Bind those buffers to the same buffer memory
@@ -867,12 +867,12 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
     vk::BindBufferMemory(device(), small_buffer.handle(), buffer_memory.handle(), 0);
 
     // Check that internal mapping from address to buffers is correctly updated
-    if (large_buffer.address() != small_buffer.address()) {
+    if (large_buffer.Address() != small_buffer.Address()) {
         GTEST_SKIP() << "Buffers address don't match";
     }
-    // calling large_buffer->address() twice should not result in this buffer being mapped twice.
+    // calling large_buffer->Address() twice should not result in this buffer being mapped twice.
     // If it is mapped twice, the error below will not be thrown.
-    const VkDeviceAddress common_address = large_buffer.address();
+    const VkDeviceAddress common_address = large_buffer.Address();
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
     dbbi.address = common_address;
@@ -895,7 +895,7 @@ TEST_F(NegativeDescriptorBuffer, BindingAndOffsets) {
                                          &index, &offset);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
@@ -923,13 +923,13 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = buffer.address();
+    dbbi.address = buffer.Address();
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
 
     CreateComputePipelineHelper pipe(*this);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &dbbi);
@@ -943,7 +943,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentBuffer) {
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
@@ -986,7 +986,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     pipe.cp_ci_.flags |= VK_PIPELINE_CREATE_DESCRIPTOR_BUFFER_BIT_EXT;
     ASSERT_EQ(VK_SUCCESS, pipe.CreateComputePipeline());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
@@ -996,7 +996,7 @@ TEST_F(NegativeDescriptorBuffer, InconsistentSet) {
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorBuffer, BindPoint) {
@@ -1038,12 +1038,12 @@ TEST_F(NegativeDescriptorBuffer, BindPoint) {
         ASSERT_TRUE(command_pool.initialized());
         vkt::CommandBuffer command_buffer(*m_device, command_pool);
 
-        command_buffer.begin();
+        command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorBufferEmbeddedSamplersEXT-pipelineBindPoint-08069");
         vk::CmdBindDescriptorBufferEmbeddedSamplersEXT(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS,
                                                        pipeline_layout.handle(), 1);
         m_errorMonitor->VerifyFound();
-        command_buffer.end();
+        command_buffer.End();
     }
 }
 
@@ -1238,7 +1238,7 @@ TEST_F(NegativeDescriptorBuffer, DescriptorGetInfoAddressRange) {
 
     d_buffer.BindMemory(mem, 0);
 
-    dai.address = d_buffer.address();
+    dai.address = d_buffer.Address();
     dai.range = 4096 * buffer_ci.size;
     dai.format = VK_FORMAT_R8_UINT;
 
@@ -1457,7 +1457,7 @@ TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
     AddRequiredExtensions(VK_AMD_SHADER_FRAGMENT_MASK_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
-    const auto q_props = vkt::PhysicalDevice(gpu()).queue_properties_;
+    const auto q_props = vkt::PhysicalDevice(Gpu()).queue_properties_;
     ASSERT_TRUE(q_props.size() > 0);
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
@@ -1483,7 +1483,7 @@ TEST_F(NegativeDescriptorBuffer, ExtensionCombination) {
     VkDevice test_device;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-None-08095");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1598,7 +1598,7 @@ TEST_F(NegativeDescriptorBuffer, Binding) {
                                        VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-08010");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1637,10 +1637,10 @@ TEST_F(NegativeDescriptorBuffer, InvalidDescriptorBufferUsage) {
     vkt::Buffer d_buffer(*m_device, buffer_ci, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT, &allocate_flag_info);
 
     VkDescriptorBufferBindingInfoEXT binding_info = vku::InitStructHelper();
-    binding_info.address = d_buffer.address();
+    binding_info.address = d_buffer.Address();
     binding_info.usage = buffer_ci.usage | 0x80000000;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-None-09499");
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1u, &binding_info);
     m_errorMonitor->VerifyFound();
@@ -1650,7 +1650,7 @@ TEST_F(NegativeDescriptorBuffer, InvalidDescriptorBufferUsage) {
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorBufferBindingInfoEXT-None-09500");
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1u, &binding_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
@@ -1662,7 +1662,7 @@ TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_UNIFORM_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires support for VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT";
     }
@@ -1670,7 +1670,7 @@ TEST_F(NegativeDescriptorBuffer, MaxTexelBufferElements) {
 
     VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
     dai.address = 0;
-    dai.range = 2 * format_size * static_cast<VkDeviceSize>(m_device->phy().limits_.maxTexelBufferElements);
+    dai.range = 2 * format_size * static_cast<VkDeviceSize>(m_device->Physical().limits_.maxTexelBufferElements);
     dai.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkDescriptorGetInfoEXT dgi = vku::InitStructHelper();
@@ -1696,7 +1696,7 @@ TEST_F(NegativeDescriptorBuffer, TexelBufferFormat) {
                        vkt::device_address);
 
     VkDescriptorAddressInfoEXT dai = vku::InitStructHelper();
-    dai.address = buffer.address();
+    dai.address = buffer.Address();
     dai.range = 4;
     dai.format = VK_FORMAT_UNDEFINED;
 

--- a/tests/unit/descriptor_buffer_positive.cpp
+++ b/tests/unit/descriptor_buffer_positive.cpp
@@ -57,7 +57,7 @@ TEST_F(PositiveDescriptorBuffer, BindBufferAndSetOffset) {
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
-    buffer_binding_info.address = buffer.address();
+    buffer_binding_info.address = buffer.Address();
     buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
     const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
@@ -72,14 +72,14 @@ TEST_F(PositiveDescriptorBuffer, BindBufferAndSetOffset) {
     const uint32_t index = 0;
     const VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &buffer_binding_info);
     vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptorBuffer, PipelineFlags2) {
@@ -94,7 +94,7 @@ TEST_F(PositiveDescriptorBuffer, PipelineFlags2) {
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
-    buffer_binding_info.address = buffer.address();
+    buffer_binding_info.address = buffer.Address();
     buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
     const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_VERTEX_BIT, nullptr};
@@ -111,14 +111,14 @@ TEST_F(PositiveDescriptorBuffer, PipelineFlags2) {
     const uint32_t index = 0;
     const VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &buffer_binding_info);
     vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &index, &offset);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptorBuffer, BindingMidBuffer) {
@@ -128,15 +128,15 @@ TEST_F(PositiveDescriptorBuffer, BindingMidBuffer) {
     VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT dbbi = vku::InitStructHelper();
-    dbbi.address = buffer.address() + descriptor_buffer_properties.descriptorBufferOffsetAlignment;
+    dbbi.address = buffer.Address() + descriptor_buffer_properties.descriptorBufferOffsetAlignment;
     dbbi.usage = VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &dbbi);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptorBuffer, Basic) {
@@ -148,11 +148,11 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, 0, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.memory().map();
+    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
-    buffer_data.memory().unmap();
+    buffer_data.Memory().Unmap();
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     vkt::DescriptorSetLayout ds_layout(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -171,7 +171,7 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
                                   vkt::device_address);
 
     VkDescriptorAddressInfoEXT addr_info = vku::InitStructHelper();
-    addr_info.address = buffer_data.address();
+    addr_info.address = buffer_data.Address();
     addr_info.range = 16;
     addr_info.format = VK_FORMAT_UNDEFINED;
 
@@ -179,10 +179,10 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     buffer_descriptor_info.data.pStorageBuffer = &addr_info;
 
-    void *mapped_descriptor_data = descriptor_buffer.memory().map();
+    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
-    descriptor_buffer.memory().unmap();
+    descriptor_buffer.Memory().Unmap();
 
     char const *cs_source = R"glsl(
         #version 450
@@ -203,11 +203,11 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
-    descriptor_buffer_binding_info.address = descriptor_buffer.address();
+    descriptor_buffer_binding_info.address = descriptor_buffer.Address();
     descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &descriptor_buffer_binding_info);
 
@@ -216,17 +216,17 @@ TEST_F(PositiveDescriptorBuffer, Basic) {
     vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
                                          &buffer_index, &buffer_offset);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     if (!IsPlatformMockICD()) {
-        data = (uint32_t *)buffer_data.memory().map();
+        data = (uint32_t *)buffer_data.Memory().Map();
         ASSERT_TRUE(data[0] == 8);
         ASSERT_TRUE(data[1] == 12);
         ASSERT_TRUE(data[2] == 20);
-        buffer_data.memory().unmap();
+        buffer_data.Memory().Unmap();
     }
 }
 
@@ -239,11 +239,11 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, 0, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.memory().map();
+    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
-    buffer_data.memory().unmap();
+    buffer_data.Memory().Unmap();
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     vkt::DescriptorSetLayout ds_layout(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -263,7 +263,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
                                   vkt::device_address);
 
     VkDescriptorAddressInfoEXT addr_info = vku::InitStructHelper();
-    addr_info.address = buffer_data.address();
+    addr_info.address = buffer_data.Address();
     addr_info.range = 4;
     addr_info.format = VK_FORMAT_UNDEFINED;
 
@@ -271,7 +271,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     buffer_descriptor_info.data.pStorageBuffer = &addr_info;
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.memory().map();
+    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
     // Sets data_buffer[0] to set 0
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
@@ -288,7 +288,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
 
-    descriptor_buffer.memory().unmap();
+    descriptor_buffer.Memory().Unmap();
 
     char const *cs_source = R"glsl(
         #version 450
@@ -313,11 +313,11 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
-    descriptor_buffer_binding_info.address = descriptor_buffer.address();
+    descriptor_buffer_binding_info.address = descriptor_buffer.Address();
     descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &descriptor_buffer_binding_info);
 
@@ -335,17 +335,17 @@ TEST_F(PositiveDescriptorBuffer, MultipleSet) {
                                          &buffer_index, &buffer_offset);
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     if (!IsPlatformMockICD()) {
-        data = (uint32_t *)buffer_data.memory().map();
+        data = (uint32_t *)buffer_data.Memory().Map();
         ASSERT_TRUE(data[0] == 8);
         ASSERT_TRUE(data[1] == 12);
         ASSERT_TRUE(data[2] == 20);
-        buffer_data.memory().unmap();
+        buffer_data.Memory().Unmap();
     }
 }
 
@@ -358,11 +358,11 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, 0, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.memory().map();
+    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
-    buffer_data.memory().unmap();
+    buffer_data.Memory().Unmap();
 
     std::vector<VkDescriptorSetLayoutBinding> bindings = {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                           {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -388,7 +388,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
                                   vkt::device_address);
 
     VkDescriptorAddressInfoEXT addr_info = vku::InitStructHelper();
-    addr_info.address = buffer_data.address();
+    addr_info.address = buffer_data.Address();
     addr_info.range = 4;
     addr_info.format = VK_FORMAT_UNDEFINED;
 
@@ -396,7 +396,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     buffer_descriptor_info.data.pStorageBuffer = &addr_info;
 
-    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.memory().map();
+    uint8_t *mapped_descriptor_data = (uint8_t *)descriptor_buffer.Memory().Map();
     // Sets data_buffer[0] to binding 0
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
@@ -411,7 +411,7 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data + ds_layout_binding_offsets[2]);
 
-    descriptor_buffer.memory().unmap();
+    descriptor_buffer.Memory().Unmap();
 
     char const *cs_source = R"glsl(
         #version 450
@@ -436,11 +436,11 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
-    descriptor_buffer_binding_info.address = descriptor_buffer.address();
+    descriptor_buffer_binding_info.address = descriptor_buffer.Address();
     descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &descriptor_buffer_binding_info);
 
@@ -450,16 +450,16 @@ TEST_F(PositiveDescriptorBuffer, MultipleBinding) {
                                          &buffer_index, &buffer_offset);
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     if (!IsPlatformMockICD()) {
-        data = (uint32_t *)buffer_data.memory().map();
+        data = (uint32_t *)buffer_data.Memory().Map();
         ASSERT_TRUE(data[0] == 8);
         ASSERT_TRUE(data[1] == 12);
         ASSERT_TRUE(data[2] == 20);
-        buffer_data.memory().unmap();
+        buffer_data.Memory().Unmap();
     }
 }

--- a/tests/unit/descriptor_indexing_positive.cpp
+++ b/tests/unit/descriptor_indexing_positive.cpp
@@ -80,7 +80,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -88,7 +88,7 @@ TEST_F(PositiveDescriptorIndexing, BindingPartiallyBound) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexed(m_command_buffer.handle(), 1, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -145,14 +145,14 @@ TEST_F(PositiveDescriptorIndexing, UpdateAfterBind) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     buffer1.destroy();
     descriptor_set.WriteDescriptorBufferInfo(0, buffer2, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -219,14 +219,14 @@ TEST_F(PositiveDescriptorIndexing, PartiallyBoundDescriptors) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     buffer1.destroy();
 

--- a/tests/unit/descriptors.cpp
+++ b/tests/unit/descriptors.cpp
@@ -185,7 +185,7 @@ TEST_F(NegativeDescriptors, DescriptorSet) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set_layout});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Set invalid set
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-parameter");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1, &bad_set,
@@ -203,7 +203,7 @@ TEST_F(NegativeDescriptors, DescriptorSet) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 2, 1, &good_set,
                               0, NULL);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DescriptorSetLayout) {
@@ -441,7 +441,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
         pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -450,7 +450,7 @@ TEST_F(NegativeDescriptors, WriteDescriptorSetConsecutiveUpdates) {
 
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
     // buffer2 just went out of scope and was destroyed
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
@@ -487,7 +487,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
         pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024);
         pipe.descriptor_set_->UpdateDescriptorSets();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -495,7 +495,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetBufferDestroyed) {
 
         vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
     // Destroy buffer should invalidate the cmd buffer, causing error on submit
 
@@ -538,7 +538,7 @@ TEST_F(NegativeDescriptors, DrawDescriptorSetBufferDestroyed) {
 
     // The buffer has now been destroyed, but it has been written into the descriptor set.
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -578,7 +578,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     VkDeviceSize align_mod = memory_reqs.size % memory_reqs.alignment;
     VkDeviceSize aligned_size = ((align_mod == 0) ? memory_reqs.size : (memory_reqs.size + memory_reqs.alignment - align_mod));
     memory_info.allocationSize = aligned_size * 2;
-    pass = m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
+    pass = m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory image_memory(*m_device, memory_info);
 
@@ -627,7 +627,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     pipe.CreateGraphicsPipeline();
 
     // First error case is destroying sampler prior to cmd buffer submission
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Transit image layout from VK_IMAGE_LAYOUT_UNDEFINED into VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
     VkImageMemoryBarrier barrier = vku::InitStructHelper();
@@ -652,7 +652,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // This first submit should be successful
     m_default_queue->Submit(m_command_buffer);
@@ -661,8 +661,8 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     // Now destroy imageview and reset cmdBuffer
     tmp_view.destroy();
 
-    m_command_buffer.reset(0);
-    m_command_buffer.begin();
+    m_command_buffer.Reset(0);
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -671,20 +671,20 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Re-update descriptor with new view
     img_info.imageView = view.handle();
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
     // Now test destroying sampler prior to cmd buffer submission
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Destroy sampler invalidates the cmd buffer, causing error on submit
     tmp_sampler.destroy();
     // Attempt to submit cmd buffer
@@ -699,14 +699,14 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
     info.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
-    m_command_buffer.begin(&info);
+    m_command_buffer.Begin(&info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Destroy image invalidates the cmd buffer, causing error on submit
     tmp_image.destroy();
 
@@ -716,7 +716,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
     // Now update descriptor to be valid, but then update and free descriptor
     img_info.imageView = view2.handle();
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, nullptr);
-    m_command_buffer.begin(&info);
+    m_command_buffer.Begin(&info);
 
     // Transit image2 layout from VK_IMAGE_LAYOUT_UNDEFINED into VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL
     barrier.image = image2.handle();
@@ -729,7 +729,7 @@ TEST_F(NegativeDescriptors, CmdBufferDescriptorSetImageSamplerDestroyed) {
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     // Immediately try to update the descriptor set in the active command buffer - failure expected
@@ -804,7 +804,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     pipe.CreateGraphicsPipeline();
 
     // First error case is destroying sampler prior to cmd buffer submission
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -814,7 +814,7 @@ TEST_F(NegativeDescriptors, DescriptorSetSamplerDestroyed) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
@@ -881,7 +881,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
         vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
         for (TestType test_type : test_list) {
-            cmd_buf.begin();
+            cmd_buf.Begin();
             // record layout different than actual descriptor layout.
             const VkFlags read_write = VK_ACCESS_MEMORY_READ_BIT | VK_ACCESS_MEMORY_WRITE_BIT;
             auto image_barrier = image->ImageMemoryBarrier(read_write, read_write, VK_IMAGE_LAYOUT_UNDEFINED, image_layout,
@@ -892,10 +892,10 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
 
             if (test_type == kExternal) {
                 // The image layout is external to the command buffer we are recording to test.  Submit to push to instance scope.
-                cmd_buf.end();
+                cmd_buf.End();
                 m_default_queue->Submit(cmd_buf);
                 m_default_queue->Wait();
-                cmd_buf.begin();
+                cmd_buf.Begin();
             }
 
             cmd_buf.BeginRenderPass(m_renderPassBeginInfo);
@@ -917,7 +917,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
             }
 
             cmd_buf.EndRenderPass();
-            cmd_buf.end();
+            cmd_buf.End();
 
             // Submit cmd buffer
             if (positive_test || (test_type == kInternal)) {
@@ -938,7 +938,7 @@ TEST_F(NegativeDescriptors, ImageDescriptorLayoutMismatch) {
             VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, /* positive */ false);
 
     // Create depth stencil image and views
-    const VkFormat format_ds = m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat format_ds = m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     bool ds_test_support = maintenance2 && (format_ds != VK_FORMAT_UNDEFINED);
     const VkImageLayout ds_image_layout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL;
     const VkImageLayout depth_descriptor_layout = VK_IMAGE_LAYOUT_DEPTH_READ_ONLY_STENCIL_ATTACHMENT_OPTIMAL;
@@ -987,7 +987,7 @@ TEST_F(NegativeDescriptors, DescriptorPoolInUseResetSignaled) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -995,7 +995,7 @@ TEST_F(NegativeDescriptors, DescriptorPoolInUseResetSignaled) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Submit cmd buffer to put pool in-flight
     m_default_queue->Submit(m_command_buffer);
     // Reset pool while in-flight, causing error
@@ -1026,7 +1026,7 @@ TEST_F(NegativeDescriptors, DescriptorImageUpdateNoMemoryBound) {
     // Update descriptor with image and sampler
     descriptor_set.WriteDescriptorImageInfo(0, view.handle(), sampler.handle());
     // Break memory binding and attempt update
-    image.memory().destroy();
+    image.Memory().destroy();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-VkDescriptorImageInfo-BoundResourceFreedMemoryAccess");
     descriptor_set.UpdateDescriptorSets();
@@ -1058,7 +1058,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetCases) {
                                              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-dynamicOffsetCount-00359");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1088,7 +1088,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetCases) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DynamicOffsetCasesMaintenance6) {
@@ -1112,7 +1112,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetCasesMaintenance6) {
                                              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkBindDescriptorSetsInfoKHR bind_ds_info = vku::InitStructHelper();
@@ -1147,7 +1147,7 @@ TEST_F(NegativeDescriptors, BindDescriptorSetsInfoPipelineLayout) {
                                              VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkBindDescriptorSetsInfoKHR bind_ds_info = vku::InitStructHelper();
@@ -1198,7 +1198,7 @@ TEST_F(NegativeDescriptors, DescriptorBufferUpdateNoMemoryBound) {
 TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
     RETURN_IF_SKIP(Init());
 
-    const VkDeviceSize partial_size = m_device->phy().limits_.minUniformBufferOffsetAlignment;
+    const VkDeviceSize partial_size = m_device->Physical().limits_.minUniformBufferOffsetAlignment;
     const VkDeviceSize buffer_size = partial_size * 10;  // make sure way more then alignment multiple
 
     // Create a buffer to update the descriptor with
@@ -1254,7 +1254,7 @@ TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
     descriptor_set_1.UpdateDescriptorSets();
     descriptor_set_2.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkDescriptorSet descriptorSets[3] = {descriptor_set_0.set_, descriptor_set_1.set_, descriptor_set_2.set_};
     uint32_t offsets[5] = {0, 0, 0, 0, 0};
@@ -1316,7 +1316,7 @@ TEST_F(NegativeDescriptors, DynamicDescriptorSet) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0, 3, descriptorSets, 5, offsets);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
@@ -1359,7 +1359,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
@@ -1392,7 +1392,7 @@ TEST_F(NegativeDescriptors, DynamicOffsetWithNullBuffer) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, BindInvalidPipelineLayout) {
@@ -1428,7 +1428,7 @@ TEST_F(NegativeDescriptors, BindInvalidPipelineLayout) {
         GTEST_SKIP() << "Driver failed to create a invalid pipeline handle";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1438,7 +1438,7 @@ TEST_F(NegativeDescriptors, BindInvalidPipelineLayout) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6944
@@ -1474,7 +1474,7 @@ TEST_F(NegativeDescriptors, DISABLED_ConstantArrayElementNotBound) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1485,13 +1485,13 @@ TEST_F(NegativeDescriptors, DISABLED_ConstantArrayElementNotBound) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, UpdateDescriptorSetMismatchType) {
     RETURN_IF_SKIP(Init());
 
-    vkt::Buffer buffer(*m_device, m_device->phy().limits_.minUniformBufferOffsetAlignment, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    vkt::Buffer buffer(*m_device, m_device->Physical().limits_.minUniformBufferOffsetAlignment, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
                                                   {1, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER_DYNAMIC, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -1628,7 +1628,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
     pipe.gp_ci_.layout = pipe_layout_fs_only.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1696,7 +1696,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibility) {
 
     // Remaining clean-up
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DescriptorSetCompatibilityCompute) {
@@ -1738,7 +1738,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityCompute) {
     pipeline.cp_ci_.layout = pipeline_layout_a.handle();
     pipeline.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_a.handle(), 0, 1,
                               &descriptor_set_storage.set_, 0, nullptr);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_b.handle(), 1, 1,
@@ -1747,7 +1747,7 @@ TEST_F(NegativeDescriptors, DescriptorSetCompatibilityCompute) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08600");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DSUsageBits) {
@@ -1757,7 +1757,7 @@ TEST_F(NegativeDescriptors, DSUsageBits) {
 
     const VkFormat buffer_format = VK_FORMAT_R8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), buffer_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), buffer_format, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format";
     }
@@ -1799,7 +1799,7 @@ TEST_F(NegativeDescriptors, DSUsageBits) {
     vkt::Buffer buffer(*m_device, buffer_size, VK_BUFFER_USAGE_UNIFORM_TEXEL_BUFFER_BIT);
     vkt::Buffer storage_texel_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
 
-    auto buff_view_ci = vkt::BufferView::createInfo(buffer.handle(), VK_FORMAT_R8_UNORM);
+    auto buff_view_ci = vkt::BufferView::CreateInfo(buffer.handle(), VK_FORMAT_R8_UNORM);
     vkt::BufferView buffer_view_obj, storage_texel_buffer_view_obj;
     buffer_view_obj.init(*m_device, buff_view_ci);
     buff_view_ci.buffer = storage_texel_buffer.handle();
@@ -1870,7 +1870,7 @@ TEST_F(NegativeDescriptors, DSUsageBitsFlags2) {
 
     const VkFormat buffer_format = VK_FORMAT_R8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), buffer_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), buffer_format, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format";
     }
@@ -1931,11 +1931,13 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
 
     for (const auto &test_case : {
              TestCase({VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
-                       m_device->phy().limits_.maxUniformBufferRange, "VUID-VkWriteDescriptorSet-descriptorType-00332",
-                       m_device->phy().limits_.minUniformBufferOffsetAlignment, "VUID-VkWriteDescriptorSet-descriptorType-00327"}),
+                       m_device->Physical().limits_.maxUniformBufferRange, "VUID-VkWriteDescriptorSet-descriptorType-00332",
+                       m_device->Physical().limits_.minUniformBufferOffsetAlignment,
+                       "VUID-VkWriteDescriptorSet-descriptorType-00327"}),
              TestCase({VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
-                       m_device->phy().limits_.maxStorageBufferRange, "VUID-VkWriteDescriptorSet-descriptorType-00333",
-                       m_device->phy().limits_.minStorageBufferOffsetAlignment, "VUID-VkWriteDescriptorSet-descriptorType-00328"}),
+                       m_device->Physical().limits_.maxStorageBufferRange, "VUID-VkWriteDescriptorSet-descriptorType-00333",
+                       m_device->Physical().limits_.minStorageBufferOffsetAlignment,
+                       "VUID-VkWriteDescriptorSet-descriptorType-00328"}),
          }) {
         // Create layout with single buffer
         OneOffDescriptorSet descriptor_set(m_device, {
@@ -1959,7 +1961,7 @@ TEST_F(NegativeDescriptors, DSBufferLimit) {
 
         VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
         mem_alloc.allocationSize = mem_reqs.size;
-        bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+        bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
         if (!pass) {
             printf("Failed to allocate memory in DSBufferLimitErrors; skipped.\n");
             continue;
@@ -2167,7 +2169,7 @@ TEST_F(NegativeDescriptors, InputAttachmentDepthStencilAspect) {
     TEST_DESCRIPTION("Checks for InputAttachment image view with more than one aspect.");
     RETURN_IF_SKIP(Init());
 
-    VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, ds_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::Image image2D(*m_device, image_ci, vkt::set_layout);
@@ -2894,7 +2896,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsDisabled) {
     descriptor_set.Clear();
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceSize offset = 0;
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers-pBuffers-04001");
@@ -2929,7 +2931,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     descriptor_set.UpdateDescriptorSets();
     descriptor_set.Clear();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceSize offset = 0;
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer, &offset);
@@ -2942,7 +2944,7 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     offset = 1;
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers-pBuffers-04002");
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer, &offset);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 
     // Make sure sampler with NULL image view doesn't cause a crash or errors
@@ -2968,14 +2970,14 @@ TEST_F(NegativeDescriptors, NullDescriptorsEnabled) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &sampler_descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8095
@@ -2985,7 +2987,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
     vkt::Image depth_image(
         *m_device, 64, 64, 1, depth_format,
         VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -3061,7 +3063,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
                                                      VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_renderPassBeginInfo.renderArea = {{0, 0}, {64, 64}};
     m_renderPassBeginInfo.renderPass = rp.Handle();
     m_renderPassBeginInfo.framebuffer = fb.handle();
@@ -3076,7 +3078,7 @@ TEST_F(NegativeDescriptors, DISABLED_ImageSubresourceOverlapBetweenAttachmentsAn
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, CreateDescriptorPoolFlags) {
@@ -3688,14 +3690,14 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06537");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3804,14 +3806,14 @@ TEST_F(NegativeDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06537");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3886,14 +3888,14 @@ TEST_F(NegativeDescriptors, DISABLED_DescriptorReadFromWriteAttachment) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09000");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3972,7 +3974,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
                                                              VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set_input_attachment.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -3983,7 +3985,7 @@ TEST_F(NegativeDescriptors, DescriptorWriteFromReadAttachment) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // https://gitlab.khronos.org/vulkan/vulkan/-/issues/3297
@@ -4115,12 +4117,12 @@ TEST_F(NegativeDescriptors, BindingDescriptorSetFromHostOnlyPool) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&ds_layout});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-04616");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, CopyMutableDescriptors) {
@@ -4557,7 +4559,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
     cs_pipeline.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&combined_image_set.layout_, &storage_image_set.layout_});
     cs_pipeline.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.Handle());
 
@@ -4569,7 +4571,7 @@ TEST_F(NegativeDescriptors, DispatchWithUnboundSet) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08600");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -4617,7 +4619,7 @@ TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2KHR(gpu(), (VkFormat)fmt, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2KHR(Gpu(), (VkFormat)fmt, &fmt_props);
 
         const bool has_sampling = (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_BIT_KHR) != 0;
         const bool has_sampling_img_depth_compare =
@@ -4664,7 +4666,7 @@ TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -4675,7 +4677,7 @@ TEST_F(NegativeDescriptors, SampledImageDepthComparisonForFormat) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, BindDescriptorWithoutPipelineLayout) {
@@ -4687,7 +4689,7 @@ TEST_F(NegativeDescriptors, BindDescriptorWithoutPipelineLayout) {
                                                      {0, VK_DESCRIPTOR_TYPE_SAMPLER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                                  });
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("UNASSIGNED-GeneralParameterError-RequiredHandle");
     VkPipelineLayout null_layout = CastFromUint64<VkPipelineLayout>(0);
@@ -4695,7 +4697,7 @@ TEST_F(NegativeDescriptors, BindDescriptorWithoutPipelineLayout) {
                               0, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, InvalidImageInfoDescriptorType) {
@@ -4740,12 +4742,12 @@ TEST_F(NegativeDescriptors, InvalidImageInfoDescriptorType) {
                                            {0, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr},
                                        });
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkDescriptorImageInfo-imageView-07795");
     descriptor_set.WriteDescriptorImageInfo(0, view, sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, CopyDescriptorSetMissingSrcFlag) {
@@ -4780,7 +4782,7 @@ TEST_F(NegativeDescriptors, CopyDescriptorSetMissingSrcFlag) {
     copy_descriptor_set.dstArrayElement = 0u;
     copy_descriptor_set.descriptorCount = 1u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyDescriptorSet-srcSet-01918");
     vk::UpdateDescriptorSets(*m_device, 0u, nullptr, 1u, &copy_descriptor_set);
@@ -4792,7 +4794,7 @@ TEST_F(NegativeDescriptors, CopyDescriptorSetMissingSrcFlag) {
     vk::UpdateDescriptorSets(*m_device, 0u, nullptr, 1u, &copy_descriptor_set);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, InvalidDescriptorWriteImageInfo) {
@@ -4821,7 +4823,7 @@ TEST_F(NegativeDescriptors, BindStorageBufferDynamicAlignment) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t alignment = static_cast<uint32_t>(m_device->phy().limits_.minStorageBufferOffsetAlignment);
+    uint32_t alignment = static_cast<uint32_t>(m_device->Physical().limits_.minStorageBufferOffsetAlignment);
     if (alignment < 2) {
         GTEST_SKIP() << "minStorageBufferOffsetAlignment too small";
     }
@@ -4833,12 +4835,12 @@ TEST_F(NegativeDescriptors, BindStorageBufferDynamicAlignment) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
     uint32_t dynamic_offset = alignment - 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDynamicOffsets-01972");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
                               &descriptor_set.set_, 1u, &dynamic_offset);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, DescriptorIndexingMissingFeatures) {
@@ -5119,7 +5121,7 @@ TEST_F(NegativeDescriptors, PushDescriptorWithoutInfo) {
 
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkWriteDescriptorSet descriptor_write = vku::InitStructHelper();
     descriptor_write.dstSet = descriptor_set.set_;
     descriptor_write.dstBinding = 0;
@@ -5130,7 +5132,7 @@ TEST_F(NegativeDescriptors, PushDescriptorWithoutInfo) {
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
                                 &descriptor_write);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDescriptors, GetSupportMutableDescriptorType) {

--- a/tests/unit/descriptors_positive.cpp
+++ b/tests/unit/descriptors_positive.cpp
@@ -111,7 +111,7 @@ TEST_F(PositiveDescriptors, IgnoreUnrelatedDescriptor) {
     // Verify VK_FORMAT_R8_UNORM supports VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT
     const VkFormat format_texel_case = VK_FORMAT_R8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format_texel_case, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format_texel_case, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Test requires to support VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT";
     }
@@ -259,7 +259,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerOnlyDescriptor) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -269,7 +269,7 @@ TEST_F(PositiveDescriptors, ImmutableSamplerOnlyDescriptor) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     sampler.destroy();
 }
@@ -343,7 +343,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
 
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write, 0, NULL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Create PSO to be used for draw-time errors below
@@ -373,7 +373,7 @@ TEST_F(PositiveDescriptors, DynamicOffsetWithInactiveBinding) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptors, CopyMutableDescriptors) {
@@ -620,7 +620,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
     descriptor_set2.WriteDescriptorImageInfo(0, image_view, sampler, VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT, VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set2.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -629,7 +629,7 @@ TEST_F(PositiveDescriptors, ImageViewAsDescriptorReadAndInputAttachment) {
                               &descriptor_set2.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptors, UpdateImageDescriptorSetThatHasImageViewUsage) {
@@ -714,10 +714,10 @@ TEST_F(PositiveDescriptors, BindingEmptyDescriptorSets) {
     OneOffDescriptorSet empty_ds(m_device, {});
     const vkt::PipelineLayout pipeline_layout(*m_device, {&empty_ds.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &empty_ds.set_, 0, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
@@ -770,7 +770,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_renderPassBeginInfo.renderPass = rp.Handle();
     m_renderPassBeginInfo.framebuffer = fb.handle();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -782,7 +782,7 @@ TEST_F(PositiveDescriptors, DrawingWithUnboundUnusedSetWithInputAttachments) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
@@ -868,13 +868,13 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
         // Bind set A to a command buffer and submit the command buffer;
         {
             auto &cb = use_single_command_buffer ? m_command_buffer : cb0;
-            cb.begin();
+            cb.Begin();
             vk::CmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1, &set_A, 0, nullptr);
             vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
             cb.BeginRenderPass(m_renderPassBeginInfo);
             vk::CmdDraw(cb, 0, 0, 0, 0);
             vk::CmdEndRenderPass(cb);
-            cb.end();
+            cb.End();
             m_default_queue->Submit(cb);
         }
 
@@ -884,13 +884,13 @@ TEST_F(PositiveDescriptors, UpdateDescritorSetsNoLongerInUse) {
         // Bind set B to a command buffer and submit the command buffer;
         {
             auto &cb = use_single_command_buffer ? m_command_buffer : cb1;
-            cb.begin();
+            cb.Begin();
             vk::CmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1, &set_B, 0, nullptr);
             vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
             cb.BeginRenderPass(m_renderPassBeginInfo);
             vk::CmdDraw(cb, 0, 0, 0, 0);
             vk::CmdEndRenderPass(cb);
-            cb.end();
+            cb.End();
             m_default_queue->Submit(cb);
         }
 
@@ -912,7 +912,7 @@ TEST_F(PositiveDescriptors, DSUsageBitsFlags2) {
 
     const VkFormat buffer_format = VK_FORMAT_R8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), buffer_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), buffer_format, &format_properties);
     if (!(format_properties.bufferFeatures & VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT for this format";
     }
@@ -999,14 +999,14 @@ TEST_F(PositiveDescriptors, AttachmentFeedbackLoopLayout) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0u, 1u,
                               &descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDescriptors, VariableDescriptorCount) {
@@ -1188,12 +1188,12 @@ TEST_F(PositiveDescriptors, ImageSubresourceOverlapBetweenRenderPassAndDescripto
                                             VK_IMAGE_LAYOUT_GENERAL);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/device_generated_commands.cpp
+++ b/tests/unit/device_generated_commands.cpp
@@ -663,18 +663,18 @@ TEST_F(NegativeDeviceGeneratedCommands, CmdExecuteGeneratedCommandsSecondary) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    secondary.begin();
+    secondary.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteGeneratedCommandsEXT-bufferlevel");
     vk::CmdExecuteGeneratedCommandsEXT(secondary.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    secondary.end();
+    secondary.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, UpdateIESPipelineFlags) {
@@ -1533,16 +1533,16 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteNoBoundPipeline) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteGeneratedCommandsEXT-indirectCommandsLayout-11053");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecuteNoBoundShaderObject) {
@@ -1599,16 +1599,16 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteNoBoundShaderObject) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteGeneratedCommandsEXT-indirectCommandsLayout-11053");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecuteIsPreprocessed) {
@@ -1643,16 +1643,16 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteIsPreprocessed) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteGeneratedCommandsEXT-indirectCommandsLayout-11141");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, PreprocessNoBoundPipeline) {
@@ -1695,21 +1695,21 @@ TEST_F(NegativeDeviceGeneratedCommands, PreprocessNoBoundPipeline) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
     vkt::CommandBuffer state_cb(*m_device, m_command_pool);
-    state_cb.begin();
+    state_cb.Begin();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPreprocessGeneratedCommandsEXT-indirectCommandsLayout-11084");
     vk::CmdPreprocessGeneratedCommandsEXT(m_command_buffer.handle(), &generated_commands_info, state_cb.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    state_cb.end();
+    state_cb.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, PreprocessRecordingState) {
@@ -1744,26 +1744,26 @@ TEST_F(NegativeDeviceGeneratedCommands, PreprocessRecordingState) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
     vkt::CommandBuffer state_cb(*m_device, m_command_pool);
-    state_cb.begin();
-    state_cb.end();
+    state_cb.Begin();
+    state_cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPreprocessGeneratedCommandsEXT-stateCommandBuffer-11138");
     vk::CmdPreprocessGeneratedCommandsEXT(m_command_buffer.handle(), &generated_commands_info, state_cb.handle());
     m_errorMonitor->VerifyFound();
 
-    state_cb.begin();
-    state_cb.end();
+    state_cb.Begin();
+    state_cb.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPreprocessGeneratedCommandsEXT-stateCommandBuffer-11138");
     vk::CmdPreprocessGeneratedCommandsEXT(m_command_buffer.handle(), &generated_commands_info, state_cb.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, PreprocessCommandLayoutFlag) {
@@ -1797,21 +1797,21 @@ TEST_F(NegativeDeviceGeneratedCommands, PreprocessCommandLayoutFlag) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
     vkt::CommandBuffer state_cb(*m_device, m_command_pool);
-    state_cb.begin();
+    state_cb.Begin();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPreprocessGeneratedCommandsEXT-pGeneratedCommandsInfo-11082");
     vk::CmdPreprocessGeneratedCommandsEXT(m_command_buffer.handle(), &generated_commands_info, state_cb.handle());
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
-    state_cb.end();
+    m_command_buffer.End();
+    state_cb.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoDynamicVertex) {
@@ -1852,17 +1852,17 @@ TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoDynamicVertex) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectCommandsLayout-11079");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoAddresses) {
@@ -1901,14 +1901,14 @@ TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoAddresses) {
     generated_commands_info.sequenceCountAddress = 3;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11073");
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectAddress-11076");
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectAddressSize-11077");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoMultiDrawLimit) {
@@ -1943,20 +1943,20 @@ TEST_F(NegativeDeviceGeneratedCommands, GeneratedCommandsInfoMultiDrawLimit) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1 << 21;
     generated_commands_info.maxSequenceCount = 1 << 4;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-maxDrawCount-11078");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkGeneratedCommandsInfoEXT-preprocessAddress-11063");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkGeneratedCommandsInfoEXT-preprocessSize-11071");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecuteStageMismatch) {
@@ -2001,17 +2001,17 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteStageMismatch) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-indirectCommandsLayout-11002");
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecutePreprocessBufferUsage) {
@@ -2052,15 +2052,15 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecutePreprocessBufferUsage) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     {
-        generated_commands_info.preprocessAddress = block_buffer.address();  // missing usage
+        generated_commands_info.preprocessAddress = block_buffer.Address();  // missing usage
         m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-preprocessAddress-11069");
         vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
         m_errorMonitor->VerifyFound();
@@ -2074,13 +2074,13 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecutePreprocessBufferUsage) {
         buffer_ci.size = 1024;
         vkt::Buffer bad_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-        generated_commands_info.preprocessAddress = bad_buffer.address();
-        bad_buffer.memory().destroy();
+        generated_commands_info.preprocessAddress = bad_buffer.Address();
+        bad_buffer.Memory().destroy();
         m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-preprocessAddress-11070");
         vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
         m_errorMonitor->VerifyFound();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecuteSequenceCountBufferUsage) {
@@ -2121,15 +2121,15 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteSequenceCountBufferUsage) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     {
-        generated_commands_info.sequenceCountAddress = block_buffer.address();  // missing usage
+        generated_commands_info.sequenceCountAddress = block_buffer.Address();  // missing usage
         m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11072");
         vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
         m_errorMonitor->VerifyFound();
@@ -2143,13 +2143,13 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteSequenceCountBufferUsage) {
         buffer_ci.size = 1024;
         vkt::Buffer bad_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-        generated_commands_info.sequenceCountAddress = bad_buffer.address();
-        bad_buffer.memory().destroy();
+        generated_commands_info.sequenceCountAddress = bad_buffer.Address();
+        bad_buffer.Memory().destroy();
         m_errorMonitor->SetDesiredError("VUID-VkGeneratedCommandsInfoEXT-sequenceCountAddress-11075");
         vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
         m_errorMonitor->VerifyFound();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDeviceGeneratedCommands, ExecuteShaderObjectStages) {
@@ -2208,12 +2208,12 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteShaderObjectStages) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, stages, shaders);
@@ -2222,5 +2222,5 @@ TEST_F(NegativeDeviceGeneratedCommands, ExecuteShaderObjectStages) {
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/device_generated_commands_positive.cpp
+++ b/tests/unit/device_generated_commands_positive.cpp
@@ -182,13 +182,13 @@ TEST_F(PositiveDeviceGeneratedCommands, CmdExecuteGeneratedCommands) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDeviceGeneratedCommands, UpdateIndirectExecutionSetPipeline) {
@@ -283,15 +283,15 @@ TEST_F(PositiveDeviceGeneratedCommands, CmdExecuteGeneratedCommandsEXT) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDeviceGeneratedCommands, ExecuteShaderObjectVertex) {
@@ -350,17 +350,17 @@ TEST_F(PositiveDeviceGeneratedCommands, ExecuteShaderObjectVertex) {
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = 64;
-    generated_commands_info.indirectAddress = block_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
     generated_commands_info.preprocessAddress = 0;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxDrawCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, stages, shaders);
     SetDefaultDynamicStatesAll(m_command_buffer.handle());
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/device_queue.cpp
+++ b/tests/unit/device_queue.cpp
@@ -21,9 +21,9 @@ TEST_F(NegativeDeviceQueue, FamilyIndex) {
     RETURN_IF_SKIP(InitFramework());
 
     uint32_t queue_family_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_props.data());
 
     uint32_t queue_family_index = queue_family_count;
 
@@ -42,7 +42,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndex) {
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-queueFamilyIndex-00381");
     VkDevice device;
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -74,7 +74,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
     qfi[0] = 0;
     CreateBufferTest(*this, &buffCI, "VUID-VkBufferCreateInfo-sharingMode-01419");
 
-    if (m_device->phy().queue_properties_.size() > 2) {
+    if (m_device->Physical().queue_properties_.size() > 2) {
         m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pSubmits-04626");
 
         // Create buffer shared to queue families 1 and 2, but submitted on queue family 0
@@ -84,9 +84,9 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
         vkt::Buffer ib;
         ib.init(*m_device, buffCI);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdFillBuffer(m_command_buffer.handle(), ib.handle(), 0, 16, 5);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -95,10 +95,10 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
     // If there is more than one queue family, create a device with a single queue family, then create a buffer
     // with SHARING_MODE_CONCURRENT that uses a non-device PDEV queue family.
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, NULL);
     std::vector<VkQueueFamilyProperties> queue_props;
     queue_props.resize(queue_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, queue_props.data());
 
     if (queue_count < 3) {
         GTEST_SKIP() << "Multiple queue families are required to run this test.";
@@ -117,7 +117,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUsage) {
 
     // Create a device with a single queue family
     VkDevice second_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &dev_info, nullptr, &second_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &dev_info, nullptr, &second_device));
 
     // Select Queue family for CONCURRENT buffer that is not owned by device
     buffCI.queueFamilyIndexCount = 2;
@@ -139,9 +139,9 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUnique) {
     VkQueueFamilyProperties queue_properties;  // selected queue family used
     uint32_t queue_family_index = 0;
     uint32_t queue_family_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_families.data());
 
     for (size_t i = 0; i < queue_families.size(); i++) {
         if (queue_families[i].queueCount > 1) {
@@ -177,7 +177,7 @@ TEST_F(NegativeDeviceQueue, FamilyIndexUnique) {
     device_create_info.enabledExtensionCount = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802");
-    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -190,9 +190,9 @@ TEST_F(NegativeDeviceQueue, MismatchedGlobalPriority) {
     RETURN_IF_SKIP(InitFramework());
 
     uint32_t queue_family_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_props.data());
 
     uint32_t queue_family_index = queue_family_count;
 
@@ -234,7 +234,7 @@ TEST_F(NegativeDeviceQueue, MismatchedGlobalPriority) {
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802");
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pQueueCreateInfos-06654");
     VkDevice device;
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -244,9 +244,9 @@ TEST_F(NegativeDeviceQueue, QueueCount) {
     RETURN_IF_SKIP(InitFramework());
 
     uint32_t queue_family_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_props.data());
 
     const uint32_t invalid_count = queue_props[0].queueCount + 1;
     std::vector<float> priorities(invalid_count);
@@ -266,7 +266,7 @@ TEST_F(NegativeDeviceQueue, QueueCount) {
 
     VkDevice device = VK_NULL_HANDLE;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-queueCount-00382");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -276,9 +276,9 @@ TEST_F(NegativeDeviceQueue, QueuePriorities) {
     RETURN_IF_SKIP(InitFramework());
 
     uint32_t queue_family_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_props.data());
 
     VkDeviceQueueCreateInfo device_queue_ci = vku::InitStructHelper();
     device_queue_ci.queueFamilyIndex = 0;
@@ -296,13 +296,13 @@ TEST_F(NegativeDeviceQueue, QueuePriorities) {
     const float priority_high = 2.0f;
     device_queue_ci.pQueuePriorities = &priority_high;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 
     const float priority_low = -1.0f;
     device_queue_ci.pQueuePriorities = &priority_low;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-pQueuePriorities-00383");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -312,7 +312,7 @@ TEST_F(NegativeDeviceQueue, BindPipeline) {
     InitRenderTarget();
 
     uint32_t only_transfer_queueFamilyIndex = vvl::kU32Max;
-    const auto q_props = m_device->phy().queue_properties_;
+    const auto q_props = m_device->Physical().queue_properties_;
     for (uint32_t i = 0; i < (uint32_t)q_props.size(); i++) {
         if (q_props[i].queueFlags == VK_QUEUE_TRANSFER_BIT) {
             only_transfer_queueFamilyIndex = i;
@@ -331,7 +331,7 @@ TEST_F(NegativeDeviceQueue, BindPipeline) {
     c_pipe.CreateComputePipeline();
 
     // Get implicit VU because using Transfer only instead of a Graphics-only or Compute-only queue
-    commandBuffer.begin();
+    commandBuffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-commandBuffer-cmdpool");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipelineBindPoint-00777");
     vk::CmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, c_pipe.Handle());
@@ -341,13 +341,13 @@ TEST_F(NegativeDeviceQueue, BindPipeline) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipelineBindPoint-00778");
     vk::CmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     m_errorMonitor->VerifyFound();
-    commandBuffer.end();
+    commandBuffer.End();
 }
 
 TEST_F(NegativeDeviceQueue, CreateCommandPool) {
     TEST_DESCRIPTION("vkCreateCommandPool with bad queue");
     RETURN_IF_SKIP(Init());
-    const size_t queue_count = m_device->phy().queue_properties_.size();
+    const size_t queue_count = m_device->Physical().queue_properties_.size();
     m_errorMonitor->SetDesiredError("VUID-vkCreateCommandPool-queueFamilyIndex-01937");
     vkt::CommandPool commandPool(*m_device, queue_count + 1);
     m_errorMonitor->VerifyFound();
@@ -381,7 +381,7 @@ TEST_F(NegativeDeviceQueue, Robustness2WithoutRobustness) {
 
     VkDevice device;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceRobustness2FeaturesEXT-robustBufferAccess2-04000");
-    vk::CreateDevice(m_device->phy().handle(), &device_ci, nullptr, &device);
+    vk::CreateDevice(m_device->Physical().handle(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -397,9 +397,9 @@ TEST_F(NegativeDeviceQueue, QueuesSameQueueFamily) {
     RETURN_IF_SKIP(InitState(nullptr, &protected_memory_features));
 
     uint32_t qf_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &qf_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &qf_count, nullptr);
     std::vector<VkQueueFamilyProperties> qf_props(qf_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &qf_count, qf_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &qf_count, qf_props.data());
 
     uint32_t index = 0;
     for (uint32_t i = 0; i < qf_count; ++i) {
@@ -427,7 +427,7 @@ TEST_F(NegativeDeviceQueue, QueuesSameQueueFamily) {
 
     VkDevice device;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pQueueCreateInfos-06755");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -439,7 +439,7 @@ TEST_F(NegativeDeviceQueue, MismatchedQueueFamiliesOnSubmit) {
     RETURN_IF_SKIP(Init());  // assumes it initializes all queue families on vk::CreateDevice
 
     // This test is meaningless unless we have multiple queue families
-    auto queue_family_properties = m_device->phy().queue_properties_;
+    auto queue_family_properties = m_device->Physical().queue_properties_;
     std::vector<uint32_t> queue_families;
     for (uint32_t i = 0; i < queue_family_properties.size(); ++i)
         if (queue_family_properties[i].queueCount > 0) queue_families.push_back(i);
@@ -457,8 +457,8 @@ TEST_F(NegativeDeviceQueue, MismatchedQueueFamiliesOnSubmit) {
     vkt::CommandPool cmd_pool(*m_device, queue_family);
     vkt::CommandBuffer cmd_buff(*m_device, cmd_pool);
 
-    cmd_buff.begin();
-    cmd_buff.end();
+    cmd_buff.Begin();
+    cmd_buff.End();
 
     // Submit on the wrong queue
     VkSubmitInfo submit_info = vku::InitStructHelper();

--- a/tests/unit/dynamic_rendering.cpp
+++ b/tests/unit/dynamic_rendering.cpp
@@ -120,7 +120,7 @@ TEST_F(NegativeDynamicRendering, CommandDraw) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-multisampledRenderToSingleSampled-07286");
@@ -128,7 +128,7 @@ TEST_F(NegativeDynamicRendering, CommandDraw) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
@@ -189,7 +189,7 @@ TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDepthWriteEnable(m_command_buffer.handle(), true);
@@ -200,7 +200,7 @@ TEST_F(NegativeDynamicRendering, CommandDrawWithShaderTileImageRead) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
@@ -209,8 +209,8 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     InitRenderTarget();
 
     VkImageFormatProperties image_format_properties{};
-    vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), m_renderTargets[0]->format(), VK_IMAGE_TYPE_2D,
-                                               VK_IMAGE_TILING_OPTIMAL, m_renderTargets[0]->usage(), 0, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), m_renderTargets[0]->Format(), VK_IMAGE_TYPE_2D,
+                                               VK_IMAGE_TILING_OPTIMAL, m_renderTargets[0]->Usage(), 0, &image_format_properties);
     if (image_format_properties.maxArrayLayers < 4) {
         GTEST_SKIP() << "Test needs to create image 2D array of 4 image view, but VkImageFormatProperties::maxArrayLayers is < 4. "
                         "Skipping test.";
@@ -220,9 +220,9 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     // to make sure that considered layer count is the one coming from frame buffer
     // (test would not fail if layer count used to do validation was 4)
     assert(!m_renderTargets.empty());
-    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->width(), m_renderTargets[0]->height(),
+    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->Width(), m_renderTargets[0]->Height(),
                                                                 m_renderTargets[0]->CreateInfo().mipLevels, 4,
-                                                                m_renderTargets[0]->format(), m_renderTargets[0]->usage());
+                                                                m_renderTargets[0]->Format(), m_renderTargets[0]->Usage());
     vkt::Image render_target(*m_device, render_target_ci, vkt::set_layout);
     vkt::ImageView render_target_view =
         render_target.CreateView(VK_IMAGE_VIEW_TYPE_2D_ARRAY, 0, 1, 0, render_target_ci.arrayLayers);
@@ -288,11 +288,11 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     };
 
     // Register clear commands to secondary command buffer
-    secondary_cmd_buffer.begin(&secondary_cmd_buffer_begin_info);
+    secondary_cmd_buffer.Begin(&secondary_cmd_buffer_begin_info);
     clear_cmds(secondary_cmd_buffer.handle(), clear_rect);
-    secondary_cmd_buffer.end();
+    secondary_cmd_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingAttachmentInfoKHR color_attachment_info = vku::InitStructHelper();
     color_attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -317,7 +317,7 @@ TEST_F(NegativeDynamicRendering, CmdClearAttachmentTests) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ClearAttachments) {
@@ -433,7 +433,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
     auto clear_cmd_test = [&](const bool use_dynamic_rendering) {
         std::array<VkFramebuffer, 4> framebuffers = {VK_NULL_HANDLE};
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         // Try to clear stencil, but image view does not have stencil aspect
         // This is a valid clear because the ImageView aspect are ignored
@@ -584,7 +584,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
             }
         }
 
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         {
             m_command_buffer.destroy();
@@ -616,7 +616,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
                 cmd_buffer_inheritance_info.framebuffer = framebuffers[3];
             }
 
-            secondary_cmd_buffer->begin(&cmd_buffer_begin_info);
+            secondary_cmd_buffer->Begin(&cmd_buffer_begin_info);
             // issue clear cmd to secondary cmd buffer
             std::array<VkClearAttachment, 3> clear_attachments = {};
             clear_attachments[0].aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -635,9 +635,9 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdClearAttachments-aspectMask-07271");
             vk::CmdClearAttachments(secondary_cmd_buffer->handle(), 1, &clear_color_out_of_range, 1, &clear_rect);
             m_errorMonitor->VerifyFound();
-            secondary_cmd_buffer->end();
+            secondary_cmd_buffer->End();
 
-            m_command_buffer.begin();
+            m_command_buffer.Begin();
 
             // begin rendering
             if (use_dynamic_rendering) {
@@ -658,7 +658,7 @@ TEST_F(NegativeDynamicRendering, ClearAttachments) {
                 m_command_buffer.EndRenderPass();
             }
 
-            m_command_buffer.end();
+            m_command_buffer.End();
         }
 
         for (auto framebuffer : framebuffers) {
@@ -677,7 +677,7 @@ TEST_F(NegativeDynamicRendering, GraphicsPipelineCreateInfo) {
     TEST_DESCRIPTION("Test graphics pipeline creation with dynamic rendering.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (m_device->phy().limits_.maxGeometryOutputVertices == 0) {
+    if (m_device->Physical().limits_.maxGeometryOutputVertices == 0) {
         GTEST_SKIP() << "Device doesn't support required maxGeometryOutputVertices";
     }
     std::vector<VkPipelineColorBlendAttachmentState> color_blend_attachment_state(2);
@@ -816,14 +816,14 @@ TEST_F(NegativeDynamicRendering, MismatchingViewMask) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-viewMask-06178");
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats) {
@@ -848,24 +848,24 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats) {
     pipeline_depth.cb_ci_.attachmentCount = 0;
     pipeline_depth.CreateGraphicsPipeline();
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     bool testStencil = false;
     VkFormat stencilFormat = VK_FORMAT_UNDEFINED;
 
-    if (FormatIsSupported(gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+    if (FormatIsSupported(Gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D16_UNORM_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D16_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D16_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D16_UNORM_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D24_UNORM_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D24_UNORM_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D32_SFLOAT_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
         testStencil = true;
     }
@@ -899,7 +899,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats) {
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching color attachment count
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -942,7 +942,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats) {
         m_command_buffer.EndRendering();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats2) {
@@ -970,7 +970,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats2) {
     pipeline_depth.cb_ci_.attachmentCount = 0;
     pipeline_depth.CreateGraphicsPipeline();
 
-    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     pipeline_rendering_info.stencilAttachmentFormat = depthStencilFormat;
@@ -992,7 +992,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats2) {
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         // Mismatching color formats
@@ -1037,7 +1037,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats2) {
         m_command_buffer.EndRendering();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3Color) {
@@ -1068,7 +1068,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3Color) {
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching color formats
     begin_rendering_info.colorAttachmentCount = 1;
@@ -1080,7 +1080,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3Color) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3DepthStencil) {
@@ -1102,24 +1102,24 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3DepthStencil) {
     pipe1.gp_ci_.pColorBlendState = nullptr;
     pipe1.CreateGraphicsPipeline();
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     bool testStencil = false;
     VkFormat stencilFormat = VK_FORMAT_UNDEFINED;
 
-    if (FormatIsSupported(gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+    if (FormatIsSupported(Gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D16_UNORM_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D16_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D16_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D16_UNORM_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D24_UNORM_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D24_UNORM_S8_UINT;
         testStencil = true;
     } else if ((depthStencilFormat != VK_FORMAT_D32_SFLOAT_S8_UINT) &&
-               FormatIsSupported(gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+               FormatIsSupported(Gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         stencilFormat = VK_FORMAT_D32_SFLOAT_S8_UINT;
         testStencil = true;
     }
@@ -1146,7 +1146,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3DepthStencil) {
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching depth format
     begin_rendering_info.colorAttachmentCount = 0;
@@ -1171,7 +1171,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentFormats3DepthStencil) {
         m_command_buffer.EndRendering();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesColor) {
@@ -1200,7 +1200,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesColor) {
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching color samples
     begin_rendering_info.colorAttachmentCount = 1;
@@ -1212,14 +1212,14 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesColor) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesDepthStencil) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering with mismatching depth/stencil sample counts");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 0;
@@ -1254,7 +1254,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesDepthStencil) {
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching depth samples
     begin_rendering_info.colorAttachmentCount = 0;
@@ -1277,7 +1277,7 @@ TEST_F(NegativeDynamicRendering, MismatchingAttachmentSamplesDepthStencil) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesColor) {
@@ -1325,7 +1325,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesColor) {
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching color samples
     begin_rendering_info.colorAttachmentCount = 1;
@@ -1338,7 +1338,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesColor) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) {
@@ -1358,7 +1358,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
 
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper(&samples_info);
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
@@ -1394,7 +1394,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     begin_rendering_info.layerCount = 1;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Mismatching depth samples
     begin_rendering_info.colorAttachmentCount = 0;
@@ -1417,7 +1417,7 @@ TEST_F(NegativeDynamicRendering, MismatchingMixedAttachmentSamplesDepthStencil) 
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, AttachmentInfo) {
@@ -1432,7 +1432,7 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
 
     VkFormat depth_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
 
-    if (!FormatFeaturesAreSupported(gpu(), depth_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), depth_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
 
@@ -1459,7 +1459,7 @@ TEST_F(NegativeDynamicRendering, AttachmentInfo) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06116");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -1581,14 +1581,14 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
 
     InitRenderTarget();
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     // Mostly likely will only find support for this on a custom profiles
-    if (!FormatFeaturesAreSupported(gpu(), depthStencilFormat, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), depthStencilFormat, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         shading_rate = false;
     }
-    if (!FormatFeaturesAreSupported(gpu(), depthStencilFormat, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), depthStencilFormat, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         fragment_density = false;
     }
@@ -1614,7 +1614,7 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
     }
 
     VkImageFormatProperties imageFormatProperties;
-    if (vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_create_info.format, image_create_info.imageType,
+    if (vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_create_info.format, image_create_info.imageType,
                                                    image_create_info.tiling, image_create_info.usage, image_create_info.flags,
                                                    &imageFormatProperties) == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "Format not supported";
@@ -1649,12 +1649,12 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
         pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRendering();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->VerifyFound();
     }
@@ -1682,12 +1682,12 @@ TEST_F(NegativeDynamicRendering, PipelineMissingFlags) {
         pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRendering(begin_rendering_info);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRendering();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->VerifyFound();
     }
@@ -1701,9 +1701,9 @@ TEST_F(NegativeDynamicRendering, LayerCount) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-viewMask-06069");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1730,7 +1730,7 @@ TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
 
-    const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
 
     vkt::Image depth_image(*m_device, 64, 64, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
@@ -1747,11 +1747,11 @@ TEST_F(NegativeDynamicRendering, InfoMismatchedSamples) {
     begin_rendering_info.pDepthAttachment = &depth_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-multisampledRenderToSingleSampled-06857");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
@@ -1765,7 +1765,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
 
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "format doesn't support FRAGMENT_SHADING_RATE_ATTACHMENT_BIT";
     }
@@ -1783,7 +1783,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR;
 
     VkImageFormatProperties imageFormatProperties;
-    if (vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
+    if (vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
                                                    image_ci.flags, &imageFormatProperties) == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "Format not supported";
     }
@@ -1800,7 +1800,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     begin_rendering_info.layerCount = 4;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06123");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -1823,7 +1823,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRate) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
@@ -1853,7 +1853,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     begin_rendering_info.pColorAttachments = &color_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
@@ -1868,7 +1868,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderPassBeginInfo) {
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06084");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
@@ -1876,7 +1876,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR not supported";
     }
@@ -1901,7 +1901,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06148");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -1955,14 +1955,14 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImage) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingDepthAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a depth attachment that has an invalid format");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    VkFormat stencil_format = FindSupportedStencilOnlyFormat(Gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -1980,11 +1980,11 @@ TEST_F(NegativeDynamicRendering, BeginRenderingDepthAttachmentFormat) {
     begin_rendering_info.pDepthAttachment = &depth_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pDepthAttachment-06547");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
@@ -1992,7 +1992,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -2014,7 +2014,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     begin_rendering_info.renderArea.extent.width = 64 * fdm_props.maxFragmentDensityTexelSize.width;
     begin_rendering_info.renderArea.extent.height = 32 * fdm_props.maxFragmentDensityTexelSize.height;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06112");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2077,7 +2077,7 @@ TEST_F(NegativeDynamicRendering, TestFragmentDensityMapRenderArea) {
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06115");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupExt) {
@@ -2089,7 +2089,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
 
     RETURN_IF_SKIP(InitFramework());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -2123,7 +2123,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
     begin_rendering_info.renderArea.extent.width = 64 * fdm_props.maxFragmentDensityTexelSize.width;
     begin_rendering_info.renderArea.extent.height = 32 * fdm_props.maxFragmentDensityTexelSize.height;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06112");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2136,7 +2136,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapRenderAreaWithoutDeviceGroupE
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
@@ -2146,7 +2146,7 @@ TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
@@ -2180,7 +2180,7 @@ TEST_F(NegativeDynamicRendering, BarrierShaderTileFeaturesNotEnabled) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
@@ -2211,7 +2211,7 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
@@ -2250,7 +2250,7 @@ TEST_F(NegativeDynamicRendering, WithoutShaderTileImageAndBarrier) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
@@ -2276,7 +2276,7 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
@@ -2397,14 +2397,14 @@ TEST_F(NegativeDynamicRendering, WithShaderTileImageAndBarrier) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingStencilAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a stencil attachment that has an invalid format");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
 
     vkt::Image image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -2419,18 +2419,18 @@ TEST_F(NegativeDynamicRendering, BeginRenderingStencilAttachmentFormat) {
     begin_rendering_info.pStencilAttachment = &stencil_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pStencilAttachment-06548");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, InheritanceRenderingInfoStencilAttachmentFormat) {
     TEST_DESCRIPTION("Test begin rendering with a stencil attachment that has an invalid format");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
 
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
 
@@ -2550,7 +2550,7 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     begin_rendering_info.renderArea.extent.width = 64;
     begin_rendering_info.renderArea.extent.height = 32;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2592,7 +2592,7 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     if ((ds_format != VK_FORMAT_UNDEFINED) && IsExtensionsEnabled(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME)) {
         vkt::Image depthImage(*m_device, 32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         vkt::ImageView depthImageView = depthImage.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
@@ -2611,7 +2611,7 @@ TEST_F(NegativeDynamicRendering, AreaGreaterThanAttachmentExtent) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
@@ -2633,7 +2633,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     begin_rendering_info.renderArea.extent.width = 64;
     begin_rendering_info.renderArea.extent.height = 32;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06079");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -2675,7 +2675,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     if ((ds_format != VK_FORMAT_UNDEFINED) && IsExtensionsEnabled(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME)) {
         vkt::Image depthImage(*m_device, 32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
         vkt::ImageView depthImageView = depthImage.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
@@ -2694,7 +2694,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupAreaGreaterThanAttachmentExtent) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
@@ -2720,10 +2720,10 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
 
-    cb.begin(&cmd_buffer_begin_info);
-    cb.end();
+    cb.Begin(&cmd_buffer_begin_info);
+    cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pBeginInfo-06020");
@@ -2731,7 +2731,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
@@ -2759,15 +2759,15 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
 
-    cb.begin(&cmd_buffer_begin_info);
-    cb.end();
+    cb.Begin(&cmd_buffer_begin_info);
+    cb.End();
 
     VkRenderPassBeginInfo render_pass_begin_info = vku::InitStructHelper();
     render_pass_begin_info.renderPass = render_pass.handle();
     render_pass_begin_info.renderArea.extent = {32, 32};
     render_pass_begin_info.framebuffer = framebuffer.handle();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass_begin_info, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     m_command_buffer.NextSubpass(VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
@@ -2776,7 +2776,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferIncompatibleSubpass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
@@ -2795,10 +2795,10 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
     cmd_buffer_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
 
-    cb.begin(&cmd_buffer_begin_info);
-    cb.end();
+    cb.Begin(&cmd_buffer_begin_info);
+    cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-contents-09680");
@@ -2806,7 +2806,7 @@ TEST_F(NegativeDynamicRendering, SecondaryCommandBufferContents) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ShaderLayerBuiltIn) {
@@ -2931,7 +2931,7 @@ TEST_F(NegativeDynamicRendering, PipelineRenderingCreateInfoFormat) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitRenderTarget();
 
-    uint32_t over_limit = m_device->phy().limits_.maxColorAttachments + 1;
+    uint32_t over_limit = m_device->Physical().limits_.maxColorAttachments + 1;
     std::vector<VkFormat> color_format(over_limit);
     std::fill(color_format.begin(), color_format.end(), VK_FORMAT_R8G8B8A8_UNORM);
 
@@ -3148,7 +3148,7 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     AddRequiredFeature(vkt::Feature::multiview);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -3168,7 +3168,7 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     begin_rendering_info.viewMask = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06157");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -3185,7 +3185,7 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     image_create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_create_info.usage = VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR | VK_IMAGE_USAGE_FRAGMENT_DENSITY_MAP_BIT_EXT;
-    if (!ImageFormatIsSupported(instance(), gpu(), image_create_info, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "format doesn't support FRAGMENT_SHADING_RATE_ATTACHMENT_BIT";
     }
 
@@ -3196,7 +3196,7 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachment) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachmentUsage) {
@@ -3216,11 +3216,11 @@ TEST_F(NegativeDynamicRendering, RenderingFragmentDensityMapAttachmentUsage) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06158");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
@@ -3229,7 +3229,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -3255,11 +3255,11 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentCreateFlags) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentDensityMapAttachmentInfoEXT-imageView-06159");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
@@ -3267,7 +3267,7 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -3294,11 +3294,11 @@ TEST_F(NegativeDynamicRendering, FragmentDensityMapAttachmentLayerCount) {
     begin_rendering_info.viewMask = 0x1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-multiview-06127");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, PNextImageView) {
@@ -3311,7 +3311,7 @@ TEST_F(NegativeDynamicRendering, PNextImageView) {
     AddRequiredFeature(vkt::Feature::multiview);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR not supported";
     }
@@ -3339,7 +3339,7 @@ TEST_F(NegativeDynamicRendering, PNextImageView) {
     begin_rendering_info.viewMask = 0x1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06126");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3372,7 +3372,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     begin_rendering_info.renderArea.extent.width = 32;
     begin_rendering_info.renderArea.extent.height = 32;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06077");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -3386,7 +3386,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     m_errorMonitor->VerifyFound();
 
     begin_rendering_info.renderArea.offset.y = 0;
-    begin_rendering_info.renderArea.offset.x = m_device->phy().limits_.maxFramebufferWidth - 16;
+    begin_rendering_info.renderArea.offset.x = m_device->Physical().limits_.maxFramebufferWidth - 16;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07815");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3405,7 +3405,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
 
     begin_rendering_info.renderArea.offset.x = 0;
     begin_rendering_info.renderArea.extent.width = 32;
-    begin_rendering_info.renderArea.offset.y = m_device->phy().limits_.maxFramebufferHeight - 16;
+    begin_rendering_info.renderArea.offset.y = m_device->Physical().limits_.maxFramebufferHeight - 16;
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-07816");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
@@ -3422,7 +3422,7 @@ TEST_F(NegativeDynamicRendering, RenderArea) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, InfoViewMask) {
@@ -3445,13 +3445,13 @@ TEST_F(NegativeDynamicRendering, InfoViewMask) {
     begin_rendering_info.renderArea.extent.height = 32;
     begin_rendering_info.viewMask = 1u << multiview_props.maxMultiviewViewCount;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-viewMask-06128");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ColorAttachmentFormat) {
@@ -3460,7 +3460,7 @@ TEST_F(NegativeDynamicRendering, ColorAttachmentFormat) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitRenderTarget();
 
-    VkFormat format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat format = FindSupportedDepthStencilFormat(Gpu());
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 1;
     pipeline_rendering_info.pColorAttachmentFormats = &format;
@@ -3507,13 +3507,13 @@ TEST_F(NegativeDynamicRendering, ResolveModeWithNonIntegerColorFormat) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06129");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveModeWithIntegerColorFormat) {
@@ -3550,13 +3550,13 @@ TEST_F(NegativeDynamicRendering, ResolveModeWithIntegerColorFormat) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06130");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveModeSamples) {
@@ -3580,13 +3580,13 @@ TEST_F(NegativeDynamicRendering, ResolveModeSamples) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06861");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewSamples) {
@@ -3622,7 +3622,7 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewSamples) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06864");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -3633,7 +3633,7 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewSamples) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewFormatMatch) {
@@ -3669,13 +3669,13 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewFormatMatch) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, AttachmentImageViewLayout) {
@@ -3696,13 +3696,13 @@ TEST_F(NegativeDynamicRendering, AttachmentImageViewLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06135");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewLayout) {
@@ -3738,13 +3738,13 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06136");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewLayoutSeparateDepthStencil) {
@@ -3781,13 +3781,13 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewLayoutSeparateDepthStencil) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06137");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, AttachmentImageViewShadingRateLayout) {
@@ -3818,7 +3818,7 @@ TEST_F(NegativeDynamicRendering, AttachmentImageViewShadingRateLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // SHADING_RATE_OPTIMAL_NV is aliased FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR so VU depends on which extensions
     const char *vuid =
@@ -3827,7 +3827,7 @@ TEST_F(NegativeDynamicRendering, AttachmentImageViewShadingRateLayout) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewShadingRateLayout) {
@@ -3872,7 +3872,7 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewShadingRateLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // SHADING_RATE_OPTIMAL_NV is aliased FRAGMENT_SHADING_RATE_ATTACHMENT_OPTIMAL_KHR so VU depends on which extensions
     const char *vuid =
@@ -3881,7 +3881,7 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewShadingRateLayout) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, AttachmentImageViewFragmentDensityLayout) {
@@ -3904,13 +3904,13 @@ TEST_F(NegativeDynamicRendering, AttachmentImageViewFragmentDensityLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06140");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewFragmentDensityLayout) {
@@ -3947,13 +3947,13 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewFragmentDensityLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06141");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ResolveImageViewReadOnlyOptimalLayout) {
@@ -3990,13 +3990,13 @@ TEST_F(NegativeDynamicRendering, ResolveImageViewReadOnlyOptimalLayout) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06142");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
@@ -4004,7 +4004,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
     AddRequiredExtensions(VK_KHR_FRAGMENT_SHADING_RATE_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR not supported";
     }
@@ -4027,13 +4027,13 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateImageView) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingFragmentShadingRateAttachmentInfoKHR-imageView-06147");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
@@ -4072,7 +4072,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
     begin_rendering_info.pColorAttachments = &color_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-colorAttachmentCount-06087");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4115,7 +4115,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
 
     color_attachment.resolveMode = VK_RESOLVE_MODE_NONE;
 
-    const uint32_t max_color_attachments = m_device->phy().limits_.maxColorAttachments + 1;
+    const uint32_t max_color_attachments = m_device->Physical().limits_.maxColorAttachments + 1;
     std::vector<VkRenderingAttachmentInfoKHR> color_attachments(max_color_attachments);
     for (auto &attachment : color_attachments) {
         attachment = vku::InitStructHelper();
@@ -4128,7 +4128,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoColorAttachment) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
@@ -4141,7 +4141,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
 
     const bool separate_ds_layouts = IsExtensionsEnabled(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
 
-    VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkPhysicalDeviceDepthStencilResolveProperties depth_stencil_resolve_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(depth_stencil_resolve_properties);
@@ -4194,7 +4194,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
     begin_rendering_info.pStencilAttachment = &stencil_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pDepthAttachment-06085");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4327,7 +4327,7 @@ TEST_F(NegativeDynamicRendering, RenderingInfoDepthAttachment) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderAreaNegativeOffset) {
@@ -4341,7 +4341,7 @@ TEST_F(NegativeDynamicRendering, RenderAreaNegativeOffset) {
     begin_rendering_info.renderArea.extent.width = 32;
     begin_rendering_info.renderArea.extent.height = 32;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06077");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4354,7 +4354,7 @@ TEST_F(NegativeDynamicRendering, RenderAreaNegativeOffset) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ZeroRenderArea) {
@@ -4370,7 +4370,7 @@ TEST_F(NegativeDynamicRendering, ZeroRenderArea) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-None-08994");
     begin_rendering_info.renderArea = {{0, 0}, {0, 64}};
@@ -4382,7 +4382,7 @@ TEST_F(NegativeDynamicRendering, ZeroRenderArea) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, Pipeline) {
@@ -4397,7 +4397,7 @@ TEST_F(NegativeDynamicRendering, Pipeline) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -4406,7 +4406,7 @@ TEST_F(NegativeDynamicRendering, Pipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize) {
@@ -4419,7 +4419,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize
 
     RETURN_IF_SKIP(InitFramework());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR not supported";
     }
@@ -4457,7 +4457,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingFragmentShadingRateAttachmentSize
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     begin_rendering_info.renderArea.offset.x = fragment_shading_rate.shadingRateAttachmentTexelSize.width * 64;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06119");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4481,7 +4481,7 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
 
     RETURN_IF_SKIP(InitFramework());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR not supported";
     }
@@ -4515,7 +4515,7 @@ TEST_F(NegativeDynamicRendering, FragmentShadingRateAttachmentSizeWithDeviceGrou
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     begin_rendering_info.renderArea.offset.x = fragment_shading_rate.shadingRateAttachmentTexelSize.width * 64;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-06119");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -4600,20 +4600,20 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstance) {
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
-    cmd_buffer1.begin(&cmd_begin);
+    cmd_buffer1.Begin(&cmd_begin);
     cmd_buffer1.BeginRendering(suspend_rendering_info);
     cmd_buffer1.EndRendering();
-    cmd_buffer1.end();
+    cmd_buffer1.End();
 
-    cmd_buffer2.begin(&cmd_begin);
+    cmd_buffer2.Begin(&cmd_begin);
     cmd_buffer2.BeginRendering(resume_rendering_info);
     cmd_buffer2.EndRendering();
-    cmd_buffer2.end();
+    cmd_buffer2.End();
 
-    cmd_buffer3.begin(&cmd_begin);
+    cmd_buffer3.Begin(&cmd_begin);
     cmd_buffer3.BeginRendering(rendering_info);
     cmd_buffer3.EndRendering();
-    cmd_buffer3.end();
+    cmd_buffer3.End();
 
     VkCommandBuffer command_buffers[3] = {cmd_buffer1.handle(), cmd_buffer2.handle()};
 
@@ -4678,20 +4678,20 @@ TEST_F(NegativeDynamicRendering, SuspendingRenderPassInstanceQueueSubmit2) {
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
-    cmd_buffer1.begin(&cmd_begin);
+    cmd_buffer1.Begin(&cmd_begin);
     cmd_buffer1.BeginRendering(suspend_rendering_info);
     cmd_buffer1.EndRendering();
-    cmd_buffer1.end();
+    cmd_buffer1.End();
 
-    cmd_buffer2.begin(&cmd_begin);
+    cmd_buffer2.Begin(&cmd_begin);
     cmd_buffer2.BeginRendering(resume_rendering_info);
     cmd_buffer2.EndRendering();
-    cmd_buffer2.end();
+    cmd_buffer2.End();
 
-    cmd_buffer3.begin(&cmd_begin);
+    cmd_buffer3.Begin(&cmd_begin);
     cmd_buffer3.BeginRendering(rendering_info);
     cmd_buffer3.EndRendering();
-    cmd_buffer3.end();
+    cmd_buffer3.End();
 
     VkCommandBufferSubmitInfo command_buffer_submit_info[3];
     command_buffer_submit_info[0] = vku::InitStructHelper();
@@ -4745,7 +4745,7 @@ TEST_F(NegativeDynamicRendering, NullDepthStencilExecuteCommands) {
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer secondary(*m_device, pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkCommandBufferInheritanceRenderingInfoKHR cbiri = vku::InitStructHelper();
     // format is defined, although no image view provided in dynamic rendering
@@ -4774,53 +4774,53 @@ TEST_F(NegativeDynamicRendering, NullDepthStencilExecuteCommands) {
     ri.renderArea = {{0, 0}, {1, 1}};
 
     // Record secondary cmd buffer with depth stencil format
-    secondary.begin(&cbbi);
-    secondary.end();
+    secondary.Begin(&cbbi);
+    secondary.End();
 
     // Record primary cmd buffer with depth stencil
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(ri);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Retry with null depth stencil attachment image view
     rai.imageView = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(ri);
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pDepthAttachment-06774");
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pStencilAttachment-06775");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Retry with nullptr attachment struct
     ri.pDepthAttachment = nullptr;
     ri.pStencilAttachment = nullptr;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(ri);
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pDepthAttachment-06774");
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pStencilAttachment-06775");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Retry with no format in inheritance info
     cbiri.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     cbiri.stencilAttachmentFormat = VK_FORMAT_UNDEFINED;
 
-    secondary.begin(&cbbi);
-    secondary.end();
+    secondary.Begin(&cbbi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(ri);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginRenderingWithSecondaryContents) {
@@ -4839,13 +4839,13 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithSecondaryContents) {
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    secondary.begin();
+    secondary.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRendering-commandBuffer-06068");
     secondary.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    secondary.end();
+    secondary.End();
 }
 
 TEST_F(NegativeDynamicRendering, BadRenderPassContentsWhenCallingCmdExecuteCommands) {
@@ -4885,10 +4885,10 @@ TEST_F(NegativeDynamicRendering, BadRenderPassContentsWhenCallingCmdExecuteComma
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -4897,7 +4897,7 @@ TEST_F(NegativeDynamicRendering, BadRenderPassContentsWhenCallingCmdExecuteComma
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNonNullRenderPass) {
@@ -4952,10 +4952,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNonNullRenderPass) {
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -4964,7 +4964,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNonNullRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingFlags) {
@@ -5004,10 +5004,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingFlags) {
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5016,7 +5016,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingFlags) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorAttachmentCount) {
@@ -5056,10 +5056,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorAttachmentCo
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5068,7 +5068,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorAttachmentCo
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFormat) {
@@ -5105,10 +5105,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFor
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
-    secondary.begin(&cmdbuff_bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff_bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5117,7 +5117,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingColorImageViewFor
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNullImageView) {
@@ -5152,10 +5152,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNullImageView) {
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
-    secondary.begin(&cmdbuff_bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff_bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5164,7 +5164,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithNullImageView) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingDepthStencilImageViewFormat) {
@@ -5174,7 +5174,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingDepthStencilImage
     AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
     if (depth_stencil_format == VK_FORMAT_D32_SFLOAT_S8_UINT) {
         GTEST_SKIP() << "Insufficient depth-stencil formats supported";
     }
@@ -5214,10 +5214,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingDepthStencilImage
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5267,10 +5267,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingViewMask) {
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
@@ -5323,10 +5323,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasteriz
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // color samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5335,7 +5335,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasteriz
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depthStencilImage(*m_device, 32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depthStencilImageView = depthStencilImage.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -5348,8 +5348,8 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasteriz
     inheritance_rendering_info.colorAttachmentCount = 0;
     inheritance_rendering_info.depthAttachmentFormat = depth_stencil_format;
 
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
     // depth samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5363,8 +5363,8 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasteriz
     inheritance_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     inheritance_rendering_info.stencilAttachmentFormat = depth_stencil_format;
 
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
     // stencil samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5373,7 +5373,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewRasteriz
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachmentSamples) {
@@ -5433,10 +5433,10 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // color samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5445,7 +5445,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depthStencilImage(*m_device, 32, 32, 1, depth_stencil_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depthStencilImageView = depthStencilImage.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -5461,8 +5461,8 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
     inheritance_rendering_info.depthAttachmentFormat = depth_stencil_format;
     samples_info.depthStencilAttachmentSamples = VK_SAMPLE_COUNT_2_BIT;
 
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
     // depth samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5476,8 +5476,8 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
     inheritance_rendering_info.depthAttachmentFormat = VK_FORMAT_UNDEFINED;
     inheritance_rendering_info.stencilAttachmentFormat = depth_stencil_format;
 
-    secondary.begin(&cmdbuff__bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff__bi);
+    secondary.End();
 
     // stencil samples mismatch
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5486,7 +5486,7 @@ TEST_F(NegativeDynamicRendering, ExecuteCommandsWithMismatchingImageViewAttachme
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
@@ -5516,10 +5516,10 @@ TEST_F(NegativeDynamicRendering, InSecondaryCommandBuffers) {
     cbbi.pInheritanceInfo = &cbii;
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary.begin(&cbbi);
+    secondary.Begin(&cbbi);
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(secondary.handle(), 3, 1, 0, 0);
-    secondary.end();
+    secondary.End();
 }
 
 TEST_F(NegativeDynamicRendering, CommandBufferInheritanceDepthFormat) {
@@ -5528,7 +5528,7 @@ TEST_F(NegativeDynamicRendering, CommandBufferInheritanceDepthFormat) {
     AddRequiredFeature(vkt::Feature::variableMultisampleRate);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    auto stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    auto stencil_format = FindSupportedStencilOnlyFormat(Gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -5569,7 +5569,7 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderArea) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5590,17 +5590,17 @@ TEST_F(NegativeDynamicRendering, DeviceGroupRenderArea) {
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    renderArea = {{0, 0}, {m_device->phy().limits_.maxFramebufferWidth + 1, 64}};
+    renderArea = {{0, 0}, {m_device->Physical().limits_.maxFramebufferWidth + 1, 64}};
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06168");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    renderArea = {{0, 0}, {64, m_device->phy().limits_.maxFramebufferWidth + 1}};
+    renderArea = {{0, 0}, {64, m_device->Physical().limits_.maxFramebufferWidth + 1}};
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06169");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MaxFramebufferLayers) {
@@ -5611,16 +5611,16 @@ TEST_F(NegativeDynamicRendering, MaxFramebufferLayers) {
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
-    begin_rendering_info.layerCount = m_device->phy().limits_.maxFramebufferLayers + 1;
+    begin_rendering_info.layerCount = m_device->Physical().limits_.maxFramebufferLayers + 1;
     begin_rendering_info.renderArea = {{0, 0}, {64, 64}};
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-layerCount-07817");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassInstance) {
@@ -5646,7 +5646,7 @@ TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassIns
 
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRendering-None-06161");
@@ -5675,7 +5675,7 @@ TEST_F(NegativeDynamicRendering, EndRenderingWithIncorrectlyStartedRenderpassIns
                                             nullptr,  // pNext
                                             VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, &cmdbuff_ii};
     cmdbuff__bi.flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-    secondary.begin(&cmdbuff__bi);
+    secondary.Begin(&cmdbuff__bi);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRendering-commandBuffer-06162");
     secondary.EndRendering();
     m_errorMonitor->VerifyFound();
@@ -5699,7 +5699,7 @@ TEST_F(NegativeDynamicRendering, EndRenderpassWithBeginRenderingRenderpassInstan
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass-None-06170");
@@ -5710,7 +5710,7 @@ TEST_F(NegativeDynamicRendering, EndRenderpassWithBeginRenderingRenderpassInstan
 
     vkt::CommandBuffer primary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
-    primary.begin();
+    primary.Begin();
     primary.BeginRendering(begin_rendering_info);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass2-None-06171");
     vk::CmdEndRenderPass2KHR(primary.handle(), &subpassEndInfo);
@@ -5730,7 +5730,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingDisabled) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRendering-dynamicRendering-06446");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -5747,7 +5747,7 @@ TEST_F(NegativeDynamicRendering, BeginRenderingDisabled) {
         m_command_buffer.EndRenderPass();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, PipelineRenderingParameters) {
@@ -5933,7 +5933,7 @@ TEST_F(NegativeDynamicRendering, DynamicColorBlendAttchment) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -5948,7 +5948,7 @@ TEST_F(NegativeDynamicRendering, DynamicColorBlendAttchment) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, BeginTwice) {
@@ -5964,13 +5964,13 @@ TEST_F(NegativeDynamicRendering, BeginTwice) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRendering-renderpass");
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, EndTwice) {
@@ -5986,13 +5986,13 @@ TEST_F(NegativeDynamicRendering, EndTwice) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRendering-renderpass");
     m_command_buffer.EndRendering();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, MissingMultisampleState) {
@@ -6019,7 +6019,7 @@ TEST_F(NegativeDynamicRendering, MismatchingDepthAttachmentFormatInSecondaryCmdB
     VkFormat depth_format2 = VK_FORMAT_UNDEFINED;
     for (uint32_t i = 0; i < size(ds_formats); ++i) {
         VkFormatProperties format_props;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), ds_formats[i], &format_props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), ds_formats[i], &format_props);
 
         if ((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0 ||
             (format_props.linearTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) {
@@ -6057,12 +6057,12 @@ TEST_F(NegativeDynamicRendering, MismatchingDepthAttachmentFormatInSecondaryCmdB
         VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     secondary_cmd_buffer_begin_info.pInheritanceInfo = &secondary_cmd_buffer_inheritance_info;
 
-    secondary_cmd_buf.begin(&secondary_cmd_buffer_begin_info);
+    secondary_cmd_buf.Begin(&secondary_cmd_buffer_begin_info);
     vk::CmdBindPipeline(secondary_cmd_buf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-dynamicRenderingUnusedAttachments-08914");
     vk::CmdDraw(secondary_cmd_buf.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
-    secondary_cmd_buf.end();
+    secondary_cmd_buf.End();
 }
 
 TEST_F(NegativeDynamicRendering, MissingImageCreateSubsampled) {
@@ -6071,7 +6071,7 @@ TEST_F(NegativeDynamicRendering, MissingImageCreateSubsampled) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
@@ -6102,11 +6102,11 @@ TEST_F(NegativeDynamicRendering, MissingImageCreateSubsampled) {
     rendering_info.colorAttachmentCount = 1u;
     rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06107");
     vk::CmdBeginRenderingKHR(m_command_buffer.handle(), &rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, DynamicRenderingInlineContents) {
@@ -6119,11 +6119,11 @@ TEST_F(NegativeDynamicRendering, DynamicRenderingInlineContents) {
     rendering_info.renderArea = {{0, 0}, {32u, 32u}};
     rendering_info.layerCount = 1u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-flags-10012");
     vk::CmdBeginRenderingKHR(m_command_buffer.handle(), &rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, IdentitySwizzleColor) {
@@ -6145,7 +6145,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleColor) {
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachments = &attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-colorAttachmentCount-09479");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
@@ -6154,7 +6154,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleColor) {
 TEST_F(NegativeDynamicRendering, IdentitySwizzleDepthStencil) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -6171,7 +6171,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleDepthStencil) {
     rendering_info.layerCount = 1;
     rendering_info.pDepthAttachment = &attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pDepthAttachment-09481");
     m_command_buffer.BeginRendering(rendering_info);
@@ -6191,7 +6191,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleFragmentShadingRate) {
     VkPhysicalDeviceFragmentShadingRatePropertiesKHR fsr_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(fsr_properties);
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR)) {
         GTEST_SKIP() << "format doesn't support FRAGMENT_SHADING_RATE_ATTACHMENT_BIT";
     }
@@ -6211,7 +6211,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleFragmentShadingRate) {
     rendering_info.renderArea = {{0, 0}, {32, 32}};
     rendering_info.layerCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-09485");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
@@ -6221,7 +6221,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleFragmentDensityMap) {
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "format doesn't support VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT";
     }
@@ -6240,7 +6240,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleFragmentDensityMap) {
     rendering_info.renderArea = {{0, 0}, {32, 32}};
     rendering_info.layerCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-09486");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
@@ -6249,7 +6249,7 @@ TEST_F(NegativeDynamicRendering, IdentitySwizzleFragmentDensityMap) {
 TEST_F(NegativeDynamicRendering, ResolveAttachmentUsage) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
     image_create_info.imageType = VK_IMAGE_TYPE_2D;
@@ -6278,7 +6278,7 @@ TEST_F(NegativeDynamicRendering, ResolveAttachmentUsage) {
     rendering_info.layerCount = 1;
     rendering_info.pDepthAttachment = &attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderingAttachmentInfo-imageView-06865");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pDepthAttachment-09477");
     m_command_buffer.BeginRendering(rendering_info);
@@ -6324,11 +6324,11 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
     rendering_info.pNext = &rp_stripe_info;
     rendering_info.renderArea = {{0, 0}, {stripe_width * stripe_count, stripe_height}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeInfoCount-09450");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Stripes overlap
     stripe_count = 8;
@@ -6342,13 +6342,13 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Offset, width and height not multiple of granularity width and height
     const uint32_t half_stripe_width = stripe_width / 2;
@@ -6359,13 +6359,13 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09453");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t non_align_stripe_width = stripe_width - 12;
     rendering_info.renderArea.extent.width = (stripe_width * (stripe_count - 1)) + non_align_stripe_width + 4;
@@ -6376,12 +6376,12 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09453");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-09535");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     rendering_info.renderArea.extent = {stripe_width, stripe_height * stripe_count};
     const uint32_t half_stripe_height = stripe_height / 2;
@@ -6392,13 +6392,13 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = i == 2 ? half_stripe_height : stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09454");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09455");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t non_align_stripe_height = stripe_height - 12;
     rendering_info.renderArea.extent.height = (stripe_height * (stripe_count - 1)) + non_align_stripe_height + 4;
@@ -6409,12 +6409,12 @@ TEST_F(NegativeDynamicRendering, BeginRenderingWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = i == 7 ? non_align_stripe_height : stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09455");
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-pNext-09535");
     m_command_buffer.BeginRendering(rendering_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderPassStripeInfoQueueSubmit2) {
@@ -6456,10 +6456,10 @@ TEST_F(NegativeDynamicRendering, RenderPassStripeInfoQueueSubmit2) {
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
-    cmd_buffer.begin(&cmd_begin);
+    cmd_buffer.Begin(&cmd_begin);
     cmd_buffer.BeginRendering(rendering_info);
     cmd_buffer.EndRendering();
-    cmd_buffer.end();
+    cmd_buffer.End();
 
     VkCommandBufferSubmitInfo cb_submit_info = vku::InitStructHelper();
     cb_submit_info.commandBuffer = cmd_buffer.handle();
@@ -6528,14 +6528,14 @@ TEST_F(NegativeDynamicRendering, PipelineLegacyDithering) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09643");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRendering, RenderPassLegacyDithering) {
@@ -6561,12 +6561,12 @@ TEST_F(NegativeDynamicRendering, RenderPassLegacyDithering) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09642");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/dynamic_rendering_local_read.cpp
+++ b/tests/unit/dynamic_rendering_local_read.cpp
@@ -88,7 +88,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdDrawColorLocation) {
     color_attachment[0].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     color_attachment[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -143,7 +143,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdDrawColorIndex) {
     color_attachment[0].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     color_attachment[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -186,7 +186,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdClearAttachments) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -229,7 +229,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrier) {
     AddRequiredFeature(vkt::Feature::shaderTileImageColorReadAccess);
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
 
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
@@ -291,7 +291,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrier) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierOwnership) {
@@ -306,7 +306,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierOwnership) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
@@ -349,7 +349,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierOwnership) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierNoBufferOrImage) {
@@ -362,7 +362,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierNoBufferOrImage) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Image image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_STORAGE_BIT);
 
@@ -401,7 +401,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierNoBufferOrImage) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierFramebufferStagesOnly) {
@@ -411,7 +411,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierFramebufferStagesOnly) {
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
@@ -458,7 +458,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierFramebufferStagesOnly) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierRequireFeature) {
@@ -470,7 +470,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierRequireFeature) {
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkMemoryBarrier2 barrier2 = vku::InitStructHelper();
@@ -498,7 +498,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierRequireFeature) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierInProperLayout) {
@@ -510,7 +510,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierInProperLayout) {
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::Image image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView imageView = image.CreateView();
@@ -561,7 +561,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ImageBarrierInProperLayout) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, BeginWithinRenderPass) {
@@ -609,7 +609,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, BeginWithinRenderPass) {
 
         VkFormatProperties props;
 
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), m_render_target_fmt, &props);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), m_render_target_fmt, &props);
 
         if (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) {
             img->Init(*m_device, m_width, m_height, 1, m_render_target_fmt,
@@ -651,7 +651,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, BeginWithinRenderPass) {
         m_renderPassBeginInfo.clearValueCount = m_renderPassClearValues.size();
         m_renderPassBeginInfo.pClearValues = m_renderPassClearValues.data();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass-initialLayout-09537");
         vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
@@ -664,7 +664,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, BeginWithinRenderPass) {
             vk::CmdBeginRenderPass2KHR(m_command_buffer.handle(), &m_renderPassBeginInfo, &subpassBeginInfo);
             m_errorMonitor->VerifyFound();
         }
-        m_command_buffer.end();
+        m_command_buffer.End();
         vk::DestroyRenderPass(*DeviceObj(), m_renderPass, nullptr);
 
         m_renderPass = VK_NULL_HANDLE;
@@ -701,7 +701,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexColorAttachmentCou
     TEST_DESCRIPTION("colorAttachmentCount in Inputs Info must be less than maxColorAttachments");
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
 
-    std::vector<uint32_t> input_attachment_indices(m_device->phy().limits_.maxColorAttachments + 1);
+    std::vector<uint32_t> input_attachment_indices(m_device->Physical().limits_.maxColorAttachments + 1);
     for (size_t i = 0; i < input_attachment_indices.size(); i++) {
         input_attachment_indices[i] = static_cast<uint32_t>(i);
     }
@@ -728,7 +728,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, ColorAttachmentCountInPipelineRenderin
     TEST_DESCRIPTION("colorAttachmentCount must be less than or equal to maxColorAttachments in VkPipelineRenderingCreateInfo");
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
 
-    std::vector<VkFormat> color_attachments(m_device->phy().limits_.maxColorAttachments + 1, VK_FORMAT_R8G8B8A8_UNORM);
+    std::vector<VkFormat> color_attachments(m_device->Physical().limits_.maxColorAttachments + 1, VK_FORMAT_R8G8B8A8_UNORM);
 
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = color_attachments.size();
@@ -759,7 +759,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentIndicesColorAttachment
     color_attachment[0].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     color_attachment[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -788,7 +788,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentIndices) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -821,7 +821,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexSetToUnused) {
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -866,7 +866,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, InputAttachmentIndexUnique) {
 
     VkRenderingAttachmentInfoKHR color_attachments[2] = {vku::InitStructHelper(), vku::InitStructHelper()};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -911,7 +911,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetAttachmentLocationsColorAttachme
     color_attachment[0].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     color_attachment[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -949,7 +949,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, NewFunctionsReportErrorExtensionDisabl
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -983,7 +983,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, CmdSetRenderingAttachmentLocations) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -1018,7 +1018,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLocationsValidity) {
     color_attachments[0].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
     color_attachments[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -1055,7 +1055,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLocationsMax) {
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -1064,7 +1064,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, AttachmentLocationsMax) {
 
     m_command_buffer.BeginRendering(rendering_info);
 
-    std::vector<uint32_t> color_attachment_locations(m_device->phy().limits_.maxColorAttachments + 1);
+    std::vector<uint32_t> color_attachment_locations(m_device->Physical().limits_.maxColorAttachments + 1);
     for (size_t i = 0; i < color_attachment_locations.size(); i++) {
         color_attachment_locations[i] = static_cast<uint32_t>(i);
     }
@@ -1086,7 +1086,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, DependencyViewLocalInsideRendering) {
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
@@ -1112,7 +1112,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, DependencyViewLocalOutsideRendering) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
     memory_barrier_2.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
@@ -1138,7 +1138,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, FramebufferSpaceStagesDst) {
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkMemoryBarrier2KHR memory_barrier_2 = vku::InitStructHelper();
@@ -1163,9 +1163,9 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingAttachmentLocationInfoMismatc
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitDynamicRenderTarget();
 
-    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->width(), m_renderTargets[0]->height(),
+    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->Width(), m_renderTargets[0]->Height(),
                                                                 m_renderTargets[0]->CreateInfo().mipLevels, 1,
-                                                                m_renderTargets[0]->format(), m_renderTargets[0]->usage());
+                                                                m_renderTargets[0]->Format(), m_renderTargets[0]->Usage());
 
     vkt::Image render_target(*m_device, render_target_ci, vkt::set_layout);
     vkt::ImageView render_target_view = render_target.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, render_target_ci.arrayLayers);
@@ -1200,10 +1200,10 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingAttachmentLocationInfoMismatc
         VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     secondary_cmd_buffer_begin_info.pInheritanceInfo = &cmd_buffer_inheritance_info;
 
-    secondary_cmd_buffer.begin(&secondary_cmd_buffer_begin_info);
-    secondary_cmd_buffer.end();
+    secondary_cmd_buffer.Begin(&secondary_cmd_buffer_begin_info);
+    secondary_cmd_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingAttachmentInfoKHR color_attachment_info = vku::InitStructHelper{};
     color_attachment_info.imageLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
@@ -1225,18 +1225,18 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingAttachmentLocationInfoMismatc
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_cmd_buffer.handle());
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Force colorAttachmentLocation mismatch.
     invalid_rendering_attachment_location_info.colorAttachmentCount = 1;
     invalid_rendering_attachment_location_info.pColorAttachmentLocations = invalid_attachment_locations;
 
-    secondary_cmd_buffer.reset();
-    secondary_cmd_buffer.begin(&secondary_cmd_buffer_begin_info);
-    secondary_cmd_buffer.end();
+    secondary_cmd_buffer.Reset();
+    secondary_cmd_buffer.Begin(&secondary_cmd_buffer_begin_info);
+    secondary_cmd_buffer.End();
 
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-09504");
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -1245,16 +1245,16 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingAttachmentLocationInfoMismatc
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicRenderingLocalRead, RenderingInputAttachmentIndexInfoMismatch) {
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
     InitDynamicRenderTarget();
 
-    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->width(), m_renderTargets[0]->height(),
+    const auto render_target_ci = vkt::Image::ImageCreateInfo2D(m_renderTargets[0]->Width(), m_renderTargets[0]->Height(),
                                                                 m_renderTargets[0]->CreateInfo().mipLevels, 1,
-                                                                m_renderTargets[0]->format(), m_renderTargets[0]->usage());
+                                                                m_renderTargets[0]->Format(), m_renderTargets[0]->Usage());
 
     vkt::Image render_target(*m_device, render_target_ci, vkt::set_layout);
     vkt::ImageView render_target_view = render_target.CreateView(VK_IMAGE_VIEW_TYPE_2D, 0, 1, 0, render_target_ci.arrayLayers);
@@ -1312,10 +1312,10 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingInputAttachmentIndexInfoMisma
     begin_rendering_info.pColorAttachments = &color_attachment_info;
 
     const auto begin_record_and_verify_cmd_buffers = [&](const VkCommandBufferBeginInfo &commandBufferBeginInfo) {
-        secondary_cmd_buffer.begin(&commandBufferBeginInfo);
-        secondary_cmd_buffer.end();
+        secondary_cmd_buffer.Begin(&commandBufferBeginInfo);
+        secondary_cmd_buffer.End();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRendering(begin_rendering_info);
 
         vk::CmdSetRenderingInputAttachmentIndicesKHR(m_command_buffer.handle(), &rendering_input_attachment_index_info);
@@ -1325,7 +1325,7 @@ TEST_F(NegativeDynamicRenderingLocalRead, RenderingInputAttachmentIndexInfoMisma
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.EndRendering();
-        m_command_buffer.end();
+        m_command_buffer.End();
     };
 
     // Force invalid colorAttachmentCount

--- a/tests/unit/dynamic_rendering_local_read_positive.cpp
+++ b/tests/unit/dynamic_rendering_local_read_positive.cpp
@@ -81,7 +81,7 @@ TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier pre_barriers[2] = {vku::InitStructHelper(), vku::InitStructHelper()};
     pre_barriers[0].oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -129,7 +129,7 @@ TEST_F(PositiveDynamicRenderingLocalRead, BasicUsage) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRenderingLocalRead, CmdClearAttachments) {
@@ -151,7 +151,7 @@ TEST_F(PositiveDynamicRenderingLocalRead, CmdClearAttachments) {
     color_attachments[1] = vku::InitStructHelper();
     color_attachments[1].imageLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     VkRenderingInfo rendering_info = vku::InitStructHelper();
@@ -186,7 +186,7 @@ TEST_F(PositiveDynamicRenderingLocalRead, CmdClearDepthAttachment) {
 
     RETURN_IF_SKIP(InitBasicDynamicRenderingLocalRead());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image depthImage(*m_device, 32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depthImageView = depthImage.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
@@ -221,10 +221,10 @@ TEST_F(PositiveDynamicRenderingLocalRead, CmdClearDepthAttachment) {
     rect.baseArrayLayer = 0u;
     rect.layerCount = 1u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     vk::CmdSetRenderingAttachmentLocationsKHR(m_command_buffer.handle(), &locationInfo);
     vk::CmdClearAttachments(m_command_buffer.handle(), 1u, &attachment, 1u, &rect);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/dynamic_rendering_positive.cpp
+++ b/tests/unit/dynamic_rendering_positive.cpp
@@ -37,10 +37,10 @@ TEST_F(PositiveDynamicRendering, BasicUsage) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, Draw) {
@@ -64,19 +64,19 @@ TEST_F(PositiveDynamicRendering, Draw) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     TEST_DESCRIPTION("Draw with Dynamic Rendering and multiple CmdBindPipeline calls.");
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const auto depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const auto depth_format = FindSupportedDepthOnlyFormat(Gpu());
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
@@ -101,7 +101,7 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
@@ -111,7 +111,7 @@ TEST_F(PositiveDynamicRendering, DrawMultiBind) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, BeginQuery) {
@@ -128,14 +128,14 @@ TEST_F(PositiveDynamicRendering, BeginQuery) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 2);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
     m_command_buffer.EndRendering();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, PipeWithDiscard) {
@@ -163,7 +163,8 @@ TEST_F(PositiveDynamicRendering, UseStencilAttachmentWithIntegerFormatAndDepthSt
     RETURN_IF_SKIP(InitBasicDynamicRendering());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_S8_UINT, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT)) {
         GTEST_SKIP() << "VK_FORMAT_S8_UINT format not supported";
     }
 
@@ -201,18 +202,18 @@ TEST_F(PositiveDynamicRendering, UseStencilAttachmentWithIntegerFormatAndDepthSt
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, FragmentDensityMapSubsampledBit) {
     TEST_DESCRIPTION("Test creating an image with subsampled bit.");
     AddRequiredExtensions(VK_EXT_FRAGMENT_DENSITY_MAP_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
-                                         VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_TILING_OPTIMAL,
+                                    VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT)) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_FRAGMENT_DENSITY_MAP_BIT_EXT not supported";
     }
 
@@ -250,7 +251,7 @@ TEST_F(PositiveDynamicRendering, FragmentDensityMapSubsampledBit) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
     begin_rendering_info.layerCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
 }
 
@@ -280,28 +281,28 @@ TEST_F(PositiveDynamicRendering, SuspendResumeDraw) {
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     begin_rendering_info.flags = VK_RENDERING_RESUMING_BIT_KHR | VK_RENDERING_SUSPENDING_BIT_KHR;
-    cb1.begin();
+    cb1.Begin();
     cb1.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(cb1.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(cb1.handle(), 3, 1, 0, 0);
     cb1.EndRendering();
-    cb1.end();
+    cb1.End();
 
     begin_rendering_info.flags = VK_RENDERING_RESUMING_BIT_KHR;
-    cb2.begin();
+    cb2.Begin();
     cb2.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(cb2.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(cb2.handle(), 3, 1, 0, 0);
     cb2.EndRendering();
-    cb2.end();
+    cb2.End();
 
     std::array cbs = {&m_command_buffer, &cb1, &cb2};
     m_default_queue->Submit(cbs);
@@ -435,7 +436,7 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDepthWriteEnable(m_command_buffer.handle(), false);
@@ -444,7 +445,7 @@ TEST_F(PositiveDynamicRendering, CommandDrawWithShaderTileImageRead) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, DualSourceBlending) {
@@ -479,7 +480,7 @@ TEST_F(PositiveDynamicRendering, DualSourceBlending) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -487,7 +488,7 @@ TEST_F(PositiveDynamicRendering, DualSourceBlending) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, ExecuteCommandsWithNullImageView) {
@@ -522,17 +523,17 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsWithNullImageView) {
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
-    secondary.begin(&cmdbuff_bi);
-    secondary.end();
+    secondary.Begin(&cmdbuff_bi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRendering(begin_rendering_info);
 
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
@@ -557,7 +558,7 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
     // Primary suspends render
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
@@ -566,17 +567,17 @@ TEST_F(PositiveDynamicRendering, SuspendPrimaryResumeInSecondary) {
     // Secondary resumes render
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     begin_rendering_info.flags = VK_RENDERING_RESUMING_BIT_KHR;
-    secondary.begin();
+    secondary.Begin();
     secondary.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(secondary.handle(), 3, 1, 0, 0);
     secondary.EndRendering();
-    secondary.end();
+    secondary.End();
 
     // Execute secondary
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -604,7 +605,7 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
     // First primary with secondary that suspends render
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
@@ -612,27 +613,27 @@ TEST_F(PositiveDynamicRendering, SuspendSecondaryResumeInPrimary) {
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
     begin_rendering_info.flags = VK_RENDERING_SUSPENDING_BIT_KHR;
-    secondary.begin();
+    secondary.Begin();
     secondary.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(secondary.handle(), 3, 1, 0, 0);
     secondary.EndRendering();
-    secondary.end();
+    secondary.End();
 
     // Execute secondary
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Second Primary resumes render
     vkt::CommandBuffer cb(*m_device, m_command_pool);
     begin_rendering_info.flags = VK_RENDERING_RESUMING_BIT_KHR;
-    cb.begin();
+    cb.Begin();
     cb.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(cb.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(cb.handle(), 3, 1, 0, 0);
     cb.EndRendering();
-    cb.end();
+    cb.End();
 
     std::array cbs = {&m_command_buffer, &cb};
     m_default_queue->Submit(cbs);
@@ -651,7 +652,7 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
 
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingInfoKHR begin_rendering_info = vku::InitStructHelper();
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
@@ -685,7 +686,7 @@ TEST_F(PositiveDynamicRendering, WithShaderTileImageAndBarrier) {
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 1, &memory_barrier, 0,
                            nullptr, 0, nullptr);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, IgnoreUnusedColorAttachment) {
@@ -737,7 +738,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
 
     vkt::Image colorImage(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UINT, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
-    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depthStencilImage(*m_device, 32, 32, 1, depthStencilFormat, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
@@ -748,7 +749,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         // Mismatching color formats
@@ -787,7 +788,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats) {
         m_command_buffer.EndRendering();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
@@ -805,7 +806,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     CreatePipelineHelper pipeline_color(*this, &pipeline_rendering_info);
     pipeline_color.CreateGraphicsPipeline();
 
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.pColorAttachmentFormats = nullptr;
@@ -838,7 +839,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
     depth_stencil_attachment.imageLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
     depth_stencil_attachment.imageView = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         // Null color image view
@@ -903,7 +904,7 @@ TEST_F(PositiveDynamicRendering, MatchingAttachmentFormats2) {
         depth_stencil_attachment.imageView = VK_NULL_HANDLE;
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, ExecuteCommandsFlags) {
@@ -938,14 +939,14 @@ TEST_F(PositiveDynamicRendering, ExecuteCommandsFlags) {
     VkCommandBufferBeginInfo cb_begin_info = vku::InitStructHelper();
     cb_begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cb_begin_info.pInheritanceInfo = &cb_inheritance_info;
-    secondary.begin(&cb_begin_info);
-    secondary.end();
+    secondary.Begin(&cb_begin_info);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, ColorAttachmentMismatch) {
@@ -1010,12 +1011,12 @@ TEST_F(PositiveDynamicRendering, PipelineUnusedAttachments) {
     begin_rendering_info.colorAttachmentCount = 1u;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, DynamicColorBlendEnable) {
@@ -1046,14 +1047,14 @@ TEST_F(PositiveDynamicRendering, DynamicColorBlendEnable) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkBool32 color_blend_enable = VK_TRUE;
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0, 1, &color_blend_enable);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, UnusedAttachmentsMismatchedFormats) {
@@ -1086,10 +1087,10 @@ TEST_F(PositiveDynamicRendering, UnusedAttachmentsMismatchedFormats) {
     cmdbuff_bi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cmdbuff_bi.pInheritanceInfo = &cmdbuff_ii;
 
-    secondary.begin(&cmdbuff_bi);
+    secondary.Begin(&cmdbuff_bi);
     vk::CmdBindPipeline(secondary.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_depth.Handle());
     vk::CmdDraw(secondary.handle(), 1, 1, 0, 0);
-    secondary.end();
+    secondary.End();
 }
 
 TEST_F(PositiveDynamicRendering, BeginRenderingWithRenderPassStriped) {
@@ -1129,10 +1130,10 @@ TEST_F(PositiveDynamicRendering, BeginRenderingWithRenderPassStriped) {
     vkt::CommandBuffer cmd_buffer(*m_device, command_pool);
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
-    cmd_buffer.begin(&cmd_begin);
+    cmd_buffer.Begin(&cmd_begin);
     cmd_buffer.BeginRendering(begin_rendering_info);
     cmd_buffer.EndRendering();
-    cmd_buffer.end();
+    cmd_buffer.End();
 
     VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper();
     vkt::Semaphore semaphores[stripe_count];
@@ -1186,12 +1187,12 @@ TEST_F(PositiveDynamicRendering, LegacyDithering) {
     begin_rendering_info.layerCount = 1;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicRendering, AttachmentCountDynamicState) {
@@ -1229,7 +1230,7 @@ TEST_F(PositiveDynamicRendering, VertexOnlyDepth) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState2);
     RETURN_IF_SKIP(InitBasicDynamicRendering());
 
-    const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
     VkPipelineRenderingCreateInfo pipeline_rendering_info = vku::InitStructHelper();
     pipeline_rendering_info.colorAttachmentCount = 0;
     pipeline_rendering_info.depthAttachmentFormat = depth_format;

--- a/tests/unit/dynamic_state.cpp
+++ b/tests/unit/dynamic_state.cpp
@@ -39,7 +39,7 @@ TEST_F(NegativeDynamicState, DepthBiasNotBound) {
     pipe.rs_state_ci_.depthBiasEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -59,7 +59,7 @@ TEST_F(NegativeDynamicState, LineWidthNotBound) {
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -96,7 +96,7 @@ TEST_F(NegativeDynamicState, LineStippleNotBound) {
     pipe.rs_state_ci_.pNext = &line_state;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -152,7 +152,7 @@ TEST_F(NegativeDynamicState, InvalidateStaticPipeline) {
     name_info.pObjectName = "No Dynamic";
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetLineStippleKHR(m_command_buffer.handle(), 1, 0);
@@ -169,7 +169,7 @@ TEST_F(NegativeDynamicState, InvalidateStaticPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ViewportNotBound) {
@@ -182,7 +182,7 @@ TEST_F(NegativeDynamicState, ViewportNotBound) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -200,7 +200,7 @@ TEST_F(NegativeDynamicState, ScissorNotBound) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -221,7 +221,7 @@ TEST_F(NegativeDynamicState, BlendConstantsNotBound) {
     pipe.cb_attachments_.blendEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -237,7 +237,7 @@ TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     AddRequiredFeature(vkt::Feature::depthBounds);
     RETURN_IF_SKIP(Init());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -250,7 +250,7 @@ TEST_F(NegativeDynamicState, DepthBoundsNotBound) {
     pipe.ds_ci_.depthBoundsTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -263,7 +263,7 @@ TEST_F(NegativeDynamicState, StencilReadNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Read dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -276,7 +276,7 @@ TEST_F(NegativeDynamicState, StencilReadNotBound) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -289,7 +289,7 @@ TEST_F(NegativeDynamicState, StencilWriteNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Write dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -302,7 +302,7 @@ TEST_F(NegativeDynamicState, StencilWriteNotBound) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -315,7 +315,7 @@ TEST_F(NegativeDynamicState, StencilRefNotBound) {
     TEST_DESCRIPTION(
         "Run a simple draw calls to validate failure when Stencil Ref dynamic state is required but not correctly bound.");
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -328,7 +328,7 @@ TEST_F(NegativeDynamicState, StencilRefNotBound) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -346,7 +346,7 @@ TEST_F(NegativeDynamicState, SetScissorParam) {
     const VkRect2D scissor = {{0, 0}, {16, 16}};
     const VkRect2D scissors[] = {scissor, scissor};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // array tests
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-firstScissor-00593");
@@ -390,7 +390,7 @@ TEST_F(NegativeDynamicState, SetScissorParam) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetScissorParamMultiviewport) {
@@ -399,13 +399,13 @@ TEST_F(NegativeDynamicState, SetScissorParamMultiviewport) {
     AddRequiredFeature(vkt::Feature::multiViewport);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-scissorCount-arraylength");
     vk::CmdSetScissor(m_command_buffer.handle(), 0, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    const auto max_scissors = m_device->phy().limits_.maxViewports;
+    const auto max_scissors = m_device->Physical().limits_.maxViewports;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetScissor-pScissors-parameter");
     vk::CmdSetScissor(m_command_buffer.handle(), 0, max_scissors, nullptr);
@@ -481,7 +481,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     m_errorMonitor->VerifyFound();
 
     vkt::CommandBuffer commandBuffer(*m_device, m_command_pool);
-    commandBuffer.begin();
+    commandBuffer.Begin();
 
     ExtendedDynStateCalls(m_errorMonitor, commandBuffer.handle(), vk::CmdSetCullModeEXT, "VUID-vkCmdSetCullMode-None-08971",
                           VK_CULL_MODE_NONE);
@@ -522,7 +522,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateDisabled) {
     vk::CmdSetViewportWithCountEXT(commandBuffer.handle(), 1, &viewport);
     m_errorMonitor->VerifyFound();
 
-    commandBuffer.end();
+    commandBuffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorPipeline) {
@@ -626,19 +626,19 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
     pipe.CreateGraphicsPipeline();
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    std::vector<VkBuffer> buffers(m_device->phy().limits_.maxVertexInputBindings + 1ull, buffer.handle());
+    std::vector<VkBuffer> buffers(m_device->Physical().limits_.maxVertexInputBindings + 1ull, buffer.handle());
     std::vector<VkDeviceSize> offsets(buffers.size(), 0);
 
     vkt::CommandBuffer commandBuffer(*m_device, m_command_pool);
-    commandBuffer.begin();
+    commandBuffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-firstBinding-03355");
-    vk::CmdBindVertexBuffers2EXT(commandBuffer.handle(), m_device->phy().limits_.maxVertexInputBindings, 1, buffers.data(),
+    vk::CmdBindVertexBuffers2EXT(commandBuffer.handle(), m_device->Physical().limits_.maxVertexInputBindings, 1, buffers.data(),
                                  offsets.data(), 0, 0);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-firstBinding-03356");
-    vk::CmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, m_device->phy().limits_.maxVertexInputBindings + 1, buffers.data(),
+    vk::CmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, m_device->Physical().limits_.maxVertexInputBindings + 1, buffers.data(),
                                  offsets.data(), 0, 0);
     m_errorMonitor->VerifyFound();
 
@@ -657,7 +657,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffers) {
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdBindVertexBuffers2-pBuffers-parameter");
         VkBuffer buffers2[1] = {VK_NULL_HANDLE};
         VkDeviceSize offsets2[1] = {16};
-        VkDeviceSize strides[1] = {m_device->phy().limits_.maxVertexInputBindingStride + 1ull};
+        VkDeviceSize strides[1] = {m_device->Physical().limits_.maxVertexInputBindingStride + 1ull};
         vk::CmdBindVertexBuffers2EXT(commandBuffer.handle(), 0, 1, buffers2, offsets2, 0, 0);
         m_errorMonitor->VerifyFound();
 
@@ -680,14 +680,14 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateBindVertexBuffersWholeSize) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize size = VK_WHOLE_SIZE;
     VkDeviceSize offset = 0;
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-pSizes-03358");
     vk::CmdBindVertexBuffers2EXT(m_command_buffer.handle(), 0, 1, &buffer.handle(), &offset, &size, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
@@ -700,7 +700,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
     InitRenderTarget();
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
@@ -712,10 +712,10 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
@@ -727,11 +727,11 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         CreatePipelineHelper pipe(*this);
         pipe.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR_WITH_COUNT);
@@ -750,7 +750,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateViewportScissorDraw) {
         vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -770,7 +770,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
     InitRenderTarget();
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
-    std::vector<VkBuffer> buffers(m_device->phy().limits_.maxVertexInputBindings + 1ull, buffer.handle());
+    std::vector<VkBuffer> buffers(m_device->Physical().limits_.maxVertexInputBindings + 1ull, buffer.handle());
     std::vector<VkDeviceSize> offsets(buffers.size(), 0);
 
     CreatePipelineHelper pipe(*this);
@@ -788,7 +788,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &attribute;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -855,7 +855,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateSetViewportScissor) {
 
     vk::CmdBindVertexBuffers2EXT(m_command_buffer.handle(), 0, 0, nullptr, nullptr, nullptr, nullptr);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
@@ -877,7 +877,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
     InitRenderTarget();
 
     vkt::CommandBuffer commandBuffer(*m_device, m_command_pool);
-    commandBuffer.begin();
+    commandBuffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewportWithCount-viewportCount-03395");
     VkViewport viewport = {0, 0, 1, 1, 0.0f, 0.0f};
@@ -891,7 +891,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicStateEnabledNoMultiview) {
     vk::CmdSetScissorWithCountEXT(commandBuffer.handle(), size(scissors), scissors);
     m_errorMonitor->VerifyFound();
 
-    commandBuffer.end();
+    commandBuffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
@@ -925,7 +925,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     m_errorMonitor->VerifyFound();
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetRasterizerDiscardEnable-None-08970");
     vk::CmdSetRasterizerDiscardEnableEXT(command_buffer.handle(), VK_TRUE);
@@ -939,7 +939,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Disabled) {
     vk::CmdSetPrimitiveRestartEnableEXT(command_buffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
@@ -967,13 +967,13 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsDisabled) {
     m_errorMonitor->VerifyFound();
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetPatchControlPointsEXT-None-09422");
     vk::CmdSetPatchControlPointsEXT(command_buffer.handle(), 3);
     m_errorMonitor->VerifyFound();
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
@@ -1001,13 +1001,13 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpDisabled) {
     m_errorMonitor->VerifyFound();
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetLogicOpEXT-None-09422");
     vk::CmdSetLogicOpEXT(command_buffer.handle(), VK_LOGIC_OP_AND);
     m_errorMonitor->VerifyFound();
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
@@ -1046,7 +1046,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
             pipe.CreateGraphicsPipeline();
 
             vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-            command_buffer.begin();
+            command_buffer.Begin();
             command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
             vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1060,7 +1060,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2Enabled) {
             vk::CmdDraw(command_buffer.handle(), 1, 1, 0, 0);
             m_errorMonitor->VerifyFound();
             vk::CmdEndRenderPass(command_buffer.handle());
-            command_buffer.end();
+            command_buffer.End();
         }
     }
 }
@@ -1082,7 +1082,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2InvalidateStaticPipeline) {
     pipe_static.CreateGraphicsPipeline();
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
     vk::CmdSetPrimitiveRestartEnableEXT(command_buffer.handle(), VK_TRUE);
     command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_static.Handle());
@@ -1092,7 +1092,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2InvalidateStaticPipeline) {
     vk::CmdDraw(command_buffer.handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     vk::CmdEndRenderPass(command_buffer.handle());
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
@@ -1127,7 +1127,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
         pipe.CreateGraphicsPipeline();
 
         vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-        command_buffer.begin();
+        command_buffer.Begin();
         command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1142,7 +1142,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2PatchControlPointsEnabled) {
         vk::CmdSetPatchControlPointsEXT(command_buffer.handle(), 0x1000);
         m_errorMonitor->VerifyFound();
         vk::CmdEndRenderPass(command_buffer.handle());
-        command_buffer.end();
+        command_buffer.End();
     }
 }
 
@@ -1180,7 +1180,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
         pipe.CreateGraphicsPipeline();
 
         vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-        command_buffer.begin();
+        command_buffer.Begin();
         command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         vk::CmdBindPipeline(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1190,7 +1190,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState2LogicOpEnabled) {
         vk::CmdDraw(command_buffer.handle(), 1, 1, 0, 0);
         m_errorMonitor->VerifyFound();
         vk::CmdEndRenderPass(command_buffer.handle());
-        command_buffer.end();
+        command_buffer.End();
     }
 }
 
@@ -1386,7 +1386,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState3CmdSetFeatureDisabled) {
 
     // Check feature is enable for each set command.
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
     {
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetTessellationDomainOriginEXT-None-09423");
         vk::CmdSetTessellationDomainOriginEXT(command_buffer.handle(), VK_TESSELLATION_DOMAIN_ORIGIN_UPPER_LEFT);
@@ -1560,7 +1560,7 @@ TEST_F(NegativeDynamicState, ExtendedDynamicState3CmdSetFeatureDisabled) {
         m_errorMonitor->VerifyFound();
     }
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ExtendedDynamicState3DuplicateStatePipeline) {
@@ -1620,7 +1620,7 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT);
@@ -1639,7 +1639,7 @@ TEST_F(NegativeDynamicState, DrawNotSetTessellationDomainOrigin) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
@@ -1654,14 +1654,14 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthClampEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07620");
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetDepthClampFeature) {
@@ -1675,14 +1675,14 @@ TEST_F(NegativeDynamicState, SetDepthClampFeature) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDepthClampEnableEXT-depthClamp-07449");
     vk::CmdSetDepthClampEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetDepthBoundsTestEnableFeature) {
@@ -1696,14 +1696,14 @@ TEST_F(NegativeDynamicState, SetDepthBoundsTestEnableFeature) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDepthBoundsTestEnable-depthBounds-10010");
     vk::CmdSetDepthBoundsTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
@@ -1720,7 +1720,7 @@ TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_POLYGON_MODE_EXT);
@@ -1744,7 +1744,7 @@ TEST_F(NegativeDynamicState, DrawNotSetPolygonMode) {
 
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
@@ -1755,7 +1755,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT);
@@ -1767,7 +1767,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAlphaToOneEnable) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, AlphaToOneFeature) {
@@ -1778,7 +1778,7 @@ TEST_F(NegativeDynamicState, AlphaToOneFeature) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT);
@@ -1790,7 +1790,7 @@ TEST_F(NegativeDynamicState, AlphaToOneFeature) {
     vk::CmdSetAlphaToOneEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
@@ -1801,7 +1801,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT);
@@ -1814,7 +1814,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLogicOpEnable) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetLogicOpFeature) {
@@ -1825,7 +1825,7 @@ TEST_F(NegativeDynamicState, SetLogicOpFeature) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT);
@@ -1838,7 +1838,7 @@ TEST_F(NegativeDynamicState, SetLogicOpFeature) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
@@ -1856,7 +1856,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
@@ -1878,7 +1878,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendEquation) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendEquationMultipleAttachments) {
@@ -1898,7 +1898,7 @@ TEST_F(NegativeDynamicState, ColorBlendEquationMultipleAttachments) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     const VkColorBlendEquationEXT equation = {VK_BLEND_FACTOR_SRC_COLOR, VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_OP_ADD,
@@ -1912,7 +1912,7 @@ TEST_F(NegativeDynamicState, ColorBlendEquationMultipleAttachments) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendEquationInvalidateStaticPipeline) {
@@ -1937,7 +1937,7 @@ TEST_F(NegativeDynamicState, ColorBlendEquationInvalidateStaticPipeline) {
     pipe_static.cb_ci_.pAttachments = color_blend;
     pipe_static.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     const VkColorBlendEquationEXT equation = {VK_BLEND_FACTOR_SRC_COLOR, VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_OP_ADD,
@@ -1955,7 +1955,7 @@ TEST_F(NegativeDynamicState, ColorBlendEquationInvalidateStaticPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
@@ -1970,7 +1970,7 @@ TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
     VkPhysicalDeviceTransformFeedbackPropertiesEXT transform_feedback_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(transform_feedback_props);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT);
@@ -1989,7 +1989,7 @@ TEST_F(NegativeDynamicState, DrawNotSetRasterizationStream) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetExtraPrimitiveOverestimationSize) {
@@ -2006,7 +2006,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExtraPrimitiveOverestimationSize) {
         GTEST_SKIP() << "conservativePointAndLineRasterization is not supported";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkPipelineRasterizationConservativeStateCreateInfoEXT cs_info = vku::InitStructHelper();
     cs_info.conservativeRasterizationMode = VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT;
@@ -2028,7 +2028,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExtraPrimitiveOverestimationSize) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
@@ -2042,7 +2042,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
     VkPhysicalDeviceBlendOperationAdvancedPropertiesEXT blend_operation_advanced = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(blend_operation_advanced);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ADVANCED_EXT);
@@ -2069,7 +2069,7 @@ TEST_F(NegativeDynamicState, DrawNotSetColorBlendAdvanced) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetProvokingVertexMode) {
@@ -2080,7 +2080,7 @@ TEST_F(NegativeDynamicState, DrawNotSetProvokingVertexMode) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_PROVOKING_VERTEX_MODE_EXT);
@@ -2096,7 +2096,7 @@ TEST_F(NegativeDynamicState, DrawNotSetProvokingVertexMode) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetLineRasterizationMode) {
@@ -2107,7 +2107,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineRasterizationMode) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT);
     pipe.CreateGraphicsPipeline();
@@ -2128,7 +2128,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineRasterizationMode) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
@@ -2140,7 +2140,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     CreatePipelineHelper pipe(*this);
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
@@ -2152,7 +2152,7 @@ TEST_F(NegativeDynamicState, DrawNotSetLineStippleEnable) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetColorWriteMask) {
@@ -2161,11 +2161,11 @@ TEST_F(NegativeDynamicState, DrawNotSetColorWriteMask) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorWriteMask);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetColorWriteMaskEXT-pColorWriteMasks-parameter");
     vk::CmdSetColorWriteMaskEXT(m_command_buffer.handle(), 0U, 1U, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, VertexInputDynamicStateDisabled) {
@@ -2183,14 +2183,14 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDisabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // VUID-vkCmdSetVertexInputEXT-None-08546
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetVertexInputEXT-None-08546");
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
@@ -2210,17 +2210,18 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     pipe.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791
     {
         VkVertexInputBindingDescription2EXT binding = {
             VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_VERTEX_INPUT_RATE_VERTEX, 1};
-        std::vector<VkVertexInputBindingDescription2EXT> bindings(m_device->phy().limits_.maxVertexInputBindings + 1u, binding);
+        std::vector<VkVertexInputBindingDescription2EXT> bindings(m_device->Physical().limits_.maxVertexInputBindings + 1u,
+                                                                  binding);
         for (uint32_t i = 0; i < bindings.size(); ++i) bindings[i].binding = i;
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetVertexInputEXT-vertexBindingDescriptionCount-04791");
-        vk::CmdSetVertexInputEXT(m_command_buffer.handle(), m_device->phy().limits_.maxVertexInputBindings + 1u, bindings.data(), 0,
-                                 nullptr);
+        vk::CmdSetVertexInputEXT(m_command_buffer.handle(), m_device->Physical().limits_.maxVertexInputBindings + 1u,
+                                 bindings.data(), 0, nullptr);
         m_errorMonitor->VerifyFound();
     }
 
@@ -2230,11 +2231,11 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
             VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_VERTEX_INPUT_RATE_VERTEX, 1};
         VkVertexInputAttributeDescription2EXT attribute = {
             VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_FORMAT_R32G32B32A32_SFLOAT, 0};
-        std::vector<VkVertexInputAttributeDescription2EXT> attributes(m_device->phy().limits_.maxVertexInputAttributes + 1u,
+        std::vector<VkVertexInputAttributeDescription2EXT> attributes(m_device->Physical().limits_.maxVertexInputAttributes + 1u,
                                                                       attribute);
         for (uint32_t i = 0; i < attributes.size(); ++i) attributes[i].location = i;
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetVertexInputEXT-vertexAttributeDescriptionCount-04792");
-        vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, m_device->phy().limits_.maxVertexInputAttributes + 1u,
+        vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, m_device->Physical().limits_.maxVertexInputAttributes + 1u,
                                  attributes.data());
         m_errorMonitor->VerifyFound();
     }
@@ -2276,7 +2277,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     {
         VkVertexInputBindingDescription2EXT binding = {VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT,
                                                        nullptr,
-                                                       m_device->phy().limits_.maxVertexInputBindings + 1u,
+                                                       m_device->Physical().limits_.maxVertexInputBindings + 1u,
                                                        0,
                                                        VK_VERTEX_INPUT_RATE_VERTEX,
                                                        1};
@@ -2290,7 +2291,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
         VkVertexInputBindingDescription2EXT binding = {VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT,
                                                        nullptr,
                                                        0,
-                                                       m_device->phy().limits_.maxVertexInputBindingStride + 1u,
+                                                       m_device->Physical().limits_.maxVertexInputBindingStride + 1u,
                                                        VK_VERTEX_INPUT_RATE_VERTEX,
                                                        1};
         m_errorMonitor->SetDesiredError("VUID-VkVertexInputBindingDescription2EXT-stride-04797");
@@ -2322,7 +2323,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
             VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_VERTEX_INPUT_RATE_VERTEX, 1};
         VkVertexInputAttributeDescription2EXT attribute = {VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
                                                            nullptr,
-                                                           m_device->phy().limits_.maxVertexInputAttributes + 1u,
+                                                           m_device->Physical().limits_.maxVertexInputAttributes + 1u,
                                                            0,
                                                            VK_FORMAT_R32G32B32A32_SFLOAT,
                                                            0};
@@ -2338,7 +2339,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
         VkVertexInputAttributeDescription2EXT attribute = {VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,
                                                            nullptr,
                                                            0,
-                                                           m_device->phy().limits_.maxVertexInputBindings + 1u,
+                                                           m_device->Physical().limits_.maxVertexInputBindings + 1u,
                                                            VK_FORMAT_R32G32B32A32_SFLOAT,
                                                            0};
         m_errorMonitor->SetDesiredError("VUID-VkVertexInputAttributeDescription2EXT-binding-06229");
@@ -2348,13 +2349,13 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     }
 
     // VUID-VkVertexInputAttributeDescription2EXT-offset-06230
-    if (m_device->phy().limits_.maxVertexInputAttributeOffset <
-        std::numeric_limits<decltype(m_device->phy().limits_.maxVertexInputAttributeOffset)>::max()) {
+    if (m_device->Physical().limits_.maxVertexInputAttributeOffset <
+        std::numeric_limits<decltype(m_device->Physical().limits_.maxVertexInputAttributeOffset)>::max()) {
         VkVertexInputBindingDescription2EXT binding = {
             VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_VERTEX_INPUT_RATE_VERTEX, 1};
         VkVertexInputAttributeDescription2EXT attribute = {
-            VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_FORMAT_R32G32B32A32_SFLOAT,
-            m_device->phy().limits_.maxVertexInputAttributeOffset + 1u};
+            VK_STRUCTURE_TYPE_VERTEX_INPUT_ATTRIBUTE_DESCRIPTION_2_EXT,     nullptr, 0, 0, VK_FORMAT_R32G32B32A32_SFLOAT,
+            m_device->Physical().limits_.maxVertexInputAttributeOffset + 1u};
         m_errorMonitor->SetDesiredError("VUID-VkVertexInputAttributeDescription2EXT-offset-06230");
         vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, 1, &attribute);
         m_errorMonitor->VerifyFound();
@@ -2364,7 +2365,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
     {
         const VkFormat format = VK_FORMAT_D16_UNORM;
         VkFormatProperties format_props;
-        vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_props);
+        vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_props);
         if ((format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
             VkVertexInputBindingDescription2EXT binding = {
                 VK_STRUCTURE_TYPE_VERTEX_INPUT_BINDING_DESCRIPTION_2_EXT, nullptr, 0, 0, VK_VERTEX_INPUT_RATE_VERTEX, 1};
@@ -2376,7 +2377,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateEnabled) {
         }
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
@@ -2393,7 +2394,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT vertex_attribute_divisor_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(vertex_attribute_divisor_properties);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // VUID-VkVertexInputBindingDescription2EXT-divisor-06226
     if (vertex_attribute_divisor_properties.maxVertexAttribDivisor < 0xFFFFFFFFu) {
@@ -2415,7 +2416,7 @@ TEST_F(NegativeDynamicState, VertexInputDynamicStateDivisor) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RasterizationSamples) {
@@ -2434,7 +2435,7 @@ TEST_F(NegativeDynamicState, RasterizationSamples) {
     pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2449,7 +2450,7 @@ TEST_F(NegativeDynamicState, RasterizationSamples) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendAttchment) {
@@ -2491,7 +2492,7 @@ TEST_F(NegativeDynamicState, ColorBlendAttchment) {
     pipe.cb_ci_.pAttachments = cb_attachments;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2508,7 +2509,7 @@ TEST_F(NegativeDynamicState, ColorBlendAttchment) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 void NegativeDynamicState::InitLineRasterizationFeatureDisabled() {
@@ -2539,7 +2540,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeDefault) {
     pipe.line_state_ci_.lineStippleFactor = 1;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2554,7 +2555,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeDefault) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RasterizationLineModeRectangular) {
@@ -2568,7 +2569,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeRectangular) {
     pipe.line_state_ci_.lineStippleFactor = 1;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2578,7 +2579,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeRectangular) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RasterizationLineModeBresenham) {
@@ -2591,7 +2592,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeBresenham) {
     pipe.line_state_ci_.lineStippleFactor = 1;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2601,7 +2602,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeBresenham) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RasterizationLineModeSmooth) {
@@ -2614,7 +2615,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeSmooth) {
     pipe.line_state_ci_.lineStippleFactor = 1;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2624,7 +2625,7 @@ TEST_F(NegativeDynamicState, RasterizationLineModeSmooth) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, PipelineColorWriteCreateInfoEXTDynaimcState3) {
@@ -2682,7 +2683,7 @@ TEST_F(NegativeDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorWriteMask);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -2711,7 +2712,7 @@ TEST_F(NegativeDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkColorBlendEquationEXT dual_color_blend_equation = {
@@ -2737,7 +2738,7 @@ TEST_F(NegativeDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorWriteDisabled) {
@@ -2774,7 +2775,7 @@ TEST_F(NegativeDynamicState, ColorWriteNotSet) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2792,7 +2793,7 @@ TEST_F(NegativeDynamicState, ColorWriteNotSet) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorWriteInvalidateStaticPipeline) {
@@ -2809,7 +2810,7 @@ TEST_F(NegativeDynamicState, ColorWriteInvalidateStaticPipeline) {
     CreatePipelineHelper pipe_static(*this);
     pipe_static.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkBool32 color_write_enable[] = {VK_FALSE};
@@ -2823,7 +2824,7 @@ TEST_F(NegativeDynamicState, ColorWriteInvalidateStaticPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
@@ -2842,12 +2843,12 @@ TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
     InitRenderTarget();
 
     // need a valid array to index into
-    std::vector<VkBool32> color_write_enable(m_device->phy().limits_.maxColorAttachments + 1, VK_TRUE);
+    std::vector<VkBool32> color_write_enable(m_device->Physical().limits_.maxColorAttachments + 1, VK_TRUE);
 
     CreatePipelineHelper helper(*this);
     helper.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
 
     // Value can't be zero
@@ -2857,7 +2858,7 @@ TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
 
     // over the limit
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetColorWriteEnableEXT-attachmentCount-06656");
-    vk::CmdSetColorWriteEnableEXT(m_command_buffer.handle(), m_device->phy().limits_.maxColorAttachments + 1,
+    vk::CmdSetColorWriteEnableEXT(m_command_buffer.handle(), m_device->Physical().limits_.maxColorAttachments + 1,
                                   color_write_enable.data());
     m_errorMonitor->VerifyFound();
 
@@ -2865,7 +2866,7 @@ TEST_F(NegativeDynamicState, ColorWriteEnableAttachmentCount) {
     // see https://gitlab.khronos.org/vulkan/vulkan/-/issues/2868
     vk::CmdSetColorWriteEnableEXT(m_command_buffer.handle(), 2, color_write_enable.data());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorWriteEnableFeature) {
@@ -2881,12 +2882,12 @@ TEST_F(NegativeDynamicState, ColorWriteEnableFeature) {
     CreatePipelineHelper helper(*this);
     helper.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetColorWriteEnableEXT-None-04803");
     vk::CmdSetColorWriteEnableEXT(m_command_buffer.handle(), 1, color_write_enable);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DiscardRectanglesInvalidateStaticPipeline) {
@@ -2905,7 +2906,7 @@ TEST_F(NegativeDynamicState, DiscardRectanglesInvalidateStaticPipeline) {
     CreatePipelineHelper pipe_static(*this);
     pipe_static.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     VkRect2D discard_rectangles[2] = {{{0, 0}, {16, 16}}, {{0, 0}, {16, 16}}};
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 2, discard_rectangles);
@@ -2919,7 +2920,7 @@ TEST_F(NegativeDynamicState, DiscardRectanglesInvalidateStaticPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
@@ -2937,7 +2938,7 @@ TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -2954,7 +2955,7 @@ TEST_F(NegativeDynamicState, DiscardRectanglesNotSet) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
@@ -2974,17 +2975,17 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
 
     VkRect2D discard_rectangles = {{0, 0}, {16, 16}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 1, &discard_rectangles);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // The dynamic state was not set for this lifetime of this command buffer
     // implicitly via vkBeginCommandBuffer
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07751");
@@ -2993,18 +2994,18 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferResetBitmask) {
     // set again for this command buffer
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 1, &discard_rectangles);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // reset command buffer from the pool
     vk::ResetCommandPool(device(), m_command_pool.handle(), 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07751");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
@@ -3044,17 +3045,17 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     pipe.ms_ci_ = pipe_ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetSampleLocationsEXT(m_command_buffer.handle(), &sample_locations_info);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // The dynamic state was not set for this lifetime of this command buffer
     // implicitly via vkBeginCommandBuffer
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06666");
@@ -3063,18 +3064,18 @@ TEST_F(NegativeDynamicState, StateNotSetWithCommandBufferReset) {
     // set again for this command buffer
     vk::CmdSetSampleLocationsEXT(m_command_buffer.handle(), &sample_locations_info);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // reset command buffer from the pool
     vk::ResetCommandPool(device(), m_command_pool.handle(), 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-06666");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SampleLocations) {
@@ -3105,14 +3106,14 @@ TEST_F(NegativeDynamicState, SampleLocations) {
 
     // If S8_UINT is supported, check not having depth with sample location compatible bit
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_S8_UINT, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_S8_UINT, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) {
         image_create_info.flags = VK_IMAGE_CREATE_SAMPLE_LOCATIONS_COMPATIBLE_DEPTH_BIT_EXT;
         image_create_info.format = VK_FORMAT_S8_UINT;
         CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-01533");
     }
 
-    const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     image_create_info.flags = 0;  // image will not have needed flag
     image_create_info.format = depth_format;
@@ -3137,7 +3138,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), static_cast<uint32_t>(attachments.size()), attachments.data(), 128, 128);
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
-    vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
+    vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     // 1 from VK_SAMPLE_COUNT_1_BIT
     const uint32_t valid_count =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height * 1;
@@ -3233,7 +3234,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
 
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 128, 128);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, dynamic_pipe.Handle());
@@ -3265,7 +3266,7 @@ TEST_F(NegativeDynamicState, SampleLocations) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetViewportParam) {
@@ -3278,7 +3279,7 @@ TEST_F(NegativeDynamicState, SetViewportParam) {
     const VkViewport vp = {0.0, 0.0, 64.0, 64.0, 0.0, 1.0};
     const VkViewport viewports[] = {vp, vp};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // array tests
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-firstViewport-01224");
@@ -3310,11 +3311,11 @@ TEST_F(NegativeDynamicState, SetViewportParam) {
     };
 
     // not necessarily boundary values (unspecified cast rounding), but guaranteed to be over limit
-    const auto one_past_max_w = NearestGreater(static_cast<float>(m_device->phy().limits_.maxViewportDimensions[0]));
-    const auto one_past_max_h = NearestGreater(static_cast<float>(m_device->phy().limits_.maxViewportDimensions[1]));
+    const auto one_past_max_w = NearestGreater(static_cast<float>(m_device->Physical().limits_.maxViewportDimensions[0]));
+    const auto one_past_max_h = NearestGreater(static_cast<float>(m_device->Physical().limits_.maxViewportDimensions[1]));
 
-    const auto min_bound = m_device->phy().limits_.viewportBoundsRange[0];
-    const auto max_bound = m_device->phy().limits_.viewportBoundsRange[1];
+    const auto min_bound = m_device->Physical().limits_.viewportBoundsRange[0];
+    const auto max_bound = m_device->Physical().limits_.viewportBoundsRange[1];
     const auto one_before_min_bounds = NearestSmaller(min_bound);
     const auto one_past_max_bounds = NearestGreater(max_bound);
 
@@ -3360,8 +3361,8 @@ TEST_F(NegativeDynamicState, SetViewportParamMaintenance1) {
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const auto &limits = m_device->phy().limits_;
-    m_command_buffer.begin();
+    const auto &limits = m_device->Physical().limits_;
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkViewport-height-01773");
     // not necessarily boundary values (unspecified cast rounding), but guaranteed to be over limit
@@ -3413,13 +3414,13 @@ TEST_F(NegativeDynamicState, SetViewportParamMultiviewport) {
     AddRequiredFeature(vkt::Feature::multiViewport);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-viewportCount-arraylength");
     vk::CmdSetViewport(m_command_buffer.handle(), 0, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    const auto max_viewports = m_device->phy().limits_.maxViewports;
+    const auto max_viewports = m_device->Physical().limits_.maxViewports;
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-pViewports-parameter");
     vk::CmdSetViewport(m_command_buffer.handle(), 0, max_viewports, nullptr);
@@ -3469,7 +3470,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTOffsets) {
     discard_rectangles.extent.width = 64;
     discard_rectangles.extent.height = 64;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEXT-x-00587");
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 1, &discard_rectangles);
     m_errorMonitor->VerifyFound();
@@ -3479,7 +3480,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTOffsets) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEXT-x-00587");
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 1, &discard_rectangles);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
@@ -3493,7 +3494,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCountOverflow) {
     discard_rectangles.extent.width = static_cast<uint32_t>(std::numeric_limits<int32_t>::max());
     discard_rectangles.extent.height = 64;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEXT-offset-00588");
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), 0, 1, &discard_rectangles);
     m_errorMonitor->VerifyFound();
@@ -3523,7 +3524,7 @@ TEST_F(NegativeDynamicState, CmdSetDiscardRectangleEXTRectangleCount) {
     discard_rectangles.extent.width = 64;
     discard_rectangles.extent.height = 64;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEXT-firstDiscardRectangle-00585");
     vk::CmdSetDiscardRectangleEXT(m_command_buffer.handle(), discard_rectangle_properties.maxDiscardRectangles, 1,
                                   &discard_rectangles);
@@ -3555,14 +3556,14 @@ TEST_F(NegativeDynamicState, DiscardRectanglesVersion) {
     pipe.dyn_state_ci_.dynamicStateCount = 0;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDiscardRectangleEnableEXT-specVersion-07851");
     vk::CmdSetDiscardRectangleEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // Not possible to hit the desired failure messages given invalid enums.
@@ -3598,7 +3599,7 @@ TEST_F(NegativeDynamicState, ViewportAndScissorUndefinedDrawState) {
     pipeline_dyn_sc.AddDynamicState(VK_DYNAMIC_STATE_SCISSOR);
     pipeline_dyn_sc.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07831");
@@ -3614,7 +3615,7 @@ TEST_F(NegativeDynamicState, ViewportAndScissorUndefinedDrawState) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, Duplicate) {
@@ -3733,7 +3734,7 @@ TEST_F(NegativeDynamicState, SettingCommands) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -3748,7 +3749,7 @@ TEST_F(NegativeDynamicState, SettingCommands) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic_state, const char *vuid) {
@@ -3761,7 +3762,7 @@ void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic
     pipe.AddDynamicState(dynamic_state);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -3770,7 +3771,7 @@ void NegativeDynamicState::ExtendedDynamicStateDrawNotSet(VkDynamicState dynamic
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetCullMode) {
@@ -3807,7 +3808,7 @@ TEST_F(NegativeDynamicState, DrawNotSetStencilOp) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
     RETURN_IF_SKIP(Init());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     vkt::ImageView depth_image_view = depth_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     InitRenderTarget(1, &depth_image_view.handle());
@@ -3818,7 +3819,7 @@ TEST_F(NegativeDynamicState, DrawNotSetStencilOp) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -3827,7 +3828,7 @@ TEST_F(NegativeDynamicState, DrawNotSetStencilOp) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
@@ -3838,7 +3839,7 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
     RETURN_IF_SKIP(Init());
 
     // Need to set format framework uses for InitRenderTarget
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -3871,7 +3872,7 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDepthBounds-minDepthBounds-00600");
@@ -3883,7 +3884,7 @@ TEST_F(NegativeDynamicState, DepthRangeUnrestricted) {
     m_errorMonitor->VerifyFound();
 
     vk::CmdSetDepthBounds(m_command_buffer.handle(), 1.0f, 1.0f);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
@@ -3894,7 +3895,7 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     RETURN_IF_SKIP(Init());
 
     // Need to set format framework uses for InitRenderTarget
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -3909,7 +3910,7 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDepthBoundsTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -3917,7 +3918,7 @@ TEST_F(NegativeDynamicState, DepthBoundsTestEnableState) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ViewportStateIgnored) {
@@ -3949,7 +3950,7 @@ TEST_F(NegativeDynamicState, Viewport) {
     RETURN_IF_SKIP(Init(&features));
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxViewports < 3) {
+    if (m_device->Physical().limits_.maxViewports < 3) {
         GTEST_SKIP() << "maxViewports is not large enough";
     }
 
@@ -4166,7 +4167,7 @@ TEST_F(NegativeDynamicState, MultiViewport) {
           "VUID-VkPipelineViewportStateCreateInfo-scissorCount-04136"}},
     };
 
-    const auto max_viewports = m_device->phy().limits_.maxViewports;
+    const auto max_viewports = m_device->Physical().limits_.maxViewports;
     const bool max_viewports_maxxed = max_viewports == std::numeric_limits<decltype(max_viewports)>::max();
     if (max_viewports_maxxed) {
         printf("VkPhysicalDeviceLimits::maxViewports is UINT32_MAX -- skipping part of test requiring to exceed maxViewports.\n");
@@ -4344,7 +4345,7 @@ TEST_F(NegativeDynamicState, DrawNotSetSampleLocations) {
     pipe.ms_ci_ = pipe_ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -4356,7 +4357,7 @@ TEST_F(NegativeDynamicState, DrawNotSetSampleLocations) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, LineWidth) {
@@ -4376,7 +4377,7 @@ TEST_F(NegativeDynamicState, LineWidth) {
     }
 
     // test vk::CmdSetLineWidth
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     for (const auto test_case : test_cases) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdSetLineWidth-lineWidth-00788");
@@ -4398,7 +4399,7 @@ TEST_F(NegativeDynamicState, SetAfterStaticPipeline) {
     CreatePipelineHelper pipe_static(*this);
     pipe_static.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetLineWidth(m_command_buffer.handle(), 1.0f);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_static.Handle());  // ignored
@@ -4413,7 +4414,7 @@ TEST_F(NegativeDynamicState, SetAfterStaticPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
@@ -4430,7 +4431,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -4439,7 +4440,7 @@ TEST_F(NegativeDynamicState, DrawNotSetAttachmentFeedbackLoopEnable) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableFeatures) {
@@ -4453,14 +4454,14 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableFeatures) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError(
         "VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-attachmentFeedbackLoopDynamicState-08862");  // attachmentFeedbackLoopDynamicState
     m_errorMonitor->SetDesiredError(
         "VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-attachmentFeedbackLoopLayout-08864");  // attachmentFeedbackLoopLayout
     vk::CmdSetAttachmentFeedbackLoopEnableEXT(m_command_buffer.handle(), VK_IMAGE_ASPECT_COLOR_BIT);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
@@ -4480,11 +4481,11 @@ TEST_F(NegativeDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetAttachmentFeedbackLoopEnableEXT-aspectMask-08863");
     vk::CmdSetAttachmentFeedbackLoopEnableEXT(m_command_buffer.handle(), VK_IMAGE_ASPECT_PLANE_0_BIT);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
@@ -4510,7 +4511,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
 
@@ -4522,7 +4523,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
     vk::CmdSetDepthBias2EXT(m_command_buffer.handle(), &depth_bias_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
@@ -4557,7 +4558,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
     CreatePipelineHelper pipe_line(*this);
     pipe_line.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
 
@@ -4593,7 +4594,7 @@ TEST_F(NegativeDynamicState, SetDepthBias2EXTDepthBiasControlFeaturesDisabled) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
@@ -4622,7 +4623,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetAlphaToCoverageEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -4630,7 +4631,7 @@ TEST_F(NegativeDynamicState, AlphaToCoverageOutputNoAlpha) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ShadingRateImageEnableNotSet) {
@@ -4647,14 +4648,14 @@ TEST_F(NegativeDynamicState, ShadingRateImageEnableNotSet) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SHADING_RATE_IMAGE_ENABLE_NV);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07647");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, CoverageReductionModeNotSet) {
@@ -4672,14 +4673,14 @@ TEST_F(NegativeDynamicState, CoverageReductionModeNotSet) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COVERAGE_REDUCTION_MODE_NV);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07649");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
@@ -4696,9 +4697,9 @@ TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
     }
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     uint32_t count;
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, nullptr);
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, nullptr);
     std::vector<VkExtensionProperties> properties(count);
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, properties.data());
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, properties.data());
     for (const auto &p : properties) {
         if (std::strcmp(p.extensionName, VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME) == 0) {
             if (p.specVersion < 2) {
@@ -4717,7 +4718,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
     pipe2.AddDynamicState(VK_DYNAMIC_STATE_EXCLUSIVE_SCISSOR_NV);
     pipe2.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07878");
@@ -4733,7 +4734,7 @@ TEST_F(NegativeDynamicState, DrawNotSetExclusiveScissor) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetDepthBiasClampDisabled) {
@@ -4741,11 +4742,11 @@ TEST_F(NegativeDynamicState, SetDepthBiasClampDisabled) {
     AddDisabledFeature(vkt::Feature::depthBiasClamp);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDepthBias-depthBiasClamp-00790");
     vk::CmdSetDepthBias(m_command_buffer.handle(), 0.0f, 1.0f, 0.0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, MultisampleStateIgnored) {
@@ -4879,7 +4880,7 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
     pipe.CreateGraphicsPipeline();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-Input-07939");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -4901,7 +4902,7 @@ TEST_F(NegativeDynamicState, VertexInputLocationMissing) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -4921,7 +4922,7 @@ TEST_F(NegativeDynamicState, MissingCmdSetVertexInput) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -4931,7 +4932,7 @@ TEST_F(NegativeDynamicState, MissingCmdSetVertexInput) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
@@ -4946,7 +4947,7 @@ TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -4962,19 +4963,19 @@ TEST_F(NegativeDynamicState, MissingCmdBindVertexBuffers2) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, CmdBindVertexBuffers2NullOffset) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     RETURN_IF_SKIP(Init());
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize size = 16;
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers2-pOffsets-parameter");
     vk::CmdBindVertexBuffers2(m_command_buffer.handle(), 0, 1, &buffer.handle(), nullptr, &size, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
@@ -4992,7 +4993,7 @@ TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
     GetPhysicalDeviceProperties2(blend_advanced_props);
     uint32_t attachment_count = blend_advanced_props.advancedBlendMaxColorAttachments + 1;
 
-    if (attachment_count > m_device->phy().limits_.maxColorAttachments) {
+    if (attachment_count > m_device->Physical().limits_.maxColorAttachments) {
         GTEST_SKIP() << "advancedBlendMaxColorAttachments is equal to maxColorAttachments";
     }
 
@@ -5033,7 +5034,7 @@ TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
     rendering_info.colorAttachmentCount = attachment_count;
     rendering_info.pColorAttachments = rendering_attachment_info.data();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -5055,7 +5056,7 @@ TEST_F(NegativeDynamicState, AdvancedBlendMaxAttachments) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
@@ -5069,7 +5070,7 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
 
     VkFormat format = VK_FORMAT_R32G32B32A32_SINT;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) == 0 ||
         (format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) != 0) {
         GTEST_SKIP() << "Required foramt features not available";
@@ -5092,7 +5093,7 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle());
     VkBool32 enable = VK_TRUE;
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0u, 1u, &enable);
@@ -5101,7 +5102,7 @@ TEST_F(NegativeDynamicState, MissingColorAttachmentBlendBit) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SampleLocationsSamplesMismatch) {
@@ -5126,7 +5127,7 @@ TEST_F(NegativeDynamicState, SampleLocationsSamplesMismatch) {
     sapmle_locations_info.sampleLocationsCount = 2u;
     sapmle_locations_info.pSampleLocations = sample_locations;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdSetSampleLocationsEXT(m_command_buffer.handle(), &sapmle_locations_info);
@@ -5135,7 +5136,7 @@ TEST_F(NegativeDynamicState, SampleLocationsSamplesMismatch) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch) {
@@ -5161,7 +5162,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch)
     sapmle_locations_info.sampleLocationsCount = 2u;
     sapmle_locations_info.pSampleLocations = sample_locations;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetSampleLocationsEXT(m_command_buffer.handle(), &sapmle_locations_info);
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -5171,7 +5172,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch)
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DynamicRasterizationSamples) {
@@ -5202,7 +5203,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamples) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32, 32);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -5212,7 +5213,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamples) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SampleLocationsEnable) {
@@ -5231,7 +5232,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     }
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
-    vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
+    vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     // 1 from VK_SAMPLE_COUNT_1_BIT
     const uint32_t valid_count =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height * 1;
@@ -5278,7 +5279,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     sample_location_state.sampleLocationsInfo.sampleLocationsPerPixel = VK_SAMPLE_COUNT_2_BIT;
 
     VkMultisamplePropertiesEXT multisample_prop2 = vku::InitStructHelper();
-    vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_2_BIT, &multisample_prop2);
+    vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_2_BIT, &multisample_prop2);
     // 2 from VK_SAMPLE_COUNT_2_BIT
     const uint32_t valid_count2 =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height * 2;
@@ -5291,7 +5292,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     pipe3.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe3.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe1.Handle());
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT);
@@ -5311,7 +5312,7 @@ TEST_F(NegativeDynamicState, SampleLocationsEnable) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
@@ -5322,7 +5323,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3RasterizationSamples);
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }
@@ -5371,7 +5372,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
     VkClearValue clear_value;
     clear_value.color = {{0, 0, 0, 0}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     vk::CmdSetSampleMaskEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT, &sample_mask);
 
@@ -5392,7 +5393,7 @@ TEST_F(NegativeDynamicState, InvalidSampleMaskSamples) {
 
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, InvalidConservativeRasterizationMode) {
@@ -5420,7 +5421,7 @@ TEST_F(NegativeDynamicState, InvalidConservativeRasterizationMode) {
     pipe.rs_state_ci_.pNext = &cs_info;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetConservativeRasterizationModeEXT(m_command_buffer.handle(), VK_CONSERVATIVE_RASTERIZATION_MODE_UNDERESTIMATE_EXT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -5428,7 +5429,7 @@ TEST_F(NegativeDynamicState, InvalidConservativeRasterizationMode) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
@@ -5445,7 +5446,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
         GTEST_SKIP() << "variableSampleLocations not supported";
     }
 
-    VkFormat format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image image(*m_device, 32u, 32u, 1u, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -5477,7 +5478,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     sample_locations_info.sampleLocationsCount = 1;
     sample_locations_info.pSampleLocations = &sample_location;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdSetSampleLocationsEXT(m_command_buffer.handle(), &sample_locations_info);
@@ -5486,7 +5487,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsEnable) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DynamicSampleLocationsGridSize) {
@@ -5506,7 +5507,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsGridSize) {
     }
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
-    vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
+    vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     // 1 from VK_SAMPLE_COUNT_1_BIT
     const uint32_t valid_count =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height * 1;
@@ -5529,7 +5530,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsGridSize) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT);
@@ -5554,7 +5555,7 @@ TEST_F(NegativeDynamicState, DynamicSampleLocationsGridSize) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, InterpolateAtSample) {
@@ -5598,7 +5599,7 @@ TEST_F(NegativeDynamicState, InterpolateAtSample) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -5606,7 +5607,7 @@ TEST_F(NegativeDynamicState, InterpolateAtSample) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
@@ -5644,7 +5645,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
                                                image_ci.flags, &image_format_properties);
     if ((image_format_properties.sampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required sample count not supported";
@@ -5676,7 +5677,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
     rendering_info.colorAttachmentCount = 1u;
     rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT);
@@ -5684,7 +5685,7 @@ TEST_F(NegativeDynamicState, DynamicRasterizationSamplesWithMSRTSS) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
@@ -5712,7 +5713,7 @@ TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_STREAM_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), pg_query_pool.handle(), 0u, 0u);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -5722,7 +5723,7 @@ TEST_F(NegativeDynamicState, PGQNonZeroRasterizationStreams) {
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
     vk::CmdEndQuery(m_command_buffer.handle(), pg_query_pool.handle(), 0u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, MissingScissorWithCount) {
@@ -5743,7 +5744,7 @@ TEST_F(NegativeDynamicState, MissingScissorWithCount) {
     const VkViewport viewport = {0, 0, 32.0f, 32.0f, 0.0f, 1.0f};
     const VkRect2D scissor = {{0, 0}, {32u, 32u}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetViewport(m_command_buffer.handle(), 0u, 1u, &viewport);
     vk::CmdSetScissor(m_command_buffer.handle(), 0u, 1u, &scissor);
@@ -5753,7 +5754,7 @@ TEST_F(NegativeDynamicState, MissingScissorWithCount) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RebindSamePipeline) {
@@ -5786,7 +5787,7 @@ TEST_F(NegativeDynamicState, RebindSamePipeline) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
@@ -5794,7 +5795,7 @@ TEST_F(NegativeDynamicState, RebindSamePipeline) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendEnableNotSet) {
@@ -5818,14 +5819,14 @@ TEST_F(NegativeDynamicState, ColorBlendEnableNotSet) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07627");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendEquationNotSet) {
@@ -5849,14 +5850,14 @@ TEST_F(NegativeDynamicState, ColorBlendEquationNotSet) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07628");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorWriteMaskNotSet) {
@@ -5880,14 +5881,14 @@ TEST_F(NegativeDynamicState, ColorWriteMaskNotSet) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07629");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, ColorBlendAdvancedNotSet) {
@@ -5911,14 +5912,14 @@ TEST_F(NegativeDynamicState, ColorBlendAdvancedNotSet) {
     pipe.gp_ci_.renderPass = render_pass.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32u, 32u);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-07635");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetColorBlendEnableArrayLength) {
@@ -5927,12 +5928,12 @@ TEST_F(NegativeDynamicState, SetColorBlendEnableArrayLength) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorBlendEnable);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBool32 color_blend_enable = VK_TRUE;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetColorBlendEnableEXT-attachmentCount-arraylength");
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0, 0, &color_blend_enable);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, SetColorBlendWriteMaskArrayLength) {
@@ -5941,12 +5942,12 @@ TEST_F(NegativeDynamicState, SetColorBlendWriteMaskArrayLength) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorWriteMask);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkColorComponentFlags write_mask = VK_COLOR_COMPONENT_R_BIT;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetColorWriteMaskEXT-attachmentCount-arraylength");
     vk::CmdSetColorWriteMaskEXT(m_command_buffer.handle(), 0, 0, &write_mask);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, RasterizationSamplesDynamicRendering) {
@@ -5997,7 +5998,7 @@ TEST_F(NegativeDynamicState, RasterizationSamplesDynamicRendering) {
     rendering_info.colorAttachmentCount = 1u;
     rendering_info.pColorAttachments = &colorAttachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_2_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -6006,7 +6007,7 @@ TEST_F(NegativeDynamicState, RasterizationSamplesDynamicRendering) {
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DrawNotSetDepthCompareOp) {
@@ -6023,7 +6024,7 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthCompareOp) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetRasterizerDiscardEnableEXT(m_command_buffer.handle(), VK_FALSE);
     vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -6048,7 +6049,7 @@ TEST_F(NegativeDynamicState, DrawNotSetDepthCompareOp) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DepthClampControl) {
@@ -6062,14 +6063,14 @@ TEST_F(NegativeDynamicState, DepthClampControl) {
     pipe.rs_state_ci_.depthClampEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-09650");
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeDynamicState, DepthClampControlNullStruct) {
@@ -6078,11 +6079,11 @@ TEST_F(NegativeDynamicState, DepthClampControlNullStruct) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetDepthClampRangeEXT-pDepthClampRange-09647");
     vk::CmdSetDepthClampRangeEXT(m_command_buffer.handle(), VK_DEPTH_CLAMP_MODE_USER_DEFINED_RANGE_EXT, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/dynamic_state_positive.cpp
+++ b/tests/unit/dynamic_state_positive.cpp
@@ -37,12 +37,12 @@ TEST_F(PositiveDynamicState, DiscardRectanglesVersion) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DISCARD_RECTANGLE_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDiscardRectangleEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, ViewportWithCountNoMultiViewport) {
@@ -100,14 +100,14 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXT) {
     vkt::Buffer vtx_buf(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &vtx_buf.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, 1, &attribute);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, CmdSetVertexInputEXTStride) {
@@ -153,14 +153,14 @@ TEST_F(PositiveDynamicState, CmdSetVertexInputEXTStride) {
     vkt::Buffer vtx_buf(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &vtx_buf.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, 1, &attribute);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, ExtendedDynamicStateBindVertexBuffersMaintenance5) {
@@ -172,12 +172,12 @@ TEST_F(PositiveDynamicState, ExtendedDynamicStateBindVertexBuffersMaintenance5) 
     AddRequiredFeature(vkt::Feature::extendedDynamicState);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize size = VK_WHOLE_SIZE;
     VkDeviceSize offset = 0;
     vk::CmdBindVertexBuffers2EXT(m_command_buffer.handle(), 0, 1, &buffer.handle(), &offset, &size, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DiscardRectanglesWithDynamicState) {
@@ -197,12 +197,12 @@ TEST_F(PositiveDynamicState, DiscardRectanglesWithDynamicState) {
     CreatePipelineHelper pipe(*this, &discard_rect_ci);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
@@ -219,7 +219,7 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     }
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -260,7 +260,7 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     ASSERT_EQ(VK_SUCCESS, pipe.CreateGraphicsPipeline());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_renderPassBeginInfo.renderPass = rp.handle();
     m_renderPassBeginInfo.framebuffer = fb.handle();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -271,7 +271,7 @@ TEST_F(PositiveDynamicState, DynamicColorWriteNoColorAttachments) {
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
@@ -280,7 +280,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     vkt::Image color_image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto color_view = color_image.CreateView();
 
-    VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image ds_image(*m_device, m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     auto ds_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -305,7 +305,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
     pipe.ds_ci_ = ds_state;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
@@ -313,7 +313,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesPipelineDepthWriteEnable) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
@@ -323,7 +323,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     vkt::Image color_image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto color_view = color_image.CreateView();
 
-    VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image ds_image(*m_device, m_width, m_height, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     auto ds_view = ds_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -347,7 +347,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
     pipe.ds_ci_ = ds_state;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
@@ -356,7 +356,7 @@ TEST_F(PositiveDynamicState, DepthTestEnableOverridesDynamicDepthWriteEnable) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, SetBeforePipeline) {
@@ -373,7 +373,7 @@ TEST_F(PositiveDynamicState, SetBeforePipeline) {
     pipe_blend.AddDynamicState(VK_DYNAMIC_STATE_BLEND_CONSTANTS);
     pipe_blend.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetLineWidth(m_command_buffer.handle(), 1.0f);
     float blends[4] = {1.0f, 1.0f, 1.0f, 1.0f};
@@ -385,7 +385,7 @@ TEST_F(PositiveDynamicState, SetBeforePipeline) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
@@ -404,7 +404,7 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetAttachmentFeedbackLoopEnableEXT(m_command_buffer.handle(), VK_IMAGE_ASPECT_COLOR_BIT);
 
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -412,7 +412,7 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnable) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
@@ -449,7 +449,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
 
@@ -465,7 +465,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampEnabled) {
                 0);  // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
@@ -501,7 +501,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
 
@@ -517,7 +517,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasClampDisabled) {
                 0);  // Without correct state tracking, VUID-vkCmdDraw-None-07834 would be thrown here
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentationInfo) {
@@ -562,7 +562,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     raster_state.depthBiasEnable = VK_TRUE;
     pipe.rs_state_ci_ = raster_state;
     pipe.CreateGraphicsPipeline();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
 
@@ -590,7 +590,7 @@ TEST_F(PositiveDynamicState, SetDepthBias2EXTDepthBiasWithDepthBiasRepresentatio
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
@@ -619,13 +619,13 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetFalse) {
     pipe.ms_ci_ = ms_state_ci;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetAlphaToCoverageEnableEXT(m_command_buffer.handle(), VK_FALSE);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, AlphaToCoverageSetTrue) {
@@ -639,13 +639,13 @@ TEST_F(PositiveDynamicState, AlphaToCoverageSetTrue) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetAlphaToCoverageEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, MultisampleStateIgnored) {
@@ -775,7 +775,7 @@ TEST_F(PositiveDynamicState, DepthBoundsTestEnableState) {
     RETURN_IF_SKIP(Init());
 
     // Need to set format framework uses for InitRenderTarget
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -790,14 +790,14 @@ TEST_F(PositiveDynamicState, DepthBoundsTestEnableState) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDepthBoundsTestEnableEXT(m_command_buffer.handle(), VK_FALSE);
     // don't need vkCmdSetDepthBounds since test is disabled now
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, ViewportInheritance) {
@@ -832,22 +832,22 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     auto hinfo = vku::InitStruct<VkCommandBufferInheritanceInfo>(&viewport_scissor_inheritance);
     hinfo.renderPass = m_renderPass;
     hinfo.subpass = 0;
-    hinfo.framebuffer = framebuffer();
+    hinfo.framebuffer = Framebuffer();
 
     auto info = vku::InitStruct<VkCommandBufferBeginInfo>();
     info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     info.pInheritanceInfo = &hinfo;
 
-    cmd_buffer.begin(&info);
+    cmd_buffer.Begin(&info);
     vk::CmdBindPipeline(cmd_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(cmd_buffer.handle(), 3, 1, 0, 0);
-    cmd_buffer.end();
+    cmd_buffer.End();
 
-    set_state.begin();
+    set_state.Begin();
     vk::CmdSetViewport(set_state.handle(), 1u, 1u, &viewports[1]);
-    set_state.end();
+    set_state.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetViewport(m_command_buffer.handle(), 0u, 2u, viewports);
     vk::CmdSetViewport(m_command_buffer.handle(), 0u, 1u, viewports);
     vk::CmdSetScissor(m_command_buffer.handle(), 0u, 2u, scissors);
@@ -856,7 +856,7 @@ TEST_F(PositiveDynamicState, ViewportInheritance) {
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &cmd_buffer.handle());
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -878,9 +878,9 @@ TEST_F(PositiveDynamicState, AttachmentFeedbackLoopEnableAspectMask) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_ATTACHMENT_FEEDBACK_LOOP_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetAttachmentFeedbackLoopEnableEXT(m_command_buffer.handle(), VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, RasterizationSamplesDynamicRendering) {
@@ -931,13 +931,13 @@ TEST_F(PositiveDynamicState, RasterizationSamplesDynamicRendering) {
     rendering_info.colorAttachmentCount = 1u;
     rendering_info.pColorAttachments = &colorAttachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_4_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, RasterizationSamples) {
@@ -979,13 +979,13 @@ TEST_F(PositiveDynamicState, RasterizationSamples) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32u, 32u);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_4_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, PrimitiveTopology) {
@@ -1005,14 +1005,14 @@ TEST_F(PositiveDynamicState, PrimitiveTopology) {
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_TRIANGLE_STRIP);
     vk::CmdSetPrimitiveRestartEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, VertexInputMultipleBindings) {
@@ -1094,14 +1094,14 @@ TEST_F(PositiveDynamicState, VertexInputMultipleBindings) {
     VkBuffer buffers[2] = {vertex_buffer.handle(), instance_buffer.handle()};
     VkDeviceSize offsets[2] = {0u, 0u};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 2, buffers, offsets);
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 2, bindings, 4, attributes);
     vk::CmdDraw(m_command_buffer.handle(), 3u, 3u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, ColorBlendEquationMultipleAttachments) {
@@ -1121,7 +1121,7 @@ TEST_F(PositiveDynamicState, ColorBlendEquationMultipleAttachments) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     const VkColorBlendEquationEXT equation = {VK_BLEND_FACTOR_SRC_COLOR, VK_BLEND_FACTOR_ONE_MINUS_SRC_COLOR, VK_BLEND_OP_ADD,
@@ -1131,7 +1131,7 @@ TEST_F(PositiveDynamicState, ColorBlendEquationMultipleAttachments) {
     vk::CmdSetColorBlendEquationEXT(m_command_buffer.handle(), 1, 1, &equation);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
@@ -1144,7 +1144,7 @@ TEST_F(PositiveDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorWriteMask);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -1171,7 +1171,7 @@ TEST_F(PositiveDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     VkColorBlendEquationEXT dual_color_blend_equation = {
@@ -1195,7 +1195,7 @@ TEST_F(PositiveDynamicState, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DynamicColorBlendEnable) {
@@ -1208,7 +1208,7 @@ TEST_F(PositiveDynamicState, DynamicColorBlendEnable) {
     InitDynamicRenderTarget();
 
     const VkFormat color_format = VK_FORMAT_B8G8R8A8_UNORM;
-    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -1259,7 +1259,7 @@ TEST_F(PositiveDynamicState, DynamicColorBlendEnable) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderingKHR(m_command_buffer.handle(), &rendering_info);
     VkBool32 color_blend_enables[] = {VK_TRUE, VK_TRUE, VK_TRUE};
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0u, 3u, color_blend_enables);
@@ -1275,7 +1275,7 @@ TEST_F(PositiveDynamicState, DynamicColorBlendEnable) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     vk::CmdEndRenderingKHR(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DynamicAdvancedBlendMaxAttachments) {
@@ -1329,7 +1329,7 @@ TEST_F(PositiveDynamicState, DynamicAdvancedBlendMaxAttachments) {
     rendering_info.colorAttachmentCount = attachment_count;
     rendering_info.pColorAttachments = rendering_attachment_info.data();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1349,7 +1349,7 @@ TEST_F(PositiveDynamicState, DynamicAdvancedBlendMaxAttachments) {
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch) {
@@ -1367,14 +1367,14 @@ TEST_F(PositiveDynamicState, DynamicSampleLocationsRasterizationSamplesMismatch)
     pipe.AddDynamicState(VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_FALSE);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_1_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveDynamicState, DepthClampControl) {
@@ -1387,7 +1387,7 @@ TEST_F(PositiveDynamicState, DepthClampControl) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_DEPTH_CLAMP_RANGE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDepthClampRangeEXT clamp_range = {0.0f, 1.0f};
@@ -1396,5 +1396,5 @@ TEST_F(PositiveDynamicState, DepthClampControl) {
     vk::CmdSetDepthClampRangeEXT(m_command_buffer.handle(), VK_DEPTH_CLAMP_MODE_VIEWPORT_RANGE_EXT, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/external_memory_sync.cpp
+++ b/tests/unit/external_memory_sync.cpp
@@ -45,7 +45,7 @@ TEST_F(NegativeExternalMemorySync, CreateBufferIncompatibleHandleTypes) {
             external_buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
             external_buffer_info.handleType = flag;
             VkExternalBufferProperties external_buffer_properties = vku::InitStructHelper();
-            vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_buffer_info, &external_buffer_properties);
+            vk::GetPhysicalDeviceExternalBufferProperties(Gpu(), &external_buffer_info, &external_buffer_properties);
             const auto external_features = external_buffer_properties.externalMemoryProperties.externalMemoryFeatures;
             if (external_features & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT) {
                 supported_handle_types |= external_buffer_info.handleType;
@@ -101,7 +101,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypes) {
             external_image_info.handleType = flag;
             VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
             VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
-            VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+            VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
             const auto external_features = external_image_properties.externalMemoryProperties.externalMemoryFeatures;
             if (result == VK_SUCCESS && (external_features & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
                 supported_handle_types |= external_image_info.handleType;
@@ -144,7 +144,7 @@ TEST_F(NegativeExternalMemorySync, CreateImageIncompatibleHandleTypesNV) {
         AllVkExternalMemoryHandleTypeFlagBitsNV, [&](VkExternalMemoryHandleTypeFlagBitsNV flag) {
             VkExternalImageFormatPropertiesNV external_image_properties = {};
             VkResult result = vk::GetPhysicalDeviceExternalImageFormatPropertiesNV(
-                gpu(), image_create_info.format, image_create_info.imageType, image_create_info.tiling, image_create_info.usage,
+                Gpu(), image_create_info.format, image_create_info.imageType, image_create_info.tiling, image_create_info.usage,
                 image_create_info.flags, flag, &external_image_properties);
             if (result == VK_SUCCESS &&
                 (external_image_properties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV)) {
@@ -179,7 +179,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto exportable_types = FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+    auto exportable_types = FindSupportedExternalMemoryHandleTypes(Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (GetBitSetCount(exportable_types) < 2) {
         GTEST_SKIP() << "Cannot find two distinct exportable handle types, skipping test";
     }
@@ -195,7 +195,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     // Create export memory with a different handle type
     VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.image = image;
-    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(gpu(), image_info, handle_type2);
+    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(Gpu(), image_info, handle_type2);
     auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
     export_memory_info.handleTypes = handle_type2;
 
@@ -207,7 +207,7 @@ TEST_F(NegativeExternalMemorySync, ExportImageHandleType) {
     // vkBindImageMemory2
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper();
     bind_image_info.image = image.handle();
-    bind_image_info.memory = image.memory();  // re-use memory object from the previous check
+    bind_image_info.memory = image.Memory();  // re-use memory object from the previous check
     m_errorMonitor->SetDesiredError("VUID-VkBindImageMemoryInfo-memory-02728");
     vk::BindImageMemory2(device(), 1, &bind_image_info);
     m_errorMonitor->VerifyFound();
@@ -222,7 +222,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::CreateInfo(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
@@ -236,7 +236,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     // Check if dedicated allocation is required
     bool dedicated_allocation = false;
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(exportable_types, [&](VkExternalMemoryHandleTypeFlagBits handle_type) {
-        if (HandleTypeNeedsDedicatedAllocation(gpu(), buffer_info, handle_type)) {
+        if (HandleTypeNeedsDedicatedAllocation(Gpu(), buffer_info, handle_type)) {
             dedicated_allocation = true;
         }
     });
@@ -248,16 +248,16 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithUnsupportedHandleType) {
     auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
     export_memory_info.handleTypes = handle_type | not_supported_type;
 
-    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(),
+    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(),
                                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &export_memory_info);
-    VkResult result = buffer.memory().try_init(*m_device, alloc_info);
+    VkResult result = buffer.Memory().TryInit(*m_device, alloc_info);
     if (result != VK_SUCCESS) {
         GTEST_SKIP() << "vkAllocateMemory failed (probably due to unsupported handle type). Unable to reach vkBindBufferMemory to "
                         "run valdiation";
     }
 
     m_errorMonitor->SetDesiredError("VUID-VkExportMemoryAllocateInfo-handleTypes-00656");
-    buffer.BindMemory(buffer.memory(), 0);
+    buffer.BindMemory(buffer.Memory(), 0);
     m_errorMonitor->VerifyFound();
 }
 
@@ -270,12 +270,12 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::CreateInfo(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
     const auto handle_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(exportable_types);
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, handle_type);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), buffer_info, handle_type);
     if ((exportable_types & compatible_types) == exportable_types) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -285,7 +285,7 @@ TEST_F(NegativeExternalMemorySync, BufferMemoryWithIncompatibleHandleTypes) {
     // Check if dedicated allocation is required
     bool dedicated_allocation = false;
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(exportable_types, [&](VkExternalMemoryHandleTypeFlagBits handle_type) {
-        if (HandleTypeNeedsDedicatedAllocation(gpu(), buffer_info, handle_type)) {
+        if (HandleTypeNeedsDedicatedAllocation(Gpu(), buffer_info, handle_type)) {
             dedicated_allocation = true;
         }
     });
@@ -318,7 +318,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto exportable_types = FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+    auto exportable_types = FindSupportedExternalMemoryHandleTypes(Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     // This test does not support the AHB handle type, which does not
     // allow to query memory requirements before memory is bound
     exportable_types &= ~VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
@@ -338,7 +338,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithUnsupportedHandleType) {
     const auto not_supported_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(~exportable_types);
     VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.image = image;
-    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(gpu(), image_info, handle_type);
+    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(Gpu(), image_info, handle_type);
     auto export_memory_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
     export_memory_info.handleTypes = handle_type | not_supported_type;
 
@@ -366,7 +366,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
     image_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    auto exportable_types = FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+    auto exportable_types = FindSupportedExternalMemoryHandleTypes(Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     // This test does not support the AHB handle type, which does not
     // allow to query memory requirements before memory is bound
     exportable_types &= ~VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
@@ -374,7 +374,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
     const auto handle_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(exportable_types);
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), image_info, handle_type);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), image_info, handle_type);
     if ((exportable_types & compatible_types) == exportable_types) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -384,7 +384,7 @@ TEST_F(NegativeExternalMemorySync, ImageMemoryWithIncompatibleHandleTypes) {
 
     bool dedicated_allocation = false;
     IterateFlags<VkExternalMemoryHandleTypeFlagBits>(exportable_types, [&](VkExternalMemoryHandleTypeFlagBits handle_type) {
-        if (HandleTypeNeedsDedicatedAllocation(gpu(), image_info, handle_type)) {
+        if (HandleTypeNeedsDedicatedAllocation(Gpu(), image_info, handle_type)) {
             dedicated_allocation = true;
         }
     });
@@ -412,7 +412,7 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     buffer_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
     buffer_info.size = 4096;
 
-    auto exportable_types = FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+    auto exportable_types = FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (GetBitSetCount(exportable_types) < 2) {
         GTEST_SKIP() << "Cannot find two distinct exportable handle types, skipping test";
     }
@@ -426,7 +426,7 @@ TEST_F(NegativeExternalMemorySync, ExportBufferHandleType) {
     vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
 
     // Check if dedicated allocation is required
-    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(gpu(), buffer_info, handle_type2);
+    const bool dedicated_allocation = HandleTypeNeedsDedicatedAllocation(Gpu(), buffer_info, handle_type2);
     VkMemoryDedicatedAllocateInfo dedicated_info = vku::InitStructHelper();
     dedicated_info.buffer = buffer;
 
@@ -479,7 +479,7 @@ TEST_F(NegativeExternalMemorySync, TimelineSemaphore) {
 
         VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
-        vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+        vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
         if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
             !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -531,7 +531,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphore) {
 
     VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -602,14 +602,14 @@ TEST_F(NegativeExternalMemorySync, SyncFdExportFromImportedSemaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT;
     {
         const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(
-            gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT);
+            Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT);
         if ((handle_types & handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_SYNC_FD_BIT is not both exportable and importable";
         }
     }
     const auto export_from_import_handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
     {
-        const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
+        const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
         if ((handle_types & export_from_import_handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT is not exportable";
         }
@@ -617,7 +617,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdExportFromImportedSemaphore) {
     VkPhysicalDeviceExternalSemaphoreInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.handleType = export_from_import_handle_type;
     VkExternalSemaphoreProperties semaphore_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu(), &semaphore_info, &semaphore_properties);
+    vk::GetPhysicalDeviceExternalSemaphoreProperties(Gpu(), &semaphore_info, &semaphore_properties);
     if ((handle_type & semaphore_properties.exportFromImportedHandleTypes) != 0) {
         GTEST_SKIP() << "cannot find handle type that does not support export from imported semaphore";
     }
@@ -662,14 +662,14 @@ TEST_F(NegativeExternalMemorySync, SyncFdExportFromImportedFence) {
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT;
     {
         const auto handle_types = FindSupportedExternalFenceHandleTypes(
-            gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT);
+            Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT);
         if ((handle_types & handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_SYNC_FD_BIT is not both exportable and importable";
         }
     }
     const auto export_from_import_handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT;
     {
-        const auto handle_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
+        const auto handle_types = FindSupportedExternalFenceHandleTypes(Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
         if ((handle_types & export_from_import_handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_FD_BIT is not exportable";
         }
@@ -677,7 +677,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdExportFromImportedFence) {
     VkPhysicalDeviceExternalFenceInfo fence_info = vku::InitStructHelper();
     fence_info.handleType = export_from_import_handle_type;
     VkExternalFenceProperties fence_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFenceProperties(gpu(), &fence_info, &fence_properties);
+    vk::GetPhysicalDeviceExternalFenceProperties(Gpu(), &fence_info, &fence_properties);
     if ((handle_type & fence_properties.exportFromImportedHandleTypes) != 0) {
         GTEST_SKIP() << "cannot find handle type that does not support export from imported fence";
     }
@@ -722,7 +722,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdSemaphoreType) {
     external_semahpore_info.handleType = handle_type;
 
     VkExternalSemaphoreProperties external_semahpore_props = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu(), &external_semahpore_info, &external_semahpore_props);
+    vk::GetPhysicalDeviceExternalSemaphoreProperties(Gpu(), &external_semahpore_info, &external_semahpore_props);
     if (!(external_semahpore_props.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(external_semahpore_props.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
         GTEST_SKIP() << "External semaphore does not support importing and exporting";
@@ -774,7 +774,7 @@ TEST_F(NegativeExternalMemorySync, TemporaryFence) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -842,7 +842,7 @@ TEST_F(NegativeExternalMemorySync, Fence) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -915,7 +915,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdFence) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -950,7 +950,7 @@ TEST_F(NegativeExternalMemorySync, SyncFdFence) {
 
     import_fence.ImportHandle(fd_handle, handle_type, VK_FENCE_IMPORT_TEMPORARY_BIT);
 
-    import_fence.wait(1000000000);
+    import_fence.Wait(1000000000);
 }
 
 TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
@@ -973,7 +973,7 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
 
     VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -1013,7 +1013,7 @@ TEST_F(NegativeExternalMemorySync, TemporarySemaphore) {
     m_errorMonitor->VerifyFound();
 
     auto index = m_device->graphics_queue_node_index_;
-    if (m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
+    if (m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
         // Wait on the imported semaphore twice in vk::QueueBindSparse, the second wait should be an error
         std::vector<VkBindSparseInfo> bi(4, vku::InitStruct<VkBindSparseInfo>());
         bi[0].signalSemaphoreCount = 1;
@@ -1064,7 +1064,7 @@ TEST_F(NegativeExternalMemorySync, Semaphore) {
 
     VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -1127,7 +1127,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     ebi.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
 
     VkExternalBufferPropertiesKHR ebp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &ebi, &ebp);
+    vk::GetPhysicalDeviceExternalBufferProperties(Gpu(), &ebi, &ebp);
     if (!(ebp.externalMemoryProperties.compatibleHandleTypes & handle_type) ||
         !(ebp.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(ebp.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -1148,10 +1148,10 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     auto buffer_info = vkt::Buffer::CreateInfo(buffer_size, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     buffer_info.pNext = &external_buffer_info;
     vkt::Buffer buffer_export(*m_device, buffer_info, vkt::no_mem);
-    const VkMemoryRequirements buffer_export_reqs = buffer_export.memory_requirements();
+    const VkMemoryRequirements buffer_export_reqs = buffer_export.MemoryRequirements();
 
     auto importable_buffer_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
     importable_buffer_types &= ~handle_type;  // we need to find a flag that is different from handle_type
     if (importable_buffer_types == 0) GTEST_SKIP() << "Cannot find two different buffer handle types, skipping test";
     auto wrong_buffer_handle_type =
@@ -1159,7 +1159,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     external_buffer_info.handleTypes = wrong_buffer_handle_type;
 
     vkt::Buffer buffer_import(*m_device, buffer_info, vkt::no_mem);
-    const VkMemoryRequirements buffer_import_reqs = buffer_import.memory_requirements();
+    const VkMemoryRequirements buffer_import_reqs = buffer_import.MemoryRequirements();
     assert(buffer_import_reqs.memoryTypeBits != 0);  // according to spec at least one bit is set
     if ((buffer_import_reqs.memoryTypeBits & buffer_export_reqs.memoryTypeBits) == 0) {
         // required by VU 01743
@@ -1205,7 +1205,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 
     vkt::Image image_export(*m_device, image_info, vkt::no_mem);
 
-    const bool image_dedicated_allocation = HandleTypeNeedsDedicatedAllocation(gpu(), image_info, handle_type);
+    const bool image_dedicated_allocation = HandleTypeNeedsDedicatedAllocation(Gpu(), image_info, handle_type);
     VkMemoryDedicatedAllocateInfo image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image_export;
 
@@ -1215,7 +1215,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     image_export.AllocateAndBindMemory(*m_device, mem_flags, &export_memory_info);
 
     auto importable_image_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
     importable_image_types &= ~handle_type;  // we need to find a flag that is different from handle_type
     if (importable_image_types == 0) {
         GTEST_SKIP() << "Cannot find two different image handle types";
@@ -1233,7 +1233,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     VkMemoryGetWin32HandleInfoKHR mghi_buffer = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
                                                  memory_buffer_export.handle(), handle_type};
     VkMemoryGetWin32HandleInfoKHR mghi_image = {VK_STRUCTURE_TYPE_MEMORY_GET_WIN32_HANDLE_INFO_KHR, nullptr,
-                                                image_export.memory().handle(), handle_type};
+                                                image_export.Memory().handle(), handle_type};
     HANDLE handle_buffer;
     HANDLE handle_image;
     ASSERT_EQ(VK_SUCCESS, vk::GetMemoryWin32HandleKHR(device(), &mghi_buffer, &handle_buffer));
@@ -1251,7 +1251,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
 
     VkMemoryGetFdInfoKHR mgfi_image = vku::InitStructHelper();
     mgfi_image.handleType = handle_type;
-    mgfi_image.memory = image_export.memory().handle();
+    mgfi_image.memory = image_export.Memory().handle();
 
     int fd_buffer;
     int fd_image;
@@ -1277,14 +1277,14 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHandleType) {
     memory_buffer_import.init(*m_device, alloc_info);
     ASSERT_TRUE(memory_buffer_import.initialized());
 
-    VkMemoryRequirements image_import_reqs = image_import.memory_requirements();
+    VkMemoryRequirements image_import_reqs = image_import.MemoryRequirements();
     if (image_import_reqs.memoryTypeBits == 0) {
         GTEST_SKIP() << "no suitable memory found, skipping test";
     }
     alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image_import_reqs, mem_flags);
     alloc_info.pNext = &import_info_image;
     if constexpr (handle_type == VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT_KHR) {
-        alloc_info.allocationSize = image_export.memory_requirements().size;
+        alloc_info.allocationSize = image_export.MemoryRequirements().size;
     }
     vkt::DeviceMemory memory_image_import;
     memory_image_import.init(*m_device, alloc_info);
@@ -1327,7 +1327,7 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithUnsupportedHandleType) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    const auto exportable_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
+    const auto exportable_types = FindSupportedExternalFenceHandleTypes(Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
@@ -1352,12 +1352,12 @@ TEST_F(NegativeExternalMemorySync, FenceExportWithIncompatibleHandleType) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    const auto exportable_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
+    const auto exportable_types = FindSupportedExternalFenceHandleTypes(Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
     const auto handle_type = LeastSignificantFlag<VkExternalFenceHandleTypeFlagBits>(exportable_types);
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), handle_type);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), handle_type);
     if ((exportable_types & compatible_types) == exportable_types) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -1379,7 +1379,7 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithUnsupportedHandleType) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
+    const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
@@ -1404,12 +1404,12 @@ TEST_F(NegativeExternalMemorySync, SemaphoreExportWithIncompatibleHandleType) {
     RETURN_IF_SKIP(Init());
     IgnoreHandleTypeError(m_errorMonitor);
 
-    const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
+    const auto exportable_types = FindSupportedExternalSemaphoreHandleTypes(Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
     if (!exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
     const auto handle_type = LeastSignificantFlag<VkExternalSemaphoreHandleTypeFlagBits>(exportable_types);
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), handle_type);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), handle_type);
     if ((exportable_types & compatible_types) == exportable_types) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -1447,8 +1447,8 @@ TEST_F(NegativeExternalMemorySync, MemoryAndMemoryNV) {
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     const auto supported_types_nv =
-        FindSupportedExternalMemoryHandleTypesNV(gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV);
-    const auto supported_types = FindSupportedExternalMemoryHandleTypes(gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypesNV(Gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV);
+    const auto supported_types = FindSupportedExternalMemoryHandleTypes(Gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!supported_types_nv || !supported_types) {
         GTEST_SKIP() << "Cannot find one regular handle type and one nvidia extension's handle type";
     }
@@ -1477,7 +1477,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     ici.tiling = VK_IMAGE_TILING_OPTIMAL;
     ici.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
-    const auto supported_types = FindSupportedExternalMemoryHandleTypes(gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+    const auto supported_types = FindSupportedExternalMemoryHandleTypes(Gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (supported_types) {
         external_mem.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(supported_types);
         CreateImageTest(*this, &ici, "VUID-VkImageCreateInfo-pNext-01443");
@@ -1485,7 +1485,7 @@ TEST_F(NegativeExternalMemorySync, MemoryImageLayout) {
     if (IsExtensionsEnabled(VK_NV_EXTERNAL_MEMORY_EXTENSION_NAME)) {
         VkExternalMemoryImageCreateInfoNV external_mem_nv = vku::InitStructHelper();
         const auto supported_types_nv =
-            FindSupportedExternalMemoryHandleTypesNV(gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV);
+            FindSupportedExternalMemoryHandleTypesNV(Gpu(), ici, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_NV);
         if (supported_types_nv) {
             external_mem_nv.handleTypes = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBitsNV>(supported_types_nv);
             ici.pNext = &external_mem_nv;
@@ -1610,7 +1610,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
         external_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT;
         external_info.handleType = handle_type;
         VkExternalBufferProperties external_properties = vku::InitStructHelper();
-        vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_properties);
+        vk::GetPhysicalDeviceExternalBufferProperties(Gpu(), &external_info, &external_properties);
         external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
         if ((external_features & required_features) != required_features) {
             GTEST_SKIP() << "External buffer does not support both export and import, skipping test";
@@ -1623,7 +1623,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
         external_info.handleTypes = handle_type;
         auto create_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
         create_info.pNext = &external_info;
-        buffer.init_no_mem(*m_device, create_info);
+        buffer.InitNoMemory(*m_device, create_info);
     }
 
     vkt::DeviceMemory memory;
@@ -1635,7 +1635,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromFdHandle) {
         dedicated_info.buffer = buffer;
         auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
         export_info.handleTypes = handle_type;
-        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &export_info);
+        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
         memory.init(*m_device, alloc_info);
         buffer.BindMemory(memory, 0);
         payload_size = alloc_info.allocationSize;
@@ -1770,7 +1770,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
         image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
         VkExternalImageFormatProperties external_properties = vku::InitStructHelper();
         VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_properties);
-        const VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+        const VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
         external_features = external_properties.externalMemoryProperties.externalMemoryFeatures;
         if (result != VK_SUCCESS || (external_features & required_features) != required_features) {
             GTEST_SKIP() << "External image does not support both export and import, skipping test";
@@ -1787,7 +1787,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
         create_info.format = VK_FORMAT_R8G8B8A8_UNORM;
         create_info.tiling = VK_IMAGE_TILING_OPTIMAL;
         create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-        image.init_no_mem(*m_device, create_info);
+        image.InitNoMemory(*m_device, create_info);
     }
 
     vkt::DeviceMemory memory;
@@ -1799,7 +1799,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFromWin32Handle) {
         dedicated_info.image = image;
         auto export_info = vku::InitStruct<VkExportMemoryAllocateInfo>(dedicated_allocation ? &dedicated_info : nullptr);
         export_info.handleTypes = handle_type;
-        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0, &export_info);
+        auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0, &export_info);
         memory.init(*m_device, alloc_info);
         image.BindMemory(memory, 0);
         payload_size = alloc_info.allocationSize;
@@ -1852,14 +1852,14 @@ TEST_F(NegativeExternalMemorySync, Win32ExportFromImportedSemaphore) {
     const auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     {
         const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(
-            gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT);
+            Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT);
         if ((handle_types & handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT is not both exportable and importable";
         }
     }
     const auto export_from_import_handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     {
-        const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
+        const auto handle_types = FindSupportedExternalSemaphoreHandleTypes(Gpu(), VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT);
         if ((handle_types & export_from_import_handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT is not exportable";
         }
@@ -1867,7 +1867,7 @@ TEST_F(NegativeExternalMemorySync, Win32ExportFromImportedSemaphore) {
     VkPhysicalDeviceExternalSemaphoreInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.handleType = export_from_import_handle_type;
     VkExternalSemaphoreProperties semaphore_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphoreProperties(gpu(), &semaphore_info, &semaphore_properties);
+    vk::GetPhysicalDeviceExternalSemaphoreProperties(Gpu(), &semaphore_info, &semaphore_properties);
     if ((handle_type & semaphore_properties.exportFromImportedHandleTypes) != 0) {
         GTEST_SKIP() << "cannot find handle type that does not support export from imported semaphore";
     }
@@ -1906,14 +1906,14 @@ TEST_F(NegativeExternalMemorySync, Win32ExportFromImportedFence) {
     const auto handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
     {
         const auto handle_types = FindSupportedExternalFenceHandleTypes(
-            gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT);
+            Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT);
         if ((handle_types & VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_BIT is not both exportable and importable";
         }
     }
     const auto export_from_import_handle_type = VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT;
     {
-        const auto handle_types = FindSupportedExternalFenceHandleTypes(gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
+        const auto handle_types = FindSupportedExternalFenceHandleTypes(Gpu(), VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT);
         if ((handle_types & export_from_import_handle_type) == 0) {
             GTEST_SKIP() << "VK_EXTERNAL_FENCE_HANDLE_TYPE_OPAQUE_WIN32_KMT_BIT is not exportable";
         }
@@ -1921,7 +1921,7 @@ TEST_F(NegativeExternalMemorySync, Win32ExportFromImportedFence) {
     VkPhysicalDeviceExternalFenceInfo fence_info = vku::InitStructHelper();
     fence_info.handleType = export_from_import_handle_type;
     VkExternalFenceProperties fence_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFenceProperties(gpu(), &fence_info, &fence_properties);
+    vk::GetPhysicalDeviceExternalFenceProperties(Gpu(), &fence_info, &fence_properties);
     if ((handle_type & fence_properties.exportFromImportedHandleTypes) != 0) {
         GTEST_SKIP() << "cannot find handle type that does not support export from imported fence";
     }
@@ -1960,7 +1960,7 @@ TEST_F(NegativeExternalMemorySync, BufferDedicatedAllocation) {
     VkExternalMemoryBufferCreateInfo external_buffer_info = vku::InitStructHelper();
     const auto buffer_info = vkt::Buffer::CreateInfo(4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
     const auto exportable_dedicated_types = FindSupportedExternalMemoryHandleTypes(
-        gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+        Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
     if (!exportable_dedicated_types) {
         GTEST_SKIP() << "Unable to find exportable handle type that requires dedicated allocation";
     }
@@ -1995,7 +1995,7 @@ TEST_F(NegativeExternalMemorySync, ImageDedicatedAllocation) {
     image_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     auto exportable_dedicated_types = FindSupportedExternalMemoryHandleTypes(
-        gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
+        Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_DEDICATED_ONLY_BIT);
     // This test does not support the AHB handle type, which does not
     // allow to query memory requirements before memory is bound
     exportable_dedicated_types &= ~VK_EXTERNAL_MEMORY_HANDLE_TYPE_ANDROID_HARDWARE_BUFFER_BIT_ANDROID;
@@ -2055,7 +2055,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32ImageNoDedicated) {
     auto image_info = vkt::Image::ImageCreateInfo2D(64, 64, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
 
     const auto handle_types = FindSupportedExternalMemoryHandleTypes(
-        gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
+        Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
     if ((handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT) == 0) {
         GTEST_SKIP() << "VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT is not both exportable and importable";
     }
@@ -2068,7 +2068,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32ImageNoDedicated) {
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0, &export_info);
+    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0, &export_info);
 
     vkt::DeviceMemory memory_export;
     memory_export.init(*m_device, alloc_info);
@@ -2088,7 +2088,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32ImageNoDedicated) {
     import_info.handle = handle;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryDedicatedAllocateInfo-image-01876");
-    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0, &import_info);
+    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 
@@ -2107,7 +2107,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
     const auto handle_types = FindSupportedExternalMemoryHandleTypes(
-        gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
+        Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT | VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT);
     if ((handle_types & VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT) == 0) {
         GTEST_SKIP() << "VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT is not both exportable and importable";
     }
@@ -2123,7 +2123,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper(&dedicated_info);
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &export_info);
+    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
     vkt::DeviceMemory memory_export;
     memory_export.init(*m_device, alloc_info);
@@ -2144,7 +2144,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferDifferentDedicated) {
     import_info.handle = handle;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01877");
-    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer2.memory_requirements(), 0, &import_info);
+    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer2.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 
@@ -2169,7 +2169,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryWin32BufferSupport) {
     external_info.usage = buffer_ci.usage;
     external_info.handleType = handle_type;
     VkExternalBufferProperties external_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &external_info, &external_properties);
+    vk::GetPhysicalDeviceExternalBufferProperties(Gpu(), &external_info, &external_properties);
 
     if ((external_properties.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT) != 0) {
         GTEST_SKIP() << "Need buffer with no import support";
@@ -2252,13 +2252,13 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
     external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find importable handle type";
     }
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
     if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -2267,7 +2267,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
-    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &export_info);
+    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
     vkt::DeviceMemory memory_export;
     memory_export.init(*m_device, alloc_info);
@@ -2291,7 +2291,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferNoDedicated) {
     import_info.fd = fd;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879");
-    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &import_info);
+    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2306,13 +2306,13 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     external_buffer_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
 
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT, nullptr, &external_buffer_info);
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find exportable handle type";
     }
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find importable handle type";
     }
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
     if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -2325,7 +2325,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
 
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper(&dedicated_info);
     export_info.handleTypes = VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT;
-    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &export_info);
+    auto alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &export_info);
 
     vkt::DeviceMemory memory_export;
     memory_export.init(*m_device, alloc_info);
@@ -2347,7 +2347,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferDifferentDedicated) {
     import_info.fd = fd;
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryDedicatedAllocateInfo-buffer-01879");
-    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer2.memory_requirements(), 0, &import_info);
+    alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer2.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2359,10 +2359,10 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBadFd) {
     IgnoreHandleTypeError(m_errorMonitor);
 
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find importable handle type";
     }
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
     if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -2375,7 +2375,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBadFd) {
 
     m_errorMonitor->SetDesiredError("VUID-VkImportMemoryFdInfoKHR-handleType-00670");
     VkMemoryAllocateInfo alloc_info =
-        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &import_info);
+        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2387,10 +2387,10 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
     IgnoreHandleTypeError(m_errorMonitor);
 
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    if (!FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (!FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Unable to find importable handle type";
     }
-    const auto compatible_types = GetCompatibleHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
+    const auto compatible_types = GetCompatibleHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT);
     if ((VK_EXTERNAL_MEMORY_HANDLE_TYPE_OPAQUE_FD_BIT & compatible_types) == 0) {
         GTEST_SKIP() << "Cannot find handle types that are supported but not compatible with each other";
     }
@@ -2403,7 +2403,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdHandleType) {
 
     m_errorMonitor->SetDesiredError("VUID-VkImportMemoryFdInfoKHR-handleType-00669");
     VkMemoryAllocateInfo alloc_info =
-        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &import_info);
+        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2417,7 +2417,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferSupport) {
 
     auto buffer_info = vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     buffer_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT;
-    if (FindSupportedExternalMemoryHandleTypes(gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Need buffer with no import support";
     }
 
@@ -2433,7 +2433,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdBufferSupport) {
 
     m_errorMonitor->SetDesiredError("VUID-VkImportMemoryFdInfoKHR-handleType-00667");
     VkMemoryAllocateInfo alloc_info =
-        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0, &import_info);
+        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2450,7 +2450,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdImageSupport) {
     image_info.format = VK_FORMAT_R8G8B8A8_UNORM;
     vkt::Image image(*m_device, image_info, vkt::no_mem);
 
-    if (FindSupportedExternalMemoryHandleTypes(gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
+    if (FindSupportedExternalMemoryHandleTypes(Gpu(), image_info, VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT)) {
         GTEST_SKIP() << "Need image with no import support";
     }
 
@@ -2464,7 +2464,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryFdImageSupport) {
 
     m_errorMonitor->SetDesiredError("VUID-VkImportMemoryFdInfoKHR-handleType-00667");
     VkMemoryAllocateInfo alloc_info =
-        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0, &import_info);
+        vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0, &import_info);
     vkt::DeviceMemory memory_import(*m_device, alloc_info);
     m_errorMonitor->VerifyFound();
 }
@@ -2552,7 +2552,7 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHostDedicated) {
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&import_info);
     alloc_info.allocationSize = alloc_size;
-    if (!m_device->phy().SetMemoryType(host_pointer_props.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
+    if (!m_device->Physical().SetMemoryType(host_pointer_props.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
         free(host_memory);
         GTEST_SKIP() << "Failed to set memory type.";
     }
@@ -2592,8 +2592,8 @@ TEST_F(NegativeExternalMemorySync, ImportMemoryHostMemoryIndex) {
     alloc_info.allocationSize = alloc_size;
 
     uint32_t unsupported_mem_type =
-        ((1 << m_device->phy().memory_properties_.memoryTypeCount) - 1) & ~host_pointer_props.memoryTypeBits;
-    bool found_type = m_device->phy().SetMemoryType(unsupported_mem_type, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+        ((1 << m_device->Physical().memory_properties_.memoryTypeCount) - 1) & ~host_pointer_props.memoryTypeBits;
+    bool found_type = m_device->Physical().SetMemoryType(unsupported_mem_type, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
     if (unsupported_mem_type == 0 || !found_type) {
         free(host_memory);
         GTEST_SKIP() << "Failed to find unsupported memory type.";
@@ -2847,7 +2847,7 @@ TEST_F(NegativeExternalMemorySync, ExportMetalObjects) {
     }
 
     const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    if (FormatIsSupported(gpu(), mp_format)) {
+    if (FormatIsSupported(Gpu(), mp_format)) {
         export_metal_object_create_info = vku::InitStructHelper();
         export_metal_object_create_info.exportObjectType = VK_EXPORT_METAL_OBJECT_TYPE_METAL_TEXTURE_BIT_EXT;
         ici.format = mp_format;

--- a/tests/unit/fragment_shading_rate.cpp
+++ b/tests/unit/fragment_shading_rate.cpp
@@ -35,7 +35,7 @@ TEST_F(NegativeFragmentShadingRate, Values) {
     VkFragmentShadingRateCombinerOpKHR combinerOps[2] = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
                                                          VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     fragmentSize.width = 0;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetFragmentShadingRateKHR-pFragmentSize-04513");
     vk::CmdSetFragmentShadingRateKHR(m_command_buffer.handle(), &fragmentSize, combinerOps);
@@ -71,7 +71,7 @@ TEST_F(NegativeFragmentShadingRate, Values) {
     vk::CmdSetFragmentShadingRateKHR(m_command_buffer.handle(), &fragmentSize, combinerOps);
     m_errorMonitor->VerifyFound();
     fragmentSize.height = 1;
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, ValuesNoFeatures) {
@@ -87,11 +87,11 @@ TEST_F(NegativeFragmentShadingRate, ValuesNoFeatures) {
     VkFragmentShadingRateCombinerOpKHR combinerOps[2] = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
                                                          VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetFragmentShadingRateKHR-pipelineFragmentShadingRate-04509");
     vk::CmdSetFragmentShadingRateKHR(m_command_buffer.handle(), &fragmentSize, combinerOps);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, CombinerOpsNoFeatures) {
@@ -116,7 +116,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsNoFeatures) {
     VkFragmentShadingRateCombinerOpKHR combinerOps[2] = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
                                                          VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     combinerOps[0] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_REPLACE_KHR;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetFragmentShadingRateKHR-primitiveFragmentShadingRate-04510");
@@ -130,7 +130,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsNoFeatures) {
     m_errorMonitor->VerifyFound();
     combinerOps[1] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, CombinerOpsNoPipelineRate) {
@@ -157,7 +157,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsNoPipelineRate) {
     VkFragmentShadingRateCombinerOpKHR combinerOps[2] = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR,
                                                          VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     fragmentSize.width = 2;
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetFragmentShadingRateKHR-pipelineFragmentShadingRate-04507");
     vk::CmdSetFragmentShadingRateKHR(m_command_buffer.handle(), &fragmentSize, combinerOps);
@@ -216,7 +216,7 @@ TEST_F(NegativeFragmentShadingRate, CombinerOpsLimit) {
         m_errorMonitor->VerifyFound();
         combinerOps[1] = VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR;
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewportLimitDynamic) {
@@ -264,7 +264,7 @@ TEST_F(NegativeFragmentShadingRate, PrimitiveFragmentShadingRateWriteMultiViewpo
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -376,7 +376,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapDuplicateReferences) {
     }
 
     // Fragment density map attachment idx referenced in multiple places
-    VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
     VkAttachmentDescription attachments[6] = {
         // 0th: color attachment
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_LOAD, VK_ATTACHMENT_STORE_OP_STORE,
@@ -846,7 +846,7 @@ TEST_F(NegativeFragmentShadingRate, DeviceFeatureCombinations) {
     GetPhysicalDeviceFeatures2(fsr_query_features);
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
-    const auto q_props = vkt::PhysicalDevice(gpu()).queue_properties_;
+    const auto q_props = vkt::PhysicalDevice(Gpu()).queue_properties_;
     ASSERT_TRUE(q_props.size() > 0);
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
@@ -876,21 +876,21 @@ TEST_F(NegativeFragmentShadingRate, DeviceFeatureCombinations) {
         if (fsr_query_features.pipelineFragmentShadingRate) {
             fsr_features.pipelineFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-shadingRateImage-04478");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.pipelineFragmentShadingRate = false;
         }
         if (fsr_query_features.primitiveFragmentShadingRate) {
             fsr_features.primitiveFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-shadingRateImage-04479");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.primitiveFragmentShadingRate = false;
         }
         if (fsr_query_features.attachmentFragmentShadingRate) {
             fsr_features.attachmentFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-shadingRateImage-04480");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.attachmentFragmentShadingRate = false;
         }
@@ -903,21 +903,21 @@ TEST_F(NegativeFragmentShadingRate, DeviceFeatureCombinations) {
         if (fsr_query_features.pipelineFragmentShadingRate) {
             fsr_features.pipelineFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-fragmentDensityMap-04481");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.pipelineFragmentShadingRate = false;
         }
         if (fsr_query_features.primitiveFragmentShadingRate) {
             fsr_features.primitiveFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-fragmentDensityMap-04482");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.primitiveFragmentShadingRate = false;
         }
         if (fsr_query_features.attachmentFragmentShadingRate) {
             fsr_features.attachmentFragmentShadingRate = true;
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-fragmentDensityMap-04483");
-            vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+            vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
             m_errorMonitor->VerifyFound();
             fsr_features.attachmentFragmentShadingRate = false;
         }
@@ -1091,7 +1091,7 @@ TEST_F(NegativeFragmentShadingRate, Attachments) {
     m_errorMonitor->VerifyFound();
     rpci.flags = 0;
     attach_desc.format =
-        FindFormatWithoutFeatures(gpu(), VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+        FindFormatWithoutFeatures(Gpu(), VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     if (attach_desc.format != VK_FORMAT_UNDEFINED) {
         m_errorMonitor->SetDesiredError("VUID-VkRenderPassCreateInfo2-pAttachments-04586");
         vk::CreateRenderPass2KHR(device(), &rpci, NULL, &rp);
@@ -1280,62 +1280,62 @@ TEST_F(NegativeFragmentShadingRate, IncompatibleFragmentRateShadingAttachmentInE
     // Test case where primary command buffer does not have an FSR attachment but
     // secondary command buffer does.
     {
-        secondary.begin(&cmdbuff__bi_fsr);
-        secondary.end();
+        secondary.Begin(&cmdbuff__bi_fsr);
+        secondary.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pBeginInfo-06020");
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_bi_no_fsr, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
         vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
-    secondary.reset();
+    m_command_buffer.Reset();
+    secondary.Reset();
 
     // Test case where primary command buffer has FSR attachment but secondary
     // command buffer does not.
     {
-        secondary.begin(&cmdbuff__bi_no_fsr);
-        secondary.end();
+        secondary.Begin(&cmdbuff__bi_no_fsr);
+        secondary.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pBeginInfo-06020");
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_bi_fsr, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
         vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
         m_errorMonitor->VerifyFound();
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
-    secondary.reset();
+    m_command_buffer.Reset();
+    secondary.Reset();
 
     // Test case where both command buffers have FSR attachments but they are
     // incompatible.
     {
-        secondary.begin(&cmdbuff__bi_fsr);
-        secondary.end();
+        secondary.Begin(&cmdbuff__bi_fsr);
+        secondary.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pBeginInfo-06020");
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp_bi_fsr, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
         vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary.handle());
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
-    secondary.reset();
+    m_command_buffer.Reset();
+    secondary.Reset();
 }
 
 TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
@@ -1349,13 +1349,13 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateUsage) {
     RETURN_IF_SKIP(Init());
 
     const VkFormat format =
-        FindFormatWithoutFeatures(gpu(), VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
+        FindFormatWithoutFeatures(Gpu(), VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     if (format == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "No format found without shading rate attachment support";
     }
 
     VkImageFormatProperties imageFormatProperties;
-    if (vk::GetPhysicalDeviceImageFormatProperties(gpu(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    if (vk::GetPhysicalDeviceImageFormatProperties(Gpu(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                    VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, 0,
                                                    &imageFormatProperties) == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "Format not supported";
@@ -1797,7 +1797,7 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     std::array<VkAttachmentDescription2, 7> attachments = {
         // FDM attachments
@@ -1992,8 +1992,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
         m_vOffsets[1].x = 1;
         m_vOffsets[1].y = 1;
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
 
         // begin renderpass that uses rbpi1 renderpass begin info
         vk::CmdBeginRenderPass(m_command_buffer.handle(), &rpbi1, VK_SUBPASS_CONTENTS_INLINE);
@@ -2019,8 +2019,8 @@ TEST_F(NegativeFragmentShadingRate, FragmentDensityMapOffsetQCOM) {
         vk::CmdEndRenderPass2KHR(m_command_buffer.handle(), &subpassEndInfo);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
 
         // begin renderpass that uses rbpi2 renderpass begin info
         vk::CmdBeginRenderPass(m_command_buffer.handle(), &rpbi2, VK_SUBPASS_CONTENTS_INLINE);
@@ -2193,7 +2193,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
     img_barrier.subresourceRange.layerCount = 1;
     img_barrier.subresourceRange.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Error trying to convert it to SRI layout
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier-oldLayout-02088");
@@ -2304,7 +2304,7 @@ TEST_F(NegativeFragmentShadingRate, ShadingRateImageNV) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, ShadingRateImageNVViewportCount) {
@@ -2375,7 +2375,7 @@ TEST_F(NegativeFragmentShadingRate, StageUsage) {
     const vkt::Event event(*m_device);
     const vkt::Event event2(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-stageMask-07316");
     vk::CmdResetEvent2KHR(m_command_buffer, event, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     m_errorMonitor->VerifyFound();
@@ -2387,7 +2387,7 @@ TEST_F(NegativeFragmentShadingRate, StageUsage) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-shadingRateImage-07314");
     vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, query_pool, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
@@ -2402,7 +2402,7 @@ TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
     const vkt::Event event(*m_device);
     const vkt::Event event2(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetEvent2-stageMask-07316");
     vk::CmdResetEvent2KHR(m_command_buffer, event, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     m_errorMonitor->VerifyFound();
@@ -2414,14 +2414,14 @@ TEST_F(NegativeFragmentShadingRate, StageUsageNV) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-shadingRateImage-07314");
     vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, query_pool, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 TEST_F(NegativeFragmentShadingRate, ImageMaxLimitsQCOM) {
     TEST_DESCRIPTION("Tests physical device limits for VK_QCOM_fragment_density_map_offset.");
     AddRequiredExtensions(VK_QCOM_FRAGMENT_DENSITY_MAP_OFFSET_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     VkImageCreateInfo image_ci = vku::InitStructHelper();
     image_ci.flags = 0;
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -2435,7 +2435,7 @@ TEST_F(NegativeFragmentShadingRate, ImageMaxLimitsQCOM) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
 
     image_ci.extent = {dev_limits.maxFramebufferWidth + 1, 64, 1};
     if (dev_limits.maxFramebufferWidth + 1 > img_limits.maxExtent.width) {
@@ -2820,7 +2820,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
     fb_info.pAttachments = ivs;
 
     // Request fb that exceeds max width
-    fb_info.width = m_device->phy().limits_.maxFramebufferWidth + 1;
+    fb_info.width = m_device->Physical().limits_.maxFramebufferWidth + 1;
     fb_info.height = 100;
     fb_info.layers = 1;
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-width-00886");
@@ -2836,7 +2836,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
 
     // Request fb that exceeds max height
     fb_info.width = 100;
-    fb_info.height = m_device->phy().limits_.maxFramebufferHeight + 1;
+    fb_info.height = m_device->Physical().limits_.maxFramebufferHeight + 1;
     fb_info.layers = 1;
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-height-00888");
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-flags-04534");
@@ -2852,7 +2852,7 @@ TEST_F(NegativeFragmentShadingRate, DISABLED_Framebuffer) {
     // Request fb that exceeds max layers
     fb_info.width = 100;
     fb_info.height = 100;
-    fb_info.layers = m_device->phy().limits_.maxFramebufferLayers + 1;
+    fb_info.layers = m_device->Physical().limits_.maxFramebufferLayers + 1;
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-layers-00890");
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-flags-04535");
     vk::CreateFramebuffer(device(), &fb_info, NULL, &fb);

--- a/tests/unit/fragment_shading_rate_positive.cpp
+++ b/tests/unit/fragment_shading_rate_positive.cpp
@@ -27,12 +27,12 @@ TEST_F(PositiveFragmentShadingRate, StageInVariousAPIs) {
     const vkt::Event event(*m_device);
     const vkt::Event event2(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Different API calls to cover three category of VUIDs: 07316, 07318, 07314
     vk::CmdResetEvent2KHR(m_command_buffer, event, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     vk::CmdSetEvent(m_command_buffer, event2, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR);
     vk::CmdWriteTimestamp(m_command_buffer, VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, query_pool, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
@@ -46,7 +46,7 @@ TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
 
     VkImageFormatProperties format_props = {};
     VkResult result = vk::GetPhysicalDeviceImageFormatProperties(
-        m_device->phy().handle(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+        m_device->Physical().handle(), VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
         VK_IMAGE_USAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, 0, &format_props);
     if (result != VK_SUCCESS) {
         GTEST_SKIP() << "Image options not supported";
@@ -67,11 +67,11 @@ TEST_F(PositiveFragmentShadingRate, StageWithPipelineBarrier) {
     imageMemoryBarrier.subresourceRange.layerCount = 1;
     imageMemoryBarrier.subresourceRange.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                            VK_PIPELINE_STAGE_FRAGMENT_SHADING_RATE_ATTACHMENT_BIT_KHR, 0u, 0u, nullptr, 0u, nullptr, 1u,
                            &imageMemoryBarrier);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveFragmentShadingRate, Attachments) {

--- a/tests/unit/geometry_tessellation.cpp
+++ b/tests/unit/geometry_tessellation.cpp
@@ -28,12 +28,12 @@ TEST_F(NegativeGeometryTessellation, StageMaskGsTsEnabled) {
     InitRenderTarget();
 
     std::vector<const char *> device_extension_names;
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     // Make sure gs & ts are disabled
     features.geometryShader = false;
     features.tessellationShader = false;
     // The sacrificial device object
-    vkt::Device test_device(gpu(), device_extension_names, &features);
+    vkt::Device test_device(Gpu(), device_extension_names, &features);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
     pool_create_info.queueFamilyIndex = test_device.graphics_queue_node_index_;
@@ -78,7 +78,7 @@ TEST_F(NegativeGeometryTessellation, GeometryShaderEnabled) {
     RETURN_IF_SKIP(Init(&deviceFeatures));
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxGeometryOutputVertices == 0) {
+    if (m_device->Physical().limits_.maxGeometryOutputVertices == 0) {
         GTEST_SKIP() << "Device doesn't support geometry shaders";
     }
 
@@ -104,7 +104,7 @@ TEST_F(NegativeGeometryTessellation, TessellationShaderEnabled) {
     RETURN_IF_SKIP(Init(&deviceFeatures));
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxTessellationPatchSize == 0) {
+    if (m_device->Physical().limits_.maxTessellationPatchSize == 0) {
         GTEST_SKIP() << "patchControlPoints not supported";
     }
 
@@ -189,7 +189,7 @@ TEST_F(NegativeGeometryTessellation, PointSizeGeomShaderWrite) {
 
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     if (features.geometryShader == VK_FALSE) {
         GTEST_SKIP() << "geometryShader not supported";
     }
@@ -428,7 +428,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGsShaderObject) {
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
     const VkShaderEXT shaders[] = {vertShader.handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, geomShader.handle(), fragShader.handle()};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5, stages, shaders);
@@ -436,7 +436,7 @@ TEST_F(NegativeGeometryTessellation, BuiltinBlockSizeMismatchVsGsShaderObject) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents) {
@@ -451,7 +451,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
         VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(gpu(), &feat);
+        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
         if (!feat.tessellationShader) {
             GTEST_SKIP() << "tessellation shader stage(s) unsupported";
         }
@@ -461,7 +461,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents
             "#version 450\n"
             "\n";
         // Input components
-        const uint32_t maxTescInComp = m_device->phy().limits_.maxTessellationControlPerVertexInputComponents + overflow;
+        const uint32_t maxTescInComp = m_device->Physical().limits_.maxTessellationControlPerVertexInputComponents + overflow;
         const uint32_t numInVec4 = maxTescInComp / 4;
         uint32_t inLocation = 0;
         if (overflow == 2) {
@@ -484,7 +484,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationControlInputOutputComponents
         }
 
         // Output components
-        const uint32_t maxTescOutComp = m_device->phy().limits_.maxTessellationControlPerVertexOutputComponents + overflow;
+        const uint32_t maxTescOutComp = m_device->Physical().limits_.maxTessellationControlPerVertexOutputComponents + overflow;
         const uint32_t numOutVec4 = maxTescOutComp / 4;
         uint32_t outLocation = 0;
         if (overflow == 2) {
@@ -554,7 +554,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputCompone
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
         VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(gpu(), &feat);
+        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
         if (!feat.tessellationShader) {
             GTEST_SKIP() << "tessellation shader stage(s) unsupported";
         }
@@ -566,7 +566,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputCompone
             "layout (triangles) in;\n"
             "\n";
         // Input components
-        const uint32_t maxTeseInComp = m_device->phy().limits_.maxTessellationEvaluationInputComponents + overflow;
+        const uint32_t maxTeseInComp = m_device->Physical().limits_.maxTessellationEvaluationInputComponents + overflow;
         const uint32_t numInVec4 = maxTeseInComp / 4;
         uint32_t inLocation = 0;
         if (overflow == 2) {
@@ -589,7 +589,7 @@ TEST_F(NegativeGeometryTessellation, MaxTessellationEvaluationInputOutputCompone
         }
 
         // Output components
-        const uint32_t maxTeseOutComp = m_device->phy().limits_.maxTessellationEvaluationOutputComponents + overflow;
+        const uint32_t maxTeseOutComp = m_device->Physical().limits_.maxTessellationEvaluationOutputComponents + overflow;
         const uint32_t numOutVec4 = maxTeseOutComp / 4;
         uint32_t outLocation = 0;
         if (overflow == 2) {
@@ -658,7 +658,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
         VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(gpu(), &feat);
+        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
         if (!feat.geometryShader) {
             GTEST_SKIP() << "geometry shader stage unsupported";
         }
@@ -670,7 +670,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
             "layout(invocations=1) in;\n";
 
         // Input components
-        const uint32_t maxGeomInComp = m_device->phy().limits_.maxGeometryInputComponents + overflow;
+        const uint32_t maxGeomInComp = m_device->Physical().limits_.maxGeometryInputComponents + overflow;
         const uint32_t numInVec4 = maxGeomInComp / 4;
         uint32_t inLocation = 0;
         if (overflow == 2) {
@@ -693,7 +693,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
         }
 
         // Output components
-        const uint32_t maxGeomOutComp = m_device->phy().limits_.maxGeometryOutputComponents + overflow;
+        const uint32_t maxGeomOutComp = m_device->Physical().limits_.maxGeometryOutputComponents + overflow;
         const uint32_t numOutVec4 = maxGeomOutComp / 4;
         uint32_t outLocation = 0;
         if (overflow == 2) {
@@ -716,7 +716,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInputOutputComponents) {
         }
 
         // Finalize
-        int max_vertices = overflow ? (m_device->phy().limits_.maxGeometryTotalOutputComponents / maxGeomOutComp + 1) : 1;
+        int max_vertices = overflow ? (m_device->Physical().limits_.maxGeometryTotalOutputComponents / maxGeomOutComp + 1) : 1;
         gsSourceStr += "layout(triangle_strip, max_vertices = " + std::to_string(max_vertices) +
                        ") out;\n"
                        "\n"
@@ -763,7 +763,7 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
     for (int overflow = 0; overflow < 2; ++overflow) {
         m_errorMonitor->Reset();
         VkPhysicalDeviceFeatures feat;
-        vk::GetPhysicalDeviceFeatures(gpu(), &feat);
+        vk::GetPhysicalDeviceFeatures(Gpu(), &feat);
         if (!feat.geometryShader) {
             GTEST_SKIP() << "geometry shader stage unsupported";
         }
@@ -777,10 +777,10 @@ TEST_F(NegativeGeometryTessellation, MaxGeometryInstanceVertexCount) {
                )";
         if (overflow) {
             gsSourceStr += "OpExecutionMode %main Invocations " +
-                           std::to_string(m_device->phy().limits_.maxGeometryShaderInvocations + 1) +
+                           std::to_string(m_device->Physical().limits_.maxGeometryShaderInvocations + 1) +
                            "\n\
                 OpExecutionMode %main OutputVertices " +
-                           std::to_string(m_device->phy().limits_.maxGeometryOutputVertices + 1);
+                           std::to_string(m_device->Physical().limits_.maxGeometryOutputVertices + 1);
         } else {
             gsSourceStr += R"(
                OpExecutionMode %main Invocations 1
@@ -935,7 +935,7 @@ TEST_F(NegativeGeometryTessellation, Tessellation) {
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
                                       "VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214");
 
-    tsci_bad.patchControlPoints = m_device->phy().limits_.maxTessellationPatchSize + 1;
+    tsci_bad.patchControlPoints = m_device->Physical().limits_.maxTessellationPatchSize + 1;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit,
                                       "VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214");
 }
@@ -1046,7 +1046,7 @@ VK_DESCRIPTOR_SET_USAGE_NON_FREE, 1, &ds_layout.handle(), &descriptorSet);
         gp_ci.pColorBlendState = NULL;
         gp_ci.flags = VK_PIPELINE_CREATE_DISABLE_OPTIMIZATION_BIT;
         gp_ci.layout = pipeline_layout.handle();
-        gp_ci.renderPass = renderPass();
+        gp_ci.renderPass = RenderPass();
 
     VkPipelineCacheCreateInfo pc_ci = vku::InitStructHelper();
         pc_ci.initialSize = 0;
@@ -1389,14 +1389,14 @@ TEST_F(NegativeGeometryTessellation, MismatchedTessellationExecutionModes) {
         RETURN_IF_SKIP(InitState(nullptr, &features2));
     } else {
         VkPhysicalDeviceFeatures features{};
-        vk::GetPhysicalDeviceFeatures(gpu(), &features);
+        vk::GetPhysicalDeviceFeatures(Gpu(), &features);
         if (features.tessellationShader == VK_FALSE) {
             GTEST_SKIP() << "geometryShader not supported";
         }
         features.shaderTessellationAndGeometryPointSize = VK_FALSE;
         RETURN_IF_SKIP(InitState(&features));
     }
-    if (m_device->phy().limits_.maxTessellationPatchSize == 0) {
+    if (m_device->Physical().limits_.maxTessellationPatchSize == 0) {
         GTEST_SKIP() << "Tessellation shaders not supported";
     }
     InitRenderTarget();
@@ -1574,7 +1574,7 @@ TEST_F(NegativeGeometryTessellation, WritingToLayerWithSingleFramebufferLayer) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3019");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();  // Creates a framebuffer with a single layer
-    if (m_device->phy().limits_.maxGeometryOutputVertices == 0) {
+    if (m_device->Physical().limits_.maxGeometryOutputVertices == 0) {
         GTEST_SKIP() << "Device doesn't support required maxGeometryOutputVertices";
     }
     const std::string_view gsSource = R"glsl(
@@ -1594,14 +1594,14 @@ TEST_F(NegativeGeometryTessellation, WritingToLayerWithSingleFramebufferLayer) {
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredWarning("Undefined-Layer-Written");
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGeometryTessellation, DrawDynamicPrimitiveTopology) {
@@ -1642,7 +1642,7 @@ TEST_F(NegativeGeometryTessellation, DrawDynamicPrimitiveTopology) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // Invalid - matches the Geometry output, but we need to match the input
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST);
@@ -1651,5 +1651,5 @@ TEST_F(NegativeGeometryTessellation, DrawDynamicPrimitiveTopology) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/geometry_tessellation_positive.cpp
+++ b/tests/unit/geometry_tessellation_positive.cpp
@@ -129,13 +129,13 @@ TEST_F(PositiveGeometryTessellation, DrawDynamicPrimitiveTopology) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), gs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_POINT_LIST);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGeometryTessellation, TessellationPointMode) {

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -53,12 +53,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vkt::Buffer buffer(*m_device, 64, 0, vkt::device_address);
-    VkDeviceAddress u_info_ptr = buffer.address();
+    VkDeviceAddress u_info_ptr = buffer.Address();
     // Will dereference the wrong ptr address
     VkDeviceAddress push_constants[2] = {u_info_ptr - 16, 4};
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(push_constants),
@@ -66,7 +66,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 3);
 
@@ -75,12 +75,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerPushConstant) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the other 3 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.memory().map());
+    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
     for (int i = 0; i < 3; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
     }
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
@@ -118,12 +118,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vkt::Buffer buffer(*m_device, 64, 0, vkt::device_address);
-    VkDeviceAddress u_info_ptr = buffer.address();
+    VkDeviceAddress u_info_ptr = buffer.Address();
     // will go over a[4] by one
     VkDeviceAddress push_constants[2] = {u_info_ptr, 5};
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(push_constants),
@@ -131,7 +131,7 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 3);
     m_default_queue->Submit(m_command_buffer);
@@ -139,12 +139,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerPushConstant) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the first 4 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.memory().map());
+    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
     }
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
@@ -161,15 +161,15 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     descriptor_set.UpdateDescriptorSets();
 
     vkt::Buffer buffer(*m_device, 64, 0, vkt::device_address);
-    VkDeviceAddress u_info_ptr = buffer.address();
+    VkDeviceAddress u_info_ptr = buffer.Address();
     // Will dereference the wrong ptr address
     VkDeviceAddress invalid_buffer_address = u_info_ptr - 16;
     uint32_t n_writes = 4;
 
-    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.memory().map();
+    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.Memory().Map();
     memcpy(uniform_buffer_ptr, &invalid_buffer_address, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     char const *shader_source = R"glsl(
         #version 450
@@ -195,14 +195,14 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 3);
 
@@ -211,12 +211,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadBeforePointerDescriptor) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the other 3 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.memory().map());
+    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
     for (int i = 0; i < 3; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
     }
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
@@ -233,14 +233,14 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     descriptor_set.UpdateDescriptorSets();
 
     vkt::Buffer buffer(*m_device, 64, 0, vkt::device_address);
-    VkDeviceAddress u_info_ptr = buffer.address();
+    VkDeviceAddress u_info_ptr = buffer.Address();
     // will go over a[4] by one
     uint32_t n_writes = 5;
 
-    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.memory().map();
+    uint8_t *uniform_buffer_ptr = (uint8_t *)uniform_buffer.Memory().Map();
     memcpy(uniform_buffer_ptr, &u_info_ptr, sizeof(VkDeviceAddress));
     memcpy(uniform_buffer_ptr + sizeof(VkDeviceAddress), &n_writes, sizeof(uint32_t));
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     char const *shader_source = R"glsl(
         #version 450
@@ -266,14 +266,14 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 3);
     m_default_queue->Submit(m_command_buffer);
@@ -281,12 +281,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ReadAfterPointerDescriptor) {
     m_errorMonitor->VerifyFound();
 
     // Make sure we wrote the first 4 values
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer.memory().map());
+    auto *buffer_ptr = static_cast<uint32_t *>(buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*buffer_ptr, 42);
         buffer_ptr += 4;
     }
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, UVec3Array) {
@@ -325,23 +325,23 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, UVec3Array) {
 
     // Hold only 3 indices
     vkt::Buffer block_buffer(*m_device, 36, 0, vkt::device_address);
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 4;  // uvec3[0] to uvec3[3]
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -379,8 +379,8 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
 
     std::vector<uint32_t> vert_shader;
     std::vector<uint32_t> frag_shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexDrawPassthroughGlsl, vert_shader);
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_FRAGMENT_BIT, fs_source, frag_shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexDrawPassthroughGlsl, vert_shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_FRAGMENT_BIT, fs_source, frag_shader);
 
     VkShaderModuleCreateInfo module_create_info_vert = vku::InitStructHelper();
     module_create_info_vert.pCode = vert_shader.data();
@@ -413,25 +413,25 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 64;  // way too large
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     descriptor_set.WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 6);
     m_default_queue->Submit(m_command_buffer);
@@ -479,28 +479,28 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ArrayOfStruct) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer block_buffer(*m_device, 32, 0, vkt::device_address);
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.memory().map();
+    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.Memory().Map();
     const uint32_t index = 8;  // out of bounds
     memcpy(buffer_ptr, &index, sizeof(uint32_t));
     memcpy(buffer_ptr + (1 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
     memcpy(buffer_ptr + (2 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
     memcpy(buffer_ptr + (3 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 
     descriptor_set.WriteDescriptorBufferInfo(0, storage_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -545,23 +545,23 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 16 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
+    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
     data[1] = 5;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
     m_default_queue->Submit(m_command_buffer);
@@ -569,12 +569,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
@@ -614,14 +614,14 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 16 * 4;
@@ -629,14 +629,14 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
 
     // Get device address of buffer to write to
     using AddrRange = sparse_container::range<VkDeviceAddress>;
-    const VkDeviceAddress storage_buffer_addr = storage_buffer.address();
+    const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
     const AddrRange shader_writes_range(storage_buffer_addr, storage_buffer_addr + storage_buffer_size + 4);
 
     // Create storage buffers for the sake of storing multiple device address ranges
     std::vector<vkt::Buffer> dummy_storage_buffers;
     for (int i = 0; i < 1024; ++i) {
         const VkDeviceAddress addr =
-            dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
+            dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
         const AddrRange addr_range(addr, addr + storage_buffer_size);
         // If new buffer address range overlaps with storage buffer range,
         // writes past its end may be valid, so remove dummy buffer
@@ -645,10 +645,10 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
         }
     }
 
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
     data[0] = storage_buffer_addr;
     data[1] = 5;  // Will provoke a 4 bytes write past buffer end
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
     m_default_queue->Submit(m_command_buffer);
@@ -656,12 +656,12 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd140NumerousRanges) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
@@ -701,23 +701,23 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 4 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
+    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
     data[1] = 5;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written", 3);
     m_default_queue->Submit(m_command_buffer);
@@ -725,11 +725,11 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430) {
     m_errorMonitor->VerifyFound();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], 42);
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
@@ -822,22 +822,22 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t storage_buffer_size = 3 * sizeof(float);  // only can fit 3 floats
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
-    const VkDeviceAddress storage_buffer_addr = storage_buffer.address();
+    const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr), so expect writing to `v.z` to cause an OOB access
     {
-        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
         data[0] = storage_buffer_addr;
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
 
         m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
         m_default_queue->Submit(m_command_buffer);
@@ -845,16 +845,16 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
         m_errorMonitor->VerifyFound();
 
         // Make sure shader wrote to float
-        auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+        auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
         ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
-        storage_buffer.memory().unmap();
+        storage_buffer.Memory().Unmap();
     }
 
     // Base buffer address is (storage_buffer_addr - 4), so expect writing to `f` to cause an OOB access
     {
-        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
         data[0] = storage_buffer_addr - sizeof(float);
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
 
         m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written");
         m_default_queue->Submit(m_command_buffer);
@@ -862,11 +862,11 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
         m_errorMonitor->VerifyFound();
 
         // Make sure shader wrote to vec3
-        auto storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+        auto storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
         ASSERT_EQ(storage_buffer_ptr[0], 1.0f);
         ASSERT_EQ(storage_buffer_ptr[1], 2.0f);
         ASSERT_EQ(storage_buffer_ptr[2], 3.0f);
-        storage_buffer.memory().unmap();
+        storage_buffer.Memory().Unmap();
     }
 }
 
@@ -911,22 +911,22 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t storage_buffer_size = 3 * sizeof(float);  // can only hold 3 floats, when SSBO uses 4
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
-    const VkDeviceAddress storage_buffer_addr = storage_buffer.address();
+    const VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
 
     // Base buffer address is (storage_buffer_addr), so expect writing to `v.z` to cause an OOB access
     {
-        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
         data[0] = storage_buffer_addr;
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
 
         m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
         m_default_queue->Submit(m_command_buffer);
@@ -934,16 +934,16 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
         m_errorMonitor->VerifyFound();
 
         // Make sure shader wrote to float
-        auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+        auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
         ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
-        storage_buffer.memory().unmap();
+        storage_buffer.Memory().Unmap();
     }
 
     // Base buffer address is (storage_buffer_addr - 4), so expect writing to `f` to cause an OOB access
     {
-        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+        auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
         data[0] = storage_buffer_addr - sizeof(float);
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
 
         m_errorMonitor->SetDesiredError("Out of bounds access: 4 bytes written");
         m_default_queue->Submit(m_command_buffer);
@@ -951,11 +951,11 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
         m_errorMonitor->VerifyFound();
 
         // Make sure shader wrote to vec3
-        auto storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+        auto storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
         ASSERT_EQ(storage_buffer_ptr[0], 1.0f);
         ASSERT_EQ(storage_buffer_ptr[1], 2.0f);
         ASSERT_EQ(storage_buffer_ptr[2], 3.0f);
-        storage_buffer.memory().unmap();
+        storage_buffer.Memory().Unmap();
     }
 }
 
@@ -1003,30 +1003,30 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     constexpr size_t nodes_count = 3;
 
     // Make a list of storage buffers, each one holding a Node
     uint32_t storage_buffer_size = (4 * sizeof(float)) + sizeof(VkDeviceAddress);
     std::vector<vkt::Buffer> storage_buffers;
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
     for (size_t i = 0; i < nodes_count; ++i) {
         // Last node's memory only holds 2 * sizeof(float), so writing to v.z is illegal
         if (i == nodes_count - 1) {
             storage_buffer_size = 2 * sizeof(float);
         }
 
-        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
+        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
         uniform_buffer_ptr[i] = addr;
     }
 
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("Out of bounds access: 12 bytes written");
     m_default_queue->Submit(m_command_buffer);
@@ -1035,13 +1035,13 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
 
     // Make sure shader wrote values to all nodes but the last
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers.data(), nodes_count - 1)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer->memory().map());
+        auto storage_buffer_ptr = static_cast<float *>(buffer->Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
         ASSERT_EQ(storage_buffer_ptr[2], float(3 * buffer_i + 3));
 
-        buffer->memory().unmap();
+        buffer->Memory().Unmap();
     }
 }
 
@@ -1089,20 +1089,20 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, DISABLED_ProxyStructLoad) {
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress buffer_ptr = bda_buffer.address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    VkDeviceAddress buffer_ptr = bda_buffer.Address();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // One for each of the 2 access
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds", 2);
@@ -1153,20 +1153,20 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadUint64) {
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress buffer_ptr = bda_buffer.address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    VkDeviceAddress buffer_ptr = bda_buffer.Address();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1215,20 +1215,20 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, ProxyStructLoadBadAddress) {
     vkt::Buffer in_buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress buffer_ptr = bda_buffer.address() + 256;  // wrong
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    VkDeviceAddress buffer_ptr = bda_buffer.Address() + 256;  // wrong
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Device address out of bounds");
     m_default_queue->Submit(m_command_buffer);

--- a/tests/unit/gpu_av_buffer_device_address_positive.cpp
+++ b/tests/unit/gpu_av_buffer_device_address_positive.cpp
@@ -64,34 +64,34 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 16 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    uniform_buffer_ptr[0] = storage_buffer.address();
+    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 4;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
@@ -133,14 +133,14 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 16 * 4;
@@ -149,24 +149,24 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd140NumerousAddressRanges) {
     // Create storage buffers for the sake of storing multiple device address ranges
     std::vector<vkt::Buffer> dummy_storage_buffers;
     for (int i = 0; i < 1024; ++i) {
-        (void)dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
+        (void)dummy_storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
     }
 
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    uniform_buffer_ptr[0] = storage_buffer.address();
+    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    uniform_buffer_ptr[0] = storage_buffer.Address();
     uniform_buffer_ptr[1] = 4;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(*storage_buffer_ptr, 42);
         storage_buffer_ptr += 4;
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430) {
@@ -206,33 +206,33 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make another buffer to write to
     const uint32_t storage_buffer_size = 4 * 4;
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
+    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
     data[1] = 4;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote 42
-    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     for (int i = 0; i < 4; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], 42);
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
@@ -268,27 +268,27 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreExplicitOffset) {
     vkt::Buffer in_buffer(*m_device, 8, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
     vkt::Buffer bda_buffer(*m_device, 64, 0, vkt::device_address);
 
-    VkDeviceAddress buffer_ptr = bda_buffer.address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    VkDeviceAddress buffer_ptr = bda_buffer.Address();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    uint8_t *bda_buffer_ptr = (uint8_t *)bda_buffer.memory().map();
+    uint8_t *bda_buffer_ptr = (uint8_t *)bda_buffer.Memory().Map();
     uint32_t output = *((uint32_t *)(bda_buffer_ptr + 32));
-    bda_buffer.memory().unmap();
+    bda_buffer.Memory().Unmap();
     ASSERT_TRUE(output == 0xca7);
 }
 
@@ -331,35 +331,35 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoad) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
 
     float expected_output = 0x00EEAADD;
-    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.memory().map();
+    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.Memory().Map();
     memcpy(block_buffer_ptr, &expected_output, sizeof(float));
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     float output = *((float *)(in_buffer_ptr + sizeof(VkDeviceAddress)));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
     ASSERT_TRUE(output == expected_output);
 }
 
@@ -406,35 +406,35 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StructLoadPadded) {
     vkt::Buffer block_buffer(*m_device, 32, 0, vkt::device_address);
 
     float expected_output = 0x00EEAADD;
-    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.memory().map();
+    uint8_t *block_buffer_ptr = (uint8_t *)block_buffer.Memory().Map();
     memcpy(block_buffer_ptr + 24, &expected_output, sizeof(float));
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     float output = *((float *)(in_buffer_ptr + sizeof(VkDeviceAddress)));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
     ASSERT_TRUE(output == expected_output);
 }
 
@@ -475,23 +475,23 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, UVec3Array) {
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
     const uint32_t n_reads = 4;  // uvec3[0] to uvec3[3]
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &n_reads, sizeof(uint32_t));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -536,29 +536,29 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, DISABLED_ArrayOfStruct) {
     pipe.CreateComputePipeline();
 
     vkt::Buffer block_buffer(*m_device, 32, 0, vkt::device_address);
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
 
     vkt::Buffer storage_buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.memory().map();
+    uint8_t *buffer_ptr = (uint8_t *)storage_buffer.Memory().Map();
     const uint32_t index = 0;
     memcpy(buffer_ptr, &index, sizeof(uint32_t));
     memcpy(buffer_ptr + (1 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
     memcpy(buffer_ptr + (2 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
     memcpy(buffer_ptr + (3 * sizeof(VkDeviceAddress)), &block_ptr, sizeof(VkDeviceAddress));
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, storage_buffer.handle(), 0, VK_WHOLE_SIZE,
                                                     VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -597,37 +597,37 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, BitCastUvec2) {
 
     vkt::Buffer buffer_node_a(*m_device, 4, 0, vkt::device_address);
     vkt::Buffer buffer_node_b(*m_device, 4, 0, vkt::device_address);
-    VkDeviceAddress block_a_ptr = buffer_node_a.address();
-    VkDeviceAddress block_b_ptr = buffer_node_b.address();
+    VkDeviceAddress block_a_ptr = buffer_node_a.Address();
+    VkDeviceAddress block_b_ptr = buffer_node_b.Address();
 
-    auto *buffer_ptr = static_cast<uint32_t *>(buffer_node_b.memory().map());
+    auto *buffer_ptr = static_cast<uint32_t *>(buffer_node_b.Memory().Map());
     *buffer_ptr = 1234;  // data to pass
-    buffer_node_b.memory().unmap();
+    buffer_node_b.Memory().Unmap();
 
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_a_ptr, sizeof(VkDeviceAddress));
     memcpy(in_buffer_ptr + sizeof(VkDeviceAddress), &block_b_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    buffer_ptr = static_cast<uint32_t *>(buffer_node_a.memory().map());
+    buffer_ptr = static_cast<uint32_t *>(buffer_node_a.Memory().Map());
     ASSERT_TRUE(*buffer_ptr == 1234);
-    buffer_node_a.memory().unmap();
+    buffer_node_a.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
@@ -720,30 +720,30 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreRelaxedBlockLayout) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t storage_buffer_size = 4 * sizeof(float);  // float + vec3
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
-    uniform_buffer.memory().unmap();
+    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote to float and vec3
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
     ASSERT_EQ(storage_buffer_ptr[1], 1.0f);
     ASSERT_EQ(storage_buffer_ptr[2], 2.0f);
     ASSERT_EQ(storage_buffer_ptr[3], 3.0f);
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
@@ -787,30 +787,30 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreScalarBlockLayout) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t storage_buffer_size = 4 * sizeof(float);  // float + vec3
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
-    uniform_buffer.memory().unmap();
+    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote to float and vec3
-    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.memory().map());
+    auto *storage_buffer_ptr = static_cast<float *>(storage_buffer.Memory().Map());
     ASSERT_EQ(storage_buffer_ptr[0], 42.0f);
     ASSERT_EQ(storage_buffer_ptr[1], 1.0f);
     ASSERT_EQ(storage_buffer_ptr[2], 2.0f);
     ASSERT_EQ(storage_buffer_ptr[3], 3.0f);
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
@@ -857,38 +857,38 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, StoreStd430LinkedList) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Make a list of storage buffers, each one holding a Node
     constexpr size_t nodes_count = 3;
     const uint32_t storage_buffer_size = (4 * sizeof(float)) + sizeof(VkDeviceAddress);
     std::vector<vkt::Buffer> storage_buffers;
-    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
+    auto *uniform_buffer_ptr = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
 
     for (size_t i = 0; i < nodes_count; ++i) {
-        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).address();
+        const VkDeviceAddress addr = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address).Address();
         uniform_buffer_ptr[i] = addr;
     }
 
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote values to all nodes
     for (auto [buffer_i, buffer] : vvl::enumerate(storage_buffers)) {
-        auto storage_buffer_ptr = static_cast<float *>(buffer->memory().map());
+        auto storage_buffer_ptr = static_cast<float *>(buffer->Memory().Map());
 
         ASSERT_EQ(storage_buffer_ptr[0], float(3 * buffer_i + 1));
         ASSERT_EQ(storage_buffer_ptr[1], float(3 * buffer_i + 2));
         ASSERT_EQ(storage_buffer_ptr[2], float(3 * buffer_i + 3));
 
-        buffer->memory().unmap();
+        buffer->Memory().Unmap();
     }
 }
 
@@ -937,12 +937,12 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleBufferReferenceBlocks) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t foo_storage_buffer_size = 4 * sizeof(float) + sizeof(float) + sizeof(int32_t);
     vkt::Buffer foo_storage_buffer(*m_device, foo_storage_buffer_size, 0, vkt::device_address);
@@ -950,21 +950,21 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, MultipleBufferReferenceBlocks) {
     const uint32_t bar_storage_buffer_size = sizeof(float) + sizeof(int32_t) + 4 * sizeof(float);
     vkt::Buffer bar_storage_buffer(*m_device, bar_storage_buffer_size, 0, vkt::device_address);
 
-    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = foo_storage_buffer.address();
-    data[1] = bar_storage_buffer.address();
-    uniform_buffer.memory().unmap();
+    auto *data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = foo_storage_buffer.Address();
+    data[1] = bar_storage_buffer.Address();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote to float and vec3
-    auto *foo_ptr = static_cast<int *>(foo_storage_buffer.memory().map());
-    auto *bar_ptr = static_cast<int *>(bar_storage_buffer.memory().map());
+    auto *foo_ptr = static_cast<int *>(foo_storage_buffer.Memory().Map());
+    auto *bar_ptr = static_cast<int *>(bar_storage_buffer.Memory().Map());
     ASSERT_EQ(bar_ptr[0], 42);
     ASSERT_EQ(foo_ptr[3], bar_ptr[0]);
-    foo_storage_buffer.memory().unmap();
-    bar_storage_buffer.memory().unmap();
+    foo_storage_buffer.Memory().Unmap();
+    bar_storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
@@ -1010,12 +1010,12 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(0, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     struct Vertex {
         float x, y, z;
@@ -1027,7 +1027,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     vkt::Buffer storage_buffer(*m_device, storage_buffer_size, 0, vkt::device_address);
 
     // Write vertex 0
-    auto vertex_buffer_ptr = static_cast<Vertex *>(storage_buffer.memory().map());
+    auto vertex_buffer_ptr = static_cast<Vertex *>(storage_buffer.Memory().Map());
     vertex_buffer_ptr[0].x = 1.0f;
     vertex_buffer_ptr[0].y = 2.0f;
     vertex_buffer_ptr[0].z = 3.0f;
@@ -1039,17 +1039,17 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     vertex_buffer_ptr[0].uv[0] = 7.0f;
     vertex_buffer_ptr[0].uv[1] = 8.0f;
 
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = storage_buffer.address();
-    uniform_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = storage_buffer.Address();
+    uniform_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure shader wrote to float and vec3
-    vertex_buffer_ptr = static_cast<Vertex *>(storage_buffer.memory().map());
+    vertex_buffer_ptr = static_cast<Vertex *>(storage_buffer.Memory().Map());
     ASSERT_EQ(vertex_buffer_ptr[0].x, 1.0f);
     ASSERT_EQ(vertex_buffer_ptr[0].y, 2.0f);
     ASSERT_EQ(vertex_buffer_ptr[0].z, 3.0f);
@@ -1077,7 +1077,7 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, LoadStoreStruct) {
     ASSERT_EQ(vertex_buffer_ptr[2].uv[0], 7.0f);
     ASSERT_EQ(vertex_buffer_ptr[2].uv[1], 8.0f);
 
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
@@ -1128,17 +1128,17 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ConcurrentAccessesToBdaBuffer) {
         // effectively adding it to the BDA table
         auto &storage_buffer = storage_buffers.emplace_back(*m_device, storage_buffer_size, 0, vkt::device_address);
 
-        auto storage_buffer_addr = storage_buffer.address();
+        auto storage_buffer_addr = storage_buffer.Address();
 
         // Read and write from storage buffer address
-        cb.begin();
+        cb.Begin();
         cb.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdPushConstants(cb, pipe.pipeline_layout_, VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(storage_buffer_addr),
                              &storage_buffer_addr);
         vk::CmdDraw(cb.handle(), 3, 1, 0, 0);
         cb.EndRenderPass();
-        cb.end();
+        cb.End();
 
         m_default_queue->Submit(cb);
     }
@@ -1183,20 +1183,20 @@ TEST_F(PositiveGpuAVBufferDeviceAddress, ProxyStructLoad) {
     vkt::Buffer in_buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress buffer_ptr = bda_buffer.address();
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    VkDeviceAddress buffer_ptr = bda_buffer.Address();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &buffer_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_debug_printf.cpp
+++ b/tests/unit/gpu_av_debug_printf.cpp
@@ -102,12 +102,12 @@ void NegativeGpuAVDebugPrintf::BasicComputeTest() {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -216,14 +216,14 @@ TEST_F(NegativeGpuAVDebugPrintf, Graphics) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
     m_errorMonitor->SetDesiredInfo("b.length == 3", 3);
@@ -263,14 +263,14 @@ TEST_F(NegativeGpuAVDebugPrintf, GPL) {
 
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), shader_source);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
     m_errorMonitor->SetDesiredInfo("b.length == 3", 3);
@@ -311,13 +311,13 @@ TEST_F(NegativeGpuAVDebugPrintf, ShaderObject) {
     const vkt::Shader cs(*m_device, VK_SHADER_STAGE_COMPUTE_BIT, GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, shader_source),
                          &dsl_handle);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_COMPUTE_BIT};
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1, stages, &cs.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08613");
     m_errorMonitor->SetDesiredInfo("b.length == 3");
@@ -366,14 +366,14 @@ TEST_F(NegativeGpuAVDebugPrintf, DynamicRendering) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), pipe.fs_->GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
     m_errorMonitor->SetDesiredInfo("b.length == 3", 3);

--- a/tests/unit/gpu_av_descriptor_buffer_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_buffer_positive.cpp
@@ -28,11 +28,11 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
     GetPhysicalDeviceProperties2(descriptor_buffer_properties);
 
     vkt::Buffer buffer_data(*m_device, 16, 0, vkt::device_address);
-    uint32_t *data = (uint32_t *)buffer_data.memory().map();
+    uint32_t *data = (uint32_t *)buffer_data.Memory().Map();
     data[0] = 8;
     data[1] = 12;
     data[2] = 1;
-    buffer_data.memory().unmap();
+    buffer_data.Memory().Unmap();
 
     VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr};
     vkt::DescriptorSetLayout ds_layout(*m_device, binding, VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT);
@@ -51,7 +51,7 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
                                   vkt::device_address);
 
     VkDescriptorAddressInfoEXT addr_info = vku::InitStructHelper();
-    addr_info.address = buffer_data.address();
+    addr_info.address = buffer_data.Address();
     addr_info.range = 16;
     addr_info.format = VK_FORMAT_UNDEFINED;
 
@@ -59,10 +59,10 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
     buffer_descriptor_info.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
     buffer_descriptor_info.data.pStorageBuffer = &addr_info;
 
-    void *mapped_descriptor_data = descriptor_buffer.memory().map();
+    void *mapped_descriptor_data = descriptor_buffer.Memory().Map();
     vk::GetDescriptorEXT(device(), &buffer_descriptor_info, descriptor_buffer_properties.storageBufferDescriptorSize,
                          mapped_descriptor_data);
-    descriptor_buffer.memory().unmap();
+    descriptor_buffer.Memory().Unmap();
 
     char const *cs_source = R"glsl(
         #version 450
@@ -83,11 +83,11 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     VkDescriptorBufferBindingInfoEXT descriptor_buffer_binding_info = vku::InitStructHelper();
-    descriptor_buffer_binding_info.address = descriptor_buffer.address();
+    descriptor_buffer_binding_info.address = descriptor_buffer.Address();
     descriptor_buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &descriptor_buffer_binding_info);
 
@@ -96,16 +96,16 @@ TEST_F(PositiveGpuAVDescriptorBuffer, Basic) {
     vk::CmdSetDescriptorBufferOffsetsEXT(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout, 0, 1,
                                          &buffer_index, &buffer_offset);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     if (!IsPlatformMockICD()) {
-        data = (uint32_t *)buffer_data.memory().map();
+        data = (uint32_t *)buffer_data.Memory().Map();
         ASSERT_TRUE(data[0] == 8);
         ASSERT_TRUE(data[1] == 12);
         ASSERT_TRUE(data[2] == 20);
-        buffer_data.memory().unmap();
+        buffer_data.Memory().Unmap();
     }
 }

--- a/tests/unit/gpu_av_descriptor_indexing.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing.cpp
@@ -111,17 +111,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_ArrayOOBBuffer) {
         pipe.gp_ci_.layout = pipeline_layout.handle();
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                   &descriptor_set.set_, 0, nullptr);
         vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
-        uint32_t *data = (uint32_t *)buffer0.memory().map();
+        m_command_buffer.End();
+        uint32_t *data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 25;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
 
         SCOPED_TRACE("Out of Bounds");
         m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
@@ -129,9 +129,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_ArrayOOBBuffer) {
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
 
-        data = (uint32_t *)buffer0.memory().map();
+        data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 5;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
 
         SCOPED_TRACE("uninitialized");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114");
@@ -231,7 +231,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -239,10 +239,10 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVertex) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 25;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 2 * 3);
 
@@ -344,17 +344,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBFragment) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 25;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
     m_default_queue->Submit(m_command_buffer);
@@ -473,17 +473,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 25;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
@@ -492,9 +492,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBRuntime) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (uint32_t *)buffer0.memory().map();
+    data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 5;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Uninitialized");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114", gpuav::glsl::kMaxErrorsPerCmd);
@@ -602,17 +602,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 6;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", gpuav::glsl::kMaxErrorsPerCmd);
@@ -621,9 +621,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBVariableDescriptorCountAllocate)
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (uint32_t *)buffer0.memory().map();
+    data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 5;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Uninitialized");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114", gpuav::glsl::kMaxErrorsPerCmd);
@@ -640,7 +640,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    if (!m_device->phy().Features().tessellationShader) {
+    if (!m_device->Physical().Features().tessellationShader) {
         GTEST_SKIP() << "Tessellation not supported";
     }
 
@@ -722,17 +722,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 25;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 3);
@@ -740,9 +740,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBTess) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (uint32_t *)buffer0.memory().map();
+    data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 5;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Uninitialized");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114", 3);
@@ -758,7 +758,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     RETURN_IF_SKIP(InitGpuVUDescriptorIndexing());
     InitRenderTarget();
 
-    if (!m_device->phy().Features().geometryShader) {
+    if (!m_device->Physical().Features().geometryShader) {
         GTEST_SKIP() << "Geometry shaders not supported";
     }
 
@@ -840,17 +840,17 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    m_command_buffer.End();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 25;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Out of Bounds");
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
@@ -858,9 +858,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBGeom) {
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
-    data = (uint32_t *)buffer0.memory().map();
+    data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 5;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     SCOPED_TRACE("Uninitialized");
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114");
@@ -941,18 +941,18 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     {
         SCOPED_TRACE("Uninitialized");
-        uint32_t *data = (uint32_t *)buffer0.memory().map();
+        uint32_t *data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 5;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
         // Invalid read
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08114");
         m_default_queue->Submit(m_command_buffer);
@@ -962,9 +962,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayOOBCompute) {
 
     {
         SCOPED_TRACE("Out of Bounds");
-        uint32_t *data = (uint32_t *)buffer0.memory().map();
+        uint32_t *data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 25;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
         // Invalid read and invalid write
         m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds", 2);
         m_default_queue->Submit(m_command_buffer);
@@ -1067,18 +1067,18 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlyDelete) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 1;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     // NOTE: object in use checking is entirely disabled for bindless descriptor sets so
     // destroying before submit still needs to be caught by GPU-AV. Once GPU-AV no
@@ -1190,18 +1190,18 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ArrayEarlySamplerDelete) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 1;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     // NOTE: object in use checking is entirely disabled for bindless descriptor sets so
     // destroying before submit still needs to be caught by GPU-AV. Once GPU-AV no
@@ -1317,18 +1317,18 @@ TEST_F(NegativeGpuAVDescriptorIndexing, ImageArrayDynamicIndexing) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 35;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     // UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout
     m_errorMonitor->SetDesiredFailureMsg(
@@ -1435,7 +1435,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBind) {
     // Make both bindings valid before binding to the command buffer
     vk::UpdateDescriptorSets(device(), 2, &descriptor_write[0], 0, nullptr);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1, &ds, 0,
                               nullptr);
@@ -1448,7 +1448,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBind) {
     // Valid to update binding 1 after being bound
     vk::UpdateDescriptorSets(device(), 1, &descriptor_write[1], 0, nullptr);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08114", gpuav::glsl::kMaxErrorsPerCmd);
 
@@ -1501,7 +1501,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBindImageViewTypeMismatch) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1511,7 +1511,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, UpdateAfterBindImageViewTypeMismatch) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-viewType-07752");
     m_default_queue->Submit(m_command_buffer);
@@ -1543,9 +1543,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_BindPipelineAfterBindingDescrip
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 4, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     *data = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     vkt::Image image(*m_device, 16, 16, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
@@ -1564,7 +1564,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_BindPipelineAfterBindingDescrip
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1573,7 +1573,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DISABLED_BindPipelineAfterBindingDescrip
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-viewType-07752");
     m_default_queue->Submit(m_command_buffer);
@@ -1589,9 +1589,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
 
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 5;  // go past textures[4]
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -1688,12 +1688,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSL) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1709,9 +1709,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 7;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -1811,12 +1811,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08114");
     m_default_queue->Submit(m_command_buffer);
@@ -1864,7 +1864,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     uint32_t index = 8;
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_COMPUTE_BIT, 0, sizeof(uint32_t),
@@ -1874,7 +1874,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PushConstant) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor index out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1890,11 +1890,11 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 3;
     data[1] = 0;  // valid
     data[2] = 5;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -1937,12 +1937,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleIndexes) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("(set = 0, binding = 1) Index of 3 used to index descriptor array of length 2");
     m_errorMonitor->SetDesiredError("(set = 0, binding = 1) Index of 5 used to index descriptor array of length 2");
@@ -2052,18 +2052,18 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
     pipe_cb_1.gp_ci_.layout = pipeline_layout_cb_1.handle();
     pipe_cb_1.CreateGraphicsPipeline();
 
-    cb_1.begin();
+    cb_1.Begin();
     cb_1.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(cb_1.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_cb_1.Handle());
     vk::CmdBindDescriptorSets(cb_1.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_cb_1.handle(), 0, 1,
                               &descriptor_set_cb_1.set_, 0, nullptr);
     vk::CmdDraw(cb_1.handle(), 3, 1, 0, 0);
     cb_1.EndRenderPass();
-    cb_1.end();
+    cb_1.End();
     {
-        uint32_t *data = (uint32_t *)buffer0.memory().map();
+        uint32_t *data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 25;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
     }
 
     // 2nd Command Buffer
@@ -2139,16 +2139,16 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBInMultipleCmdBuffers) {
     pipe_cb_2.cp_ci_.layout = pipeline_layout_cb_2.handle();
     pipe_cb_2.CreateComputePipeline();
 
-    cb_2.begin();
+    cb_2.Begin();
     vk::CmdBindPipeline(cb_2.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe_cb_2.Handle());
     vk::CmdBindDescriptorSets(cb_2.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_cb_2.handle(), 0, 1,
                               &descriptor_set_cb_2.set_, 0, nullptr);
     vk::CmdDispatch(cb_2.handle(), 1, 1, 1);
-    cb_2.end();
+    cb_2.End();
     {
-        uint32_t *data = (uint32_t *)buffer0_cb_2.memory().map();
+        uint32_t *data = (uint32_t *)buffer0_cb_2.Memory().Map();
         data[0] = 25;
-        buffer0_cb_2.memory().unmap();
+        buffer0_cb_2.Memory().Unmap();
     }
 
     m_errorMonitor->SetDesiredError("vkCmdDraw():  (set = 0, binding = 1) Index of 25 used to index descriptor array of length 6",
@@ -2262,7 +2262,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
     pipe_cb_1.gp_ci_.layout = pipeline_layout_cb_1.handle();
     pipe_cb_1.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_cb_1.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_cb_1.handle(), 0, 1,
@@ -2270,9 +2270,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
     {
-        uint32_t *data = (uint32_t *)buffer0.memory().map();
+        uint32_t *data = (uint32_t *)buffer0.Memory().Map();
         data[0] = 25;
-        buffer0.memory().unmap();
+        buffer0.Memory().Unmap();
     }
 
     // Make a uniform buffer to be passed to the shader that contains the invalid array index.
@@ -2347,11 +2347,11 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MultipleOOBTypesInOneCmdBuffer) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_cb_2.handle(), 0, 1,
                               &descriptor_set_cb_2.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     {
-        uint32_t *data = (uint32_t *)buffer0_cb_2.memory().map();
+        uint32_t *data = (uint32_t *)buffer0_cb_2.Memory().Map();
         data[0] = 25;
-        buffer0_cb_2.memory().unmap();
+        buffer0_cb_2.Memory().Unmap();
     }
 
     m_errorMonitor->SetDesiredError("vkCmdDraw():  (set = 0, binding = 1) Index of 25 used to index descriptor array of length 6",
@@ -2387,7 +2387,8 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MixingProtectedResources) {
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs_image_protected.size;
-    if (!m_device->phy().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
+    if (!m_device->Physical().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info,
+                                            VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
         GTEST_SKIP() << "Memory type not found";
     }
     vkt::DeviceMemory memory_image_protected(*m_device, alloc_info);
@@ -2397,9 +2398,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MixingProtectedResources) {
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;  // access protected
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -2442,12 +2443,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, MixingProtectedResources) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-commandBuffer-02707");
     m_default_queue->Submit(m_command_buffer);
@@ -2487,12 +2488,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, PartialBoundDescriptorSSBO) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -2513,9 +2514,9 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BindingOOB) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(
         m_device, {
@@ -2557,12 +2558,12 @@ TEST_F(NegativeGpuAVDescriptorIndexing, BindingOOB) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     // VUID-vkCmdDispatch-None-08114
     m_errorMonitor->SetDesiredError("(set = 0, binding = 2) Descriptor index 1 is uninitialized");
     m_default_queue->Submit(m_command_buffer);
@@ -2603,7 +2604,7 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DestroyedPipelineLayout) {
         pipe2.CreateGraphicsPipeline();
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe2.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // We will create a fake pipeline layout underneath here
@@ -2615,5 +2616,5 @@ TEST_F(NegativeGpuAVDescriptorIndexing, DestroyedPipelineLayout) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/gpu_av_descriptor_indexing_positive.cpp
+++ b/tests/unit/gpu_av_descriptor_indexing_positive.cpp
@@ -46,9 +46,9 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -89,12 +89,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Basic) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -108,9 +108,9 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -209,12 +209,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSL) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -228,9 +228,9 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 7;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -330,12 +330,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BasicHLSLRuntimeArray) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -419,18 +419,18 @@ TEST_F(PositiveGpuAVDescriptorIndexing, UnInitImage) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 1;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -518,18 +518,18 @@ TEST_F(PositiveGpuAVDescriptorIndexing, ImageMultiBinding) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)buffer0.memory().map();
+    uint32_t *data = (uint32_t *)buffer0.Memory().Map();
     data[0] = 1;
-    buffer0.memory().unmap();
+    buffer0.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -591,7 +591,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_2d.Handle());
@@ -601,7 +601,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, BindingUnusedPipeline) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -668,7 +668,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingArray) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     const VkDescriptorSet sets[2] = {descriptor_set.set_, descriptor_set.set_};
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 2, sets, 0,
@@ -676,7 +676,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingArray) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -724,11 +724,11 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingBDA) {
     VkShaderObj fs(this, fs_source, VK_SHADER_STAGE_FRAGMENT_BIT);
 
     vkt::Buffer storage_buffer(*m_device, 12, 0, vkt::device_address);
-    uint32_t *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.memory().map());
+    uint32_t *storage_buffer_ptr = static_cast<uint32_t *>(storage_buffer.Memory().Map());
     storage_buffer_ptr[0] = 8;  // texture_cube_id
     storage_buffer_ptr[1] = 7;  // texture_2d_id
     storage_buffer_ptr[2] = 0;  // sampler_id
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {{4, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE, 16, VK_SHADER_STAGE_ALL, nullptr},
                                                   {5, VK_DESCRIPTOR_TYPE_SAMPLER, 16, VK_SHADER_STAGE_ALL, nullptr}});
@@ -764,18 +764,18 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SampledImageShareBindingBDA) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     const VkDescriptorSet sets[2] = {descriptor_set.set_, descriptor_set.set_};
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 2, sets, 0,
                               nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
-    VkDeviceAddress storage_buffer_addr = storage_buffer.address();
+    VkDeviceAddress storage_buffer_addr = storage_buffer.Address();
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout.handle(), VK_SHADER_STAGE_FRAGMENT_BIT, 0,
                          sizeof(storage_buffer_addr), &storage_buffer_addr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -791,9 +791,9 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Stress) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
     // send index to select in image array
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 0;  // index
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -888,12 +888,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, Stress) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -919,7 +919,8 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MixingProtectedResources) {
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs_image_protected.size;
-    if (!m_device->phy().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
+    if (!m_device->Physical().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info,
+                                            VK_MEMORY_PROPERTY_PROTECTED_BIT)) {
         GTEST_SKIP() << "Memory type not found";
     }
     vkt::DeviceMemory memory_image_protected(*m_device, alloc_info);
@@ -929,9 +930,9 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MixingProtectedResources) {
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device,
                                        {
@@ -974,12 +975,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, MixingProtectedResources) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -1017,12 +1018,12 @@ TEST_F(PositiveGpuAVDescriptorIndexing, PartialBoundDescriptorSSBO) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, shader_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -1118,7 +1119,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetCompute) {
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_2.handle(), 0, 2,
                               descriptor_sets, 0, nullptr);
@@ -1132,7 +1133,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetCompute) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe2.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1239,7 +1240,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_2.handle(), 0, 2,
@@ -1258,7 +1259,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphics) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1359,7 +1360,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_2.handle(), 0, 2,
@@ -1378,7 +1379,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsGPL) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1496,7 +1497,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout_2.handle(), 0, 2,
@@ -1514,7 +1515,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1579,7 +1580,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsPushCo
     std::array<uint32_t, 3> push_constants_data = {{1, 2, 3}};
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout_2.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0,
@@ -1601,7 +1602,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsPushCo
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1682,7 +1683,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     std::array<uint32_t, 3> push_constants_data = {{1, 2, 3}};
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     vk::CmdPushConstants(m_command_buffer.handle(), pipeline_layout_2.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0,
@@ -1703,7 +1704,7 @@ TEST_F(PositiveGpuAVDescriptorIndexing, SharedPipelineLayoutSubsetGraphicsShader
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }

--- a/tests/unit/gpu_av_indirect_buffer.cpp
+++ b/tests/unit/gpu_av_indirect_buffer.cpp
@@ -53,24 +53,24 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxDrawIndirectCount = 1;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState(nullptr, (features13.dynamicRendering || mesh_shader_enabled) ? (void *)&features13 : nullptr));
     InitRenderTarget();
 
     vkt::Buffer draw_buffer(*m_device, 2 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
+    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndirectCommand));
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = vku::InitStructHelper();
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
@@ -80,7 +80,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -89,13 +89,13 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
                                 sizeof(VkDrawIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
 
     if (features13.dynamicRendering) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -104,7 +104,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
                                     sizeof(VkDrawIndirectCommand));
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -130,22 +130,22 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimit) {
                                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
         VkDrawMeshTasksIndirectCommandEXT *mesh_draw_ptr =
-            static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.memory().map());
+            static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.Memory().Map());
         mesh_draw_ptr->groupCountX = 0;
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
-        mesh_draw_buffer.memory().unmap();
+        mesh_draw_buffer.Memory().Unmap();
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-02717");
-        count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+        count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 2;
-        count_buffer.memory().unmap();
-        m_command_buffer.begin(&begin_info);
+        count_buffer.Memory().Unmap();
+        m_command_buffer.Begin(&begin_info);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, mesh_pipe.Handle());
         vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer.handle(), mesh_draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -164,9 +164,9 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxDrawIndirectCount = 1;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     AddRequiredFeature(vkt::Feature::drawIndirectCount);
     AddRequiredFeature(vkt::Feature::synchronization2);
@@ -175,15 +175,15 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
 
     vkt::Buffer draw_buffer(*m_device, 2 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndexedIndirectCommand *draw_ptr = static_cast<VkDrawIndexedIndirectCommand *>(draw_buffer.memory().map());
+    VkDrawIndexedIndirectCommand *draw_ptr = static_cast<VkDrawIndexedIndirectCommand *>(draw_buffer.Memory().Map());
     memset(draw_ptr, 0, 2 * sizeof(VkDrawIndexedIndirectCommand));
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;  // Fits in buffer but exceeds (fake) limit
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -195,7 +195,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
@@ -205,7 +205,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCountDeviceLimitSubmit2) {
                                     sizeof(VkDrawIndexedIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // use vkQueueSumit2
     m_default_queue->Submit2(m_command_buffer);
     m_default_queue->Wait();
@@ -235,12 +235,12 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
 
     vkt::Buffer draw_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
+    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
     draw_ptr->firstInstance = 0;
     draw_ptr->firstVertex = 0;
     draw_ptr->instanceCount = 1;
     draw_ptr->vertexCount = 3;
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -255,34 +255,34 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_errorMonitor->SetDesiredErrorRegex("VUID-vkCmdDrawIndirectCount-countBuffer-03122",
                                          "Indirect draw count of 2 would exceed buffer size 16 of buffer .* stride = 16 offset = 0 "
                                          ".* = 36");
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vk::CmdDrawIndirectCountKHR(m_command_buffer.handle(), draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                 sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
-    count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndirectCount-countBuffer-03121");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // Offset of 4 should error
     vk::CmdDrawIndirectCountKHR(m_command_buffer.handle(), draw_buffer.handle(), 4, count_buffer.handle(), 0, 1,
                                 sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -290,18 +290,18 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03154");
     vkt::Buffer indexed_draw_buffer(*m_device, sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
+    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
     indexed_draw_ptr->indexCount = 3;
     indexed_draw_ptr->firstIndex = 0;
     indexed_draw_ptr->instanceCount = 1;
     indexed_draw_ptr->firstInstance = 0;
     indexed_draw_ptr->vertexOffset = 0;
-    indexed_draw_buffer.memory().unmap();
+    indexed_draw_buffer.Memory().Unmap();
 
-    count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 2;
-    count_buffer.memory().unmap();
-    m_command_buffer.begin(&begin_info);
+    count_buffer.Memory().Unmap();
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
@@ -309,16 +309,16 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_draw_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
-    count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 1;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawIndexedIndirectCount-countBuffer-03153");
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
@@ -326,7 +326,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_draw_buffer.handle(), 4, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -350,37 +350,37 @@ TEST_F(NegativeGpuAVIndirectBuffer, DrawCount) {
                                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
         VkDrawMeshTasksIndirectCommandEXT *mesh_draw_ptr =
-            +static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.memory().map());
+            +static_cast<VkDrawMeshTasksIndirectCommandEXT *>(mesh_draw_buffer.Memory().Map());
         mesh_draw_ptr->groupCountX = 0;
         mesh_draw_ptr->groupCountY = 0;
         mesh_draw_ptr->groupCountZ = 0;
-        mesh_draw_buffer.memory().unmap();
+        mesh_draw_buffer.Memory().Unmap();
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07098");
-        count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+        count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 1;
-        count_buffer.memory().unmap();
-        m_command_buffer.begin(&begin_info);
+        count_buffer.Memory().Unmap();
+        m_command_buffer.Begin(&begin_info);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, mesh_pipe.Handle());
         vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer.handle(), mesh_draw_buffer.handle(), 8, count_buffer.handle(), 0, 1,
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectCountEXT-countBuffer-07099");
-        count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+        count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
         *count_ptr = 2;
-        count_buffer.memory().unmap();
-        m_command_buffer.begin(&begin_info);
+        count_buffer.Memory().Unmap();
+        m_command_buffer.Begin(&begin_info);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, mesh_pipe.Handle());
         vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer.handle(), mesh_draw_buffer.handle(), 4, count_buffer.handle(), 0, 1,
                                              sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
         m_errorMonitor->VerifyFound();
@@ -414,14 +414,14 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
 
     vkt::Buffer draw_buffer(*m_device, buffer_size, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.memory().map());
+    uint32_t *draw_ptr = static_cast<uint32_t *>(draw_buffer.Memory().Map());
     memset(draw_ptr, 0, buffer_size);
 
     vkt::Buffer count_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.memory().map());
+    uint32_t *count_ptr = static_cast<uint32_t *>(count_buffer.Memory().Map());
     *count_ptr = 3;
-    count_buffer.memory().unmap();
+    count_buffer.Memory().Unmap();
     char const *mesh_shader_source = R"glsl(
         #version 450
         #extension GL_EXT_mesh_shader : require
@@ -441,14 +441,14 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     // Set x in third draw
     draw_ptr[8] = mesh_shader_props.maxMeshWorkGroupCount[0] + 1;
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, mesh_pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-VkDrawMeshTasksIndirectCommandEXT-TaskEXT-07326");
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), draw_buffer.handle(), 0, 3,
                                     (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -499,13 +499,13 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
     task_pipe.shader_stages_[1] = mesh_shader.GetStageCreateInfo();
     task_pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, task_pipe.Handle());
     vk::CmdDrawMeshTasksIndirectCountEXT(m_command_buffer.handle(), draw_buffer.handle(), 0, count_buffer.handle(), 0, 3,
                                          (sizeof(VkDrawMeshTasksIndirectCommandEXT) + 4));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Set x in second draw
     draw_ptr[4] = mesh_shader_props.maxTaskWorkGroupCount[0] + 1;
@@ -546,7 +546,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, Mesh) {
         draw_ptr[1] = 0;
         draw_ptr[0] = 0;
     }
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 }
 
 TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
@@ -561,7 +561,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
 
     vkt::Buffer draw_buffer(*m_device, 4 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
+    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
         draw_ptr->instanceCount = 1;
@@ -569,7 +569,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
         draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         draw_ptr++;
     }
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     VkPipelineLayoutCreateInfo pipelineLayoutCreateInfo = vku::InitStructHelper();
     vkt::PipelineLayout pipeline_layout(*m_device, pipelineLayoutCreateInfo);
@@ -581,12 +581,12 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
 
     m_errorMonitor->SetDesiredError("VUID-VkDrawIndirectCommand-firstInstance-00501");
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirect(m_command_buffer.handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -595,7 +595,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     m_errorMonitor->SetDesiredError("VUID-VkDrawIndexedIndirectCommand-firstInstance-00554");
     vkt::Buffer indexed_draw_buffer(*m_device, 4 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
+    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
         indexed_draw_ptr->instanceCount = 1;
@@ -604,9 +604,9 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
         indexed_draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         indexed_draw_ptr++;
     }
-    indexed_draw_buffer.memory().unmap();
+    indexed_draw_buffer.Memory().Unmap();
 
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
@@ -614,7 +614,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, FirstInstance) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), indexed_draw_buffer.handle(), sizeof(VkDrawIndexedIndirectCommand), 3,
                                sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -631,17 +631,17 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxComputeWorkGroupCount[0] = 2;
     props.limits.maxComputeWorkGroupCount[1] = 2;
     props.limits.maxComputeWorkGroupCount[2] = 2;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer indirect_buffer(*m_device, 5 * sizeof(VkDispatchIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.memory().map());
+    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
     ptr->y = 2;
@@ -666,12 +666,12 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     ptr->x = 3;  // over
     ptr->y = 2;
     ptr->z = 3;  // over
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
     CreateComputePipelineHelper pipe(*this);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
@@ -690,13 +690,13 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Check again in a 2nd submitted command buffer
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
@@ -707,7 +707,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSize) {
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 0);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
@@ -725,18 +725,18 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxComputeWorkGroupCount[0] = 2;
     props.limits.maxComputeWorkGroupCount[1] = 2;
     props.limits.maxComputeWorkGroupCount[2] = 2;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     AddRequiredFeature(vkt::Feature::shaderObject);
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer indirect_buffer(*m_device, 5 * sizeof(VkDispatchIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.memory().map());
+    VkDispatchIndirectCommand *ptr = static_cast<VkDispatchIndirectCommand *>(indirect_buffer.Memory().Map());
     // VkDispatchIndirectCommand[0]
     ptr->x = 4;  // over
     ptr->y = 2;
@@ -761,12 +761,12 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     ptr->x = 3;  // over
     ptr->y = 2;
     ptr->z = 3;  // over
-    indirect_buffer.memory().unmap();
+    indirect_buffer.Memory().Unmap();
 
     VkShaderStageFlagBits stage = VK_SHADER_STAGE_COMPUTE_BIT;
     vkt::Shader shader(*m_device, stage, GLSLToSPV(stage, kMinimalShaderGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stage, &shader.handle());
 
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
@@ -785,13 +785,13 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 4 * sizeof(VkDispatchIndirectCommand));
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Check again in a 2nd submitted command buffer
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stage, &shader.handle());
 
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
@@ -802,7 +802,7 @@ TEST_F(NegativeGpuAVIndirectBuffer, DispatchWorkgroupSizeShaderObjects) {
     m_errorMonitor->SetDesiredError("VUID-VkDispatchIndirectCommand-x-00417");
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 0);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();

--- a/tests/unit/gpu_av_oob.cpp
+++ b/tests/unit/gpu_av_oob.cpp
@@ -69,18 +69,18 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     robust_pipe.gp_ci_.layout = pipeline_layout.handle();
     robust_pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, robust_pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)uniform_buffer.memory().map();
+    uint32_t *data = (uint32_t *)uniform_buffer.Memory().Map();
     *data = 0;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
     // normally VUID-vkCmdDraw-uniformBuffers-06935
     m_errorMonitor->SetDesiredWarning("size is 4 bytes, 4 bytes were bound, and the highest out of bounds access was at [19] bytes",
                                       3);
@@ -88,9 +88,9 @@ TEST_F(NegativeGpuAVOOB, RobustBuffer) {
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     m_errorMonitor->VerifyFound();
-    data = (uint32_t *)uniform_buffer.memory().map();
+    data = (uint32_t *)uniform_buffer.Memory().Map();
     *data = 1;
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
     // normally VUID-vkCmdDraw-storageBuffers-06936
     m_errorMonitor->SetDesiredWarning(
         "size is 16 bytes, 16 bytes were bound, and the highest out of bounds access was at [35] bytes", 3);
@@ -135,18 +135,18 @@ TEST_F(NegativeGpuAVOOB, Basic) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
 
@@ -208,7 +208,7 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
 
     VkFormat color_formats = VK_FORMAT_UNDEFINED;
     VkPipelineRenderingCreateInfoKHR pipeline_rendering_info = vku::InitStructHelper();
-    const auto depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const auto depth_format = FindSupportedDepthOnlyFormat(Gpu());
 
     if (shader_objects) {
         pipeline_rendering_info.colorAttachmentCount = 1;
@@ -219,7 +219,7 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
 
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     if (shader_objects) {
         m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     } else {
@@ -245,7 +245,7 @@ void NegativeGpuAVOOB::ShaderBufferSizeTest(VkDeviceSize buffer_size, VkDeviceSi
     } else {
         m_command_buffer.EndRenderPass();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     vk::DeviceWaitIdle(*m_device);
     m_errorMonitor->VerifyFound();
@@ -404,9 +404,9 @@ TEST_F(NegativeGpuAVOOB, GPLWrite) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     static const char vertshader[] = R"glsl(
         #version 450
@@ -419,14 +419,14 @@ TEST_F(NegativeGpuAVOOB, GPLWrite) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vertshader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
 
@@ -466,14 +466,14 @@ TEST_F(NegativeGpuAVOOB, GPLRead) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vertshader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-uniformBuffers-06935", 3);
 
@@ -517,14 +517,14 @@ TEST_F(NegativeGpuAVOOB, GPLTexelFetch) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vertshader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds", 3);
 
@@ -568,14 +568,14 @@ TEST_F(NegativeGpuAVOOB, GPLImageLoad) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vertshader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds", 3);
 
@@ -619,14 +619,14 @@ TEST_F(NegativeGpuAVOOB, GPLImageStore) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vertshader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds", 3);
 
@@ -674,9 +674,9 @@ TEST_F(NegativeGpuAVOOB, GPLReadWriteIndependentSets) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     static const char vert_shader[] = R"glsl(
         #version 450
@@ -706,14 +706,14 @@ TEST_F(NegativeGpuAVOOB, GPLReadWriteIndependentSets) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vert_shader, frag_shader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);  // write
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-uniformBuffers-06935", 3);  // read
@@ -761,9 +761,9 @@ TEST_F(NegativeGpuAVOOB, GPLTexelFetchIndependentSets) {
 
     const std::array<VkDescriptorSet, 3> desc_sets = {vertex_set.set_, common_set.set_, fragment_set.set_};
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     static const char vert_shader[] = R"glsl(
         #version 450
@@ -791,14 +791,14 @@ TEST_F(NegativeGpuAVOOB, GPLTexelFetchIndependentSets) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vert_shader, frag_shader);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -871,14 +871,14 @@ TEST_F(NegativeGpuAVOOB, GPLImageLoadStoreIndependentSets) {
         }
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vert_shader, frag_shader);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // one for Load and one for Store
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds", 2);
@@ -907,9 +907,9 @@ TEST_F(NegativeGpuAVOOB, GPLNonInlined) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     static const char vertshader[] = R"glsl(
         #version 450
@@ -966,14 +966,14 @@ TEST_F(NegativeGpuAVOOB, GPLNonInlined) {
     exe_pipe_ci.layout = pipeline_layout.handle();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);
 
@@ -1030,21 +1030,21 @@ TEST_F(NegativeGpuAVOOB, StorageBuffer) {
     vkt::Buffer in_buffer(*m_device, 8, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    VkDeviceAddress block_ptr = block_buffer.address();
+    VkDeviceAddress block_ptr = block_buffer.Address();
 
-    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.memory().map();
+    uint8_t *in_buffer_ptr = (uint8_t *)in_buffer.Memory().Map();
     memcpy(in_buffer_ptr, &block_ptr, sizeof(VkDeviceAddress));
-    in_buffer.memory().unmap();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);
@@ -1070,12 +1070,12 @@ void NegativeGpuAVOOB::ComputeStorageBufferTest(const char *expected_error, cons
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError(expected_error);
     m_default_queue->Submit(m_command_buffer);
@@ -1163,12 +1163,12 @@ TEST_F(NegativeGpuAVOOB, TexelFetch) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, uniform_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1220,12 +1220,12 @@ TEST_F(NegativeGpuAVOOB, TexelFetchArray) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, partial_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1274,12 +1274,12 @@ TEST_F(NegativeGpuAVOOB, ImageLoad) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, storage_buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds");
     m_default_queue->Submit(m_command_buffer);
@@ -1321,12 +1321,12 @@ TEST_F(NegativeGpuAVOOB, ImageStore) {
     pipe.descriptor_set_->WriteDescriptorBufferView(0, storage_buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Texel Buffer texel out of bounds", 2);
     m_default_queue->Submit(m_command_buffer);
@@ -1372,14 +1372,14 @@ TEST_F(NegativeGpuAVOOB, Geometry) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);
@@ -1432,14 +1432,14 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationControl) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);
@@ -1490,14 +1490,14 @@ TEST_F(NegativeGpuAVOOB, DISABLED_TessellationEvaluation) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);
@@ -1631,14 +1631,14 @@ TEST_F(NegativeGpuAVOOB, VertexFragmentMultiEntrypoint) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-uniformBuffers-06935", 3);  // vertex
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-storageBuffers-06936", 3);  // fragment
@@ -1689,12 +1689,12 @@ TEST_F(NegativeGpuAVOOB, PartialBoundDescriptorCopy) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_dst.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);
@@ -1736,18 +1736,18 @@ TEST_F(NegativeGpuAVOOB, ConstantArrayOOBBuffer) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-Descriptor Buffer index out of bounds", 3);
 
@@ -1802,16 +1802,16 @@ TEST_F(NegativeGpuAVOOB, DISABLED_ConstantArrayOOBTexture) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    uint32_t *data = (uint32_t *)storage_buffer.memory().map();
+    uint32_t *data = (uint32_t *)storage_buffer.Memory().Map();
     *data = 8;
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-uniformBuffers-06935");
     m_default_queue->Submit(m_command_buffer);
@@ -1894,29 +1894,29 @@ TEST_F(NegativeGpuAVOOB, DeviceGeneratedCommandsCompute) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.memory().map();
+    VkDispatchIndirectCommand *block_buffer_ptr = (VkDispatchIndirectCommand *)block_buffer.Memory().Map();
     block_buffer_ptr->x = 1;
     block_buffer_ptr->y = 1;
     block_buffer_ptr->z = 1;
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     VkGeneratedCommandsInfoEXT generated_commands_info = vku::InitStructHelper(&pipeline_info);
     generated_commands_info.shaderStages = VK_SHADER_STAGE_COMPUTE_BIT;
     generated_commands_info.indirectExecutionSet = VK_NULL_HANDLE;
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = sizeof(VkDispatchIndirectCommand);
-    generated_commands_info.indirectAddress = block_buffer.address();
-    generated_commands_info.preprocessAddress = pre_process_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
+    generated_commands_info.preprocessAddress = pre_process_buffer.Address();
     generated_commands_info.preprocessSize = pre_process_size;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxSequenceCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteGeneratedCommandsEXT-storageBuffers-06936");
     m_default_queue->Submit(m_command_buffer);

--- a/tests/unit/gpu_av_oob_positive.cpp
+++ b/tests/unit/gpu_av_oob_positive.cpp
@@ -75,30 +75,30 @@ TEST_F(PositiveGpuAVOOB, Basic) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 1;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    data = (uint32_t *)offset_buffer.memory().map();
+    data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 2;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    data = (uint32_t *)offset_buffer.memory().map();
+    data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 3;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -145,12 +145,12 @@ TEST_F(PositiveGpuAVOOB, ImageLoadStoreTexelFetch) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, storage_buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -199,12 +199,12 @@ TEST_F(PositiveGpuAVOOB, AtomicImageLoadStore) {
     pipe.descriptor_set_->WriteDescriptorBufferView(0, storage_buffer_view.handle(), VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -271,30 +271,30 @@ TEST_F(PositiveGpuAVOOB, GPL) {
     )glsl";
     vkt::SimpleGPL pipe(*this, pipeline_layout.handle(), vs_source);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 1;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    data = (uint32_t *)offset_buffer.memory().map();
+    data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 2;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    data = (uint32_t *)offset_buffer.memory().map();
+    data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 3;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -319,9 +319,9 @@ TEST_F(PositiveGpuAVOOB, GPLNonInlined) {
     descriptor_set.WriteDescriptorBufferInfo(1, write_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *offset_buffer_ptr = (uint32_t *)offset_buffer.Memory().Map();
     *offset_buffer_ptr = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     static const char vertshader[] = R"glsl(
         #version 450
@@ -378,14 +378,14 @@ TEST_F(PositiveGpuAVOOB, GPLNonInlined) {
     exe_pipe_ci.layout = pipeline_layout.handle();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -424,20 +424,20 @@ TEST_F(PositiveGpuAVOOB, GPLFragmentIndependentSets) {
     fragment_set.UpdateDescriptorSets();
 
     {
-        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.memory().map()),
+        vvl::span<uint32_t> vert_data(static_cast<uint32_t *>(vs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : vert_data) {
             v = 0x01030507;
         }
-        vs_buffer.memory().unmap();
+        vs_buffer.Memory().Unmap();
     }
     {
-        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.memory().map()),
+        vvl::span<uint32_t> frag_data(static_cast<uint32_t *>(fs_buffer.Memory().Map()),
                                       static_cast<uint32_t>(buffer_size) / sizeof(uint32_t));
         for (auto &v : frag_data) {
             v = 0x02040608;
         }
-        fs_buffer.memory().unmap();
+        fs_buffer.Memory().Unmap();
     }
 
     const std::array<VkDescriptorSet, 2> desc_sets = {vertex_set.set_, fragment_set.set_};
@@ -508,14 +508,14 @@ TEST_F(PositiveGpuAVOOB, GPLFragmentIndependentSets) {
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
     vkt::Pipeline pipe(*m_device, exe_pipe_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, layout, 0,
                               static_cast<uint32_t>(desc_sets.size()), desc_sets.data(), 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -648,14 +648,14 @@ TEST_F(PositiveGpuAVOOB, VertexFragmentMultiEntrypoint) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -693,12 +693,12 @@ TEST_F(PositiveGpuAVOOB, PartialBoundDescriptorSSBO) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -737,12 +737,12 @@ TEST_F(PositiveGpuAVOOB, PartialBoundDescriptorBuffer) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -791,12 +791,12 @@ TEST_F(PositiveGpuAVOOB, PartialBoundDescriptorCopy) {
     pipe.cs_ = std::make_unique<VkShaderObj>(this, cs_source, VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_dst.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -851,12 +851,12 @@ TEST_F(PositiveGpuAVOOB, TexelFetchArray) {
     pipe.descriptor_set_->WriteDescriptorBufferView(1, partial_buffer_view.handle(), VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER, 1);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_positive.cpp
+++ b/tests/unit/gpu_av_positive.cpp
@@ -86,18 +86,18 @@ TEST_F(PositiveGpuAV, RobustBuffer) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    uint32_t *data = (uint32_t *)offset_buffer.memory().map();
+    uint32_t *data = (uint32_t *)offset_buffer.Memory().Map();
     *data = 8;
-    offset_buffer.memory().unmap();
+    offset_buffer.Memory().Unmap();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -124,7 +124,7 @@ TEST_F(PositiveGpuAV, ReserveBinding) {
 
     VkPhysicalDeviceProperties properties;
     vk::GetPhysicalDeviceProperties(phys_devices[m_gpu_index], &properties);
-    if (m_device->phy().limits_.maxBoundDescriptorSets != properties.limits.maxBoundDescriptorSets - 1) {
+    if (m_device->Physical().limits_.maxBoundDescriptorSets != properties.limits.maxBoundDescriptorSets - 1) {
         m_errorMonitor->SetError("VK_VALIDATION_FEATURE_ENABLE_GPU_ASSISTED_RESERVE_BINDING_SLOT_EXT not functioning as expected");
     }
     vk::DestroyInstance(test_inst, nullptr);
@@ -203,20 +203,20 @@ TEST_F(PositiveGpuAV, InlineUniformBlock) {
     pipe1.cp_ci_.layout = pipeline_layout.handle();
     pipe1.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe1.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     ASSERT_TRUE(*data = test_data);
     *data = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
@@ -277,7 +277,7 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
     descriptor_writes[1].descriptorType = VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK_EXT;
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
-    const uint32_t set_count = m_device->phy().limits_.maxBoundDescriptorSets + 1;  // account for reserved set
+    const uint32_t set_count = m_device->Physical().limits_.maxBoundDescriptorSets + 1;  // account for reserved set
     VkPhysicalDeviceInlineUniformBlockPropertiesEXT inline_uniform_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(inline_uniform_props);
     if (inline_uniform_props.maxPerStageDescriptorInlineUniformBlocks < set_count) {
@@ -314,22 +314,22 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         pipe.cp_ci_.layout = pl_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pl_layout.handle(), 0, 1,
                                   &descriptor_set.set_, 0, nullptr);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
 
         pl_layout.destroy();
 
-        uint32_t *data = (uint32_t *)buffer.memory().map();
+        uint32_t *data = (uint32_t *)buffer.Memory().Map();
         if (*data != test_data)
             m_errorMonitor->SetError("Pipeline recovery when resources unavailable not functioning as expected");
         *data = 0;
-        buffer.memory().unmap();
+        buffer.Memory().Unmap();
     }
 
     // Now make sure we can still use the shader with instrumentation
@@ -340,18 +340,18 @@ TEST_F(PositiveGpuAV, InlineUniformBlockAndRecovery) {
         pipe.cp_ci_.layout = pipeline_layout.handle();
         pipe.CreateComputePipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                                   &descriptor_set.set_, 0, nullptr);
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
-        uint32_t *data = (uint32_t *)buffer.memory().map();
+        uint32_t *data = (uint32_t *)buffer.Memory().Map();
         if (*data != test_data) m_errorMonitor->SetError("Using shader after pipeline recovery not functioning as expected");
         *data = 0;
-        buffer.memory().unmap();
+        buffer.Memory().Unmap();
     }
 }
 
@@ -362,7 +362,7 @@ TEST_F(PositiveGpuAV, SetSSBOBindDescriptor) {
     InitRenderTarget();
 
     VkPhysicalDeviceProperties properties = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &properties);
+    vk::GetPhysicalDeviceProperties(Gpu(), &properties);
     if (properties.limits.maxBoundDescriptorSets < 8) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
@@ -405,12 +405,12 @@ TEST_F(PositiveGpuAV, SetSSBOBindDescriptor) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(1, buffer_1.handle(), 0, 1024, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -424,7 +424,7 @@ TEST_F(PositiveGpuAV, SetSSBOPushDescriptor) {
     InitRenderTarget();
 
     VkPhysicalDeviceProperties properties = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &properties);
+    vk::GetPhysicalDeviceProperties(Gpu(), &properties);
     if (properties.limits.maxBoundDescriptorSets < 8) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
@@ -486,13 +486,13 @@ TEST_F(PositiveGpuAV, SetSSBOPushDescriptor) {
     VkDescriptorBufferInfo buffer_info_1 = {buffer_1.handle(), 0, 1024};
     descriptor_writes[1].pBufferInfo = &buffer_info_1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 2,
                                 descriptor_writes);
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -537,7 +537,7 @@ TEST_F(PositiveGpuAV, MutableBuffer) {
     InitRenderTarget();
 
     VkPhysicalDeviceProperties properties = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &properties);
+    vk::GetPhysicalDeviceProperties(Gpu(), &properties);
     if (properties.limits.maxBoundDescriptorSets < 8) {
         GTEST_SKIP() << "maxBoundDescriptorSets is too low";
     }
@@ -627,13 +627,13 @@ TEST_F(PositiveGpuAV, MutableBuffer) {
     descriptor_copy.dstArrayElement = 0;
     vk::UpdateDescriptorSets(device(), 0, nullptr, 1, &descriptor_copy);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
 
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -647,7 +647,7 @@ TEST_F(PositiveGpuAV, MaxDescriptorsClamp) {
     auto desc_indexing_props = vku::InitStruct<VkPhysicalDeviceDescriptorIndexingProperties>();
     auto props2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&desc_indexing_props);
 
-    vk::GetPhysicalDeviceProperties2(gpu(), &props2);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
 
     ASSERT_GE(gpuav::glsl::kDebugInputBindlessMaxDescriptors, desc_indexing_props.maxUpdateAfterBindDescriptorsInAllPools);
 }
@@ -661,7 +661,7 @@ TEST_F(PositiveGpuAV, MaxDescriptorsClamp13) {
     auto vk12_props = vku::InitStruct<VkPhysicalDeviceVulkan12Properties>();
     auto props2 = vku::InitStruct<VkPhysicalDeviceProperties2>(&vk12_props);
 
-    vk::GetPhysicalDeviceProperties2(gpu(), &props2);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props2);
 
     ASSERT_GE(gpuav::glsl::kDebugInputBindlessMaxDescriptors, vk12_props.maxUpdateAfterBindDescriptorsInAllPools);
 }
@@ -711,14 +711,14 @@ TEST_F(PositiveGpuAV, SelectInstrumentedShaders) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Should not get a warning since buggy vertex shader wasn't instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
     m_default_queue->Submit(m_command_buffer);
@@ -755,9 +755,9 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     const vkt::PipelineLayout pipeline_layout(*m_device, {&descriptor_set.layout_});
 
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
-    uint32_t *data = (uint32_t*)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     vkt::Buffer index_buffer(*m_device, sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
 
@@ -783,7 +783,7 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -791,7 +791,7 @@ TEST_F(PositiveGpuAV, BindingPartiallyBound) {
     vk::CmdBindIndexBuffer(m_command_buffer.handle(), index_buffer.handle(), 0, VK_INDEX_TYPE_UINT32);
     vk::CmdDrawIndexed(m_command_buffer.handle(), 1, 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -848,7 +848,7 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_, &descriptor_set.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 1, 1,
                               &descriptor_set.set_, 0, nullptr);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -857,7 +857,7 @@ TEST_F(PositiveGpuAV, DrawingWithUnboundUnusedSet) {
     vk::CmdDrawIndexedIndirectCountKHR(m_command_buffer.handle(), indexed_indirect_buffer.handle(), 0, count_buffer.handle(), 0, 1,
                                        sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGpuAV, FirstInstance) {
@@ -870,7 +870,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
 
     vkt::Buffer draw_buffer(*m_device, 4 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
+    auto draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
         draw_ptr->instanceCount = 1;
@@ -878,25 +878,25 @@ TEST_F(PositiveGpuAV, FirstInstance) {
         draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         draw_ptr++;
     }
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirect(m_command_buffer.handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Now with an offset and indexed draw
     vkt::Buffer indexed_draw_buffer(*m_device, 4 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
+    auto indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
         indexed_draw_ptr->instanceCount = 1;
@@ -905,9 +905,9 @@ TEST_F(PositiveGpuAV, FirstInstance) {
         indexed_draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         indexed_draw_ptr++;
     }
-    indexed_draw_buffer.memory().unmap();
+    indexed_draw_buffer.Memory().Unmap();
 
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
@@ -915,7 +915,7 @@ TEST_F(PositiveGpuAV, FirstInstance) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), indexed_draw_buffer.handle(), sizeof(VkDrawIndexedIndirectCommand), 3,
                                sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -933,7 +933,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
                                 VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    float *ptr = static_cast<float *>(copy_src_buffer.memory().map());
+    float *ptr = static_cast<float *>(copy_src_buffer.Memory().Map());
     for (size_t i = 0; i < 64 * 64; ++i) {
         if (i % 2) {
             ptr[i] = 1.0f;
@@ -941,13 +941,13 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
             ptr[i] = 0.0f;
         }
     }
-    copy_src_buffer.memory().unmap();
+    copy_src_buffer.Memory().Unmap();
 
     vkt::Image copy_dst_image(*m_device, 64, 64, 1, VK_FORMAT_D32_SFLOAT,
                               VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkBufferImageCopy buffer_image_copy_1;
     buffer_image_copy_1.bufferOffset = 0;
@@ -967,7 +967,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32) {
     vk::CmdCopyBufferToImage(m_command_buffer, copy_src_buffer, copy_dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
                              &buffer_image_copy_2);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     vk::DeviceWaitIdle(*m_device);
 }
@@ -984,7 +984,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
     vkt::Buffer copy_src_buffer(*m_device, 5 * 64 * 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    auto ptr = static_cast<uint8_t *>(copy_src_buffer.memory().map());
+    auto ptr = static_cast<uint8_t *>(copy_src_buffer.Memory().Map());
     std::memset(ptr, 0, static_cast<size_t>(copy_src_buffer.CreateInfo().size));
     for (size_t i = 0; i < 64 * 64; ++i) {
         auto ptr_float = reinterpret_cast<float *>(ptr + 5 * i);
@@ -995,13 +995,13 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
         }
     }
 
-    copy_src_buffer.memory().unmap();
+    copy_src_buffer.Memory().Unmap();
 
     vkt::Image copy_dst_image(*m_device, 64, 64, 1, VK_FORMAT_D32_SFLOAT_S8_UINT,
                               VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     copy_dst_image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkBufferImageCopy buffer_image_copy;
     buffer_image_copy.bufferOffset = 0;
@@ -1014,7 +1014,7 @@ TEST_F(PositiveGpuAV, CopyBufferToImageD32U8) {
     vk::CmdCopyBufferToImage(m_command_buffer, copy_src_buffer, copy_dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
                              &buffer_image_copy);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     vk::DeviceWaitIdle(*m_device);
 }
@@ -1040,14 +1040,14 @@ TEST_F(PositiveGpuAV, CopyBufferToImageTwoSubmit) {
     region.imageExtent = {32, 32, 1};
     region.bufferOffset = 0;
 
-    cb_0.begin();
+    cb_0.Begin();
     vk::CmdCopyBufferToImage(cb_0.handle(), buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1, &region);
-    cb_0.end();
+    cb_0.End();
     m_default_queue->Submit(cb_0);
     m_default_queue->Wait();
 
-    cb_1.begin();
-    cb_1.end();
+    cb_1.Begin();
+    cb_1.End();
     m_default_queue->Submit(cb_1);
     m_default_queue->Wait();
 }
@@ -1091,9 +1091,9 @@ TEST_F(PositiveGpuAV, AliasImageBinding) {
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     *data = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, float_image_view.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
                                                    VK_IMAGE_LAYOUT_GENERAL, 0);
@@ -1102,12 +1102,12 @@ TEST_F(PositiveGpuAV, AliasImageBinding) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(1, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     vk::DeviceWaitIdle(*m_device);
 }
@@ -1157,9 +1157,9 @@ TEST_F(PositiveGpuAV, AliasImageBindingNonFixed) {
 
     vkt::Buffer buffer(*m_device, 64, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                        VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     *data = 0;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, float_image_view.handle(), VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE,
                                                    VK_IMAGE_LAYOUT_GENERAL, 0);
@@ -1168,12 +1168,12 @@ TEST_F(PositiveGpuAV, AliasImageBindingNonFixed) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(1, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     vk::DeviceWaitIdle(*m_device);
 }
@@ -1191,7 +1191,7 @@ TEST_F(PositiveGpuAV, SwapchainImage) {
     {
         auto result = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
         ASSERT_TRUE(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
-        fence.wait(vvl::kU32Max);
+        fence.Wait(vvl::kU32Max);
     }
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -1233,7 +1233,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
 
     vkt::Buffer draw_buffer(*m_device, 4 * sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.memory().map());
+    VkDrawIndirectCommand *draw_ptr = static_cast<VkDrawIndirectCommand *>(draw_buffer.Memory().Map());
     for (uint32_t i = 0; i < 4; i++) {
         draw_ptr->vertexCount = 3;
         draw_ptr->instanceCount = 1;
@@ -1241,25 +1241,25 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
         draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         draw_ptr++;
     }
-    draw_buffer.memory().unmap();
+    draw_buffer.Memory().Unmap();
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDrawIndirect(m_command_buffer.handle(), draw_buffer.handle(), 0, 4, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Now with an offset and indexed draw
     vkt::Buffer indexed_draw_buffer(*m_device, 4 * sizeof(VkDrawIndexedIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.memory().map();
+    VkDrawIndexedIndirectCommand *indexed_draw_ptr = (VkDrawIndexedIndirectCommand *)indexed_draw_buffer.Memory().Map();
     for (uint32_t i = 0; i < 4; i++) {
         indexed_draw_ptr->indexCount = 3;
         indexed_draw_ptr->instanceCount = 1;
@@ -1268,9 +1268,9 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
         indexed_draw_ptr->firstInstance = (i == 3) ? 1 : 0;
         indexed_draw_ptr++;
     }
-    indexed_draw_buffer.memory().unmap();
+    indexed_draw_buffer.Memory().Unmap();
 
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer index_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_INDEX_BUFFER_BIT);
@@ -1278,7 +1278,7 @@ TEST_P(PositiveGpuAVParameterized, SettingsCombinations) {
     vk::CmdDrawIndexedIndirect(m_command_buffer.handle(), indexed_draw_buffer.handle(), sizeof(VkDrawIndexedIndirectCommand), 3,
                                sizeof(VkDrawIndexedIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1345,13 +1345,13 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.memory().map());
+    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
     indirect_draw_parameters.firstInstance = 0;
 
-    indirect_draw_parameters_buffer.memory().unmap();
+    indirect_draw_parameters_buffer.Memory().Unmap();
 
     constexpr int32_t int_count = 16;
     vkt::Buffer storage_buffer(*m_device, int_count * sizeof(int32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
@@ -1368,8 +1368,8 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
         int32_t integers_2[int_count / 2];
     } push_constants;
 
-    push_constants.storage_buffer_ptr_1 = storage_buffer.address();
-    push_constants.storage_buffer__ptr_2 = storage_buffer.address() + sizeof(int32_t) * (int_count / 2);
+    push_constants.storage_buffer_ptr_1 = storage_buffer.Address();
+    push_constants.storage_buffer__ptr_2 = storage_buffer.Address() + sizeof(int32_t) * (int_count / 2);
     for (int32_t i = 0; i < int_count / 2; ++i) {
         push_constants.integers_1[i] = i;
         push_constants.integers_2[i] = (int_count / 2) + i;
@@ -1442,7 +1442,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
     pipe.CreateGraphicsPipeline();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1458,15 +1458,15 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants) {
     // Vertex shader will write 8 values to storage buffer, fragment shader another 8
     vk::CmdDrawIndirect(m_command_buffer.handle(), indirect_draw_parameters_buffer.handle(), 0, 1, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.memory().map());
+    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], i);
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
@@ -1552,19 +1552,19 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
                                         vkt::device_address);
 
     PushConstants graphics_push_constants;
-    graphics_push_constants.storage_buffer = graphics_storage_buffer.address();
+    graphics_push_constants.storage_buffer = graphics_storage_buffer.Address();
     for (int32_t i = 0; i < int_count; ++i) {
         graphics_push_constants.integers[i] = i;
     }
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.memory().map());
+    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
     indirect_draw_parameters.firstInstance = 0;
-    indirect_draw_parameters_buffer.memory().unmap();
+    indirect_draw_parameters_buffer.Memory().Unmap();
 
     CreatePipelineHelper graphics_pipe(*this);
     graphics_pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
@@ -1607,7 +1607,7 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
                                        vkt::device_address);
 
     PushConstants compute_push_constants;
-    compute_push_constants.storage_buffer = compute_storage_buffer.address();
+    compute_push_constants.storage_buffer = compute_storage_buffer.Address();
     for (int32_t i = 0; i < int_count; ++i) {
         compute_push_constants.integers[i] = int_count + i;
     }
@@ -1620,17 +1620,17 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
     vkt::Buffer indirect_dispatch_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     auto &indirect_dispatch_parameters =
-        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.memory().map());
+        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1;
     indirect_dispatch_parameters.y = 1;
     indirect_dispatch_parameters.z = 1;
-    indirect_dispatch_parameters_buffer.memory().unmap();
+    indirect_dispatch_parameters_buffer.Memory().Unmap();
 
     // Submit commands
     // ---
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, graphics_pipe.Handle());
@@ -1648,21 +1648,21 @@ TEST_F(PositiveGpuAV, RestoreUserPushConstants2) {
                          sizeof(compute_push_constants), &compute_push_constants);
     // Compute shaders will write 8 values to compute storage buffer
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_dispatch_parameters_buffer.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.memory().map());
+    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(compute_storage_buffer_ptr[i], int_count + i);
     }
-    compute_storage_buffer.memory().unmap();
+    compute_storage_buffer.Memory().Unmap();
 
-    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.memory().map());
+    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(graphics_storage_buffer_ptr[i], i);
     }
-    graphics_storage_buffer.memory().unmap();
+    graphics_storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAV, PipelineLayoutMixing) {
@@ -1675,13 +1675,13 @@ TEST_F(PositiveGpuAV, PipelineLayoutMixing) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.memory().map());
+    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
     indirect_draw_parameters.firstInstance = 0;
 
-    indirect_draw_parameters_buffer.memory().unmap();
+    indirect_draw_parameters_buffer.Memory().Unmap();
 
     VkPushConstantRange push_constant_ranges = {VK_SHADER_STAGE_VERTEX_BIT, 0, sizeof(int)};
     VkPipelineLayoutCreateInfo pipe_layout_ci_1 = vku::InitStructHelper();
@@ -1706,7 +1706,7 @@ TEST_F(PositiveGpuAV, PipelineLayoutMixing) {
     pipe_2.descriptor_set_->UpdateDescriptorSets();
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // CmdPushConstants with layout 1 (is associated to pipeline 1, only has a push constant range)
@@ -1725,7 +1725,7 @@ TEST_F(PositiveGpuAV, PipelineLayoutMixing) {
     vk::CmdDrawIndirect(m_command_buffer.handle(), indirect_draw_parameters_buffer.handle(), 0, 1, sizeof(VkDrawIndirectCommand));
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -1795,7 +1795,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubset) {
     vk::UpdateDescriptorSets(device(), 2, descriptor_writes, 0, nullptr);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout_2.handle(), 0, 2,
                               descriptor_sets, 0, nullptr);
@@ -1803,7 +1803,7 @@ TEST_F(PositiveGpuAV, SharedPipelineLayoutSubset) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1822,12 +1822,12 @@ TEST_F(PositiveGpuAV, DestroyedPipelineLayout) {
         pipe.CreateGraphicsPipeline();
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGpuAV, DestroyedPipelineLayout2) {
@@ -1861,14 +1861,14 @@ TEST_F(PositiveGpuAV, DestroyedPipelineLayout2) {
         pipe.CreateGraphicsPipeline();
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGpuAV, DeviceGeneratedCommandsIES) {
@@ -1988,31 +1988,31 @@ TEST_F(PositiveGpuAV, DeviceGeneratedCommandsIES) {
     buffer_ci.size = pre_process_size;
     vkt::Buffer pre_process_buffer(*m_device, buffer_ci, 0, &allocate_flag_info);
 
-    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.memory().map();
+    uint32_t *block_buffer_ptr = (uint32_t *)block_buffer.Memory().Map();
     block_buffer_ptr[0] = 2;  // pick pipeline 2
     VkDispatchIndirectCommand *indirect_command_ptr = (VkDispatchIndirectCommand *)(block_buffer_ptr + 1);
     indirect_command_ptr->x = 1;
     indirect_command_ptr->y = 1;
     indirect_command_ptr->z = 1;
-    block_buffer.memory().unmap();
+    block_buffer.Memory().Unmap();
 
     VkGeneratedCommandsInfoEXT generated_commands_info = vku::InitStructHelper();
     generated_commands_info.shaderStages = VK_SHADER_STAGE_COMPUTE_BIT;
     generated_commands_info.indirectExecutionSet = exe_set.handle();
     generated_commands_info.indirectCommandsLayout = command_layout.handle();
     generated_commands_info.indirectAddressSize = sizeof(uint32_t) + sizeof(VkDispatchIndirectCommand);
-    generated_commands_info.indirectAddress = block_buffer.address();
-    generated_commands_info.preprocessAddress = pre_process_buffer.address();
+    generated_commands_info.indirectAddress = block_buffer.Address();
+    generated_commands_info.preprocessAddress = pre_process_buffer.Address();
     generated_commands_info.preprocessSize = pre_process_size;
     generated_commands_info.sequenceCountAddress = 0;
     generated_commands_info.maxSequenceCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, init_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, init_pipe.pipeline_layout_.handle(), 0, 1,
                               &init_pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdExecuteGeneratedCommandsEXT(m_command_buffer.handle(), false, &generated_commands_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_ray_query.cpp
+++ b/tests/unit/gpu_av_ray_query.cpp
@@ -59,17 +59,17 @@ TEST_F(NegativeGpuAVRayQuery, NegativeTmin) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = -2.0f;  // t_min
     uniform_buffer_ptr[1] = 42.0f;  // t_max
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
     m_default_queue->Submit(m_command_buffer);
@@ -113,17 +113,17 @@ TEST_F(NegativeGpuAVRayQuery, TMaxLessThenTmin) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 9.9f;  // t_min
     uniform_buffer_ptr[1] = 9.8f;  // t_max
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06350");
     m_default_queue->Submit(m_command_buffer);
@@ -165,16 +165,16 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsBothSkip) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0x100 | 0x200;  // SkipTrianglesKHR and SkipAABBsKHR
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06889");
     m_default_queue->Submit(m_command_buffer);
@@ -216,16 +216,16 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayFlagsOpaque) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0x1 | 0x2;  // OpaqueKHR and NoOpaqueKHR
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06891");
     m_default_queue->Submit(m_command_buffer);
@@ -270,17 +270,17 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNaN) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 1.0f;  // x
     uniform_buffer_ptr[1] = 0.0f;  // y
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06351");
     m_default_queue->Submit(m_command_buffer);
@@ -325,17 +325,17 @@ TEST_F(NegativeGpuAVRayQuery, ComputeRayOriginNonFinite) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, uniform_buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0.0f;  // t_min
     uniform_buffer_ptr[1] = 0.0f;  // t_max
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06348");
     m_default_queue->Submit(m_command_buffer);
@@ -381,16 +381,16 @@ TEST_F(NegativeGpuAVRayQuery, ComputeUseQueryUninit) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto buffer_ptr = static_cast<float *>(buffer.memory().map());
+    auto buffer_ptr = static_cast<float *>(buffer.Memory().Map());
     buffer_ptr[0] = -4.0f;  // t_min
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
     m_default_queue->Submit(m_command_buffer);
@@ -436,23 +436,23 @@ TEST_F(NegativeGpuAVRayQuery, RayGenUseQueryUninit) {
 
     vkt::Buffer ssbo(*m_device, 4096, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto buffer_ptr = static_cast<float *>(ssbo.memory().map());
+    auto buffer_ptr = static_cast<float *>(ssbo.Memory().Map());
     buffer_ptr[0] = -16.0f;
-    ssbo.memory().unmap();
+    ssbo.Memory().Unmap();
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, ssbo.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
 
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
 
     pipeline.Build();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349");
     m_default_queue->Submit(m_command_buffer);
@@ -503,18 +503,18 @@ TEST_F(NegativeGpuAVRayQuery, FragmentUseQueryUninit) {
     pipeline.descriptor_set_->WriteDescriptorBufferInfo(1, buffer, 0, VK_WHOLE_SIZE);
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    auto buffer_ptr = static_cast<float *>(buffer.memory().map());
+    auto buffer_ptr = static_cast<float *>(buffer.Memory().Map());
     buffer_ptr[0] = -4.0f;  // t_min
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-OpRayQueryInitializeKHR-06349", gpuav::glsl::kMaxErrorsPerCmd);
 

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -59,12 +59,12 @@ TEST_F(PositiveGpuAVRayQuery, ComputeBasic) {
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -111,27 +111,27 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
 
     // Ray query with t_min dynamically set to 0
     {
-        auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+        auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 0.0f;   // t_min
         uniform_buffer_ptr[1] = 42.0f;  // t_max
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
     }
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     // Ray query with both t_min and t_max dynamically set to 42
     {
-        auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.memory().map());
+        auto uniform_buffer_ptr = static_cast<float *>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 42.0f;  // t_min
         uniform_buffer_ptr[1] = 42.0f;  // t_max
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
     }
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -176,16 +176,16 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlags) {
 
     // Ray query with t_min dynamically set to 0
     {
-        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.memory().map());
+        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 4u | 16u;  // gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsCullBackFacingTrianglesEXT
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
     }
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -231,16 +231,16 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicRayFlagsSkipTriangles) {
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
     {
-        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.memory().map());
+        auto uniform_buffer_ptr = static_cast<uint32_t *>(uniform_buffer.Memory().Map());
         uniform_buffer_ptr[0] = 4u | 0x100;  // gl_RayFlagsTerminateOnFirstHitEXT | gl_RayFlagsSkipTrianglesEXT
-        uniform_buffer.memory().unmap();
+        uniform_buffer.Memory().Unmap();
     }
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -276,14 +276,14 @@ TEST_F(PositiveGpuAVRayQuery, GraphicsBasic) {
     pipeline.descriptor_set_->WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
     pipeline.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.pipeline_layout_.handle(), 0, 1,
                               &pipeline.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -324,14 +324,14 @@ TEST_F(PositiveGpuAVRayQuery, RayTracingBasic) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }

--- a/tests/unit/gpu_av_ray_tracing.cpp
+++ b/tests/unit/gpu_av_ray_tracing.cpp
@@ -100,7 +100,7 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
-    const VkDeviceAddress sbt_address = sbt_buffer.address();
+    const VkDeviceAddress sbt_address = sbt_buffer.Address();
 
     VkStridedDeviceAddressRegionKHR stridebufregion = {};
     stridebufregion.deviceAddress = sbt_address;
@@ -114,9 +114,9 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
 
     VkTraceRaysIndirectCommandKHR ray_query_dimensions{vvl::kU32Max, 1, 1};
 
-    uint8_t *ray_query_dimensions_buffer_1_ptr = (uint8_t *)ray_query_dimensions_buffer_1.memory().map();
+    uint8_t *ray_query_dimensions_buffer_1_ptr = (uint8_t *)ray_query_dimensions_buffer_1.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_1_ptr, &ray_query_dimensions, sizeof(ray_query_dimensions));
-    ray_query_dimensions_buffer_1.memory().unmap();
+    ray_query_dimensions_buffer_1.Memory().Unmap();
 
     ray_query_dimensions = {1, vvl::kU32Max, 1};
 
@@ -124,9 +124,9 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
         *m_device, 4096, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
 
-    uint8_t *ray_query_dimensions_buffer_2_ptr = (uint8_t *)ray_query_dimensions_buffer_2.memory().map();
+    uint8_t *ray_query_dimensions_buffer_2_ptr = (uint8_t *)ray_query_dimensions_buffer_2.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_2_ptr, &ray_query_dimensions, sizeof(ray_query_dimensions));
-    ray_query_dimensions_buffer_2.memory().unmap();
+    ray_query_dimensions_buffer_2.Memory().Unmap();
 
     ray_query_dimensions = {1, 1, vvl::kU32Max};
 
@@ -134,12 +134,12 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
         *m_device, 4096, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
 
-    uint8_t *ray_query_dimensions_buffer_3_ptr = (uint8_t *)ray_query_dimensions_buffer_3.memory().map();
+    uint8_t *ray_query_dimensions_buffer_3_ptr = (uint8_t *)ray_query_dimensions_buffer_3.Memory().Map();
     std::memcpy(ray_query_dimensions_buffer_3_ptr, &ray_query_dimensions, sizeof(ray_query_dimensions));
-    ray_query_dimensions_buffer_3.memory().unmap();
+    ray_query_dimensions_buffer_3.Memory().Unmap();
 
     // Trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, raytracing_pipeline);
 
@@ -147,25 +147,28 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_CmdTraceRaysIndirectKHR) {
                               &desc_set.set_, 0, nullptr);
 
     vk::CmdTraceRaysIndirectKHR(m_command_buffer.handle(), &stridebufregion, &stridebufregion, &stridebufregion, &stridebufregion,
-                                ray_query_dimensions_buffer_1.address());
+                                ray_query_dimensions_buffer_1.Address());
 
     vk::CmdTraceRaysIndirectKHR(m_command_buffer.handle(), &stridebufregion, &stridebufregion, &stridebufregion, &stridebufregion,
-                                ray_query_dimensions_buffer_2.address());
+                                ray_query_dimensions_buffer_2.Address());
 
     vk::CmdTraceRaysIndirectKHR(m_command_buffer.handle(), &stridebufregion, &stridebufregion, &stridebufregion, &stridebufregion,
-                                ray_query_dimensions_buffer_3.address());
+                                ray_query_dimensions_buffer_3.Address());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    if (uint64_t(physDevProps().limits.maxComputeWorkGroupCount[0]) * uint64_t(physDevProps().limits.maxComputeWorkGroupSize[0]) <
+    if (uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupCount[0]) *
+            uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupSize[0]) <
         uint64_t(vvl::kU32Max)) {
         m_errorMonitor->SetDesiredError("VUID-VkTraceRaysIndirectCommandKHR-width-03638");
     }
-    if (uint64_t(physDevProps().limits.maxComputeWorkGroupCount[1]) * uint64_t(physDevProps().limits.maxComputeWorkGroupSize[1]) <
+    if (uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupCount[1]) *
+            uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupSize[1]) <
         uint64_t(vvl::kU32Max)) {
         m_errorMonitor->SetDesiredError("VUID-VkTraceRaysIndirectCommandKHR-height-03639");
     }
-    if (uint64_t(physDevProps().limits.maxComputeWorkGroupCount[2]) * uint64_t(physDevProps().limits.maxComputeWorkGroupSize[2]) <
+    if (uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupCount[2]) *
+            uint64_t(PhysicalDeviceProps().limits.maxComputeWorkGroupSize[2]) <
         uint64_t(vvl::kU32Max)) {
         m_errorMonitor->SetDesiredError("VUID-VkTraceRaysIndirectCommandKHR-depth-03640");
     }
@@ -258,15 +261,15 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     vkt::Buffer rt_params_buffer(*m_device, 4 * sizeof(float), 0, vkt::device_address);  // missing space for Tmin and Tmax
     vkt::Buffer uniform_buffer(*m_device, 16, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.memory().map());
-    data[0] = rt_params_buffer.address();
-    uniform_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(uniform_buffer.Memory().Map());
+    data[0] = rt_params_buffer.Address();
+    uniform_buffer.Memory().Unmap();
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer.handle(), 0, 16, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
 
     // Add one to use the descriptor slot GPU-AV tried to reserve
-    const uint32_t max_bound_desc_sets = m_device->phy().limits_.maxBoundDescriptorSets + 1;
+    const uint32_t max_bound_desc_sets = m_device->Physical().limits_.maxBoundDescriptorSets + 1;
 
     // First try to use too many sets in the pipeline layout
     {
@@ -295,14 +298,14 @@ TEST_F(NegativeGpuAVRayTracing, DISABLED_BasicTraceRaysDeferredBuild) {
     RETURN_IF_SKIP(pipeline.Build());
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -90,14 +90,14 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRays) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -177,14 +177,14 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultipleStages) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -278,10 +278,10 @@ TEST_F(PositiveGpuAVRayTracing, DynamicTminTmax) {
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<float*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0.1f;   // t_min
     uniform_buffer_ptr[1] = 42.0f;  // t_max
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
     pipeline.GetDescriptorSet().UpdateDescriptorSets();
@@ -290,14 +290,14 @@ TEST_F(PositiveGpuAVRayTracing, DynamicTminTmax) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -387,9 +387,9 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDynamicRayFlags) {
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 16;  // gl_RayFlagsCullBackFacingTrianglesEXT
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
@@ -399,14 +399,14 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDynamicRayFlags) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -500,9 +500,9 @@ TEST_F(PositiveGpuAVRayTracing, DynamicRayFlagsSkipTriangle) {
     vkt::Buffer uniform_buffer(*m_device, 4096, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT,
                                VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
 
-    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.memory().map());
+    auto uniform_buffer_ptr = static_cast<uint32_t*>(uniform_buffer.Memory().Map());
     uniform_buffer_ptr[0] = 0x100;  // gl_RayFlagsSkipTrianglesEXT, or RayFlagsSkipTrianglesKHRMask in SPIR-V
-    uniform_buffer.memory().unmap();
+    uniform_buffer.Memory().Unmap();
 
     pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, uniform_buffer.handle(), 0, 4096, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER);
 
@@ -512,14 +512,14 @@ TEST_F(PositiveGpuAVRayTracing, DynamicRayFlagsSkipTriangle) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -723,14 +723,14 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultiEntryPoint) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -805,14 +805,14 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysDeferredBuild) {
     RETURN_IF_SKIP(pipeline.Build());
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }

--- a/tests/unit/gpu_av_shader_debug_info.cpp
+++ b/tests/unit/gpu_av_shader_debug_info.cpp
@@ -37,19 +37,19 @@ void NegativeGpuAVShaderDebugInfo::BasicSingleStorageBufferComputeOOB(const char
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.memory().map());
-    data[0] = block_buffer.address();
-    in_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    data[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // UNASSIGNED-Device address out of bounds
     m_errorMonitor->SetDesiredError(error);
@@ -358,19 +358,19 @@ TEST_F(NegativeGpuAVShaderDebugInfo, PipelineHandles) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.memory().map());
-    data[0] = block_buffer.address();
-    in_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    data[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // UNASSIGNED-Device address out of bounds
     m_errorMonitor->SetDesiredError("Pipeline (bad_pipeline)");
@@ -410,9 +410,9 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.memory().map());
-    data[0] = block_buffer.address();
-    in_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    data[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
     descriptor_set.WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
@@ -430,12 +430,12 @@ TEST_F(NegativeGpuAVShaderDebugInfo, ShaderObjectHandle) {
     name_info.pObjectName = object_name;
     vk::SetDebugUtilsObjectNameEXT(device(), &name_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1, shader_stages, &comp_shader.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // UNASSIGNED-Device address out of bounds
     m_errorMonitor->SetDesiredError("Shader Object (bad_shader_object)");
@@ -478,9 +478,9 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.memory().map());
-    data[0] = block_buffer.address();
-    in_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    data[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
 
     bad_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     bad_pipe.descriptor_set_->UpdateDescriptorSets();
@@ -490,7 +490,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
     CreatePipelineHelper empty_graphics_pipe(*this);
     empty_graphics_pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, empty_compute_pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);  // dispatch index 0
 
@@ -503,7 +503,7 @@ TEST_F(NegativeGpuAVShaderDebugInfo, CommandBufferCommandIndex) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe.pipeline_layout_.handle(), 0, 1,
                               &bad_pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);  // dispatch index 1
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // UNASSIGNED-Device address out of bounds
     m_errorMonitor->SetDesiredError("Compute Dispatch Index 1");
@@ -547,19 +547,19 @@ TEST_F(NegativeGpuAVShaderDebugInfo, DISABLED_StageInfo) {
     vkt::Buffer block_buffer(*m_device, 16, 0, vkt::device_address);
     vkt::Buffer in_buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto data = static_cast<VkDeviceAddress *>(in_buffer.memory().map());
-    data[0] = block_buffer.address();
-    in_buffer.memory().unmap();
+    auto data = static_cast<VkDeviceAddress *>(in_buffer.Memory().Map());
+    data[0] = block_buffer.Address();
+    in_buffer.Memory().Unmap();
 
     bad_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, in_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     bad_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, bad_pipe.pipeline_layout_.handle(), 0, 1,
                               &bad_pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 2, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // UNASSIGNED-Device address out of bounds
     m_errorMonitor->SetDesiredError("Global invocation ID (x, y, z) = (1, 0, 0)");

--- a/tests/unit/gpu_av_shader_object_positive.cpp
+++ b/tests/unit/gpu_av_shader_object_positive.cpp
@@ -78,7 +78,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
     vert_descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 4, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     vert_descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -86,7 +86,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
                               &vert_descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Should get a warning since shader was instrumented
     m_errorMonitor->SetDesiredWarning("VUID-vkCmdDraw-None-08613", 3);
@@ -96,7 +96,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
 
     vert_create_info.pNext = nullptr;
     const vkt::Shader vertShader2(*m_device, vert_create_info);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader2, fragShader);
@@ -104,7 +104,7 @@ TEST_F(PositiveGpuAVShaderObject, SelectInstrumentedShaders) {
                               &vert_descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Should not get a warning since shader was not instrumented
     m_errorMonitor->ExpectSuccess(kWarningBit | kErrorBit);
@@ -124,13 +124,13 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.memory().map());
+    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
     indirect_draw_parameters.firstInstance = 0;
 
-    indirect_draw_parameters_buffer.memory().unmap();
+    indirect_draw_parameters_buffer.Memory().Unmap();
 
     constexpr int32_t int_count = 16;
     vkt::Buffer storage_buffer(*m_device, int_count * sizeof(int32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, vkt::device_address);
@@ -147,8 +147,8 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
         int32_t integers_2[int_count / 2];
     } push_constants;
 
-    push_constants.storage_buffer_ptr_1 = storage_buffer.address();
-    push_constants.storage_buffer_ptr_2 = storage_buffer.address() + sizeof(int32_t) * (int_count / 2);
+    push_constants.storage_buffer_ptr_1 = storage_buffer.Address();
+    push_constants.storage_buffer_ptr_2 = storage_buffer.Address() + sizeof(int32_t) * (int_count / 2);
     for (int32_t i = 0; i < int_count / 2; ++i) {
         push_constants.integers_1[i] = i;
         push_constants.integers_2[i] = (int_count / 2) + i;
@@ -225,7 +225,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     const vkt::Shader fs(*m_device, fs_ci);
 
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    m_command_buffer.begin(&begin_info);
+    m_command_buffer.Begin(&begin_info);
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vs, fs);
@@ -242,15 +242,15 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants) {
     // Vertex shader will write 8 values to storage buffer, fragment shader another 8
     vk::CmdDrawIndirect(m_command_buffer.handle(), indirect_draw_parameters_buffer.handle(), 0, 1, sizeof(VkDrawIndirectCommand));
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.memory().map());
+    auto storage_buffer_ptr = static_cast<int32_t *>(storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(storage_buffer_ptr[i], i);
     }
-    storage_buffer.memory().unmap();
+    storage_buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
@@ -339,19 +339,19 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
                                         vkt::device_address);
 
     PushConstants graphics_push_constants;
-    graphics_push_constants.storage_buffer = graphics_storage_buffer.address();
+    graphics_push_constants.storage_buffer = graphics_storage_buffer.Address();
     for (int32_t i = 0; i < int_count; ++i) {
         graphics_push_constants.integers[i] = i;
     }
 
     vkt::Buffer indirect_draw_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.memory().map());
+    auto &indirect_draw_parameters = *static_cast<VkDrawIndirectCommand *>(indirect_draw_parameters_buffer.Memory().Map());
     indirect_draw_parameters.vertexCount = 3;
     indirect_draw_parameters.instanceCount = 1;
     indirect_draw_parameters.firstVertex = 0;
     indirect_draw_parameters.firstInstance = 0;
-    indirect_draw_parameters_buffer.memory().unmap();
+    indirect_draw_parameters_buffer.Memory().Unmap();
 
     VkShaderCreateInfoEXT vs_ci =
         ShaderCreateInfo(vs_spv, VK_SHADER_STAGE_VERTEX_BIT, 0, nullptr, 1, &graphics_push_constant_ranges);
@@ -398,7 +398,7 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
                                        vkt::device_address);
 
     PushConstants compute_push_constants;
-    compute_push_constants.storage_buffer = compute_storage_buffer.address();
+    compute_push_constants.storage_buffer = compute_storage_buffer.Address();
     for (int32_t i = 0; i < int_count; ++i) {
         compute_push_constants.integers[i] = int_count + i;
     }
@@ -411,16 +411,16 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
     vkt::Buffer indirect_dispatch_parameters_buffer(*m_device, sizeof(VkDrawIndirectCommand), VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT,
                                                     VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     auto &indirect_dispatch_parameters =
-        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.memory().map());
+        *static_cast<VkDispatchIndirectCommand *>(indirect_dispatch_parameters_buffer.Memory().Map());
     indirect_dispatch_parameters.x = 1;
     indirect_dispatch_parameters.y = 1;
     indirect_dispatch_parameters.z = 1;
-    indirect_dispatch_parameters_buffer.memory().unmap();
+    indirect_dispatch_parameters_buffer.Memory().Unmap();
 
     // Submit commands
     // ---
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
 
@@ -439,19 +439,19 @@ TEST_F(PositiveGpuAVShaderObject, RestoreUserPushConstants2) {
                          sizeof(compute_push_constants), &compute_push_constants);
     // Compute shaders will write 8 values to compute storage buffer
     vk::CmdDispatchIndirect(m_command_buffer.handle(), indirect_dispatch_parameters_buffer.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.memory().map());
+    auto compute_storage_buffer_ptr = static_cast<int32_t *>(compute_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(compute_storage_buffer_ptr[i], int_count + i);
     }
-    compute_storage_buffer.memory().unmap();
+    compute_storage_buffer.Memory().Unmap();
 
-    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.memory().map());
+    auto graphics_storage_buffer_ptr = static_cast<int32_t *>(graphics_storage_buffer.Memory().Map());
     for (int32_t i = 0; i < int_count; ++i) {
         ASSERT_EQ(graphics_storage_buffer_ptr[i], i);
     }
-    graphics_storage_buffer.memory().unmap();
+    graphics_storage_buffer.Memory().Unmap();
 }

--- a/tests/unit/gpu_av_spirv.cpp
+++ b/tests/unit/gpu_av_spirv.cpp
@@ -96,23 +96,23 @@ TEST_F(NegativeGpuAVSpirv, DISABLED_LoopHeaderPhi) {
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     // Will get to data[4] in loop and can crash
     data[0] = 32;  // data[0]
     data[1] = 32;  // data[1]
     data[2] = 32;  // data[2]
     data[3] = 32;  // data[3]
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/gpu_av_spirv_positive.cpp
+++ b/tests/unit/gpu_av_spirv_positive.cpp
@@ -32,9 +32,9 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     vkt::Buffer buffer_uniform(*m_device, 1024, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, mem_props);
     vkt::Buffer buffer_storage(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
 
-    uint32_t *data = (uint32_t *)buffer_uniform.memory().map();
+    uint32_t *data = (uint32_t *)buffer_uniform.Memory().Map();
     data[0] = 4;  // Scene.lightCount
-    buffer_uniform.memory().unmap();
+    buffer_uniform.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -159,14 +159,14 @@ TEST_F(PositiveGpuAVSpirv, LoopPhi) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -241,29 +241,29 @@ TEST_F(PositiveGpuAVSpirv, LoopHeaderPhi) {
 
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;  // data[0]
     data[1] = 2;  // data[1]
     data[2] = 3;  // data[2]
     data[3] = 0;  // data[3]
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
-    data = (uint32_t *)buffer.memory().map();
+    data = (uint32_t *)buffer.Memory().Map();
     ASSERT_EQ(4u, data[0]);
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 }
 
 TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
@@ -279,9 +279,9 @@ TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
     VkMemoryPropertyFlags mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     vkt::Buffer buffer(*m_device, 256, VK_BUFFER_USAGE_STORAGE_BUFFER_BIT, mem_props);
 
-    uint32_t *data = (uint32_t *)buffer.memory().map();
+    uint32_t *data = (uint32_t *)buffer.Memory().Map();
     data[0] = 1;
-    buffer.memory().unmap();
+    buffer.Memory().Unmap();
 
     OneOffDescriptorSet descriptor_set(m_device, {
                                                      {0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr},
@@ -342,12 +342,12 @@ TEST_F(PositiveGpuAVSpirv, VulkanMemoryModelDeviceScope) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -384,12 +384,12 @@ TEST_F(PositiveGpuAVSpirv, FindMultipleStores) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, write_buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();

--- a/tests/unit/graphics_library.cpp
+++ b/tests/unit/graphics_library.cpp
@@ -110,7 +110,7 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetsLinkOnly) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -166,7 +166,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSets) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&ds.layout_, &ds2.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-06563");
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                               static_cast<uint32_t>(sets.size()), sets.data(), 0, nullptr);
@@ -193,7 +193,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorSetsGPL) {
 
     vkt::PipelineLayout pipeline_layout(*m_device, {&ds.layout_, &ds2.layout_});
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Now bind with a layout that was _not_ created with independent sets, which should trigger 06754
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-pDescriptorSets-06563");
@@ -391,7 +391,7 @@ TEST_F(NegativeGraphicsLibrary, ImplicitVUIDs) {
     pipe.CreateGraphicsPipeline(false);
     m_errorMonitor->VerifyFound();
 
-    pipe.gp_ci_.renderPass = renderPass();
+    pipe.gp_ci_.renderPass = RenderPass();
     pipe.gp_ci_.stageCount = 0;
     pipe.shader_stages_.clear();
     pipe.gp_ci_.pStages = nullptr;
@@ -663,7 +663,7 @@ TEST_F(NegativeGraphicsLibrary, DSLShaderBindingsLinkOnly) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06758");
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
@@ -766,11 +766,11 @@ TEST_F(NegativeGraphicsLibrary, ImmutableSamplersIncompatibleDSL) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout_fs.handle();
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Draw with pipeline created with null set
@@ -1012,7 +1012,7 @@ TEST_F(NegativeGraphicsLibrary, DescriptorBufferLibrary) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     VkPipeline pipeline;
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-08096");
     vk::CreateGraphicsPipelines(m_device->handle(), VK_NULL_HANDLE, 1, &exe_pipe_ci, nullptr, &pipeline);
@@ -1206,7 +1206,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         libs[1] = pre_raster_lib.Handle();
         VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
-        exe_pipe_ci.renderPass = renderPass();
+        exe_pipe_ci.renderPass = RenderPass();
         m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-topology-08889");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();
@@ -1252,7 +1252,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         CreatePipelineHelper pre_raster_lib(*this);
         pre_raster_lib.InitPreRasterLibInfoFromContainer(tess_shaders);
         tsci_bad = tsci;
-        tsci_bad.patchControlPoints = m_device->phy().limits_.maxTessellationPatchSize + 1;
+        tsci_bad.patchControlPoints = m_device->Physical().limits_.maxTessellationPatchSize + 1;
         pre_raster_lib.gp_ci_.pTessellationState = &tsci_bad;
         m_errorMonitor->SetDesiredError("VUID-VkPipelineTessellationStateCreateInfo-patchControlPoints-01214");
         pre_raster_lib.CreateGraphicsPipeline(false);
@@ -1278,7 +1278,7 @@ TEST_F(NegativeGraphicsLibrary, Tessellation) {
         libs[1] = pre_raster_lib.Handle();
         VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = fs_lib.gp_ci_.layout;
-        exe_pipe_ci.renderPass = renderPass();
+        exe_pipe_ci.renderPass = RenderPass();
         m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pStages-08888");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();
@@ -1313,7 +1313,7 @@ TEST_F(NegativeGraphicsLibrary, PipelineExecutableProperties) {
 
         VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
-        exe_pipe_ci.renderPass = renderPass();
+        exe_pipe_ci.renderPass = RenderPass();
         m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06646");
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         m_errorMonitor->VerifyFound();
@@ -1437,12 +1437,12 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pipeline_layout.handle();
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06681");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Using an "empty" descriptor set is not legal
@@ -1458,7 +1458,7 @@ TEST_F(NegativeGraphicsLibrary, BindEmptyDS) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGraphicsLibrary, BindLibraryPipeline) {
@@ -1473,11 +1473,11 @@ TEST_F(NegativeGraphicsLibrary, BindLibraryPipeline) {
     CreatePipelineHelper pipeline(*this);
     pipeline.InitVertexInputLibInfo();
     pipeline.CreateGraphicsPipeline(false);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipeline-03382");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGraphicsLibrary, ShaderModuleIdentifier) {
@@ -1687,7 +1687,7 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayouts) {
 
     VkGraphicsPipelineCreateInfo exe_ci = vku::InitStructHelper(&link_info);
     exe_ci.layout = pipeline_layout_exe.handle();
-    exe_ci.renderPass = renderPass();
+    exe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with pre-raster state
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with fragment shader state
     vkt::Pipeline exe_pipe(*m_device, exe_ci);
@@ -1743,7 +1743,7 @@ TEST_F(NegativeGraphicsLibrary, IncompatibleLayoutsMultipleSubsets) {
 
     VkGraphicsPipelineCreateInfo exe_ci = vku::InitStructHelper(&link_info);
     exe_ci.layout = pipeline_layout_exe.handle();
-    exe_ci.renderPass = renderPass();
+    exe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with pre-raster state
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");  // incompatible with fragment shader state
     vkt::Pipeline exe_pipe(*m_device, exe_ci);
@@ -1798,7 +1798,7 @@ TEST_F(NegativeGraphicsLibrary, MissingLinkingLayout) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = VK_NULL_HANDLE;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-layout-07827");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -1836,7 +1836,7 @@ TEST_F(NegativeGraphicsLibrary, NullLibrary) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -1875,7 +1875,7 @@ TEST_F(NegativeGraphicsLibrary, BadLibrary) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pLibraries-parameter");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -1920,16 +1920,16 @@ TEST_F(NegativeGraphicsLibrary, DestroyedLibrary) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 
     frag_shader_lib.Destroy();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipeline-parameter");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGraphicsLibrary, DestroyedLibraryNested) {
@@ -1976,16 +1976,16 @@ TEST_F(NegativeGraphicsLibrary, DestroyedLibraryNested) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 
     vertex_input_lib.Destroy();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipeline-parameter");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
@@ -2043,11 +2043,11 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     exe_pipe_ci.pDynamicState = &dynamic_create_info;
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
@@ -2057,7 +2057,7 @@ TEST_F(NegativeGraphicsLibrary, DynamicPrimitiveTopolgyIngoreState) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeGraphicsLibrary, PushConstantStages) {
@@ -2099,7 +2099,7 @@ TEST_F(NegativeGraphicsLibrary, PushConstantStages) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2143,7 +2143,7 @@ TEST_F(NegativeGraphicsLibrary, PushConstantSize) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2187,7 +2187,7 @@ TEST_F(NegativeGraphicsLibrary, PushConstantMultiple) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2230,7 +2230,7 @@ TEST_F(NegativeGraphicsLibrary, PushConstantDifferentCount) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2323,7 +2323,7 @@ TEST_F(NegativeGraphicsLibrary, SetLayoutCountLinking) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2555,7 +2555,7 @@ TEST_F(NegativeGraphicsLibrary, NullDSLLinking) {
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06681");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -2582,7 +2582,7 @@ TEST_F(NegativeGraphicsLibrary, NullLayoutPreRasterFragShader) {
     pipe.gp_ci_.pViewportState = &pipe.vp_state_ci_;
     pipe.gp_ci_.pRasterizationState = &pipe.rs_state_ci_;
     pipe.gp_ci_.pMultisampleState = &pipe.ms_ci_;
-    pipe.gp_ci_.renderPass = renderPass();
+    pipe.gp_ci_.renderPass = RenderPass();
     pipe.gp_ci_.subpass = 0;
     pipe.gp_ci_.layout = pipeline_layout.handle();
 
@@ -2785,7 +2785,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateBothLibrary) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635");
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2883,7 +2883,7 @@ TEST_F(NegativeGraphicsLibrary, FragmentShadingRateStateBothLibrary) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06639");
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2940,7 +2940,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArray) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635");
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -2996,7 +2996,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateSampleMaskArrayNull) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635");
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -3040,7 +3040,7 @@ TEST_F(NegativeGraphicsLibrary, MultisampleStateMultipleSubsets) {
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-pLibraries-06635");
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = shader_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
 }
@@ -3204,7 +3204,7 @@ TEST_F(NegativeGraphicsLibrary, MissingFragmentOutput) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-flags-08909");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -3342,7 +3342,7 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetLayoutNull) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = VK_NULL_HANDLE;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     m_errorMonitor->SetDesiredError("VUID-VkGraphicsPipelineCreateInfo-flags-06730");
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     m_errorMonitor->VerifyFound();
@@ -3407,7 +3407,7 @@ TEST_F(NegativeGraphicsLibrary, IndependentSetLayoutCompatible) {
     link_info.pLibraries = libraries;
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
 
     // Stage are different
     {

--- a/tests/unit/graphics_library_positive.cpp
+++ b/tests/unit/graphics_library_positive.cpp
@@ -186,7 +186,7 @@ TEST_F(PositiveGraphicsLibrary, CombinedShaderSubsets) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = shader_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 }
 
@@ -268,7 +268,7 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Draw with pipeline created with null set
@@ -278,7 +278,7 @@ TEST_F(PositiveGraphicsLibrary, DrawWithNullDSLs) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, VertexInputAttributeDescriptionOffset) {
@@ -286,7 +286,7 @@ TEST_F(PositiveGraphicsLibrary, VertexInputAttributeDescriptionOffset) {
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
     VkPhysicalDeviceProperties device_props = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &device_props);
+    vk::GetPhysicalDeviceProperties(Gpu(), &device_props);
     if (device_props.limits.maxVertexInputAttributeOffset == 0xFFFFFFFF) {
         GTEST_SKIP() << "maxVertexInputAttributeOffset is max<uint32_t> already";
     }
@@ -295,7 +295,7 @@ TEST_F(PositiveGraphicsLibrary, VertexInputAttributeDescriptionOffset) {
 
     VkVertexInputBindingDescription vertex_input_binding_description{};
     vertex_input_binding_description.binding = 0;
-    vertex_input_binding_description.stride = m_device->phy().limits_.maxVertexInputBindingStride;
+    vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride;
     vertex_input_binding_description.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     // Test when offset is greater than maximum.
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
@@ -450,7 +450,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetPrimitiveTopology(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
@@ -458,7 +458,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyAllState) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
@@ -537,7 +537,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetPrimitiveTopology(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
@@ -545,7 +545,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateAndLinked) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
@@ -614,11 +614,11 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetPrimitiveTopology(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
@@ -626,7 +626,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicPrimitiveTopolgyVertexStateOnly) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
@@ -691,7 +691,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetAlphaToOneEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -699,7 +699,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentOutput) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
@@ -764,7 +764,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdSetAlphaToOneEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -772,7 +772,7 @@ TEST_F(PositiveGraphicsLibrary, DynamicAlphaToOneEnableFragmentShader) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, FragmentShaderNoStageCount) {
@@ -870,7 +870,7 @@ TEST_F(PositiveGraphicsLibrary, FSIgnoredPointerGPLDynamicRendering) {
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -942,7 +942,7 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -1029,12 +1029,12 @@ TEST_F(PositiveGraphicsLibrary, GPLDynamicRenderingWithDepthDraw) {
     begin_rendering_info.pDepthAttachment = &depth_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, exe_pipe.handle());
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveGraphicsLibrary, DepthState) {
@@ -1044,7 +1044,7 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState2);
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -1106,7 +1106,7 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
 
         VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
         exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
-        exe_pipe_ci.renderPass = renderPass();
+        exe_pipe_ci.renderPass = RenderPass();
         vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
         ASSERT_TRUE(exe_pipe.initialized());
     }
@@ -1136,7 +1136,7 @@ TEST_F(PositiveGraphicsLibrary, DepthState) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pr_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }
@@ -1148,7 +1148,7 @@ TEST_F(PositiveGraphicsLibrary, FOIgnoredDynamicRendering) {
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(InitBasicGraphicsLibrary());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -1290,7 +1290,7 @@ TEST_F(PositiveGraphicsLibrary, ShaderModuleIdentifier) {
     VkGraphicsPipelineCreateInfo pipe_ci = vku::InitStructHelper(&link_info);
     pipe_ci.flags |= VK_PIPELINE_CREATE_FAIL_ON_PIPELINE_COMPILE_REQUIRED_BIT;
     pipe_ci.layout = pipe.gp_ci_.layout;
-    pipe_ci.renderPass = renderPass();
+    pipe_ci.renderPass = RenderPass();
     VkPipeline pipeline;
     VkResult result = vk::CreateGraphicsPipelines(device(), VK_NULL_HANDLE, 1u, &pipe_ci, nullptr, &pipeline);
     ASSERT_TRUE(result == VK_SUCCESS || result == VK_PIPELINE_COMPILE_REQUIRED);
@@ -1430,7 +1430,7 @@ TEST_F(PositiveGraphicsLibrary, PipelineLibraryNoRendering) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }
@@ -1512,7 +1512,7 @@ TEST_F(PositiveGraphicsLibrary, IgnoredTessellationState) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
 
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
@@ -1555,7 +1555,7 @@ TEST_F(PositiveGraphicsLibrary, PushConstant) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
 }
 
@@ -1594,7 +1594,7 @@ TEST_F(PositiveGraphicsLibrary, PushConstantOneLibrary) {
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     vkt::Pipeline lib(*m_device, lib_ci);
 }
 
@@ -1703,7 +1703,7 @@ TEST_F(PositiveGraphicsLibrary, LinkWithNoLayout) {
     CreatePipelineHelper vertex_input_lib(*this);
     vertex_input_lib.InitVertexInputLibInfo(&link_info);
     vertex_input_lib.gp_ci_.layout = VK_NULL_HANDLE;
-    vertex_input_lib.gp_ci_.renderPass = renderPass();
+    vertex_input_lib.gp_ci_.renderPass = RenderPass();
     vertex_input_lib.CreateGraphicsPipeline(false);
 }
 
@@ -1781,7 +1781,7 @@ TEST_F(PositiveGraphicsLibrary, MultisampleStateSampleMaskArray) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
 }
 
@@ -1856,7 +1856,7 @@ TEST_F(PositiveGraphicsLibrary, RasterizerDiscardEnable) {
 
     VkGraphicsPipelineCreateInfo exe_pipe_ci = vku::InitStructHelper(&link_info);
     exe_pipe_ci.layout = pre_raster_lib.gp_ci_.layout;
-    exe_pipe_ci.renderPass = renderPass();
+    exe_pipe_ci.renderPass = RenderPass();
     vkt::Pipeline exe_pipe(*m_device, exe_pipe_ci);
     ASSERT_TRUE(exe_pipe.initialized());
 }

--- a/tests/unit/host_image_copy.cpp
+++ b/tests/unit/host_image_copy.cpp
@@ -478,7 +478,7 @@ TEST_F(NegativeHostImageCopy, Image1D) {
     copy_from_image.regionCount = 1;
     copy_from_image.pRegions = &region_from_image;
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) != 0) {
         // Can't use sampled image
         image_ci.samples = VK_SAMPLE_COUNT_2_BIT;
@@ -554,8 +554,9 @@ TEST_F(NegativeHostImageCopy, CompressedFormat) {
     }
 
     VkImageFormatProperties img_prop = {};
-    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), compressed_format, image_ci.imageType,
-                                                                 image_ci.tiling, image_ci.usage, image_ci.flags, &img_prop)) {
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), compressed_format,
+                                                                 image_ci.imageType, image_ci.tiling, image_ci.usage,
+                                                                 image_ci.flags, &img_prop)) {
         GTEST_SKIP() << "Image format properties not supported";
     }
 
@@ -692,7 +693,7 @@ TEST_F(NegativeHostImageCopy, DepthStencil) {
         GTEST_SKIP() << "Depth Stencil layout not supported";
     }
 
-    auto stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto stencil_format = FindSupportedDepthStencilFormat(Gpu());
     if (!(m_device->FormatFeaturesOptimal(stencil_format) & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT)) {
         GTEST_SKIP() << "Device does not support host image on depth format";
     }
@@ -772,7 +773,7 @@ TEST_F(NegativeHostImageCopy, DepthStencil) {
 
     VkImageFormatProperties img_prop = {};
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), stencil_format, image_ci.imageType, image_ci.tiling,
+                          m_device->Physical().handle(), stencil_format, image_ci.imageType, image_ci.tiling,
                           VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT, image_ci.flags,
                           &img_prop)) {
         // The aspectMask member of imageSubresource must only have a single bit set
@@ -837,8 +838,9 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
 
     VkImageFormatProperties img_prop = {};
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &img_prop)) {
+                          m_device->Physical().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D,
+                          VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0,
+                          &img_prop)) {
         // imageSubresource.aspectMask must be VK_IMAGE_ASPECT_PLANE_0_BIT or VK_IMAGE_ASPECT_PLANE_1_BIT
         vkt::Image image_multi_planar2(*m_device, 128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM,
                                        VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -856,8 +858,9 @@ TEST_F(NegativeHostImageCopy, MultiPlanar) {
     }
 
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &img_prop)) {
+                          m_device->Physical().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TYPE_2D,
+                          VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0,
+                          &img_prop)) {
         // imageSubresource.aspectMask must be VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or
         // VK_IMAGE_ASPECT_PLANE_2_BIT
         vkt::Image image_multi_planar3(*m_device, 128, 128, 1, VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM,
@@ -1056,7 +1059,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImage) {
     copy_image_to_image.dstImageLayout = layout;
 
     VkFormat no_hic_feature_format =
-        FindFormatWithoutFeatures2(gpu(), image_ci.tiling, VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT);
+        FindFormatWithoutFeatures2(Gpu(), image_ci.tiling, VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT);
     if (no_hic_feature_format != VK_FORMAT_UNDEFINED) {
         // If VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT, then format features must have VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT
         image_ci.format = no_hic_feature_format;
@@ -1088,7 +1091,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImage) {
     // Note that because the images need to be identical to avoid 09069, we'll go ahead and test for src and dst errors in one call
 
     if (CopyLayoutSupported(copy_src_layouts, copy_dst_layouts, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL)) {
-        auto stencil_format = FindSupportedDepthStencilFormat(gpu());
+        auto stencil_format = FindSupportedDepthStencilFormat(Gpu());
         image_ci.format = stencil_format;
         image_ci.usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
         vkt::Image image_stencil1(*m_device, image_ci, vkt::set_layout);
@@ -1346,7 +1349,7 @@ TEST_F(NegativeHostImageCopy, CopyImageToImage) {
     }
 
     if (compressed_format != VK_FORMAT_UNDEFINED) {
-        if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), compressed_format,
+        if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), compressed_format,
                                                                      image_ci.imageType, image_ci.tiling, image_ci.usage,
                                                                      image_ci.flags, &img_prop)) {
             image_ci.format = compressed_format;
@@ -1405,8 +1408,9 @@ TEST_F(NegativeHostImageCopy, CopyImageToImage) {
     image_copy_2.dstSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
 
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &img_prop)) {
+                          m_device->Physical().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D,
+                          VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0,
+                          &img_prop)) {
         // imageSubresource.aspectMask must be VK_IMAGE_ASPECT_PLANE_0_BIT or VK_IMAGE_ASPECT_PLANE_1_BIT
         vkt::Image image_multi_twoplane1(*m_device, 128, 128, 1, VK_FORMAT_G8_B8R8_2PLANE_420_UNORM,
                                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -1427,8 +1431,9 @@ TEST_F(NegativeHostImageCopy, CopyImageToImage) {
     }
 
     if (VK_SUCCESS == vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &img_prop)) {
+                          m_device->Physical().handle(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TYPE_2D,
+                          VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0,
+                          &img_prop)) {
         // imageSubresource.aspectMask must be VK_IMAGE_ASPECT_PLANE_0_BIT, VK_IMAGE_ASPECT_PLANE_1_BIT, or
         // VK_IMAGE_ASPECT_PLANE_2_BIT
         vkt::Image image_multi_threeplane1(*m_device, 128, 128, 1, VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM,
@@ -1702,9 +1707,9 @@ TEST_F(NegativeHostImageCopy, TransitionImageLayoutMultiPlanar) {
 
     VkImageFormatProperties img_prop = {};
     if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
-                          VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, VK_IMAGE_CREATE_DISJOINT_BIT,
-                          &img_prop)) {
+                          m_device->Physical().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TYPE_2D,
+                          VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+                          VK_IMAGE_CREATE_DISJOINT_BIT, &img_prop)) {
         GTEST_SKIP() << "Image Format Properties not supported";
     }
 
@@ -1736,13 +1741,13 @@ TEST_F(NegativeHostImageCopy, TransitionImageLayoutMultiPlanar) {
     // Find a valid memory type index to memory to be allocated from
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-    m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0);
+    m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0);
     vk::AllocateMemory(device(), &alloc_info, NULL, &plane_0_memory);
 
     image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
     vk::GetImageMemoryRequirements2(device(), &mem_req_info2, &mem_req2);
     alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-    m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0);
+    m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0);
     vk::AllocateMemory(device(), &alloc_info, NULL, &plane_1_memory);
 
     VkBindImagePlaneMemoryInfo plane_0_memory_info = vku::InitStructHelper();
@@ -1820,14 +1825,14 @@ TEST_F(NegativeHostImageCopy, TransitionImageLayoutDepthStencil) {
         GTEST_SKIP() << "Depth/Stencil image layout not supported";
     }
 
-    auto stencil_format = FindSupportedDepthStencilFormat(gpu());
+    auto stencil_format = FindSupportedDepthStencilFormat(Gpu());
     if (!(m_device->FormatFeaturesOptimal(stencil_format) & VK_FORMAT_FEATURE_2_HOST_IMAGE_TRANSFER_BIT_EXT)) {
         GTEST_SKIP() << "Device does not support host image on depth format";
     }
 
     VkImageFormatProperties img_prop = {};
     if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(
-                          m_device->phy().handle(), stencil_format, image_ci.imageType, image_ci.tiling,
+                          m_device->Physical().handle(), stencil_format, image_ci.imageType, image_ci.tiling,
                           VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT, image_ci.flags,
                           &img_prop)) {
         GTEST_SKIP() << "Image Format Properties not supported";
@@ -1894,7 +1899,7 @@ TEST_F(NegativeHostImageCopy, Features) {
     RETURN_IF_SKIP(InitState(nullptr, &host_copy_features));
     image_ci = vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT);
     VkImageFormatProperties img_prop = {};
-    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), image_ci.format, image_ci.imageType,
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), image_ci.format, image_ci.imageType,
                                                                  image_ci.tiling, image_ci.usage, image_ci.flags, &img_prop)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1967,7 +1972,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     vkt::Image image(*m_device, image_ci, (VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT));
     image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, layout);
 
-    VkDeviceAddress *data = (VkDeviceAddress *)image.memory().map();
+    VkDeviceAddress *data = (VkDeviceAddress *)image.Memory().Map();
 
     VkImageSubresourceLayers imageSubresource = {};
     imageSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -2024,7 +2029,7 @@ TEST_F(NegativeHostImageCopy, ImageMemoryOverlap) {
     vk::CopyMemoryToImageEXT(*m_device, &copy_memory_to_image);
     m_errorMonitor->VerifyFound();
 
-    image.memory().unmap();
+    image.Memory().Unmap();
 }
 
 TEST_F(NegativeHostImageCopy, ImageMemorySparseUnbound) {

--- a/tests/unit/host_image_copy_positive.cpp
+++ b/tests/unit/host_image_copy_positive.cpp
@@ -45,7 +45,7 @@ void HostImageCopyTest::InitHostImageCopyTest(const VkImageCreateInfo &create_in
 
     RETURN_IF_SKIP(InitState(nullptr, &host_copy_features));
     VkImageFormatProperties img_prop = {};
-    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), create_info.format,
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), create_info.format,
                                                                  create_info.imageType, create_info.tiling, create_info.usage,
                                                                  create_info.flags, &img_prop)) {
         GTEST_SKIP() << "Required formats/features not supported";
@@ -172,10 +172,10 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
 
     image_barrier.oldLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     image_barrier.newLayout = VK_IMAGE_LAYOUT_GENERAL;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &image_barrier);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -194,7 +194,7 @@ TEST_F(PositiveHostImageCopy, BasicUsage) {
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     image_format_info.usage = VK_IMAGE_USAGE_HOST_TRANSFER_BIT_EXT;
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
 }
 
 TEST_F(PositiveHostImageCopy, CopyImageToMemoryMipLevel) {

--- a/tests/unit/image.cpp
+++ b/tests/unit/image.cpp
@@ -29,7 +29,7 @@ TEST_F(NegativeImage, UsageBits) {
     RETURN_IF_SKIP(Init());
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 
-    auto format = FindSupportedDepthStencilFormat(gpu());
+    auto format = FindSupportedDepthStencilFormat(Gpu());
     // Initialize image with transfer source usage
     vkt::Image image(*m_device, 128, 128, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -58,7 +58,7 @@ TEST_F(NegativeImage, UsageBits) {
     region.imageExtent.depth = 1;
 
     // Buffer usage not set to TRANSFER_SRC and image usage not set to TRANSFER_DST
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // two separate errors from this call:
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-dstImage-00177");
@@ -144,12 +144,12 @@ TEST_F(NegativeImage, SampleCounts) {
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImage-00233");
         vk::CmdBlitImage(m_command_buffer.handle(), src_image.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst_image.handle(),
                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_NEAREST);
         m_errorMonitor->VerifyFound();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     // Create two images, the dest with sampleCount = 4, and attempt to blit
@@ -163,12 +163,12 @@ TEST_F(NegativeImage, SampleCounts) {
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-dstImage-00234");
         vk::CmdBlitImage(m_command_buffer.handle(), src_image.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, dst_image.handle(),
                          VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_NEAREST);
         m_errorMonitor->VerifyFound();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     VkBufferImageCopy copy_region = {};
@@ -188,13 +188,13 @@ TEST_F(NegativeImage, SampleCounts) {
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         vkt::Image dst_image(*m_device, image_create_info, vkt::set_layout);
         dst_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError(
             "was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT");
         vk::CmdCopyBufferToImage(m_command_buffer.handle(), src_buffer.handle(), dst_image.handle(),
                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
         m_errorMonitor->VerifyFound();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     // Create dst buffer and src image with sampleCount = 4 and attempt to copy
@@ -204,13 +204,13 @@ TEST_F(NegativeImage, SampleCounts) {
         image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
         image_create_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
         vkt::Image src_image(*m_device, (const VkImageCreateInfo &)image_create_info, 0);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError(
             "was created with a sample count of VK_SAMPLE_COUNT_4_BIT but must be VK_SAMPLE_COUNT_1_BIT");
         vk::CmdCopyImageToBuffer(m_command_buffer.handle(), src_image.handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL,
                                  dst_buffer.handle(), 1, &copy_region);
         m_errorMonitor->VerifyFound();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -227,23 +227,23 @@ TEST_F(NegativeImage, BlitFormatTypes) {
     VkFormat f_depth2 = VK_FORMAT_D32_SFLOAT;
     VkFormat f_ycbcr = VK_FORMAT_B16G16R16G16_422_UNORM;
 
-    if (!FormatIsSupported(gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL) ||
-        !FormatIsSupported(gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL) ||
-        !FormatIsSupported(gpu(), f_float, VK_IMAGE_TILING_OPTIMAL) ||
-        !FormatIsSupported(gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL) ||
-        !FormatIsSupported(gpu(), f_depth2, VK_IMAGE_TILING_OPTIMAL)) {
+    if (!FormatIsSupported(Gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL) ||
+        !FormatIsSupported(Gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL) ||
+        !FormatIsSupported(Gpu(), f_float, VK_IMAGE_TILING_OPTIMAL) ||
+        !FormatIsSupported(Gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL) ||
+        !FormatIsSupported(Gpu(), f_depth2, VK_IMAGE_TILING_OPTIMAL)) {
         GTEST_SKIP() << "Requested formats not supported";
     }
 
     // Note any missing feature bits
-    bool usrc = !FormatFeaturesAreSupported(gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-    bool udst = !FormatFeaturesAreSupported(gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
-    bool ssrc = !FormatFeaturesAreSupported(gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-    bool sdst = !FormatFeaturesAreSupported(gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
-    bool fsrc = !FormatFeaturesAreSupported(gpu(), f_float, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-    bool fdst = !FormatFeaturesAreSupported(gpu(), f_float, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
-    bool d1dst = !FormatFeaturesAreSupported(gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
-    bool d2src = !FormatFeaturesAreSupported(gpu(), f_depth2, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+    bool usrc = !FormatFeaturesAreSupported(Gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+    bool udst = !FormatFeaturesAreSupported(Gpu(), f_unsigned, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+    bool ssrc = !FormatFeaturesAreSupported(Gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+    bool sdst = !FormatFeaturesAreSupported(Gpu(), f_signed, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+    bool fsrc = !FormatFeaturesAreSupported(Gpu(), f_float, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+    bool fdst = !FormatFeaturesAreSupported(Gpu(), f_float, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+    bool d1dst = !FormatFeaturesAreSupported(Gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+    bool d2src = !FormatFeaturesAreSupported(Gpu(), f_depth2, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
 
     vkt::Image unsigned_image(*m_device, 64, 64, 1, f_unsigned, VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     unsigned_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
@@ -268,7 +268,7 @@ TEST_F(NegativeImage, BlitFormatTypes) {
     blitRegion.dstOffsets[0] = {0, 0, 0};
     blitRegion.dstOffsets[1] = {32, 32, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Unsigned int vs not an int
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImage-00230");
@@ -384,9 +384,9 @@ TEST_F(NegativeImage, BlitFormatTypes) {
     m_errorMonitor->VerifyFound();
 
     if (IsExtensionsEnabled(VK_KHR_SAMPLER_YCBCR_CONVERSION_EXTENSION_NAME) &&
-        FormatIsSupported(gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL)) {
-        bool ycbcrsrc = !FormatFeaturesAreSupported(gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
-        bool ycbcrdst = !FormatFeaturesAreSupported(gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
+        FormatIsSupported(Gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL)) {
+        bool ycbcrsrc = !FormatFeaturesAreSupported(Gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT);
+        bool ycbcrdst = !FormatFeaturesAreSupported(Gpu(), f_ycbcr, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT);
 
         vkt::Image ycbcr_image(*m_device, 64, 64, 1, f_ycbcr, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
         ycbcr_image.SetLayout(VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_GENERAL);
@@ -416,7 +416,7 @@ TEST_F(NegativeImage, BlitFormatTypes) {
                      depth_image.Layout(), 1, &blitRegion, VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, BlitFilters) {
@@ -425,7 +425,7 @@ TEST_F(NegativeImage, BlitFilters) {
     const bool cubic_support = IsExtensionsEnabled(VK_IMG_FILTER_CUBIC_EXTENSION_NAME);
 
     VkFormat fmt = VK_FORMAT_R8_UINT;
-    if (!FormatIsSupported(gpu(), fmt, VK_IMAGE_TILING_OPTIMAL)) {
+    if (!FormatIsSupported(Gpu(), fmt, VK_IMAGE_TILING_OPTIMAL)) {
         GTEST_SKIP() << "No R8_UINT format support";
     }
 
@@ -455,10 +455,10 @@ TEST_F(NegativeImage, BlitFilters) {
     blitRegion.dstOffsets[0] = {0, 0, 0};
     blitRegion.dstOffsets[1] = {64, 64, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // UINT format should not support linear filtering, but check to be sure
-    if (!FormatFeaturesAreSupported(gpu(), fmt, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), fmt, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT)) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-filter-02001");
         vk::CmdBlitImage(m_command_buffer.handle(), src2D.handle(), src2D.Layout(), dst2D.handle(), dst2D.Layout(), 1, &blitRegion,
                          VK_FILTER_LINEAR);
@@ -466,7 +466,7 @@ TEST_F(NegativeImage, BlitFilters) {
     }
 
     if (cubic_support &&
-        !FormatFeaturesAreSupported(gpu(), fmt, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG)) {
+        !FormatFeaturesAreSupported(Gpu(), fmt, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_CUBIC_BIT_IMG)) {
         // Invalid filter CUBIC_IMG
         m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-filter-02002");
         vk::CmdBlitImage(m_command_buffer.handle(), src2D.handle(), src2D.Layout(), dst2D.handle(), dst2D.Layout(), 1, &blitRegion,
@@ -481,7 +481,7 @@ TEST_F(NegativeImage, BlitFilters) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, BlitLayout) {
@@ -509,7 +509,7 @@ TEST_F(NegativeImage, BlitLayout) {
     blit_region.dstOffsets[0] = {32, 32, 0};
     blit_region.dstOffsets[1] = {64, 64, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBlitImage(m_command_buffer.handle(), img_general.handle(), img_general.Layout(), img_general.handle(),
                      img_general.Layout(), 1, &blit_region, VK_FILTER_LINEAR);
@@ -525,41 +525,41 @@ TEST_F(NegativeImage, BlitLayout) {
     vk::CmdBlitImage(m_command_buffer.handle(), img_src_transfer.handle(), img_src_transfer.Layout(), img_dst_transfer.handle(),
                      VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
 
     m_default_queue->Wait();
 
-    m_command_buffer.reset(0);
-    m_command_buffer.begin();
+    m_command_buffer.Reset(0);
+    m_command_buffer.Begin();
 
     // Source image in invalid layout at start of the CB
     m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
     vk::CmdBlitImage(m_command_buffer.handle(), img_src_transfer.handle(), img_src_transfer.Layout(), img_color.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &blit_region, VK_FILTER_LINEAR);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 
-    m_command_buffer.reset(0);
-    m_command_buffer.begin();
+    m_command_buffer.Reset(0);
+    m_command_buffer.Begin();
 
     // Destination image in invalid layout at start of the CB
     m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
     vk::CmdBlitImage(m_command_buffer.handle(), img_color.handle(), VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer.handle(),
                      img_dst_transfer.Layout(), 1, &blit_region, VK_FILTER_LINEAR);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 
     // Source image in invalid layout in the middle of CB
-    m_command_buffer.reset(0);
-    m_command_buffer.begin();
+    m_command_buffer.Reset(0);
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = 0;
@@ -582,14 +582,14 @@ TEST_F(NegativeImage, BlitLayout) {
     vk::CmdBlitImage(m_command_buffer.handle(), img_general.handle(), VK_IMAGE_LAYOUT_GENERAL, img_dst_transfer.handle(),
                      img_dst_transfer.Layout(), 1, &blit_region, VK_FILTER_LINEAR);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
 
     // Destination image in invalid layout in the middle of CB
-    m_command_buffer.reset(0);
-    m_command_buffer.begin();
+    m_command_buffer.Reset(0);
+    m_command_buffer.Begin();
 
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
     img_barrier.newLayout = VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL;
@@ -602,7 +602,7 @@ TEST_F(NegativeImage, BlitLayout) {
     vk::CmdBlitImage(m_command_buffer.handle(), img_src_transfer.handle(), img_src_transfer.Layout(), img_dst_transfer.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &blit_region, VK_FILTER_LINEAR);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_errorMonitor->VerifyFound();
     m_default_queue->Wait();
@@ -612,7 +612,7 @@ TEST_F(NegativeImage, BlitOffsets) {
     RETURN_IF_SKIP(Init());
 
     VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
-    if (!FormatFeaturesAreSupported(gpu(), fmt, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), fmt, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
         GTEST_SKIP() << "No blit feature format support";
     }
@@ -641,7 +641,7 @@ TEST_F(NegativeImage, BlitOffsets) {
     blit_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     blit_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // 1D, with src/dest y offsets other than (0,1)
     blit_region.srcOffsets[0] = {0, 1, 0};
@@ -729,7 +729,7 @@ TEST_F(NegativeImage, BlitOffsets) {
                      &blit_region, VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, BlitOverlap) {
@@ -738,7 +738,7 @@ TEST_F(NegativeImage, BlitOverlap) {
     RETURN_IF_SKIP(Init());
 
     VkFormat fmt = VK_FORMAT_R8G8B8A8_UNORM;
-    if (!FormatFeaturesAreSupported(gpu(), fmt, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), fmt, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
         GTEST_SKIP() << "No blit feature format support";
     }
@@ -759,7 +759,7 @@ TEST_F(NegativeImage, BlitOverlap) {
     blit_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     blit_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     blit_region.srcOffsets[0] = {0, 0, 0};
     blit_region.srcOffsets[1] = {31, 31, 1};
@@ -770,7 +770,7 @@ TEST_F(NegativeImage, BlitOverlap) {
                      &blit_region, VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, MiscBlitTests) {
@@ -778,7 +778,7 @@ TEST_F(NegativeImage, MiscBlitTests) {
 
     VkFormat f_color = VK_FORMAT_R32_SFLOAT;  // Need features ..BLIT_SRC_BIT & ..BLIT_DST_BIT
 
-    if (!FormatFeaturesAreSupported(gpu(), f_color, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), f_color, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
         GTEST_SKIP() << "No blit feature format support";
     }
@@ -815,7 +815,7 @@ TEST_F(NegativeImage, MiscBlitTests) {
     blitRegion.dstOffsets[0] = {32, 32, 0};
     blitRegion.dstOffsets[1] = {64, 64, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Blit with aspectMask errors
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -897,7 +897,7 @@ TEST_F(NegativeImage, MiscBlitTests) {
                      color_3D_img.Layout(), 1, &blitRegion, VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, BlitRemainingArrayLayers) {
@@ -907,7 +907,7 @@ TEST_F(NegativeImage, BlitRemainingArrayLayers) {
     RETURN_IF_SKIP(Init());
 
     VkFormat f_color = VK_FORMAT_R32_SFLOAT;  // Need features ..BLIT_SRC_BIT & ..BLIT_DST_BIT
-    if (!FormatFeaturesAreSupported(gpu(), f_color, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), f_color, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_BLIT_SRC_BIT | VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
         GTEST_SKIP() << "No blit feature format support";
     }
@@ -937,7 +937,7 @@ TEST_F(NegativeImage, BlitRemainingArrayLayers) {
     blitRegion.dstOffsets[0] = {32, 32, 0};
     blitRegion.dstOffsets[1] = {64, 64, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkImageBlit-layerCount-08801");
     vk::CmdBlitImage(m_command_buffer.handle(), image.handle(), image.Layout(), image.handle(), image.Layout(), 1, &blitRegion,
@@ -949,9 +949,9 @@ TEST_F(NegativeImage, BlitToDepth) {
     RETURN_IF_SKIP(Init());
 
     const VkFormat f_depth = VK_FORMAT_D32_SFLOAT;
-    if (!FormatFeaturesAreSupported(gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_SRC_BIT)) {
         GTEST_SKIP() << "Required depth VK_FORMAT_FEATURE_BLIT_SRC_BIT features not supported";
-    } else if (FormatFeaturesAreSupported(gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
+    } else if (FormatFeaturesAreSupported(Gpu(), f_depth, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_BLIT_DST_BIT)) {
         GTEST_SKIP() << "Required no depth VK_FORMAT_FEATURE_BLIT_DST_BIT features not supported";
     }
 
@@ -977,7 +977,7 @@ TEST_F(NegativeImage, BlitToDepth) {
     blitRegion.dstOffsets[0] = {32, 32, 0};
     blitRegion.dstOffsets[1] = {64, 64, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Blit depth image - has SRC_BIT but not DST_BIT
     blitRegion.srcSubresource.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
@@ -987,7 +987,7 @@ TEST_F(NegativeImage, BlitToDepth) {
                      &blitRegion, VK_FILTER_NEAREST);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, Array2DImageType) {
@@ -1055,7 +1055,7 @@ TEST_F(NegativeImage, ImageLayout) {
 
     const bool copy_commands2 = IsExtensionsEnabled(VK_KHR_COPY_COMMANDS_2_EXTENSION_NAME);
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     const VkFormat tex_format = VK_FORMAT_B8G8R8A8_UNORM;
     const int32_t tex_width = 32;
@@ -1083,7 +1083,7 @@ TEST_F(NegativeImage, ImageLayout) {
     image_create_info.usage |= VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
     vkt::Image depth_image(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageCopy copy_region;
     copy_region.srcSubresource.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     copy_region.srcSubresource.mipLevel = 0;
@@ -1299,7 +1299,7 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
         IsExtensionsEnabled(VK_KHR_MAINTENANCE_1_EXTENSION_NAME) || DeviceValidationVersion() >= VK_API_VERSION_1_1;
 
     VkPhysicalDeviceMemoryProperties memProps;
-    vk::GetPhysicalDeviceMemoryProperties(m_device->phy().handle(), &memProps);
+    vk::GetPhysicalDeviceMemoryProperties(m_device->Physical().handle(), &memProps);
 
     // Test mismatch detection for image of type VK_IMAGE_TYPE_1D
     VkImageCreateInfo imgInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -1417,13 +1417,13 @@ TEST_F(NegativeImage, ImageViewBreaksParameterCompatibilityRequirements) {
     // Check if the device can make the image required for this test case.
     VkImageFormatProperties formProps = {{0, 0, 0}, 0, 0, 0, 0};
     VkResult res = vk::GetPhysicalDeviceImageFormatProperties(
-        m_device->phy().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_3D, VK_IMAGE_TILING_OPTIMAL,
+        m_device->Physical().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_3D, VK_IMAGE_TILING_OPTIMAL,
         VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
         VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT | VK_IMAGE_CREATE_2D_ARRAY_COMPATIBLE_BIT_KHR | VK_IMAGE_CREATE_SPARSE_BINDING_BIT,
         &formProps);
 
     // If not, skip this part of the test.
-    if (res || !m_device->phy().Features().sparseBinding || !maintenance1_support) {
+    if (res || !m_device->Physical().Features().sparseBinding || !maintenance1_support) {
         GTEST_SKIP() << "Missing supported features";
     }
 
@@ -1513,16 +1513,16 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
         // Modify formats to have mismatched features
 
         // Format for image
-        fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_UINT, &formatProps);
+        fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_UINT, &formatProps);
         formatProps.optimalTilingFeatures |= features[i];
-        fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_UINT, formatProps);
+        fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_UINT, formatProps);
 
         memset(&formatProps, 0, sizeof(formatProps));
 
         // Format for view
-        fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_SINT, &formatProps);
+        fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_SINT, &formatProps);
         formatProps.optimalTilingFeatures = features[(i + 1) % feature_count];
-        fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_SINT, formatProps);
+        fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_SINT, formatProps);
 
         // Create image with modified format
         VkImageCreateInfo imgInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -1560,22 +1560,22 @@ TEST_F(NegativeImage, ImageViewFormatFeatureMismatch) {
     // Test for VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT.  Needs special formats
 
     // Only run this test if format supported
-    if (!FormatIsSupported(gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
+    if (!FormatIsSupported(Gpu(), VK_FORMAT_D24_UNORM_S8_UINT, VK_IMAGE_TILING_OPTIMAL)) {
         GTEST_SKIP() << "VK_FORMAT_D24_UNORM_S8_UINT format not supported";
     }
     // Modify formats to have mismatched features
 
     // Format for image
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_D24_UNORM_S8_UINT, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_D24_UNORM_S8_UINT, &formatProps);
     formatProps.optimalTilingFeatures |= features[i];
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_D24_UNORM_S8_UINT, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_D24_UNORM_S8_UINT, formatProps);
 
     memset(&formatProps, 0, sizeof(formatProps));
 
     // Format for view
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, &formatProps);
     formatProps.optimalTilingFeatures = features[(i + 1) % feature_count];
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, formatProps);
 
     // Create image with modified format
     VkImageCreateInfo imgInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -1628,10 +1628,10 @@ TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
 
     // Ensure image format claims support for sampled and storage, excludes color attachment
     memset(&formatProps, 0, sizeof(formatProps));
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_UINT, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_UINT, &formatProps);
     formatProps.optimalTilingFeatures |= (VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT | VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT);
     formatProps.optimalTilingFeatures = formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_UINT, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_UINT, formatProps);
 
     // Create image with sampled and storage usages
     VkImageCreateInfo imgInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
@@ -1653,10 +1653,10 @@ TEST_F(NegativeImage, ImageViewUsageCreateInfo) {
 
     // Force the imageview format to exclude storage feature, include color attachment
     memset(&formatProps, 0, sizeof(formatProps));
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_SINT, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_SINT, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT);
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_R32G32B32A32_SINT, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_R32G32B32A32_SINT, formatProps);
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
     ivci.image = image.handle();
@@ -1695,7 +1695,7 @@ TEST_F(NegativeImage, ImageViewNoSeparateStencilUsage) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     // without VK_EXT_separate_stencil_usage explicitly enabled
     RETURN_IF_SKIP(Init());
-    const auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    const auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
     const VkImageSubresourceRange range = {aspect, 0, 1, 0, 1};
@@ -1740,7 +1740,7 @@ TEST_F(NegativeImage, ImageViewStencilUsageCreateInfo) {
     AddRequiredExtensions(VK_EXT_SEPARATE_STENCIL_USAGE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    const auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     const VkImageAspectFlags aspect = VK_IMAGE_ASPECT_STENCIL_BIT;
     const VkImageSubresourceRange range = {aspect, 0, 1, 0, 1};
@@ -1937,13 +1937,13 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
     {
         VkFormat format = VK_FORMAT_D32_SFLOAT;
         VkFormatProperties image_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &image_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), format, &image_format_properties);
         VkImageFormatProperties format_limits{};
         VkResult result =
-            vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
-                                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
+            vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), format, VK_IMAGE_TYPE_2D,
+                                                       VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
         if ((result == VK_SUCCESS) &&
-            FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+            FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
             auto image_ci =
                 vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
             vkt::Image img(*m_device, image_ci);
@@ -1961,13 +1961,13 @@ TEST_F(NegativeImage, GetImageSubresourceLayout) {
     {
         VkFormat format = VK_FORMAT_S8_UINT;
         VkFormatProperties image_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &image_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), format, &image_format_properties);
         VkImageFormatProperties format_limits{};
         VkResult result =
-            vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_LINEAR,
-                                                       VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
+            vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), format, VK_IMAGE_TYPE_2D,
+                                                       VK_IMAGE_TILING_LINEAR, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0, &format_limits);
         if ((result == VK_SUCCESS) &&
-            FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+            FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_LINEAR, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
             auto image_ci =
                 vkt::Image::ImageCreateInfo2D(32, 32, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, VK_IMAGE_TILING_LINEAR);
             vkt::Image img(*m_device, image_ci);
@@ -2108,13 +2108,13 @@ TEST_F(NegativeImage, ImageViewFormatMismatchUnrelated) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkFormatProperties formatProps;
 
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), depth_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), depth_format, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), depth_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), depth_format, formatProps);
 
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
 
@@ -2146,9 +2146,9 @@ TEST_F(NegativeImage, ImageViewNoMutableFormatBit) {
 
     VkFormatProperties formatProps;
 
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_B8G8R8A8_UINT, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_B8G8R8A8_UINT, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), VK_FORMAT_B8G8R8A8_UINT, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), VK_FORMAT_B8G8R8A8_UINT, formatProps);
 
     VkImageViewCreateInfo imgViewInfo = vku::InitStructHelper();
     imgViewInfo.image = image.handle();
@@ -2233,7 +2233,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
     VkImageViewCreateInfo img_view_info_template = vku::InitStructHelper();
     img_view_info_template.image = image.handle();
     img_view_info_template.viewType = VK_IMAGE_VIEW_TYPE_2D_ARRAY;
-    img_view_info_template.format = image.format();
+    img_view_info_template.format = image.Format();
     // subresourceRange to be filled later for the purposes of this test
     img_view_info_template.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
     img_view_info_template.subresourceRange.baseMipLevel = 0;
@@ -2321,7 +2321,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRange) {
         VkImageViewCreateInfo cube_img_view_info_template = vku::InitStructHelper();
         cube_img_view_info_template.image = cubeArrayImg.handle();
         cube_img_view_info_template.viewType = VK_IMAGE_VIEW_TYPE_CUBE;
-        cube_img_view_info_template.format = cubeArrayImg.format();
+        cube_img_view_info_template.format = cubeArrayImg.Format();
         // subresourceRange to be filled later for the purposes of this test
         cube_img_view_info_template.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
         cube_img_view_info_template.subresourceRange.baseMipLevel = 0;
@@ -2407,7 +2407,7 @@ TEST_F(NegativeImage, ImageViewInvalidSubresourceRangeMaintenance1) {
 
     VkImageViewCreateInfo volume_img_view_info_template = vku::InitStructHelper();
     volume_img_view_info_template.image = volumeImage.handle();
-    volume_img_view_info_template.format = volumeImage.format();
+    volume_img_view_info_template.format = volumeImage.Format();
 
     // 3D views
     // first mip
@@ -2640,7 +2640,7 @@ TEST_F(NegativeImage, ImageViewLayerCount) {
 
     image_ci.imageType = VK_IMAGE_TYPE_3D;
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
     vkt::Image image_3d_array;
     image_ci.arrayLayers = 1;  // arrayLayers must be 1 for 3D images
     if (img_limits.maxArrayLayers >= image_ci.arrayLayers) {
@@ -2745,7 +2745,7 @@ TEST_F(NegativeImage, ImageMisc) {
 
     const VkImageCreateInfo safe_image_ci = DefaultImageInfo();
 
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &safe_image_ci));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &safe_image_ci));
 
     {
         VkImageCreateInfo image_ci = safe_image_ci;
@@ -2960,7 +2960,7 @@ TEST_F(NegativeImage, MaxLimitsMipLevels) {
         image_ci.format = format;
 
         VkImageFormatProperties img_limits;
-        if (VK_SUCCESS == GPDIFPHelper(gpu(), &image_ci, &img_limits) && img_limits.maxMipLevels == 1) {
+        if (VK_SUCCESS == GPDIFPHelper(Gpu(), &image_ci, &img_limits) && img_limits.maxMipLevels == 1) {
             CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-mipLevels-02255");
             return;  // end test
         }
@@ -2975,7 +2975,7 @@ TEST_F(NegativeImage, MaxLimitsArrayLayers) {
     VkImageCreateInfo image_ci = DefaultImageInfo();
 
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
 
     if (img_limits.maxArrayLayers == vvl::kU32Max) {
         GTEST_SKIP() << "VkImageFormatProperties::maxArrayLayers is already UINT32_MAX; skipping part of test";
@@ -2997,7 +2997,7 @@ TEST_F(NegativeImage, MaxLimitsSamples) {
              samples = static_cast<VkSampleCountFlagBits>(samples >> 1)) {
             image_ci.samples = samples;
             VkImageFormatProperties img_limits;
-            if (VK_SUCCESS == GPDIFPHelper(gpu(), &image_ci, &img_limits) && !(img_limits.sampleCounts & samples)) {
+            if (VK_SUCCESS == GPDIFPHelper(Gpu(), &image_ci, &img_limits) && !(img_limits.sampleCounts & samples)) {
                 CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-samples-02258");
                 return;  // end test
             }
@@ -3014,7 +3014,7 @@ TEST_F(NegativeImage, MaxLimitsExtent) {
     image_ci.imageType = VK_IMAGE_TYPE_3D;
 
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
 
     image_ci.extent = {img_limits.maxExtent.width + 1, 1, 1};
     CreateImageTest(*this, &image_ci, "VUID-VkImageCreateInfo-extent-02252");
@@ -3030,12 +3030,12 @@ TEST_F(NegativeImage, MaxLimitsFramebuffer) {
     TEST_DESCRIPTION("Create invalid image with invalid parameters exceeding physical device limits.");
     RETURN_IF_SKIP(Init());
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     VkImageCreateInfo image_ci = DefaultImageInfo();
     image_ci.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;  // (any attachment bit)
 
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_ci, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_ci, &img_limits));
 
     if (dev_limits.maxFramebufferWidth != vvl::kU32Max) {
         image_ci.extent = {dev_limits.maxFramebufferWidth + 1, 64, 1};
@@ -3066,7 +3066,7 @@ TEST_F(NegativeImage, DepthStencilImageViewWithColorAspectBit) {
     //  then when we cause aspect fail next, bad format check will be preempted
 
     RETURN_IF_SKIP(Init());
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     // One bad format and one good format for Color attachment
     const VkFormat tex_format_bad = depth_format;
@@ -3203,12 +3203,12 @@ TEST_F(NegativeImage, Stencil) {
     // VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT or VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT
     image_stencil_create_info.stencilUsage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539");
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(m_device->phy().handle(), &image_format_info2, &image_format_properties2);
+    vk::GetPhysicalDeviceImageFormatProperties2KHR(m_device->Physical().handle(), &image_format_info2, &image_format_properties2);
     m_errorMonitor->VerifyFound();
     // test vkCreateImage as well for this case
     CreateImageTest(*this, &image_create_info, "VUID-VkImageStencilUsageCreateInfo-stencilUsage-02539");
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
 
     if (dev_limits.maxFramebufferWidth != vvl::kU32Max) {
         // depth-stencil format image with VkImageStencilUsageCreateInfo with
@@ -3379,8 +3379,8 @@ TEST_F(NegativeImage, ImageViewIncompatibleDepthFormat) {
     AddOptionalExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkFormat depthOnlyFormat = FindSupportedDepthOnlyFormat(gpu());
-    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depthOnlyFormat = FindSupportedDepthOnlyFormat(Gpu());
+    const VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
 
     VkImageCreateInfo imageInfo = {VK_STRUCTURE_TYPE_IMAGE_CREATE_INFO,
                                    nullptr,
@@ -3553,7 +3553,7 @@ TEST_F(NegativeImage, ImageFormatListSizeCompatible) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_ASTC_4x4_UNORM_BLOCK, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_ASTC_4x4_UNORM_BLOCK, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -3596,7 +3596,7 @@ TEST_F(NegativeImage, BlockTextImageViewCompatibleFormat) {
     image_ci.format = VK_FORMAT_R8G8B8A8_UNORM;
 
     VkImageFormatProperties image_properties;
-    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_ci.format, image_ci.imageType, image_ci.tiling,
+    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling,
                                                               image_ci.usage, image_ci.flags, &image_properties);
     if (res != VK_SUCCESS) {
         GTEST_SKIP() << "Image format not valid for format, type, tiling, usage and flags combination.";
@@ -3614,7 +3614,7 @@ TEST_F(NegativeImage, BlockTextImageViewCompatibleFlag) {
     image_ci.format = VK_FORMAT_BC3_UNORM_BLOCK;
 
     VkImageFormatProperties image_properties;
-    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_ci.format, image_ci.imageType, image_ci.tiling,
+    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling,
                                                               image_ci.usage, image_ci.flags, &image_properties);
     if (res != VK_SUCCESS) {
         GTEST_SKIP() << "Image format not valid for format, type, tiling, usage and flags combination.";
@@ -3813,7 +3813,7 @@ TEST_F(NegativeImage, BlockTexelViewLevelOrLayerCount) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_create_info.format, &image_fmt);
     if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
@@ -3867,7 +3867,7 @@ TEST_F(NegativeImage, BlockTexelViewCompatibleMultipleLayers) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_create_info.format, &image_fmt);
     if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
@@ -3941,7 +3941,7 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     mem_alloc.allocationSize = mem_reqs.size;
     mem_alloc.memoryTypeIndex = mem_reqs.memoryTypeBits;
 
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     if (!pass) {
         GTEST_SKIP() << "Failed to set memory type.";
     }
@@ -3953,8 +3953,8 @@ TEST_F(NegativeImage, BindIMageMemoryDeviceGroupInfo) {
     VkRect2D region = {};
     region.offset.x = 0;
     region.offset.y = 0;
-    region.extent.width = image.width();
-    region.extent.height = image.height();
+    region.extent.width = image.Width();
+    region.extent.height = image.Height();
 
     VkBindImageMemoryDeviceGroupInfo bimdgi = vku::InitStructHelper();
     bimdgi.deviceIndexCount = 1;
@@ -3993,7 +3993,7 @@ TEST_F(NegativeImage, BlockTexelViewType) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_create_info.format, &image_fmt);
     if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
@@ -4032,7 +4032,7 @@ TEST_F(NegativeImage, BlockTexelViewFormat) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkFormatProperties image_fmt;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), image_create_info.format, &image_fmt);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), image_create_info.format, &image_fmt);
     if (!vkt::Image::IsCompatible(*m_device, image_create_info.usage, image_fmt.optimalTilingFeatures)) {
         GTEST_SKIP() << "Image usage and format not compatible on device";
     }
@@ -4074,7 +4074,7 @@ TEST_F(NegativeImage, ImageSubresourceRangeAspectMask) {
 
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
 
-    if (!FormatFeaturesAreSupported(gpu(), mp_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), mp_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
@@ -4140,7 +4140,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
     ci.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
     ci.sharingMode = VK_SHARING_MODE_CONCURRENT;
 
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &ci));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &ci));
 
     // Invalid pQueueFamilyIndices
     {
@@ -4169,7 +4169,7 @@ TEST_F(NegativeImage, CreateImageSharingModeConcurrentQueueFamilies) {
     // vkGetPhysicalDeviceQueueFamilyProperties or vkGetPhysicalDeviceQueueFamilyProperties2
     {
         uint32_t queue_node_count = 0;
-        vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, nullptr);
+        vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_node_count, nullptr);
 
         const std::array queue_families = {0U, queue_node_count};
         ci.queueFamilyIndexCount = size32(queue_families);
@@ -4184,7 +4184,7 @@ TEST_F(NegativeImage, MultiSampleImageView) {
 
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     if ((dev_limits.sampledImageColorSampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required VkSampleCountFlagBits are not supported; skipping";
     }
@@ -4203,7 +4203,7 @@ TEST_F(NegativeImage, MultiSampleImageView) {
     image_create_info.usage = VK_IMAGE_USAGE_SAMPLED_BIT;
 
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_create_info.format, image_create_info.imageType,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_create_info.format, image_create_info.imageType,
                                                image_create_info.tiling, image_create_info.usage, image_create_info.flags,
                                                &image_format_properties);
 
@@ -4430,7 +4430,7 @@ TEST_F(NegativeImage, ColorWthDepthAspect) {
 
     RETURN_IF_SKIP(Init());
 
-    auto format = FindSupportedDepthStencilFormat(gpu());
+    auto format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image color_image(*m_device, 64, 64, 1, format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
@@ -4494,7 +4494,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
             vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, format, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, imageTiling);
         image_create_info.pNext = &compression_control;
 
-        bool supported = ImageFormatIsSupported(instance(), gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+        bool supported = ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
 
         if (supported) {
             image.init(*m_device, image_create_info, 0);
@@ -4553,7 +4553,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // Depth format, Stencil aspect
     {
-        const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+        const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
         vkt::Image image;
         if (create_compressed_image(depth_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredError("VUID-vkGetImageSubresourceLayout2KHR-format-04462");
@@ -4568,7 +4568,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
         }
     }
     // Stencil format, Depth aspect
-    const VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    const VkFormat stencil_format = FindSupportedStencilOnlyFormat(Gpu());
     if (stencil_format != VK_FORMAT_UNDEFINED) {
         vkt::Image image;
         if (create_compressed_image(stencil_format, VK_IMAGE_TILING_LINEAR, image)) {
@@ -4586,7 +4586,7 @@ TEST_F(NegativeImage, ImageCompressionControl) {
 
     // AspectMask should be a bitset
     {
-        const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+        const VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
         vkt::Image image;
         if (create_compressed_image(depth_stencil_format, VK_IMAGE_TILING_LINEAR, image)) {
             m_errorMonitor->SetDesiredError("VUID-vkGetImageSubresourceLayout2KHR-aspectMask-00997");
@@ -4719,7 +4719,7 @@ TEST_F(NegativeImage, AttachmentFeedbackLoopLayoutFeature) {
     image.SetLayout(VK_IMAGE_LAYOUT_ATTACHMENT_FEEDBACK_LOOP_OPTIMAL_EXT);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageMemoryBarrier2KHR img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -5044,12 +5044,12 @@ TEST_F(NegativeImage, ImageViewTextureSampleWeighted) {
     // check the format feature flags
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
     if ((fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM) == 0) {
         GTEST_SKIP() << "Required VK_FORMAT_FEATURE_2_WEIGHT_IMAGE_BIT_QCOM bit not supported for R8_UNORM";
     }
     fmt_props_3 = vku::InitStructHelper();
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
     if ((fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM) == 0) {
         GTEST_SKIP() << "Required VK_FORMAT_FEATURE_2_WEIGHT_SAMPLED_IMAGE_BIT_QCOM bit not supported for VK_FORMAT_R8G8B8A8_UNORM";
     }
@@ -5262,12 +5262,12 @@ TEST_F(NegativeImage, ComputeImageLayout) {
 
     {  // Verify invalid image layout with CmdDispatch
         vkt::CommandBuffer cmd(*m_device, m_command_pool);
-        cmd.begin();
+        cmd.Begin();
         vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                                   &pipe.descriptor_set_->set_, 0, nullptr);
         vk::CmdBindPipeline(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatch(cmd.handle(), 1, 1, 1);
-        cmd.end();
+        cmd.End();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
         m_default_queue->Submit(cmd);
@@ -5277,12 +5277,12 @@ TEST_F(NegativeImage, ComputeImageLayout) {
 
     {  // Verify invalid image layout with CmdDispatchBaseKHR
         vkt::CommandBuffer cmd(*m_device, m_command_pool);
-        cmd.begin();
+        cmd.Begin();
         vk::CmdBindDescriptorSets(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                                   &pipe.descriptor_set_->set_, 0, nullptr);
         vk::CmdBindPipeline(cmd.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
         vk::CmdDispatchBaseKHR(cmd.handle(), 0, 0, 0, 1, 1, 1);
-        cmd.end();
+        cmd.End();
 
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
         m_default_queue->Submit(cmd);
@@ -5321,12 +5321,12 @@ TEST_F(NegativeImage, ComputeImageLayout11) {
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatchBase(m_command_buffer.handle(), 0, 0, 0, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
     m_default_queue->Submit(m_command_buffer);
@@ -5342,7 +5342,7 @@ TEST_F(NegativeImage, GetPhysicalDeviceImageFormatProperties) {
     if (!IsPlatformMockICD()) {
         GTEST_SKIP() << "Test only supported by MockICD";
     }
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_STORAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_E5B9G9R9_UFLOAT_PACK32, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_STORAGE_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
@@ -5357,11 +5357,11 @@ TEST_F(NegativeImage, BlitColorToDepth) {
 
     vkt::Image color_image(*m_device, 32, 32, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_SRC_BIT);
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image depth_image(*m_device, 32, 32, 1, depth_format, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
 
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), depth_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), depth_format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_2_BLIT_DST_BIT) == 0) {
         GTEST_SKIP() << "VK_FORMAT_FEATURE_2_BLIT_DST_BIT not supported for depth format";
     }
@@ -5374,20 +5374,20 @@ TEST_F(NegativeImage, BlitColorToDepth) {
     region.dstOffsets[0] = {0, 0, 0};
     region.dstOffsets[1] = {32, 32, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-srcImage-00231");
     m_errorMonitor->SetDesiredError("VUID-VkImageBlit-aspectMask-00238");
     vk::CmdBlitImage(m_command_buffer.handle(), color_image.handle(), VK_IMAGE_LAYOUT_GENERAL, depth_image.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1u, &region, VK_FILTER_LINEAR);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, ResolveDepthImage) {
     TEST_DESCRIPTION("Blit a color image to a depth image");
     RETURN_IF_SKIP(Init());
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkImageCreateInfo image_ci = vkt::Image::CreateInfo();
     image_ci.imageType = VK_IMAGE_TYPE_2D;
@@ -5402,7 +5402,7 @@ TEST_F(NegativeImage, ResolveDepthImage) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_ci.format, image_ci.imageType, image_ci.tiling, image_ci.usage,
                                                image_ci.flags, &image_format_properties);
     if ((image_format_properties.sampleCounts & image_ci.samples) == 0) {
         GTEST_SKIP() << "Required formats samples not supported";
@@ -5419,13 +5419,13 @@ TEST_F(NegativeImage, ResolveDepthImage) {
     region.dstOffset = {0, 0, 0};
     region.extent = {32, 32, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkImageResolve-aspectMask-00266");
     m_errorMonitor->SetDesiredError("VUID-vkCmdResolveImage-dstImage-02003");
     vk::CmdResolveImage(m_command_buffer.handle(), image1.handle(), VK_IMAGE_LAYOUT_GENERAL, image2.handle(),
                         VK_IMAGE_LAYOUT_GENERAL, 1u, &region);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeImage, ImageCompressionControlPlaneCount) {

--- a/tests/unit/image_drm.cpp
+++ b/tests/unit/image_drm.cpp
@@ -44,12 +44,12 @@ TEST_F(NegativeImageDrm, Basic) {
     drm_format_mod_info.drmFormatModifier = mods[0];
     drm_format_mod_info.sharingMode = VK_SHARING_MODE_EXCLUSIVE;
     image_format_info.pNext = (void *)&drm_format_mod_info;
-    vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+    vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
 
     {
         VkImageFormatProperties dummy_props;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties-tiling-02248");
-        vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), image_info.format, image_info.imageType,
+        vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), image_info.format, image_info.imageType,
                                                    image_info.tiling, image_info.usage, image_info.flags, &dummy_props);
         m_errorMonitor->VerifyFound();
     }
@@ -83,7 +83,8 @@ TEST_F(NegativeImageDrm, Basic) {
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.drmFormatModifier = mods[1];
     image_format_info.pNext = &drm_format_modifier;
-    VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+    VkResult result =
+        vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
     if (result == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         printf("Format VK_FORMAT_R8G8B8A8_UNORM not supported with format modifiers, Skipping the remaining tests.\n");
         return;
@@ -123,13 +124,13 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
 
     VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 
     image_format_info.pNext = nullptr;
     image_format_info.tiling = VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02249");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 
     VkImageFormatListCreateInfo format_list = vku::InitStructHelper(&image_drm_format_modifier);
@@ -137,7 +138,7 @@ TEST_F(NegativeImageDrm, ImageFormatInfo) {
     image_format_info.pNext = &format_list;
     image_format_info.flags = VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_format_info, &image_format_properties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -177,7 +178,7 @@ TEST_F(NegativeImageDrm, GetImageSubresourceLayoutPlane) {
         image_info.usage = create_info.usage;
         image_info.flags = create_info.flags;
         VkImageFormatProperties2 image_properties = vku::InitStructHelper();
-        if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
+        if (vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             // Works with Mesa, Pixel 7 doesn't support this combo
             GTEST_SKIP() << "Required formats/features not supported";
         }
@@ -234,7 +235,7 @@ TEST_F(NegativeImageDrm, ImageSubresourceRangeAspectMask) {
     RETURN_IF_SKIP(InitBasicImageDrm());
 
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    if (!FormatFeaturesAreSupported(gpu(), mp_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), mp_format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
@@ -365,13 +366,13 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfo) {
     VkImageFormatProperties2 image_properties = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02315");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
     m_errorMonitor->VerifyFound();
 
     drm_format_modifier.queueFamilyIndexCount = 2;
     drm_format_modifier.pQueueFamilyIndices = nullptr;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02314");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -381,7 +382,7 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfoQuery) {
     RETURN_IF_SKIP(InitBasicImageDrm());
 
     uint32_t queue_family_property_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties2(gpu(), &queue_family_property_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties2(Gpu(), &queue_family_property_count, nullptr);
     if (queue_family_property_count < 2) {
         GTEST_SKIP() << "pQueueFamilyPropertyCount is not 2 or more";
     }
@@ -407,7 +408,7 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfoQuery) {
     // Count too large
     queue_family_indices[0] = queue_family_property_count + 1;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02316");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
     m_errorMonitor->VerifyFound();
 
     // Not unique indices
@@ -415,7 +416,7 @@ TEST_F(NegativeImageDrm, PhysicalDeviceImageDrmFormatModifierInfoQuery) {
     queue_family_indices[1] = 0;
     drm_format_modifier.queueFamilyIndexCount = queue_family_property_count;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceImageDrmFormatModifierInfoEXT-sharingMode-02316");
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -455,7 +456,7 @@ TEST_F(NegativeImageDrm, MultiPlanarGetImageMemoryRequirements) {
         image_info.usage = create_info.usage;
         image_info.flags = create_info.flags;
         auto image_properties = vku::InitStruct<VkImageFormatProperties2>();
-        if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
+        if (vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             GTEST_SKIP() << "Required formats/features not supported";
         }
     }
@@ -514,7 +515,7 @@ TEST_F(NegativeImageDrm, MultiPlanarBindMemory) {
         image_info.usage = create_info.usage;
         image_info.flags = create_info.flags;
         auto image_properties = vku::InitStruct<VkImageFormatProperties2>();
-        if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
+        if (vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             GTEST_SKIP() << "Required formats/features not supported";
         }
     }
@@ -538,7 +539,7 @@ TEST_F(NegativeImageDrm, MultiPlanarBindMemory) {
     vk::GetImageMemoryRequirements2(device(), &mem_req_info2, &mem_reqs2);
     uint32_t mem_type = 0;
     auto phys_mem_props2 = vku::InitStruct<VkPhysicalDeviceMemoryProperties2>();
-    vk::GetPhysicalDeviceMemoryProperties2(gpu(), &phys_mem_props2);
+    vk::GetPhysicalDeviceMemoryProperties2(Gpu(), &phys_mem_props2);
     for (mem_type = 0; mem_type < phys_mem_props2.memoryProperties.memoryTypeCount; mem_type++) {
         if ((mem_reqs2.memoryRequirements.memoryTypeBits & (1 << mem_type)) &&
             ((phys_mem_props2.memoryProperties.memoryTypes[mem_type].propertyFlags & mem_props) == mem_props)) {

--- a/tests/unit/image_drm_positive.cpp
+++ b/tests/unit/image_drm_positive.cpp
@@ -24,14 +24,14 @@ std::vector<uint64_t> ImageDrmTest::GetFormatModifier(VkFormat format, VkFormatF
     std::vector<uint64_t> mods;
     VkDrmFormatModifierPropertiesListEXT mod_props = vku::InitStructHelper();
     VkFormatProperties2 format_props = vku::InitStructHelper(&mod_props);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
     if (mod_props.drmFormatModifierCount == 0) {
         return mods;
     }
 
     std::vector<VkDrmFormatModifierPropertiesEXT> mod_props_length(mod_props.drmFormatModifierCount);
     mod_props.pDrmFormatModifierProperties = mod_props_length.data();
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
 
     for (uint32_t i = 0; i < mod_props.drmFormatModifierCount; ++i) {
         auto &mod = mod_props.pDrmFormatModifierProperties[i];
@@ -91,7 +91,7 @@ TEST_F(PositiveImageDrm, Basic) {
 
         // bind memory
         VkPhysicalDeviceMemoryProperties phys_mem_props;
-        vk::GetPhysicalDeviceMemoryProperties(gpu(), &phys_mem_props);
+        vk::GetPhysicalDeviceMemoryProperties(Gpu(), &phys_mem_props);
         VkMemoryRequirements mem_reqs;
         vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
         VkDeviceMemory mem_obj = VK_NULL_HANDLE;
@@ -187,7 +187,7 @@ TEST_F(PositiveImageDrm, ExternalMemory) {
         VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
         VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
 
-        if (const auto result = vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+        if (const auto result = vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
             result != VK_SUCCESS) {
             GTEST_SKIP() << "Unable to create image. VkResult = " << string_VkResult(result);
         }
@@ -236,7 +236,7 @@ TEST_F(PositiveImageDrm, GetImageSubresourceLayoutPlane) {
         image_info.usage = create_info.usage;
         image_info.flags = create_info.flags;
         VkImageFormatProperties2 image_properties = vku::InitStructHelper();
-        if (vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties) != VK_SUCCESS) {
+        if (vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties) != VK_SUCCESS) {
             // Works with Mesa, Pixel 7 doesn't support this combo
             GTEST_SKIP() << "Required formats/features not supported";
         }
@@ -336,7 +336,7 @@ TEST_F(PositiveImageDrm, PhysicalDeviceImageDrmFormatModifierInfoExclusive) {
     VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
     VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
 
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
 }
 
 TEST_F(PositiveImageDrm, PhysicalDeviceImageDrmFormatModifierInfoConcurrent) {
@@ -345,12 +345,12 @@ TEST_F(PositiveImageDrm, PhysicalDeviceImageDrmFormatModifierInfoConcurrent) {
     RETURN_IF_SKIP(InitBasicImageDrm());
 
     uint32_t queue_family_property_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties2(gpu(), &queue_family_property_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties2(Gpu(), &queue_family_property_count, nullptr);
     if (queue_family_property_count < 2) {
         GTEST_SKIP() << "pQueueFamilyPropertyCount is not 2 or more";
     }
     std::vector<VkQueueFamilyProperties2> queue_family_props(queue_family_property_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties2(gpu(), &queue_family_property_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties2(Gpu(), &queue_family_property_count, nullptr);
 
     VkPhysicalDeviceImageDrmFormatModifierInfoEXT drm_format_modifier = vku::InitStructHelper();
     drm_format_modifier.sharingMode = VK_SHARING_MODE_CONCURRENT;
@@ -371,5 +371,5 @@ TEST_F(PositiveImageDrm, PhysicalDeviceImageDrmFormatModifierInfoConcurrent) {
     VkExternalImageFormatProperties external_image_properties = vku::InitStructHelper();
     VkImageFormatProperties2 image_properties = vku::InitStructHelper(&external_image_properties);
 
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &image_info, &image_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &image_info, &image_properties);
 }

--- a/tests/unit/imageless_framebuffer.cpp
+++ b/tests/unit/imageless_framebuffer.cpp
@@ -113,9 +113,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         framebufferCreateInfo.flags = VK_FRAMEBUFFER_CREATE_IMAGELESS_BIT_KHR;
         vkt::Framebuffer framebuffer(*m_device, framebufferCreateInfo);
         renderPassBeginInfo.framebuffer = framebuffer.handle();
-        m_command_buffer.begin(&cmd_begin_info);
+        m_command_buffer.Begin(&cmd_begin_info);
         m_command_buffer.BeginRenderPass(renderPassBeginInfo);
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 
     // Imageless framebuffer creation bit not present
@@ -299,9 +299,9 @@ TEST_F(NegativeImagelessFramebuffer, RenderPassBeginImageViewMismatch) {
         renderPassBeginInfo.framebuffer = framebuffer.handle();
         renderPassBeginInfo.renderArea.extent.height = renderPassBeginInfo.renderArea.extent.height / 2;
         renderPassBeginInfo.renderArea.extent.width = renderPassBeginInfo.renderArea.extent.width / 2;
-        m_command_buffer.begin(&cmd_begin_info);
+        m_command_buffer.Begin(&cmd_begin_info);
         m_command_buffer.BeginRenderPass(renderPassBeginInfo);
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
         renderPassAttachmentBeginInfo.pAttachments = &imageView.handle();
         imageViewCreateInfo.subresourceRange.baseMipLevel = 0;
         framebufferAttachmentImageInfo.height = framebufferAttachmentImageInfo.height * 2;
@@ -679,7 +679,7 @@ TEST_F(NegativeImagelessFramebuffer, DepthStencilResolveAttachment) {
 
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
-    VkFormat attachmentFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat attachmentFormat = FindSupportedDepthStencilFormat(Gpu());
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(attachmentFormat, VK_SAMPLE_COUNT_4_BIT);  // Depth/stencil

--- a/tests/unit/imageless_framebuffer_positive.cpp
+++ b/tests/unit/imageless_framebuffer_positive.cpp
@@ -132,10 +132,10 @@ TEST_F(PositiveImagelessFramebuffer, Image3D) {
     render_pass_bi.clearValueCount = 1;
     render_pass_bi.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass_bi);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveImagelessFramebuffer, SecondaryCmdBuffer) {
@@ -148,7 +148,7 @@ TEST_F(PositiveImagelessFramebuffer, SecondaryCmdBuffer) {
 
     uint32_t attachment_width = 512;
     uint32_t attachment_height = 512;
-    VkFormat format = FindSupportedDepthOnlyFormat(gpu());
+    VkFormat format = FindSupportedDepthOnlyFormat(Gpu());
 
     // Create a renderPass with a single attachment
     RenderPassSingleSubpass rp(*this);
@@ -207,9 +207,9 @@ TEST_F(PositiveImagelessFramebuffer, SecondaryCmdBuffer) {
     clearAttachment.colorAttachment = 0;
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary.begin(&beginInfo);
+    secondary.Begin(&beginInfo);
     vk::CmdClearAttachments(secondary.handle(), 1u, &clearAttachment, 1u, &clearRect);
-    secondary.end();
+    secondary.End();
 }
 
 TEST_F(PositiveImagelessFramebuffer, FragmentShadingRateDimensionsMultiview) {

--- a/tests/unit/instance_positive.cpp
+++ b/tests/unit/instance_positive.cpp
@@ -81,7 +81,7 @@ TEST_F(PositiveInstance, ValidEnumBeforeLogicalDevice) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    ImageFormatIsSupported(instance(), gpu(), ci, features);
+    ImageFormatIsSupported(instance(), Gpu(), ci, features);
 }
 
 TEST_F(PositiveInstance, EmptyVkLayerSettingEXT) {

--- a/tests/unit/memory.cpp
+++ b/tests/unit/memory.cpp
@@ -30,7 +30,7 @@ TEST_F(NegativeMemory, MapMemory) {
     VkDeviceMemory mem;
     VkMemoryRequirements mem_reqs;
 
-    const VkDeviceSize atom_size = m_device->phy().limits_.nonCoherentAtomSize;
+    const VkDeviceSize atom_size = m_device->Physical().limits_.nonCoherentAtomSize;
 
     VkBufferCreateInfo buf_info = vku::InitStructHelper();
     buf_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
@@ -45,7 +45,7 @@ TEST_F(NegativeMemory, MapMemory) {
     // Want to make sure entire allocation is aligned to atom size
     static const VkDeviceSize allocation_size = atom_size * 64;
     alloc_info.allocationSize = allocation_size;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         vk::DestroyBuffer(device(), buffer, NULL);
         GTEST_SKIP() << "Failed to set memory type";
@@ -157,7 +157,7 @@ TEST_F(NegativeMemory, MapMemory) {
     // device memory not atom size aligned
     alloc_info.allocationSize = (atom_size * 4) + 1;
     ASSERT_EQ(VK_SUCCESS, vk::CreateBuffer(device(), &buf_info, NULL, &buffer));
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         vk::DestroyBuffer(device(), buffer, NULL);
         GTEST_SKIP() << "Failed to set memory type";
@@ -173,8 +173,8 @@ TEST_F(NegativeMemory, MapMemory) {
         vk::FlushMappedMemoryRanges(device(), 1, &mmr);
     }
 
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-                                         VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                                              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     vk::UnmapMemory(device(), mem);
     if (!pass) {
         vk::FreeMemory(device(), mem, NULL);
@@ -204,7 +204,7 @@ TEST_F(NegativeMemory, MapMemory2) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory memory(*m_device, memory_info);
@@ -255,7 +255,7 @@ TEST_F(NegativeMemory, MapMemoryNullppData) {
 
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = 1024;
-    ASSERT_TRUE(m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory memory(*m_device, memory_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkMapMemory-ppData-parameter");
@@ -271,7 +271,7 @@ TEST_F(NegativeMemory, MapMemWithoutHostVisibleBit) {
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.allocationSize = 1024;
 
-    if (!m_device->phy().SetMemoryType(0xFFFFFFFF, &mem_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+    if (!m_device->Physical().SetMemoryType(0xFFFFFFFF, &mem_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
         // If we can't find any unmappable memory this test doesn't make sense
         GTEST_SKIP() << "No unmappable memory types found";
     }
@@ -305,7 +305,7 @@ TEST_F(NegativeMemory, MapMemory2WithoutHostVisibleBit) {
 
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.allocationSize = 1024;
-    if (!m_device->phy().SetMemoryType(
+    if (!m_device->Physical().SetMemoryType(
             0xFFFFFFFF, &mem_alloc, 0,
             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {  // If we can't find any unmappable memory this test doesn't make sense
         GTEST_SKIP() << "No unmappable memory types found";
@@ -344,7 +344,7 @@ TEST_F(NegativeMemory, MapMemoryPlaced) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory memory(*m_device, memory_info);
@@ -402,7 +402,7 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedEnabled) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory memory(*m_device, memory_info);
 
@@ -453,7 +453,7 @@ TEST_F(NegativeMemory, MemoryMapRangePlacedDisabled) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory memory(*m_device, memory_info);
 
@@ -536,7 +536,7 @@ TEST_F(NegativeMemory, RebindMemoryMultiObjectDebugUtils) {
     vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
 
     mem_alloc.allocationSize = mem_reqs.size;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
 
     // allocate 2 memory objects
@@ -571,13 +571,14 @@ TEST_F(NegativeMemory, QueryMemoryCommitmentWithoutLazyProperty) {
     image_ci.usage = VK_IMAGE_USAGE_TRANSIENT_ATTACHMENT_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
-    const auto mem_reqs = image.memory_requirements();
+    const auto mem_reqs = image.MemoryRequirements();
     VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
     image_alloc_info.allocationSize = mem_reqs.size;
 
     // the last argument is the "forbid" argument for SetMemoryType, disallowing
     // that particular memory type rather than requiring it
-    if (!m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &image_alloc_info, 0, VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
+    if (!m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &image_alloc_info, 0,
+                                            VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT)) {
         GTEST_SKIP() << "Failed to set memory type";
     }
     vkt::DeviceMemory mem(*m_device, image_alloc_info);
@@ -607,7 +608,7 @@ TEST_F(NegativeMemory, BindImageMemoryType) {
     // Introduce Failure, select invalid TypeIndex
     VkPhysicalDeviceMemoryProperties memory_info;
 
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
     uint32_t i = 0;
     for (; i < memory_info.memoryTypeCount; i++) {
         // Would require deviceCoherentMemory feature
@@ -652,9 +653,9 @@ TEST_F(NegativeMemory, BindMemory) {
         VkMemoryAllocateInfo image_mem_alloc = vku::InitStructHelper();
         VkMemoryAllocateInfo buffer_mem_alloc = vku::InitStructHelper();
         image_mem_alloc.allocationSize = image_mem_reqs.size;
-        m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_mem_alloc, 0);
+        m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_mem_alloc, 0);
         buffer_mem_alloc.allocationSize = buffer_mem_reqs.size;
-        m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_mem_alloc, 0);
+        m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_mem_alloc, 0);
 
         VkDeviceMemory image_mem = VK_NULL_HANDLE, buffer_mem = VK_NULL_HANDLE;
         vk::AllocateMemory(device(), &image_mem_alloc, nullptr, &image_mem);
@@ -684,8 +685,8 @@ TEST_F(NegativeMemory, BindMemory) {
         VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
         image_alloc_info.allocationSize = image_mem_reqs.size;
         buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
-        m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
-        m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+        m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
+        m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
 
         vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
         vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
@@ -714,8 +715,8 @@ TEST_F(NegativeMemory, BindMemory) {
         // Leave some extra space for alignment wiggle room
         image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
         buffer_alloc_info.allocationSize = buffer_mem_reqs.size + buffer_mem_reqs.alignment;
-        m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
-        m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+        m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
+        m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
         vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
         vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
 
@@ -775,11 +776,11 @@ TEST_F(NegativeMemory, BindMemory) {
         VkImageCreateInfo sparse_image_create_info = image_create_info;
         sparse_image_create_info.flags |= VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         VkImageFormatProperties image_format_properties = {};
-        VkResult err = vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), sparse_image_create_info.format,
+        VkResult err = vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), sparse_image_create_info.format,
                                                                   sparse_image_create_info.imageType,
                                                                   sparse_image_create_info.tiling, sparse_image_create_info.usage,
                                                                   sparse_image_create_info.flags, &image_format_properties);
-        if (!m_device->phy().Features().sparseResidencyImage2D || err == VK_ERROR_FORMAT_NOT_SUPPORTED) {
+        if (!m_device->Physical().Features().sparseResidencyImage2D || err == VK_ERROR_FORMAT_NOT_SUPPORTED) {
             // most likely means sparse formats aren't supported here; skip this test.
         } else {
             if (image_format_properties.maxExtent.width == 0) {
@@ -792,7 +793,7 @@ TEST_F(NegativeMemory, BindMemory) {
                     VkMemoryAllocateInfo sparse_mem_alloc = vku::InitStructHelper();
                     sparse_mem_alloc.allocationSize = sparse_mem_reqs.size;
                     sparse_mem_alloc.memoryTypeIndex = 0;
-                    m_device->phy().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
+                    m_device->Physical().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                     vkt::DeviceMemory memory(*m_device, sparse_mem_alloc);
                     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-image-01045");
                     vk::BindImageMemory(device(), sparse_image.handle(), memory.handle(), 0);
@@ -806,7 +807,7 @@ TEST_F(NegativeMemory, BindMemory) {
     {
         VkBufferCreateInfo sparse_buffer_create_info = buffer_create_info;
         sparse_buffer_create_info.flags |= VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
-        if (!m_device->phy().Features().sparseResidencyBuffer) {
+        if (!m_device->Physical().Features().sparseResidencyBuffer) {
             // most likely means sparse formats aren't supported here; skip this test.
         } else {
             vkt::Buffer sparse_buffer(*m_device, sparse_buffer_create_info, vkt::no_mem);
@@ -816,7 +817,7 @@ TEST_F(NegativeMemory, BindMemory) {
                 VkMemoryAllocateInfo sparse_mem_alloc = vku::InitStructHelper();
                 sparse_mem_alloc.allocationSize = sparse_mem_reqs.size;
                 sparse_mem_alloc.memoryTypeIndex = 0;
-                m_device->phy().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
+                m_device->Physical().SetMemoryType(sparse_mem_reqs.memoryTypeBits, &sparse_mem_alloc, 0);
                 vkt::DeviceMemory memory(*m_device, sparse_mem_alloc);
                 m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-buffer-01030");
                 vk::BindBufferMemory(device(), sparse_buffer.handle(), memory.handle(), 0);
@@ -846,12 +847,13 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     // Create a mask of available memory types *not* supported by these resources,
     // and try to use one of them.
     VkPhysicalDeviceMemoryProperties memory_properties = {};
-    vk::GetPhysicalDeviceMemoryProperties(m_device->phy().handle(), &memory_properties);
+    vk::GetPhysicalDeviceMemoryProperties(m_device->Physical().handle(), &memory_properties);
 
     uint32_t image_unsupported_mem_type_bits = ((1 << memory_properties.memoryTypeCount) - 1) & ~image_mem_reqs.memoryTypeBits;
     // can't have protected bit because feature bit is not added
-    bool found_type = m_device->phy().SetMemoryType(image_unsupported_mem_type_bits, &image_alloc_info, 0,
-                                                    VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
+    bool found_type =
+        m_device->Physical().SetMemoryType(image_unsupported_mem_type_bits, &image_alloc_info, 0,
+                                           VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
     if (image_unsupported_mem_type_bits != 0 && found_type) {
         vkt::DeviceMemory memory(*m_device, image_alloc_info);
         m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-01047");
@@ -860,8 +862,8 @@ TEST_F(NegativeMemory, BindMemoryUnsupported) {
     }
 
     uint32_t buffer_unsupported_mem_type_bits = ((1 << memory_properties.memoryTypeCount) - 1) & ~buffer_mem_reqs.memoryTypeBits;
-    found_type = m_device->phy().SetMemoryType(buffer_unsupported_mem_type_bits, &buffer_alloc_info, 0,
-                                               VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
+    found_type = m_device->Physical().SetMemoryType(buffer_unsupported_mem_type_bits, &buffer_alloc_info, 0,
+                                                    VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
     if (buffer_unsupported_mem_type_bits != 0 && found_type) {
         vkt::DeviceMemory memory(*m_device, buffer_alloc_info);
         m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memory-01035");
@@ -894,7 +896,7 @@ TEST_F(NegativeMemory, BindMemoryNoCheck) {
         VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
         // Leave some extra space for alignment wiggle room
         buffer_alloc_info.allocationSize = buffer_mem_reqs.size + buffer_mem_reqs.alignment;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0));
         vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
         vkt::DeviceMemory unchecked_buffer_mem(*m_device, buffer_alloc_info);
 
@@ -928,7 +930,7 @@ TEST_F(NegativeMemory, BindMemoryNoCheck) {
         VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
         // Leave some extra space for alignment wiggle room
         image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
         vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
         vkt::DeviceMemory unchecked_image_mem(*m_device, image_alloc_info);
 
@@ -957,7 +959,7 @@ TEST_F(NegativeMemory, BindMemoryNoCheck) {
         // Check for support of format used by all multi-planar tests
         const VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
         VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &mp_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
         if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
               (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
             GTEST_SKIP() << "test rely on a supported disjoint format";
@@ -992,13 +994,13 @@ TEST_F(NegativeMemory, BindMemoryNoCheck) {
         mp_image_alloc_info[1] = vku::InitStructHelper();
 
         mp_image_alloc_info[0].allocationSize = mp_image_mem_reqs2[0].memoryRequirements.size;
-        ASSERT_TRUE(
-            m_device->phy().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits,
+                                                       &mp_image_alloc_info[0], 0));
         // Leave some extra space for alignment wiggle room
         mp_image_alloc_info[1].allocationSize =
             mp_image_mem_reqs2[1].memoryRequirements.size + mp_image_mem_reqs2[1].memoryRequirements.alignment;
-        ASSERT_TRUE(
-            m_device->phy().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits,
+                                                       &mp_image_alloc_info[1], 0));
 
         ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[0], NULL, &mp_image_mem[0]));
         ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &mp_image_alloc_info[1], NULL, &mp_image_mem[1]));
@@ -1068,12 +1070,12 @@ TEST_F(NegativeMemory, BindMemory2BindInfos) {
         vk::GetImageMemoryRequirements(device(), image_a, &image_mem_reqs);
         VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
         image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
         vkt::DeviceMemory image_a_mem(*m_device, image_alloc_info);
 
         vk::GetImageMemoryRequirements(device(), image_b, &image_mem_reqs);
         image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
         vkt::DeviceMemory image_b_mem(*m_device, image_alloc_info);
 
         // Try binding same image twice in array
@@ -1104,7 +1106,7 @@ TEST_F(NegativeMemory, BindMemory2BindInfos) {
 
         // Check for support of format used by all multi-planar tests
         VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &mp_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
         if (!((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
               (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
             GTEST_SKIP() << "test rely on a supported disjoint format";
@@ -1116,7 +1118,7 @@ TEST_F(NegativeMemory, BindMemory2BindInfos) {
         vk::GetImageMemoryRequirements(device(), normal_image, &image_mem_reqs);
         VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
         image_alloc_info.allocationSize = image_mem_reqs.size;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0));
         vkt::DeviceMemory normal_image_mem(*m_device, image_alloc_info);
 
         // Create 2 disjoint images with memory backing each plane
@@ -1143,7 +1145,7 @@ TEST_F(NegativeMemory, BindMemory2BindInfos) {
             VkMemoryAllocateInfo mp_image_alloc_info = vku::InitStructHelper();
             mp_image_alloc_info.allocationSize = mp_image_mem_reqs2.memoryRequirements.size;
             ASSERT_TRUE(
-                m_device->phy().SetMemoryType(mp_image_mem_reqs2.memoryRequirements.memoryTypeBits, &mp_image_alloc_info, 0));
+                m_device->Physical().SetMemoryType(mp_image_mem_reqs2.memoryRequirements.memoryTypeBits, &mp_image_alloc_info, 0));
             vk::AllocateMemory(device(), &mp_image_alloc_info, NULL, mp_image_mem);
         };
 
@@ -1234,7 +1236,7 @@ TEST_F(NegativeMemory, BindMemoryToDestroyedObject) {
     vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
 
     mem_alloc.allocationSize = mem_reqs.size;
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory mem(*m_device, mem_alloc);
@@ -1261,10 +1263,10 @@ TEST_F(NegativeMemory, AllocationCount) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     if (props.limits.maxMemoryAllocationCount > max_mems) {
         props.limits.maxMemoryAllocationCount = max_mems;
-        fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+        fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     }
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredError("VUID-vkAllocateMemory-maxMemoryAllocationCount-04101");
@@ -1302,14 +1304,14 @@ TEST_F(NegativeMemory, ImageMemoryNotBound) {
     mem_alloc.memoryTypeIndex = 0;
     vk::GetImageMemoryRequirements(device(), image, &mem_reqs);
     mem_alloc.allocationSize = mem_reqs.size;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory image_mem(*m_device, mem_alloc);
 
     // Introduce error, do not call vk::BindImageMemory(device(), image, image_mem, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdClearColorImage-image-00003");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkClearColorValue ccv;
     ccv.float32[0] = 1.0f;
     ccv.float32[1] = 1.0f;
@@ -1322,7 +1324,7 @@ TEST_F(NegativeMemory, ImageMemoryNotBound) {
     isr.layerCount = 1;
     isr.levelCount = 1;
     vk::CmdClearColorImage(m_command_buffer.handle(), image, VK_IMAGE_LAYOUT_GENERAL, &ccv, 1, &isr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1343,7 +1345,7 @@ TEST_F(NegativeMemory, BufferMemoryNotBound) {
     alloc_info.allocationSize = 1024;
     VkMemoryRequirements mem_reqs;
     vk::GetBufferMemoryRequirements(device(), buffer, &mem_reqs);
-    if (!m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
+    if (!m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT)) {
         GTEST_SKIP() << "Failed to set memory type";
     }
 
@@ -1356,11 +1358,11 @@ TEST_F(NegativeMemory, BufferMemoryNotBound) {
     region.imageExtent.height = 4;
     region.imageExtent.width = 4;
     region.imageExtent.depth = 1;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyBufferToImage-srcBuffer-00176");
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer, image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMemory, DedicatedAllocationBinding) {
@@ -1370,7 +1372,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     const VkDeviceSize resource_size = 1024;
     auto buffer_info = vkt::Buffer::CreateInfo(resource_size, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer(*m_device, buffer_info, vkt::no_mem);
-    auto buffer_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), mem_flags);
+    auto buffer_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), mem_flags);
     VkMemoryDedicatedAllocateInfoKHR buffer_dedicated_info = vku::InitStructHelper();
     buffer_dedicated_info.buffer = buffer.handle();
     buffer_alloc_info.pNext = &buffer_dedicated_info;
@@ -1387,7 +1389,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     // Bind with non-zero offset (same VUID)
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-memory-01508");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindBufferMemory-size-01037");    // offset pushes us past size
-    auto offset = buffer.memory_requirements().alignment;
+    auto offset = buffer.MemoryRequirements().alignment;
     vk::BindBufferMemory(m_device->handle(), buffer.handle(), dedicated_buffer_memory.handle(), offset);
     m_errorMonitor->VerifyFound();
 
@@ -1404,7 +1406,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
 
     VkMemoryDedicatedAllocateInfoKHR image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image.handle();
-    auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), mem_flags);
+    auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
     vkt::DeviceMemory dedicated_image_memory;
     dedicated_image_memory.init(*m_device, image_alloc_info);
@@ -1417,7 +1419,7 @@ TEST_F(NegativeMemory, DedicatedAllocationBinding) {
     // Bind with non-zero offset (same VUID)
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02628");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-size-01049");    // offset pushes us past size
-    auto image_offset = image.memory_requirements().alignment;
+    auto image_offset = image.MemoryRequirements().alignment;
     vk::BindImageMemory(m_device->handle(), image.handle(), dedicated_image_memory.handle(), image_offset);
     m_errorMonitor->VerifyFound();
 
@@ -1445,7 +1447,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
 
     VkMemoryDedicatedAllocateInfoKHR image_dedicated_info = vku::InitStructHelper();
     image_dedicated_info.image = image.handle();
-    auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), mem_flags);
+    auto image_alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), mem_flags);
     image_alloc_info.pNext = &image_dedicated_info;
     vkt::DeviceMemory dedicated_image_memory;
     dedicated_image_memory.init(*m_device, image_alloc_info);
@@ -1470,7 +1472,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
 
     // Bind with a larger image (not supported, and not enough memory)
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02629");
-    if (larger_image.memory_requirements().size > image.memory_requirements().size) {
+    if (larger_image.MemoryRequirements().size > image.MemoryRequirements().size) {
         m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-size-01049");
     }
     vk::BindImageMemory(m_device->handle(), larger_image.handle(), dedicated_image_memory.handle(), 0);
@@ -1479,7 +1481,7 @@ TEST_F(NegativeMemory, DedicatedAllocationImageAliasing) {
     // Bind with non-zero offset
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-memory-02629");  // offset must be zero
     m_errorMonitor->SetDesiredError("VUID-vkBindImageMemory-size-01049");    // offset pushes us past size
-    auto image_offset = image.memory_requirements().alignment;
+    auto image_offset = image.MemoryRequirements().alignment;
     vk::BindImageMemory(m_device->handle(), image.handle(), dedicated_image_memory.handle(), image_offset);
     m_errorMonitor->VerifyFound();
 
@@ -1528,7 +1530,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressEXT) {
     vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
-    m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     vkt::DeviceMemory buffer_mem(*m_device, buffer_alloc_info);
 
     vk::BindBufferMemory(device(), buffer, buffer_mem, 0);
@@ -1600,7 +1602,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHR) {
     vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
-    m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     VkDeviceMemory buffer_mem;
     vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
 
@@ -1670,7 +1672,7 @@ TEST_F(NegativeMemory, BufferDeviceAddressKHRDisabled) {
     vk::GetBufferMemoryRequirements(device(), buffer, &buffer_mem_reqs);
     VkMemoryAllocateInfo buffer_alloc_info = vku::InitStructHelper();
     buffer_alloc_info.allocationSize = buffer_mem_reqs.size;
-    m_device->phy().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
+    m_device->Physical().SetMemoryType(buffer_mem_reqs.memoryTypeBits, &buffer_alloc_info, 0);
     VkDeviceMemory buffer_mem;
     vk::AllocateMemory(device(), &buffer_alloc_info, NULL, &buffer_mem);
     VkDeviceMemoryOpaqueCaptureAddressInfoKHR mem_opaque_addr_info = vku::InitStructHelper();
@@ -1697,7 +1699,7 @@ TEST_F(NegativeMemory, MemoryType) {
 
     RETURN_IF_SKIP(Init());
     VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkAllocateMemory-pAllocateInfo-01714");
 
@@ -1716,7 +1718,7 @@ TEST_F(NegativeMemory, AllocationBeyondHeapSize) {
 
     RETURN_IF_SKIP(Init());
     VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
 
     m_errorMonitor->SetDesiredError("VUID-vkAllocateMemory-pAllocateInfo-01713");
 
@@ -1747,7 +1749,7 @@ TEST_F(NegativeMemory, DeviceCoherentMemoryDisabledAMD) {
 
     // Find a memory type that includes the device coherent memory property
     VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
     uint32_t deviceCoherentMemoryTypeIndex = memory_info.memoryTypeCount;  // Set to an invalid value just in case
 
     for (uint32_t i = 0; i < memory_info.memoryTypeCount; ++i) {
@@ -1784,9 +1786,9 @@ TEST_F(NegativeMemory, DedicatedAllocation) {
     const VkFormat disjoint_format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
     const VkFormat normal_format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), disjoint_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), disjoint_format, &format_properties);
 
-    bool sparse_support = (m_device->phy().Features().sparseBinding == VK_TRUE);
+    bool sparse_support = (m_device->Physical().Features().sparseBinding == VK_TRUE);
     bool disjoint_support = ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) != 0);
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
@@ -1914,7 +1916,7 @@ TEST_F(NegativeMemory, MemoryRequirements) {
     // Need to make sure disjoint is supported for format
     // Also need to support an arbitrary image usage feature
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, &format_properties);
     if (!((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
           (format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT))) {
         GTEST_SKIP() << "test requires disjoint/sampled feature bit on format";
@@ -2110,7 +2112,7 @@ TEST_F(NegativeMemory, DeviceImageMemoryRequirementsDisjoint) {
 
     const VkFormat format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) == 0) {
         GTEST_SKIP() << "Test requires disjoint support extensions";
     }
@@ -2262,7 +2264,7 @@ TEST_F(NegativeMemory, SetDeviceMemoryPriority) {
     vkt::Buffer buffer(*m_device, vkt::Buffer::CreateInfo(1024, VK_BUFFER_USAGE_TRANSFER_DST_BIT), vkt::no_mem);
 
     vkt::DeviceMemory buffer_memory;
-    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0));
+    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
 
     m_errorMonitor->SetDesiredError("VUID-vkSetDeviceMemoryPriorityEXT-priority-06258");
     vk::SetDeviceMemoryPriorityEXT(*m_device, buffer_memory.handle(), -0.01f);
@@ -2316,7 +2318,7 @@ TEST_F(NegativeMemory, DISABLED_PartialBoundBuffer) {
     vkt::Buffer buffer_0(*m_device, buffer_create_info, vkt::no_mem);
     vkt::Buffer buffer_1(*m_device, buffer_create_info, vkt::no_mem);
 
-    VkMemoryAllocateInfo alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_0.memory_requirements(), 0);
+    VkMemoryAllocateInfo alloc_info = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_0.MemoryRequirements(), 0);
     vkt::DeviceMemory buffer_memory(*m_device, alloc_info);
 
     VkBindBufferMemoryInfo bind_buffer_infos[2];

--- a/tests/unit/memory_positive.cpp
+++ b/tests/unit/memory_positive.cpp
@@ -36,7 +36,7 @@ TEST_F(PositiveMemory, MapMemory2) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory memory(*m_device, memory_info);
@@ -90,7 +90,7 @@ TEST_F(PositiveMemory, MapMemoryPlaced) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = allocation_size;
 
-    bool pass = m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory memory(*m_device, memory_info);
@@ -199,7 +199,7 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
     vk::BindImageMemory(device(), image.handle(), image_memory.handle(), 0);
 
     // Now execute arbitrary commands that use the test buffer and image
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Fill buffer with 0
     vk::CmdFillBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_WHOLE_SIZE, 0);
@@ -214,7 +214,7 @@ TEST_F(PositiveMemory, GetMemoryRequirements2) {
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &color, 1, &subresource_range);
 
     // Submit and verify no validation errors
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -231,7 +231,7 @@ TEST_F(PositiveMemory, BindMemory2) {
 
     // Allocate buffer memory
     vkt::DeviceMemory buffer_memory;
-    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0));
+    buffer_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0));
 
     // Bind buffer memory with extension
     VkBindBufferMemoryInfoKHR buffer_bind_info = {VK_STRUCTURE_TYPE_BIND_BUFFER_MEMORY_INFO_KHR, nullptr, buffer.handle(),
@@ -250,7 +250,7 @@ TEST_F(PositiveMemory, BindMemory2) {
 
     // Allocate image memory
     vkt::DeviceMemory image_memory;
-    image_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0));
+    image_memory.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
 
     // Bind image memory with extension
     VkBindImageMemoryInfoKHR image_bind_info = {VK_STRUCTURE_TYPE_BIND_IMAGE_MEMORY_INFO_KHR, nullptr, image.handle(),
@@ -258,7 +258,7 @@ TEST_F(PositiveMemory, BindMemory2) {
     vk::BindImageMemory2KHR(device(), 1, &image_bind_info);
 
     // Now execute arbitrary commands that use the test buffer and image
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Fill buffer with 0
     vk::CmdFillBuffer(m_command_buffer.handle(), buffer.handle(), 0, VK_WHOLE_SIZE, 0);
@@ -273,7 +273,7 @@ TEST_F(PositiveMemory, BindMemory2) {
     vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &color, 1, &subresource_range);
 
     // Submit and verify no validation errors
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -288,7 +288,7 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
 
     VkMemoryRequirements mem_reqs;
     mem_reqs.memoryTypeBits = 0xFFFFFFFF;
-    const VkDeviceSize atom_size = m_device->phy().limits_.nonCoherentAtomSize;
+    const VkDeviceSize atom_size = m_device->Physical().limits_.nonCoherentAtomSize;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.memoryTypeIndex = 0;
 
@@ -296,14 +296,14 @@ TEST_F(PositiveMemory, NonCoherentMapping) {
     alloc_info.allocationSize = allocation_size;
 
     // Find a memory configurations WITHOUT a COHERENT bit, otherwise exit
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
-                                              VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT,
+                                                   VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
     if (!pass) {
-        pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info,
-                                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                             VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+        pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info,
+                                                  VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                  VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
         if (!pass) {
-            pass = m_device->phy().SetMemoryType(
+            pass = m_device->Physical().SetMemoryType(
                 mem_reqs.memoryTypeBits, &alloc_info,
                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT | VK_MEMORY_PROPERTY_HOST_CACHED_BIT,
                 VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
@@ -374,7 +374,7 @@ TEST_F(PositiveMemory, MappingWithMultiInstanceHeapFlag) {
     AddRequiredExtensions(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     VkPhysicalDeviceMemoryProperties memory_info;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &memory_info);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &memory_info);
 
     uint32_t memory_index = std::numeric_limits<uint32_t>::max();
     for (uint32_t i = 0; i < memory_info.memoryTypeCount; ++i) {
@@ -432,7 +432,7 @@ TEST_F(PositiveMemory, BindImageMemoryMultiThreaded) {
             VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
             mem_alloc.memoryTypeIndex = 0;
             mem_alloc.allocationSize = mem_reqs.size;
-            const bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+            const bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
             ASSERT_TRUE(pass);
 
             vkt::DeviceMemory mem(*m_device, mem_alloc);
@@ -472,7 +472,7 @@ TEST_F(PositiveMemory, DeviceBufferMemoryRequirements) {
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs2.memoryRequirements.size;
 
-    const bool pass = m_device->phy().SetMemoryType(memory_reqs2.memoryRequirements.memoryTypeBits, &memory_info, 0);
+    const bool pass = m_device->Physical().SetMemoryType(memory_reqs2.memoryRequirements.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory buffer_memory(*m_device, memory_info);
@@ -500,7 +500,7 @@ TEST_F(PositiveMemory, DeviceImageMemoryRequirements) {
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.memoryTypeIndex = 0;
     mem_alloc.allocationSize = mem_reqs.memoryRequirements.size;
-    const bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryRequirements.memoryTypeBits, &mem_alloc, 0);
+    const bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryRequirements.memoryTypeBits, &mem_alloc, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory mem(*m_device, mem_alloc);
@@ -533,7 +533,7 @@ TEST_F(PositiveMemory, BindMemoryDX11Handle) {
     memory_import.handle = (HANDLE)0x12345678;  // Use arbitrary non-zero value as DX11 resource handle
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&memory_import);  // Set zero allocation size
-    m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     vkt::DeviceMemory memory(*m_device, alloc_info);
     // This should not trigger VUs that take into accout allocation size (e.g. 01049/01046)
     vk::BindImageMemory(device(), image, memory, 0);
@@ -562,7 +562,7 @@ TEST_F(PositiveMemory, BindMemoryDX12Handle) {
     memory_import.handle = (HANDLE)0x12345678;  // Use arbitrary non-zero value as DX12 resource handle
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&memory_import);  // Set zero allocation size
-    m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     vkt::DeviceMemory memory(*m_device, alloc_info);
     // This should not trigger VUs that take into accout allocation size (e.g. 01049/01046)
     vk::BindImageMemory(device(), image, memory, 0);

--- a/tests/unit/mesh.cpp
+++ b/tests/unit/mesh.cpp
@@ -670,7 +670,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
     buffer_create_info.usage = VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectNV-None-08606");
@@ -682,7 +682,7 @@ TEST_F(NegativeMesh, BasicUsageNV) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMesh, ExtensionDisabledNV) {
@@ -706,7 +706,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
     const auto event = event_obj.handle();
     ASSERT_TRUE(event_obj.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent-stageMask-04095");
     vk::CmdSetEvent(m_command_buffer.handle(), event, VK_PIPELINE_STAGE_MESH_SHADER_BIT_NV);
@@ -748,7 +748,7 @@ TEST_F(NegativeMesh, ExtensionDisabledNV) {
                            0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore_obj(*m_device);
     const auto semaphore = semaphore_obj.handle();
@@ -913,7 +913,7 @@ TEST_F(NegativeMesh, DrawCmds) {
     CreatePipelineHelper pipe1(*this);
     pipe1.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -944,12 +944,12 @@ TEST_F(NegativeMesh, DrawCmds) {
     vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), buffer.handle(), 0, 2, sizeof(VkDrawMeshTasksIndirectCommandEXT));
     m_errorMonitor->VerifyFound();
 
-    if (m_device->phy().limits_.maxDrawIndirectCount < vvl::MaxTypeValue(m_device->phy().limits_.maxDrawIndirectCount)) {
+    if (m_device->Physical().limits_.maxDrawIndirectCount < vvl::MaxTypeValue(m_device->Physical().limits_.maxDrawIndirectCount)) {
         m_errorMonitor->SetUnexpectedError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02718");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-07090");
         m_errorMonitor->SetDesiredError("VUID-vkCmdDrawMeshTasksIndirectEXT-drawCount-02719");
         vk::CmdDrawMeshTasksIndirectEXT(m_command_buffer.handle(), buffer.handle(), 0,
-                                        m_device->phy().limits_.maxDrawIndirectCount + 1,
+                                        m_device->Physical().limits_.maxDrawIndirectCount + 1,
                                         sizeof(VkDrawMeshTasksIndirectCommandEXT));
         m_errorMonitor->VerifyFound();
     }
@@ -981,7 +981,7 @@ TEST_F(NegativeMesh, DrawCmds) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMesh, MultiDrawIndirect) {
@@ -1051,7 +1051,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     pipe.shader_stages_[0] = mesh_shader.GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1099,7 +1099,7 @@ TEST_F(NegativeMesh, MultiDrawIndirect) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMesh, DrawCmdsNV) {
@@ -1149,7 +1149,7 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
     CreatePipelineHelper pipe1(*this);
     pipe1.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1176,7 +1176,7 @@ TEST_F(NegativeMesh, DrawCmdsNV) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMesh, MeshTasksWorkgroupCount) {
@@ -1362,7 +1362,7 @@ TEST_F(NegativeMesh, MeshIncompatibleActiveQueries) {
     vkt::QueryPool xfb_query_pool(*m_device, VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT, 1);
     vkt::QueryPool pg_query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1379,7 +1379,7 @@ TEST_F(NegativeMesh, MeshIncompatibleActiveQueries) {
     vk::CmdEndQuery(m_command_buffer.handle(), pg_query_pool.handle(), 0u);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMesh, DrawIndexMesh) {

--- a/tests/unit/mesh_positive.cpp
+++ b/tests/unit/mesh_positive.cpp
@@ -47,14 +47,14 @@ TEST_F(PositiveMesh, BasicUsage) {
     pipe.gp_ci_.pInputAssemblyState = nullptr;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDrawMeshTasksEXT(m_command_buffer.handle(), 1, 1, 1);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveMesh, MeshShaderOnly) {

--- a/tests/unit/multiview.cpp
+++ b/tests/unit/multiview.cpp
@@ -42,7 +42,7 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -51,7 +51,7 @@ TEST_F(NegativeMultiview, MaxInstanceIndex) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMultiview, ClearColorAttachments) {
@@ -96,7 +96,7 @@ TEST_F(NegativeMultiview, ClearColorAttachments) {
     vkt::Framebuffer framebuffer(*m_device, rp.Handle(), 1, &imageView.handle());
 
     // Start no RenderPass
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkClearAttachment color_attachment;
     color_attachment.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
@@ -237,7 +237,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         CreatePipelineHelper pipe(*this);
         pipe.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This bind should not be valid after we begin the renderpass
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -257,10 +257,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
 
     // Dynamic state (checking with line width)
     {
@@ -278,7 +278,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
             pipelines[i].init(*m_device, pipe_info);
         }
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This line width set should not be valid for next subpass
         vk::CmdSetLineWidth(m_command_buffer.handle(), 1.0f);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -300,10 +300,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
 
     // Push constants
     {
@@ -342,7 +342,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         // Set up complete
 
         const float dummy_values[16] = {};
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This push constants should not be counted when render pass begins
         vk::CmdPushConstants(m_command_buffer.handle(), layout.handle(), VK_SHADER_STAGE_VERTEX_BIT, push_constant_range.offset,
                              push_constant_range.size, dummy_values);
@@ -366,10 +366,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
 
     // Descriptor sets
     {
@@ -401,7 +401,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
         // Set up complete
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This descriptor bind should not be counted when render pass begins
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                                   &descriptor_set.set_, 0, nullptr);
@@ -425,10 +425,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
 
     // Vertex buffer
     {
@@ -475,7 +475,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         // Set up complete
         VkDeviceSize offset = 0;
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This vertex buffer bind should not be counted when render pass begins
         vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &vbo.handle(), &offset);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -499,10 +499,10 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
 
     // Index buffer
     {
@@ -552,7 +552,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         // Set up complete
 
         VkDeviceSize offset = 0;
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // This index buffer bind should not be counted when render pass begins
         vk::CmdBindIndexBuffer(m_command_buffer.handle(), ibo.handle(), 0, VK_INDEX_TYPE_UINT32);
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -576,7 +576,7 @@ TEST_F(NegativeMultiview, UnboundResourcesAfterBeginRenderPassAndNextSubpass) {
         }
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -623,7 +623,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -637,7 +637,7 @@ TEST_F(NegativeMultiview, BeginTransformFeedback) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeMultiview, Features) {
@@ -658,19 +658,19 @@ TEST_F(NegativeMultiview, Features) {
     // Set false to trigger VUs
     multiview_features.multiview = VK_FALSE;
 
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
     }
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&features2);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.ppEnabledExtensionNames = device_extensions.data();
     device_create_info.enabledExtensionCount = device_extensions.size();
     VkDevice testDevice;
@@ -685,7 +685,7 @@ TEST_F(NegativeMultiview, Features) {
     if (multiview_features.multiviewTessellationShader == VK_TRUE) {
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceMultiviewFeatures-multiviewTessellationShader-00581");
     }
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -957,7 +957,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
 
     // End rp[0]
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Begin rp2[0] for VK_VERSION_1_2 test cases
     if (rp2Supported) {
@@ -985,7 +985,7 @@ TEST_F(NegativeMultiview, DrawWithPipelineIncompatibleWithRenderPass) {
 
         // End rp2[0]
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -1202,12 +1202,12 @@ TEST_F(NegativeMultiview, DynamicRenderingMaxMultiviewInstanceIndex) {
     renderingInfo.pColorAttachments = &color_attachment;
     renderingInfo.viewMask = 0x1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, multiview_properties.maxMultiviewInstanceIndex);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/nvidia_best_practices.cpp
+++ b/tests/unit/nvidia_best_practices.cpp
@@ -43,7 +43,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
     {
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-CreateDevice-PageableDeviceLocalMemory");
         VkDevice test_device = VK_NULL_HANDLE;
-        VkResult err = vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
+        VkResult err = vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
         m_errorMonitor->VerifyFound();
         if (err == VK_SUCCESS) {
             vk::DestroyDevice(test_device, nullptr);
@@ -57,7 +57,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, PageableDeviceLocalMemory) {
 
     {
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-CreateDevice-PageableDeviceLocalMemory");
-        vkt::Device test_device(gpu(), device_ci);
+        vkt::Device test_device(Gpu(), device_ci);
         m_errorMonitor->Finish();
     }
 }
@@ -127,7 +127,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
 
-    if (!m_device->phy().Features().sparseBinding) {
+    if (!m_device->Physical().Features().sparseBinding) {
         GTEST_SKIP() << "Test requires sparseBinding";
     }
 
@@ -171,7 +171,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
     device_ci.pQueueCreateInfos = queue_cis;
     device_ci.pEnabledFeatures = &features;
 
-    vkt::Device test_device(gpu(), device_ci);
+    vkt::Device test_device(Gpu(), device_ci);
 
     VkQueue graphics_queue = VK_NULL_HANDLE;
     VkQueue transfer_queue = VK_NULL_HANDLE;
@@ -188,7 +188,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, QueueBindSparse_NotAsync) {
 
     vkt::Buffer sparse_buffer(test_device, sparse_buffer_ci, vkt::no_mem);
 
-    const VkMemoryRequirements memory_requirements = sparse_buffer.memory_requirements();
+    const VkMemoryRequirements memory_requirements = sparse_buffer.MemoryRequirements();
     ASSERT_NE(memory_requirements.memoryTypeBits, 0);
 
     // Find first valid bit, whatever it is
@@ -270,7 +270,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
         vkt::CommandPool compute_pool(*m_device, queue->family_index);
         vkt::CommandBuffer cmd_buffer(*m_device, compute_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY);
 
-        cmd_buffer.begin();
+        cmd_buffer.Begin();
 
         // Those 3 are triggered when allocating memory for the destination acceleration structure buffer and the scratch buffer.
         // This is expected.
@@ -287,7 +287,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, AccelerationStructure_NotAsync) {
             m_errorMonitor->VerifyFound();
         }
 
-        cmd_buffer.end();
+        cmd_buffer.End();
     }
 }
 
@@ -372,7 +372,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     device_ci.enabledExtensionCount = m_device_extension_names.size();
     device_ci.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    vkt::Device test_device(gpu(), device_ci);
+    vkt::Device test_device(Gpu(), device_ci);
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 0x100000;
@@ -380,7 +380,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_NoPriority) {
     vkt::Buffer buffer_a(test_device, buffer_ci, vkt::no_mem);
     vkt::Buffer buffer_b(test_device, buffer_ci, vkt::no_mem);
 
-    const VkMemoryRequirements memory_requirements = buffer_a.memory_requirements();
+    const VkMemoryRequirements memory_requirements = buffer_a.MemoryRequirements();
     ASSERT_NE(memory_requirements.memoryTypeBits, 0);
 
     // Find first valid bit, whatever it is
@@ -438,7 +438,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_StaticPriority) {
     device_ci.enabledExtensionCount = m_device_extension_names.size();
     device_ci.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    vkt::Device test_device(gpu(), device_ci);
+    vkt::Device test_device(Gpu(), device_ci);
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
     buffer_ci.size = 0x100000;
@@ -446,7 +446,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindMemory_StaticPriority) {
     vkt::Buffer buffer_a(test_device, buffer_ci, vkt::no_mem);
     vkt::Buffer buffer_b(test_device, buffer_ci, vkt::no_mem);
 
-    const VkMemoryRequirements memory_requirements = buffer_a.memory_requirements();
+    const VkMemoryRequirements memory_requirements = buffer_a.MemoryRequirements();
     ASSERT_NE(memory_requirements.memoryTypeBits, 0);
 
     // Find first valid bit, whatever it is
@@ -526,7 +526,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_SeparateSampler) {
 TEST_F(VkNvidiaBestPracticesLayerTest, CreatePipelineLayout_LargePipelineLayout) {
     RETURN_IF_SKIP(InitBestPracticesFramework(kEnableNVIDIAValidation));
     RETURN_IF_SKIP(InitState());
-    if (m_device->phy().limits_.maxPerStageDescriptorStorageBuffers < 16) {
+    if (m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers < 16) {
         GTEST_SKIP() << "maxPerStageDescriptorStorageBuffers of 16 required";
     }
 
@@ -587,7 +587,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
 
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    if (m_device->phy().limits_.maxGeometryOutputVertices <= 3) {
+    if (m_device->Physical().limits_.maxGeometryOutputVertices <= 3) {
         GTEST_SKIP() << "Device doesn't support requried maxGeometryOutputVertices";
     }
 
@@ -618,7 +618,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_SwitchTessGeometryMesh)
     vgsPipe.rs_state_ci_.rasterizerDiscardEnable = VK_TRUE;
     vgsPipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         m_errorMonitor->SetAllowedFailureMsg("BestPractices-Pipeline-SortAndBind");
@@ -719,7 +719,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection) {
     pipe.CreateGraphicsPipeline();
 
     auto cmd = m_command_buffer.handle();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdSetDepthTestEnable(cmd, VK_TRUE);
@@ -996,7 +996,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BindPipeline_ZcullDirection) {
         m_errorMonitor->Finish();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
@@ -1052,7 +1052,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
 
     VkClearRect clear_rect = {{{0, 0}, {m_width, m_height}}, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRendering(m_command_buffer.handle(), &begin_rendering_info);
 
     {
@@ -1100,7 +1100,7 @@ TEST_F(VkNvidiaBestPracticesLayerTest, ClearColor_NotCompressed)
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
@@ -1126,8 +1126,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
     {
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-vkBeginCommandBuffer-one-time-submit");
 
-        command_buffer0.begin(&begin_info);
-        command_buffer0.end();
+        command_buffer0.Begin(&begin_info);
+        command_buffer0.End();
 
         m_default_queue->Submit(command_buffer0);
         m_device->Wait();
@@ -1138,8 +1138,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
     {
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-vkBeginCommandBuffer-one-time-submit");
 
-        command_buffer1.begin(&begin_info);
-        command_buffer1.end();
+        command_buffer1.Begin(&begin_info);
+        command_buffer1.End();
 
         for (int i = 0; i < 2; ++i) {
             m_default_queue->Submit(command_buffer1);
@@ -1153,8 +1153,8 @@ TEST_F(VkNvidiaBestPracticesLayerTest, BeginCommandBuffer_OneTimeSubmit) {
         begin_info.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT;
         m_errorMonitor->SetDesiredFailureMsg(kPerformanceWarningBit, "BestPractices-NVIDIA-vkBeginCommandBuffer-one-time-submit");
 
-        command_buffer2.begin(&begin_info);
-        command_buffer2.end();
+        command_buffer2.Begin(&begin_info);
+        command_buffer2.End();
 
         m_default_queue->Submit(command_buffer2);
         m_device->Wait();

--- a/tests/unit/object_lifetime.cpp
+++ b/tests/unit/object_lifetime.cpp
@@ -40,7 +40,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferDestroyed) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         vk::DestroyBuffer(device(), buffer, NULL);
         GTEST_SKIP() << "Failed to set memory type";
@@ -51,9 +51,9 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferDestroyed) {
     err = vk::BindBufferMemory(device(), buffer, mem, 0);
     ASSERT_EQ(VK_SUCCESS, err);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), buffer, 0, VK_WHOLE_SIZE, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
     // Destroy buffer dependency prior to submit to cause ERROR
@@ -79,7 +79,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
 
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory buffer_mem(*m_device, alloc_info);
@@ -87,7 +87,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
 
     ASSERT_EQ(VK_SUCCESS, vk::BindBufferMemory(device(), buffer.handle(), buffer_mem.handle(), 0));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBufferMemoryBarrier buf_barrier = vku::InitStructHelper();
     buf_barrier.buffer = buffer.handle();
     buf_barrier.offset = 0;
@@ -95,7 +95,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierBufferDestroyed) {
 
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            NULL, 1, &buf_barrier, 0, NULL);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -120,7 +120,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     ASSERT_TRUE(pass);
 
     image_mem.init(*m_device, alloc_info);
@@ -128,7 +128,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
     auto err = vk::BindImageMemory(device(), image.handle(), image_mem.handle(), 0);
     ASSERT_EQ(VK_SUCCESS, err);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -137,7 +137,7 @@ TEST_F(NegativeObjectLifetime, CmdBarrierImageDestroyed) {
 
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0,
                            NULL, 0, NULL, 1, &img_barrier);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -169,7 +169,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         vk::DestroyBuffer(device(), buffer, NULL);
         GTEST_SKIP() << "Failed to set memory type";
@@ -181,7 +181,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierBufferDestroyed) {
     ASSERT_EQ(VK_SUCCESS, err);
 
     m_errorMonitor->SetDesiredError("VUID-vkEndCommandBuffer-commandBuffer-00059");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBufferMemoryBarrier2KHR buf_barrier = vku::InitStructHelper();
     buf_barrier.buffer = buffer;
     buf_barrier.offset = 0;
@@ -228,7 +228,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.allocationSize = mem_reqs.size;
     bool pass = false;
-    pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     ASSERT_TRUE(pass);
 
     err = vk::AllocateMemory(device(), &alloc_info, NULL, &image_mem);
@@ -238,7 +238,7 @@ TEST_F(NegativeObjectLifetime, Sync2CmdBarrierImageDestroyed) {
     ASSERT_EQ(VK_SUCCESS, err);
 
     m_errorMonitor->SetDesiredError("VUID-vkEndCommandBuffer-commandBuffer-00059");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageMemoryBarrier2KHR img_barrier = vku::InitStructHelper();
     img_barrier.image = image;
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -312,7 +312,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
             GTEST_SKIP() << "Unable to compile shader";
         }
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         // Bind pipeline to cmd buffer - This causes crash on Mali
@@ -343,7 +343,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferBufferViewDestroyed) {
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Delete BufferView in order to invalidate cmd buffer
     vk::DestroyBufferView(device(), view, NULL);
@@ -371,7 +371,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferImageDestroyed) {
         image_create_info.flags = 0;
         vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         VkClearColorValue ccv;
         ccv.float32[0] = 1.0f;
         ccv.float32[1] = 1.0f;
@@ -384,7 +384,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferImageDestroyed) {
         isr.layerCount = 1;
         isr.levelCount = 1;
         vk::CmdClearColorImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, &ccv, 1, &isr);
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
     // Destroy image dependency prior to submit to cause ERROR
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
@@ -398,7 +398,7 @@ TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
     RETURN_IF_SKIP(Init());
     VkFormatProperties format_properties;
     VkResult err = VK_SUCCESS;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
     if (!(format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Image format doesn't support required features";
     }
@@ -444,10 +444,10 @@ TEST_F(NegativeObjectLifetime, CmdBufferFramebufferImageDestroyed) {
         m_renderPassBeginInfo.renderArea.extent.width = 32;
         m_renderPassBeginInfo.renderArea.extent.height = 32;
         // Create Null cmd buffer for submit
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
     // Destroy image attached to framebuffer to invalidate cmd buffer
     // Now attempt to submit cmd buffer and verify error
@@ -464,7 +464,7 @@ TEST_F(NegativeObjectLifetime, FramebufferAttachmentMemoryFreed) {
     TEST_DESCRIPTION("Attempt to create framebuffer with attachment which memory was freed.");
     RETURN_IF_SKIP(Init());
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
     if (!(format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Image format doesn't support required features";
     }
@@ -487,7 +487,7 @@ TEST_F(NegativeObjectLifetime, FramebufferAttachmentMemoryFreed) {
     vkt::Image image(*m_device, image_ci, vkt::no_mem);
 
     vkt::DeviceMemory *image_memory = new vkt::DeviceMemory;
-    image_memory->init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0));
+    image_memory->init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
     image.BindMemory(*image_memory, 0);
 
     VkImageViewCreateInfo ivci = {
@@ -538,7 +538,7 @@ TEST_F(NegativeObjectLifetime, DescriptorPoolInUseDestroyedSignaled) {
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -546,7 +546,7 @@ TEST_F(NegativeObjectLifetime, DescriptorPoolInUseDestroyedSignaled) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Submit cmd buffer to put pool in-flight
     m_default_queue->Submit(m_command_buffer);
     // Destroy pool while in-flight, causing error
@@ -565,7 +565,7 @@ TEST_F(NegativeObjectLifetime, FramebufferInUseDestroyedSignaled) {
     TEST_DESCRIPTION("Delete in-use framebuffer.");
     RETURN_IF_SKIP(Init());
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_B8G8R8A8_UNORM, &format_properties);
 
     InitRenderTarget();
 
@@ -581,10 +581,10 @@ TEST_F(NegativeObjectLifetime, FramebufferInUseDestroyedSignaled) {
     // Just use default renderpass with our framebuffer
     m_renderPassBeginInfo.framebuffer = fb;
     // Create Null cmd buffer for submit
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Submit cmd buffer to put it in-flight
     m_default_queue->Submit(m_command_buffer);
     // Destroy framebuffer while in-flight
@@ -639,13 +639,13 @@ TEST_F(NegativeObjectLifetime, PushDescriptorUniformDestroySignaled) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // In Intel GPU, it needs to bind pipeline before push descriptor set.
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
                                 &descriptor_write);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -673,10 +673,10 @@ TEST_F(NegativeObjectLifetime, FramebufferImageInUseDestroyedSignaled) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle(), 256, 256);
 
     // Create Null cmd buffer for submit
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     // Submit cmd buffer to put framebuffer and children in-flight
     m_default_queue->Submit(m_command_buffer);
     // Destroy image attached to framebuffer while in-flight
@@ -694,14 +694,14 @@ TEST_F(NegativeObjectLifetime, EventInUseDestroyedSignaled) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkEvent event;
     VkEventCreateInfo event_create_info = vku::InitStructHelper();
     vk::CreateEvent(device(), &event_create_info, nullptr, &event);
     vk::CmdSetEvent(m_command_buffer.handle(), event, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     vk::DestroyEvent(device(), event, nullptr);
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
@@ -736,7 +736,7 @@ TEST_F(NegativeObjectLifetime, InUseDestroyedSignaled) {
     VkEventCreateInfo event_create_info = vku::InitStructHelper();
     vk::CreateEvent(device(), &event_create_info, nullptr, &event);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdSetEvent(m_command_buffer.handle(), event, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
 
@@ -744,7 +744,7 @@ TEST_F(NegativeObjectLifetime, InUseDestroyedSignaled) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, NULL);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     VkSubmitInfo submit_info = vku::InitStructHelper();
     submit_info.commandBufferCount = 1;
@@ -796,11 +796,11 @@ TEST_F(NegativeObjectLifetime, PipelineInUseDestroyedSignaled) {
 
         delete_this_pipeline = pipe.Handle();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         // Bind pipeline to cmd buffer
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Submit cmd buffer and then pipeline destroyed while in-flight
         m_default_queue->Submit(m_command_buffer);
@@ -846,7 +846,7 @@ TEST_F(NegativeObjectLifetime, ImageViewInUseDestroyedSignaled) {
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroyImageView-imageView-01026");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // Bind pipeline to cmd buffer
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -855,7 +855,7 @@ TEST_F(NegativeObjectLifetime, ImageViewInUseDestroyedSignaled) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submit cmd buffer and then destroy imageView while in-flight
     m_default_queue->Submit(m_command_buffer);
@@ -910,7 +910,7 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroyBufferView-bufferView-00936");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // Bind pipeline to cmd buffer
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -918,7 +918,7 @@ TEST_F(NegativeObjectLifetime, BufferViewInUseDestroyedSignaled) {
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submit cmd buffer and then destroy bufferView while in-flight
     m_default_queue->Submit(m_command_buffer);
@@ -962,7 +962,7 @@ TEST_F(NegativeObjectLifetime, SamplerInUseDestroyedSignaled) {
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroySampler-sampler-01082");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // Bind pipeline to cmd buffer
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -971,7 +971,7 @@ TEST_F(NegativeObjectLifetime, SamplerInUseDestroyedSignaled) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submit cmd buffer and then destroy sampler while in-flight
     m_default_queue->Submit(m_command_buffer);
@@ -995,9 +995,9 @@ TEST_F(NegativeObjectLifetime, CmdBufferEventDestroyed) {
     VkResult result = vk::CreateEvent(device(), &evci, NULL, &event);
     ASSERT_EQ(VK_SUCCESS, result);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer.handle(), event, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
     // Destroy event dependency prior to submit to cause ERROR
@@ -1013,7 +1013,7 @@ TEST_F(NegativeObjectLifetime, ImportFdSemaphoreInUse) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_FD_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_FD_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through fd handle";
     }
 
@@ -1046,7 +1046,7 @@ TEST_F(NegativeObjectLifetime, ImportWin32SemaphoreInUse) {
     AddRequiredExtensions(VK_KHR_EXTERNAL_SEMAPHORE_WIN32_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -1084,7 +1084,7 @@ TEST_F(NegativeObjectLifetime, LeakAnObject) {
     }
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
-    const auto q_props = vkt::PhysicalDevice(gpu()).queue_properties_;
+    const auto q_props = vkt::PhysicalDevice(Gpu()).queue_properties_;
     ASSERT_TRUE(q_props.size() > 0);
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
@@ -1099,7 +1099,7 @@ TEST_F(NegativeObjectLifetime, LeakAnObject) {
     device_ci.pQueueCreateInfos = &queue_ci;
 
     VkDevice leaky_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_ci, nullptr, &leaky_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_ci, nullptr, &leaky_device));
 
     const VkFenceCreateInfo fence_ci = vku::InitStructHelper();
     VkFence leaked_fence;
@@ -1125,11 +1125,11 @@ TEST_F(NegativeObjectLifetime, LeakABuffer) {
     }
 
     // Workaround for overzealous layers checking even the guaranteed 0th queue family
-    const auto q_props = vkt::PhysicalDevice(gpu()).queue_properties_;
+    const auto q_props = vkt::PhysicalDevice(Gpu()).queue_properties_;
     ASSERT_TRUE(q_props.size() > 0);
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
-    auto features = vkt::PhysicalDevice(gpu()).Features();
+    auto features = vkt::PhysicalDevice(Gpu()).Features();
     if (!features.sparseBinding) {
         GTEST_SKIP() << "Test requires unsupported sparseBinding feature";
     }
@@ -1146,7 +1146,7 @@ TEST_F(NegativeObjectLifetime, LeakABuffer) {
     device_ci.pEnabledFeatures = &features;
 
     VkDevice leaky_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_ci, nullptr, &leaky_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_ci, nullptr, &leaky_device));
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;

--- a/tests/unit/other_positive.cpp
+++ b/tests/unit/other_positive.cpp
@@ -41,11 +41,11 @@ TEST_F(VkPositiveLayerTest, Maintenance1Tests) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_1_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
     vkt::CommandBuffer cmd_buf(*m_device, m_command_pool);
-    cmd_buf.begin();
+    cmd_buf.Begin();
     // Set Negative height, should give error if Maintenance 1 is not enabled
     VkViewport viewport = {0, 0, 16, -16, 0, 1};
     vk::CmdSetViewport(cmd_buf.handle(), 0, 1, &viewport);
-    cmd_buf.end();
+    cmd_buf.End();
 }
 
 TEST_F(VkPositiveLayerTest, ValidStructPNext) {
@@ -73,7 +73,7 @@ TEST_F(VkPositiveLayerTest, ValidStructPNext) {
     memory_info.allocationSize = memory_reqs.size;
 
     bool pass;
-    pass = m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
+    pass = m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory buffer_memory(*m_device, memory_info);
@@ -94,7 +94,7 @@ TEST_F(VkPositiveLayerTest, DeviceIDPropertiesExtensions) {
 
     VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &props2);
 }
 
 TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
@@ -109,12 +109,12 @@ TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
     GetPhysicalDeviceFeatures2(features2);
 
     // We're not creating a valid m_device, but the phy wrapper is useful
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     // Only request creation with queuefamilies that have at least one queue
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
@@ -131,7 +131,7 @@ TEST_F(VkPositiveLayerTest, ParameterLayerFeatures2Capture) {
     dev_info.pEnabledFeatures = nullptr;
 
     VkDevice device;
-    err = vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
+    err = vk::CreateDevice(Gpu(), &dev_info, nullptr, &device);
     ASSERT_EQ(VK_SUCCESS, err);
 
     if (features2.features.samplerAnisotropy) {
@@ -183,7 +183,7 @@ TEST_F(VkPositiveLayerTest, ModifyPnext) {
     shading.maxFragmentShadingRateInvocationCount = static_cast<VkSampleCountFlagBits>(0);
     VkPhysicalDeviceProperties2 props = vku::InitStructHelper(&shading);
 
-    vk::GetPhysicalDeviceProperties2(gpu(), &props);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &props);
 }
 
 TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
@@ -202,7 +202,7 @@ TEST_F(VkPositiveLayerTest, UseFirstQueueUnqueried) {
     device_ci.pQueueCreateInfos = &queue_ci;
 
     VkDevice test_device;
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &test_device);
 
     vk::DestroyDevice(test_device, nullptr);
 }
@@ -243,7 +243,7 @@ TEST_F(VkPositiveLayerTest, GetDevProcAddrExtensions) {
     device_ci.pQueueCreateInfos = &queue_ci;
 
     VkDevice device;
-    vk::CreateDevice(gpu(), &device_ci, NULL, &device);
+    vk::CreateDevice(Gpu(), &device_ci, NULL, &device);
 
     vkTrimCommandPoolKHR = vk::GetDeviceProcAddr(device, "vkTrimCommandPoolKHR");
     if (nullptr == vkTrimCommandPoolKHR) m_errorMonitor->SetError("Unexpected null pointer");
@@ -270,7 +270,7 @@ TEST_F(VkPositiveLayerTest, Vulkan12FeaturesBufferDeviceAddress) {
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
                        &alloc_flags);
-    (void)buffer.address();
+    (void)buffer.Address();
 
     // Also verify that we don't get the KHR extension address without enabling the KHR extension
     auto vkGetBufferDeviceAddressKHR =
@@ -359,8 +359,8 @@ TEST_F(VkPositiveLayerTest, FormatProperties3FromProfiles) {
     RETURN_IF_SKIP(Init());
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8_UNORM, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 }
 
 TEST_F(VkPositiveLayerTest, GDPAWithMultiCmdExt) {
@@ -424,9 +424,9 @@ TEST_F(VkPositiveLayerTest, ExtensionExpressions) {
     VkExtent2D fragment_size = {1, 1};
     std::array combiner_ops = {VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR, VK_FRAGMENT_SHADING_RATE_COMBINER_OP_KEEP_KHR};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetFragmentShadingRateKHR(m_command_buffer, &fragment_size, combiner_ops.data());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveLayerTest, AllowedDuplicateStype) {
@@ -501,10 +501,10 @@ TEST_F(VkPositiveLayerTest, ExclusiveScissorVersionCount) {
     }
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBool32 exclusiveScissorEnable = VK_TRUE;
     vk::CmdSetExclusiveScissorEnableNV(m_command_buffer.handle(), 0u, 1u, &exclusiveScissorEnable);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPositiveLayerTest, GetCalibratedTimestamps) {
@@ -514,12 +514,12 @@ TEST_F(VkPositiveLayerTest, GetCalibratedTimestamps) {
     RETURN_IF_SKIP(Init());
 
     uint32_t count = 0;
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, nullptr);
     if (count < 2) {
         GTEST_SKIP() << "only 1 TimeDomain supported";
     }
     std::vector<VkTimeDomainEXT> time_domains(count);
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, time_domains.data());
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, time_domains.data());
 
     VkCalibratedTimestampInfoEXT timestamp_infos[2];
     timestamp_infos[0] = vku::InitStructHelper();
@@ -539,12 +539,12 @@ TEST_F(VkPositiveLayerTest, GetCalibratedTimestampsKHR) {
     RETURN_IF_SKIP(Init());
 
     uint32_t count = 0;
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &count, nullptr);
     if (count < 2) {
         GTEST_SKIP() << "only 1 TimeDomain supported";
     }
     std::vector<VkTimeDomainKHR> time_domains(count);
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu(), &count, time_domains.data());
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &count, time_domains.data());
 
     VkCalibratedTimestampInfoKHR timestamp_infos[2];
     timestamp_infos[0] = vku::InitStructHelper();
@@ -580,7 +580,7 @@ TEST_F(VkPositiveLayerTest, NoExtensionFromInstanceFunction) {
     RETURN_IF_SKIP(Init());
     VkFormatProperties format_properties;
     // need VK_KHR_sampler_ycbcr_conversion if it was a device function
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_B16G16R16G16_422_UNORM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_B16G16R16G16_422_UNORM, &format_properties);
 }
 
 TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct0) {
@@ -589,7 +589,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct0) {
     SetTargetApiVersion(VK_API_VERSION_1_0);
     AddRequiredExtensions(VK_KHR_GET_PHYSICAL_DEVICE_PROPERTIES_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_IMAGE_FORMAT_LIST_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_image_format_list is not supported";
     }
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
@@ -607,7 +607,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct0) {
 
     VkImageFormatProperties2 image_format_properties = vku::InitStructHelper();
     // Requires instance extension (VK_KHR_get_physical_device_properties2)
-    vk::GetPhysicalDeviceImageFormatProperties2KHR(gpu(), &image_format_info, &image_format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2KHR(Gpu(), &image_format_info, &image_format_properties);
 }
 
 TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct1) {
@@ -615,7 +615,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct1) {
         "Use VkBufferUsageFlags2CreateInfoKHR with VkPhysicalDeviceExternalBufferInfo if VK_KHR_maintenance5 is available");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is not supported";
     }
 
@@ -633,7 +633,7 @@ TEST_F(VkPositiveLayerTest, InstanceExtensionsCallingDeviceStruct1) {
     externalBufferInfo.handleType = handle_type;
     VkExternalBufferProperties externalBufferProperties = vku::InitStructHelper();
     // Instance extension promoted to VK_VERSION_1_1
-    vk::GetPhysicalDeviceExternalBufferProperties(gpu(), &externalBufferInfo, &externalBufferProperties);
+    vk::GetPhysicalDeviceExternalBufferProperties(Gpu(), &externalBufferInfo, &externalBufferProperties);
 }
 
 TEST_F(VkPositiveLayerTest, TimelineSemaphoreWithVulkan11) {
@@ -647,11 +647,11 @@ TEST_F(VkPositiveLayerTest, TimelineSemaphoreWithVulkan11) {
 TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is not supported";
     }
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), static_cast<VkFormat>(8000), &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), static_cast<VkFormat>(8000), &format_properties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -659,22 +659,22 @@ TEST_F(VkPositiveLayerTest, UnrecognizedEnumOutOfRange2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is not supported";
     }
     VkFormatProperties2 format_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), static_cast<VkFormat>(8000), &format_properties);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), static_cast<VkFormat>(8000), &format_properties);
 }
 
 TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is not supported";
     }
 
     VkImageFormatProperties format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_1D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_1D, VK_IMAGE_TILING_OPTIMAL,
                                                static_cast<VkImageUsageFlags>(0xffffffff), 0, &format_properties);
 }
 
@@ -682,7 +682,7 @@ TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange2) {
     TEST_DESCRIPTION("https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8367");
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is not supported";
     }
 
@@ -693,5 +693,5 @@ TEST_F(VkPositiveLayerTest, UnrecognizedFlagOutOfRange2) {
     format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     format_info.type = VK_IMAGE_TYPE_1D;
     format_info.usage = static_cast<VkImageUsageFlags>(0xffffffff);
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &format_info, &format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &format_info, &format_properties);
 }

--- a/tests/unit/others.cpp
+++ b/tests/unit/others.cpp
@@ -52,7 +52,7 @@ TEST_F(VkLayerTest, VersionCheckPromotedAPIs) {
     VkPhysicalDeviceProperties2 phys_dev_props_2 = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredError("UNASSIGNED-API-Version-Violation");
-    vkGetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+    vkGetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
     m_errorMonitor->VerifyFound();
 }
 
@@ -67,10 +67,10 @@ TEST_F(VkLayerTest, UnsupportedPnextApiVersion) {
         VkPhysicalDeviceDepthStencilResolveProperties unenabled_device_ext_struct = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 phys_dev_props_2 = vku::InitStructHelper(&unenabled_device_ext_struct);
         if (DeviceValidationVersion() >= VK_API_VERSION_1_1) {
-            vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+            vk::GetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
         } else {
             m_errorMonitor->SetDesiredError("UNASSIGNED-API-Version-Violation");
-            vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+            vk::GetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
             m_errorMonitor->VerifyFound();
         }
     }
@@ -220,17 +220,17 @@ TEST_F(VkLayerTest, DuplicateMessageLimit) {
 
     // Should get the first three errors just fine
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
     m_errorMonitor->VerifyFound();
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
     m_errorMonitor->VerifyFound();
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
     m_errorMonitor->VerifyFound();
 
     // Limit should prevent the message from coming through a fourth time
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
 }
 
 TEST_F(VkLayerTest, VuidCheckForHashCollisions) {
@@ -364,13 +364,13 @@ TEST_F(VkLayerTest, RequiredParameter) {
     // Specify NULL for a pointer to a handle
     // Expected to trigger an error with
     // StatelessValidation::ValidateRequiredPointer
-    vk::GetPhysicalDeviceFeatures(gpu(), NULL);
+    vk::GetPhysicalDeviceFeatures(Gpu(), NULL);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceQueueFamilyProperties-pQueueFamilyPropertyCount-parameter");
     // Specify NULL for pointer to array count
     // Expected to trigger an error with StatelessValidation::ValidateArray
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), NULL, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), NULL, NULL);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetViewport-viewportCount-arraylength");
@@ -467,7 +467,7 @@ TEST_F(VkLayerTest, SpecLinks) {
     }
 
     m_errorMonitor->SetDesiredError(spec_version.c_str());
-    vk::GetPhysicalDeviceFeatures(gpu(), NULL);
+    vk::GetPhysicalDeviceFeatures(Gpu(), NULL);
     m_errorMonitor->VerifyFound();
 
     // Now generate a 'default' message and check the link
@@ -526,7 +526,7 @@ TEST_F(VkLayerTest, DeviceIDPropertiesUnsupported) {
     VkPhysicalDeviceIDProperties id_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&id_props);
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &props2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &props2);
     m_errorMonitor->VerifyFound();
 }
 
@@ -574,10 +574,10 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     indexing_features.descriptorBindingUniformBufferUpdateAfterBind = 800;
 
     uint32_t queue_node_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, NULL);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_node_count, NULL);
     std::vector<VkQueueFamilyProperties> queue_props;
     queue_props.resize(queue_node_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_node_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_node_count, queue_props.data());
     float priorities[] = {1.0f};
     VkDeviceQueueCreateInfo queue_info = vku::InitStructHelper();
     queue_info.flags = 0;
@@ -595,7 +595,7 @@ TEST_F(VkLayerTest, PnextOnlyStructValidation) {
     VkDevice dev;
     m_errorMonitor->SetDesiredError("is neither VK_TRUE nor VK_FALSE");
     m_errorMonitor->SetUnexpectedError("Failed to create");
-    vk::CreateDevice(gpu(), &dev_info, NULL, &dev);
+    vk::CreateDevice(Gpu(), &dev_info, NULL, &dev);
     m_errorMonitor->VerifyFound();
 }
 
@@ -672,13 +672,13 @@ TEST_F(VkLayerTest, InvalidStructPNext) {
     // in vkGetPhysicalDeviceProperties2, VkPhysicalDeviceProperties2 is not a const
     VkPhysicalDeviceProperties2 physical_device_properties2 = vku::InitStructHelper(&app_info);
 
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &physical_device_properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &physical_device_properties2);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange) {
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
@@ -687,32 +687,32 @@ TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange) {
     // Expected to trigger an error with
     // StatelessValidation::ValidateRangedEnum
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), static_cast<VkFormat>(8000), &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), static_cast<VkFormat>(8000), &format_properties);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, UnrecognizedEnumOutOfRange2) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceFormatProperties2-format-parameter");
     VkFormatProperties2 format_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), static_cast<VkFormat>(8000), &format_properties);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), static_cast<VkFormat>(8000), &format_properties);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange) {
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties-usage-parameter");
     VkImageFormatProperties format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_1D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_1D, VK_IMAGE_TILING_OPTIMAL,
                                                static_cast<VkImageUsageFlags>(0xffffffff), 0, &format_properties);
     m_errorMonitor->VerifyFound();
 }
@@ -720,7 +720,7 @@ TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange) {
 TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange2) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
@@ -732,13 +732,13 @@ TEST_F(VkLayerTest, UnrecognizedFlagOutOfRange2) {
     format_info.tiling = VK_IMAGE_TILING_OPTIMAL;
     format_info.type = VK_IMAGE_TYPE_1D;
     format_info.usage = static_cast<VkImageUsageFlags>(0xffffffff);
-    vk::GetPhysicalDeviceImageFormatProperties2(gpu(), &format_info, &format_properties);
+    vk::GetPhysicalDeviceImageFormatProperties2(Gpu(), &format_info, &format_properties);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, UnrecognizedValueBadMask) {
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
@@ -746,7 +746,7 @@ TEST_F(VkLayerTest, UnrecognizedValueBadMask) {
     // Specify an invalid VkFlags bitmask value
     // Expected to trigger an error with StatelessValidation::ValidateFlags
     VkImageFormatProperties image_format_properties;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                static_cast<VkImageUsageFlags>(1 << 25), 0, &image_format_properties);
     m_errorMonitor->VerifyFound();
 }
@@ -788,14 +788,14 @@ TEST_F(VkLayerTest, UnrecognizedValueBadBool) {
 
 TEST_F(VkLayerTest, UnrecognizedValueMaxEnum) {
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
     // Specify MAX_ENUM
     VkFormatProperties format_properties;
     m_errorMonitor->SetDesiredError("does not fall within the begin..end range");
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_MAX_ENUM, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_MAX_ENUM, &format_properties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -816,7 +816,7 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     queue_info.pQueuePriorities = &priorities[0];
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     device_create_info.queueCreateInfoCount = 1;
     device_create_info.pQueueCreateInfos = &queue_info;
     device_create_info.enabledLayerCount = 0;
@@ -824,7 +824,7 @@ TEST_F(VkLayerTest, UseObjectWithWrongDevice) {
     device_create_info.pEnabledFeatures = &features;
 
     VkDevice second_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_create_info, NULL, &second_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, NULL, &second_device));
 
     // Try to destroy the renderpass from the first device using the second device
     m_errorMonitor->SetDesiredError("VUID-vkDestroyRenderPass-renderPass-parent");
@@ -900,20 +900,20 @@ TEST_F(VkLayerTest, DeviceFeature2AndVertexAttributeDivisorExtensionUnenabled) {
     VkPhysicalDeviceFeatures2 pd_features2 = vku::InitStructHelper();
 
     RETURN_IF_SKIP(Init());
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&pd_features2);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     VkDevice testDevice;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-pNext");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 
     VkPhysicalDeviceVertexAttributeDivisorFeaturesEXT vadf = vku::InitStructHelper();
     device_create_info.pNext = &vadf;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-pNext");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -949,25 +949,25 @@ TEST_F(VkLayerTest, Features12Features13AndpNext) {
         m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-06532");
     }
 
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
     }
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&features12);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-02829");
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-02830");
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -980,11 +980,11 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
 
     const bool test_1_2 = (DeviceValidationVersion() >= VK_API_VERSION_1_2);
 
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
@@ -1006,29 +1006,29 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
     std::vector<const char *> device_extensions;
 
     // Go through each extension and if supported add to list and add failure to check for
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME)) {
         device_extensions.push_back(VK_KHR_SHADER_DRAW_PARAMETERS_EXTENSION_NAME);
         m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-04476");
     }
     if (test_1_2 == true) {
-        if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
+        if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME)) {
             device_extensions.push_back(VK_KHR_DRAW_INDIRECT_COUNT_EXTENSION_NAME);
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02831");
         }
-        if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME)) {
+        if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME)) {
             device_extensions.push_back(VK_KHR_SAMPLER_MIRROR_CLAMP_TO_EDGE_EXTENSION_NAME);
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02832");
         }
-        if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
+        if (DeviceExtensionSupported(Gpu(), nullptr, VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME)) {
             device_extensions.push_back(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
             device_extensions.push_back(VK_KHR_MAINTENANCE_3_EXTENSION_NAME);
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02833");
         }
-        if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME)) {
+        if (DeviceExtensionSupported(Gpu(), nullptr, VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME)) {
             device_extensions.push_back(VK_EXT_SAMPLER_FILTER_MINMAX_EXTENSION_NAME);
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02834");
         }
-        if (DeviceExtensionSupported(gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
+        if (DeviceExtensionSupported(Gpu(), nullptr, VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME)) {
             device_extensions.push_back(VK_EXT_SHADER_VIEWPORT_INDEX_LAYER_EXTENSION_NAME);
             m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-ppEnabledExtensionNames-02835");
         }
@@ -1038,14 +1038,14 @@ TEST_F(VkLayerTest, RequiredPromotedFeaturesExtensions) {
     }
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&features11);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.ppEnabledExtensionNames = device_extensions.data();
     device_create_info.enabledExtensionCount = device_extensions.size();
     VkDevice testDevice;
 
     m_errorMonitor->SetUnexpectedError("Failed to create device chain");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1073,25 +1073,25 @@ TEST_F(VkLayerTest, FeaturesVariablePointer) {
 
     variable_features.variablePointersStorageBuffer = VK_FALSE;
 
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
     }
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&features2);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.ppEnabledExtensionNames = device_extensions.data();
     device_create_info.enabledExtensionCount = device_extensions.size();
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceVariablePointersFeatures-variablePointers-01431");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1122,7 +1122,7 @@ TEST_F(VkLayerTest, UnclosedAndDuplicateQueries) {
     vk::GetDeviceQueue(device(), m_device->graphics_queue_node_index_, 0, &queue);
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 5);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 5);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryPool-01922");
@@ -1150,9 +1150,9 @@ TEST_F(VkLayerTest, ExecuteUnrecordedCB) {
 
     // Testing an "unfinished secondary CB" crashes on some HW/drivers (notably Pixel 3 and RADV)
     // vkt::CommandBuffer cb(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    // m_command_buffer.begin();
+    // m_command_buffer.Begin();
     // vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &cb.handle());
-    // m_command_buffer.end();
+    // m_command_buffer.End();
 
     // m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00072");
     // vk::QueueSubmit(m_default_queue->handle(), 1, &si, VK_NULL_HANDLE);
@@ -1162,18 +1162,18 @@ TEST_F(VkLayerTest, ExecuteUnrecordedCB) {
 TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     TEST_DESCRIPTION("Attempt to enable AMD_negative_viewport_height and Maintenance1_KHR extension simultaneously");
     RETURN_IF_SKIP(Init());
-    if (!((DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) &&
-          (DeviceExtensionSupported(gpu(), nullptr, VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME)))) {
+    if (!((DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_1_EXTENSION_NAME)) &&
+          (DeviceExtensionSupported(Gpu(), nullptr, VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME)))) {
         GTEST_SKIP() << "Maintenance1 and AMD_negative viewport height extensions not supported";
     }
 
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
     const char *extension_names[2] = {"VK_KHR_maintenance1", "VK_AMD_negative_viewport_height"};
     VkDevice testDevice;
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
-    auto features = m_device->phy().Features();
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    auto features = m_device->Physical().Features();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
     device_create_info.enabledExtensionCount = 2;
@@ -1184,7 +1184,7 @@ TEST_F(VkLayerTest, Maintenance1AndNegativeViewport) {
     // The following unexpected error is coming from the LunarG loader. Do not make it a desired message because platforms that do
     // not use the LunarG loader (e.g. Android) will not see the message and the test will fail.
     m_errorMonitor->SetUnexpectedError("Failed to create device chain.");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1201,8 +1201,8 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     const char *extension_names[1] = {VK_AMD_NEGATIVE_VIEWPORT_HEIGHT_EXTENSION_NAME};
     VkDevice testDevice;
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
     device_create_info.enabledExtensionCount = 1;
@@ -1213,7 +1213,7 @@ TEST_F(VkLayerTest, ApiVersion1_1AndNegativeViewport) {
     // The following unexpected error is coming from the LunarG loader. Do not make it a desired message because platforms that do
     // not use the LunarG loader (e.g. Android) will not see the message and the test will fail.
     m_errorMonitor->SetUnexpectedError("Failed to create device chain.");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1274,7 +1274,7 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
     m_errorMonitor->VerifyFound();
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindDescriptorSets-descriptorSetCount-arraylength");
     vk::CmdBindDescriptorSets(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 0,
@@ -1290,7 +1290,7 @@ TEST_F(VkLayerTest, ValidateArrayLength) {
                       0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
 
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
@@ -1316,12 +1316,12 @@ TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
 
     RETURN_IF_SKIP(InitState());
 
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
 
     VkDeviceCreateInfo create_info = vku::InitStructHelper();
     create_info.pNext = &create_device_pnext;
-    create_info.queueCreateInfoCount = queue_info.size();
-    create_info.pQueueCreateInfos = queue_info.data();
+    create_info.queueCreateInfoCount = queue_info.Size();
+    create_info.pQueueCreateInfos = queue_info.Data();
     create_info.enabledLayerCount = 0;
     create_info.ppEnabledLayerNames = nullptr;
     create_info.enabledExtensionCount = m_device_extension_names.size();
@@ -1329,7 +1329,7 @@ TEST_F(VkLayerTest, DuplicatePhysicalDevices) {
 
     VkDevice device;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupDeviceCreateInfo-pPhysicalDevices-00375");
-    vk::CreateDevice(gpu(), &create_info, nullptr, &device);
+    vk::CreateDevice(Gpu(), &create_info, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1361,29 +1361,29 @@ TEST_F(VkLayerTest, InvalidCombinationOfDeviceFeatures) {
     AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_EXTENSION_NAME);
     AddRequiredExtensions(VK_EXT_SHADER_ATOMIC_FLOAT_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
     device_create_info.pNext = &pd_features2;
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
     device_create_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-None-04896");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 
     pd_features2.pNext = &shader_atomic_float_feature;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-None-04897");
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-None-04898");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 
     pd_features2.pNext = &shader_atomic_float_feature2;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-sparseImageFloat32AtomicMinMax-04975");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1457,7 +1457,7 @@ TEST_F(VkLayerTest, Features12AndppEnabledExtensionNames) {
 
     VkDevice testDevice;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-04748");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1533,24 +1533,24 @@ TEST_F(VkLayerTest, DuplicateValidPNextStructures) {
     VkPhysicalDeviceProperties2 physical_device_properties2 =
         vku::InitStructHelper(&protected_memory_properties_1);
 
-    vk::GetPhysicalDeviceProperties2(gpu(), &physical_device_properties2);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &physical_device_properties2);
     m_errorMonitor->VerifyFound();
 }
 
 TEST_F(VkLayerTest, GetPhysicalDeviceImageFormatPropertiesFlags) {
     RETURN_IF_SKIP(Init());
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_MAINTENANCE_5_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_maintenance5 is supported";
     }
 
     VkImageFormatProperties dummy_props;
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties-usage-requiredbitmask");
-    vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D,
+    vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D,
                                                VK_IMAGE_TILING_OPTIMAL, 0, 0, &dummy_props);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceImageFormatProperties-flags-parameter");
-    vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D,
+    vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D,
                                                VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0xBAD00000, &dummy_props);
     m_errorMonitor->VerifyFound();
 }
@@ -1562,9 +1562,9 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicate) {
     RETURN_IF_SKIP(Init());
 
     uint32_t count = 0;
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, nullptr);
     std::vector<VkTimeDomainEXT> time_domains(count);
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, time_domains.data());
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, time_domains.data());
 
     VkCalibratedTimestampInfoEXT timestamp_infos[2];
     timestamp_infos[0] = vku::InitStructHelper();
@@ -1586,9 +1586,9 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsDuplicateKHR) {
     RETURN_IF_SKIP(Init());
 
     uint32_t count = 0;
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &count, nullptr);
     std::vector<VkTimeDomainEXT> time_domains(count);
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(gpu(), &count, time_domains.data());
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsKHR(Gpu(), &count, time_domains.data());
 
     VkCalibratedTimestampInfoEXT timestamp_infos[2];
     timestamp_infos[0] = vku::InitStructHelper();
@@ -1610,9 +1610,9 @@ TEST_F(VkLayerTest, GetCalibratedTimestampsQuery) {
     RETURN_IF_SKIP(Init());
 
     uint32_t count = 0;
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, nullptr);
     std::vector<VkTimeDomainEXT> time_domains(count);
-    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(gpu(), &count, time_domains.data());
+    vk::GetPhysicalDeviceCalibrateableTimeDomainsEXT(Gpu(), &count, time_domains.data());
 
     for (uint32_t i = 0; i < count; i++) {
         if (time_domains[i] == VK_TIME_DOMAIN_QUERY_PERFORMANCE_COUNTER_EXT) {
@@ -1665,7 +1665,7 @@ TEST_F(VkLayerTest, RequiredMeshShaderFeatures) {
         device_create_info.pNext = &features2;
 
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceMeshShaderFeaturesEXT-multiviewMeshShader-07032");
-        vk::CreateDevice(gpu(), &device_create_info, nullptr, &device);
+        vk::CreateDevice(Gpu(), &device_create_info, nullptr, &device);
         m_errorMonitor->VerifyFound();
     }
 
@@ -1676,7 +1676,7 @@ TEST_F(VkLayerTest, RequiredMeshShaderFeatures) {
         device_create_info.pNext = &features2;
 
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceMeshShaderFeaturesEXT-primitiveFragmentShadingRateMeshShader-07033");
-        vk::CreateDevice(gpu(), &device_create_info, nullptr, &device);
+        vk::CreateDevice(Gpu(), &device_create_info, nullptr, &device);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -1706,7 +1706,7 @@ TEST_F(VkLayerTest, RayTracingStageFlagWithoutFeature) {
     m_errorMonitor->VerifyFound();
 
     vkt::Event event(*m_device);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent-stageMask-07949");
     vk::CmdSetEvent(m_command_buffer.handle(), event.handle(), stage);
@@ -1736,7 +1736,7 @@ TEST_F(VkLayerTest, RayTracingStageFlagWithoutFeature) {
                            nullptr);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Wait();
 }
@@ -1885,7 +1885,7 @@ TEST_F(VkLayerTest, MissingExtensionPhysicalDeviceProperties) {
     VkPhysicalDeviceIDPropertiesKHR id_properties = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 properties2 = vku::InitStructHelper(&id_properties);
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-    vk::GetPhysicalDeviceProperties2KHR(gpu(), &properties2);
+    vk::GetPhysicalDeviceProperties2KHR(Gpu(), &properties2);
     m_errorMonitor->VerifyFound();
 }
 
@@ -1908,12 +1908,12 @@ TEST_F(VkLayerTest, InvalidGetExternalBufferPropertiesUsage) {
     VkExternalBufferProperties externalBufferProperties = vku::InitStructHelper();
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceExternalBufferInfo-None-09499");
-    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &externalBufferInfo, &externalBufferProperties);
+    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(Gpu(), &externalBufferInfo, &externalBufferProperties);
     m_errorMonitor->VerifyFound();
 
     externalBufferInfo.usage = 0u;
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceExternalBufferInfo-None-09500");
-    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &externalBufferInfo, &externalBufferProperties);
+    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(Gpu(), &externalBufferInfo, &externalBufferProperties);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2046,7 +2046,7 @@ TEST_F(VkLayerTest, Features11WithoutVulkan12) {
     }
     app_info_.apiVersion = m_instance_api_version.Value();
     RETURN_IF_SKIP(InitFramework());
-    if (physDevProps().apiVersion > VK_API_VERSION_1_1) {
+    if (PhysicalDeviceProps().apiVersion > VK_API_VERSION_1_1) {
         GTEST_SKIP() << "Need 1.0/1.1 device support";
     }
 
@@ -2064,14 +2064,14 @@ TEST_F(VkLayerTest, Features11WithoutVulkan12) {
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-pNext");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 
-    if (physDevProps().apiVersion == VK_API_VERSION_1_1) {
+    if (PhysicalDeviceProps().apiVersion == VK_API_VERSION_1_1) {
         VkPhysicalDeviceVulkan12Properties bad_version_1_1_struct = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 phys_dev_props_2 = vku::InitStructHelper(&bad_version_1_1_struct);
         m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceProperties2-pNext-pNext");
-        vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+        vk::GetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -2272,7 +2272,7 @@ TEST_F(VkLayerTest, PhysicalDeviceLayeredApiVulkanPropertiesKHR) {
     VkPhysicalDeviceProperties2 phys_dev_props_2 = vku::InitStructHelper(&api_prop_lists);
 
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceLayeredApiVulkanPropertiesKHR-pNext-10011");
-    vk::GetPhysicalDeviceProperties2(gpu(), &phys_dev_props_2);
+    vk::GetPhysicalDeviceProperties2(Gpu(), &phys_dev_props_2);
     m_errorMonitor->VerifyFound();
 }
 

--- a/tests/unit/parent.cpp
+++ b/tests/unit/parent.cpp
@@ -47,16 +47,16 @@ TEST_F(NegativeParent, FillBuffer) {
     TEST_DESCRIPTION("Test VUID-*-commonparent checks not sharing the same Device");
 
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Buffer buffer(*m_second_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdFillBuffer-commonparent");
     vk::CmdFillBuffer(m_command_buffer.handle(), buffer, 0, VK_WHOLE_SIZE, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeParent, BindBuffer) {
@@ -64,7 +64,7 @@ TEST_F(NegativeParent, BindBuffer) {
 
     AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkBufferCreateInfo buffer_ci = vku::InitStructHelper();
@@ -80,7 +80,7 @@ TEST_F(NegativeParent, BindBuffer) {
 
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.allocationSize = mem_reqs.size;
-    m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     vkt::DeviceMemory memory(*m_second_device, mem_alloc);
 
     VkBindBufferMemoryInfo bind_buffer_info = vku::InitStructHelper();
@@ -100,7 +100,7 @@ TEST_F(NegativeParent, DISABLED_BindImage) {
 
     AddRequiredExtensions(VK_KHR_BIND_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_TRANSFER_DST_BIT);
@@ -114,7 +114,7 @@ TEST_F(NegativeParent, DISABLED_BindImage) {
 
     VkMemoryAllocateInfo mem_alloc = vku::InitStructHelper();
     mem_alloc.allocationSize = mem_reqs.size;
-    m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
+    m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &mem_alloc, 0);
     vkt::DeviceMemory memory(*m_second_device, mem_alloc);
 
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper();
@@ -131,7 +131,7 @@ TEST_F(NegativeParent, ImageView) {
     TEST_DESCRIPTION("Test VUID-*-commonparent checks not sharing the same Device");
 
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(128, 128, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -156,7 +156,7 @@ TEST_F(NegativeParent, BindPipeline) {
     TEST_DESCRIPTION("Test binding pipeline from another device");
 
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
@@ -171,16 +171,16 @@ TEST_F(NegativeParent, BindPipeline) {
     pipeline_ci.stage = cs.GetStageCreateInfo();
     vkt::Pipeline pipeline(*m_second_device, pipeline_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-commonparent");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeParent, PipelineShaderStageCreateInfo) {
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
@@ -203,7 +203,7 @@ TEST_F(NegativeParent, RenderPassFramebuffer) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();  // Renderpass created on first device
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     m_errorMonitor->SetDesiredError("VUID-VkFramebufferCreateInfo-commonparent");
@@ -220,7 +220,7 @@ TEST_F(NegativeParent, RenderPassImagelessFramebuffer) {
     RETURN_IF_SKIP(InitState(nullptr, &imageless_framebuffer));
 
     InitRenderTarget();
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;
@@ -256,11 +256,11 @@ TEST_F(NegativeParent, RenderPassImagelessFramebuffer) {
     m_renderPassBeginInfo.pNext = &render_pass_attachment_bi;
     m_renderPassBeginInfo.framebuffer = fb.handle();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-02780");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeParent, RenderPassCommandBuffer) {
@@ -268,25 +268,25 @@ TEST_F(NegativeParent, RenderPassCommandBuffer) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(Init());
     InitRenderTarget();  // Renderpass created on first device
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::CommandPool command_pool(*m_second_device, m_device->graphics_queue_node_index_, 0);
     vkt::CommandBuffer command_buffer(*m_second_device, command_pool);
 
-    command_buffer.begin();
+    command_buffer.Begin();
     // one for each the framebuffer and renderpass being different from the CommandBuffer
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-commonparent");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-commonparent");
     auto subpass_begin_info = vku::InitStruct<VkSubpassBeginInfoKHR>(nullptr, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBeginRenderPass2(command_buffer.handle(), &m_renderPassBeginInfo, &subpass_begin_info);
     m_errorMonitor->VerifyFound();
-    command_buffer.end();
+    command_buffer.End();
 }
 
 TEST_F(NegativeParent, FreeCommandBuffer) {
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::CommandPool command_pool_1(*m_device, m_device->graphics_queue_node_index_, 0);
@@ -320,7 +320,7 @@ TEST_F(NegativeParent, Instance_PhysicalDeviceAndSurface) {
 
     VkBool32 supported = VK_FALSE;
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceSupportKHR-commonparent");
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, instance2_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, instance2_surface, &supported);
     m_errorMonitor->VerifyFound();
 }
 
@@ -543,7 +543,7 @@ TEST_F(NegativeParent, PhysicalDevice_Display) {
     // display from a different physical device
     uint32_t mode_count = 0;
     m_errorMonitor->SetDesiredError("VUID-vkGetDisplayModePropertiesKHR-display-parent");
-    vk::GetDisplayModePropertiesKHR(gpu(), display, &mode_count, nullptr);
+    vk::GetDisplayModePropertiesKHR(Gpu(), display, &mode_count, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -631,7 +631,7 @@ TEST_F(NegativeParent, PhysicalDevice_DisplayMode) {
     // display mode from a different physical device
     VkDisplayPlaneCapabilitiesKHR plane_capabilities{};
     m_errorMonitor->SetDesiredError("VUID-vkGetDisplayPlaneCapabilitiesKHR-mode-parent");
-    vk::GetDisplayPlaneCapabilitiesKHR(gpu(), display_mode, 0, &plane_capabilities);
+    vk::GetDisplayPlaneCapabilitiesKHR(Gpu(), display_mode, 0, &plane_capabilities);
     m_errorMonitor->VerifyFound();
 }
 
@@ -677,7 +677,7 @@ TEST_F(NegativeParent, UpdateDescriptorSetsBuffer) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Buffer buffer(*m_second_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
@@ -696,7 +696,7 @@ TEST_F(NegativeParent, UpdateDescriptorSetsImage) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Image image(*m_second_device, 32, 32, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_SAMPLED_BIT);
@@ -716,7 +716,7 @@ TEST_F(NegativeParent, DescriptorSetLayout) {
     TEST_DESCRIPTION("Create pipeline layout from a descriptor set layout that was created on a different device");
     RETURN_IF_SKIP(Init());
 
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     OneOffDescriptorSet descriptor_set(m_device,
@@ -735,14 +735,14 @@ TEST_F(NegativeParent, DescriptorSetLayout) {
 
 TEST_F(NegativeParent, FlushInvalidateMemory) {
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
     alloc_info.memoryTypeIndex = 0;
     alloc_info.allocationSize = 64;
 
-    bool pass = m_device->phy().SetMemoryType(0xFFFFFFFF, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    bool pass = m_device->Physical().SetMemoryType(0xFFFFFFFF, &alloc_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!pass) {
         GTEST_SKIP() << "Host Visible memory not found";
     }
@@ -773,7 +773,7 @@ TEST_F(NegativeParent, GetDescriptorSetLayoutSupport) {
     AddRequiredExtensions(VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::descriptorBuffer);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Sampler sampler(*m_device, SafeSaneSamplerCreateInfo());
@@ -788,7 +788,7 @@ TEST_F(NegativeParent, GetDescriptorSetLayoutSupport) {
 
 TEST_F(NegativeParent, BufferView) {
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Buffer buffer(*m_second_device, 64, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
@@ -803,7 +803,7 @@ TEST_F(NegativeParent, BufferView) {
 
 TEST_F(NegativeParent, CmdPipelineBarrier) {
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     auto image_ci = vkt::Image::ImageCreateInfo2D(256, 256, 1, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -824,7 +824,7 @@ TEST_F(NegativeParent, CmdPipelineBarrier2) {
     SetTargetApiVersion(VK_API_VERSION_1_3);
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     vkt::Buffer buffer(*m_second_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
@@ -842,18 +842,18 @@ TEST_F(NegativeParent, CmdPipelineBarrier2) {
     buffer_dependency.bufferMemoryBarrierCount = 1;
     buffer_dependency.pBufferMemoryBarriers = &buffer_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("UNASSIGNED-vkCmdPipelineBarrier2-commandBuffer-commonparent");
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &buffer_dependency);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeParent, ShaderObjectDescriptorSetLayout) {
     AddRequiredExtensions(VK_EXT_SHADER_OBJECT_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::shaderObject);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     OneOffDescriptorSet descriptor_set(m_second_device, {{0, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}});
@@ -868,12 +868,12 @@ TEST_F(NegativeParent, ShaderObjectDescriptorSetLayout) {
 TEST_F(NegativeParent, MapMemory2) {
     AddRequiredExtensions(VK_KHR_MAP_MEMORY_2_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = 64;
-    m_device->phy().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+    m_device->Physical().SetMemoryType(vvl::kU32Max, &memory_info, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     vkt::DeviceMemory memory(*m_second_device, memory_info);
 
     VkMemoryMapInfoKHR map_info = vku::InitStructHelper();

--- a/tests/unit/parent_positive.cpp
+++ b/tests/unit/parent_positive.cpp
@@ -28,7 +28,7 @@ TEST_F(PositiveParent, ImagelessFramebuffer) {
     GetPhysicalDeviceFeatures2(imageless_framebuffer);
     RETURN_IF_SKIP(InitState(nullptr, &imageless_framebuffer));
     InitRenderTarget();  // Renderpass created on first device
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     m_second_device = new vkt::Device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkFormat format = VK_FORMAT_B8G8R8A8_UNORM;

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -31,7 +31,7 @@ TEST_F(NegativePipeline, NotBound) {
 
     VkPipeline badPipeline = CastToHandle<VkPipeline, uintptr_t>(0xbaadb1be);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, badPipeline);
 
     m_errorMonitor->VerifyFound();
@@ -48,7 +48,7 @@ TEST_F(NegativePipeline, WrongBindPointGraphics) {
     CreateComputePipelineHelper pipe(*this);
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     m_errorMonitor->VerifyFound();
@@ -74,7 +74,7 @@ TEST_F(NegativePipeline, BasicCompute) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
 
@@ -94,7 +94,7 @@ TEST_F(NegativePipeline, WrongBindPointCompute) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     m_errorMonitor->VerifyFound();
@@ -201,9 +201,9 @@ TEST_F(NegativePipeline, CmdBufferPipelineDestroyed) {
         helper.CreateGraphicsPipeline();
 
         // Bind helper pipeline to command buffer
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // pipeline will be destroyed when helper goes out of scope
     }
@@ -239,7 +239,7 @@ TEST_F(NegativePipeline, BadPipelineObject) {
 
     // Attempt to bind an invalid Pipeline to a valid Command Buffer
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipeline-parameter");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, bad_pipeline);
     m_errorMonitor->VerifyFound();
 
@@ -313,13 +313,13 @@ TEST_F(NegativePipeline, NoPipelineDynamicState) {
     RETURN_IF_SKIP(Init());
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08606");
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, ShaderStageName) {
@@ -473,7 +473,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     subpass.pColorAttachments = attachmentRefs.data();
 
     VkAttachmentDescription attach_desc = {};
-    attach_desc.format = m_renderTargets[0]->format();
+    attach_desc.format = m_renderTargets[0]->Format();
     attach_desc.samples = VK_SAMPLE_COUNT_1_BIT;
     attach_desc.loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
     attach_desc.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -490,8 +490,8 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
 
     auto render_target_view = m_renderTargets[0]->CreateView();
 
-    const uint32_t fb_width = m_renderTargets[0]->width();
-    const uint32_t fb_height = m_renderTargets[0]->height();
+    const uint32_t fb_width = m_renderTargets[0]->Width();
+    const uint32_t fb_height = m_renderTargets[0]->Height();
     vkt::Framebuffer framebuffer(*m_device, renderpass, 1, &render_target_view.handle(), fb_width, fb_height);
 
     CreatePipelineHelper pipeline_1(*this);
@@ -504,7 +504,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     pipeline_2.gp_ci_.renderPass = renderpass.handle();
     pipeline_2.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(renderpass.handle(), framebuffer, fb_width, fb_height);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_1.Handle());
@@ -517,7 +517,7 @@ TEST_F(NegativePipeline, SubpassRasterizationSamples) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, RenderPassShaderResolveQCOM) {
@@ -624,7 +624,7 @@ TEST_F(NegativePipeline, RenderPassShaderResolveQCOM) {
 TEST_F(NegativePipeline, RasterizerDiscardWithFragmentShader) {
     TEST_DESCRIPTION("Create Graphics Pipeline with fragment shader and rasterizer discard");
     RETURN_IF_SKIP(Init());
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -694,7 +694,7 @@ TEST_F(NegativePipeline, CreateGraphicsPipelineWithBadBasePointer) {
 
     RETURN_IF_SKIP(Init());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -829,7 +829,7 @@ TEST_F(NegativePipeline, NumSamplesMismatch) {
     m_errorMonitor->SetUnexpectedError("VUID-VkGraphicsPipelineCreateInfo-multisampledRenderToSingleSampled-06853");
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -838,7 +838,7 @@ TEST_F(NegativePipeline, NumSamplesMismatch) {
 
     // Finalize recording of the command buffer
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1058,7 +1058,7 @@ TEST_F(NegativePipeline, NullStagepNameMaintenance5) {
     InitRenderTarget();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();
@@ -1086,7 +1086,7 @@ TEST_F(NegativePipeline, NullStagepNameMaintenance5Compute) {
     RETURN_IF_SKIP(Init());
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();
@@ -1213,7 +1213,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamples) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     struct TestCase {
         VkSampleCountFlagBits color_samples;
@@ -1296,14 +1296,14 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
     uint32_t combination_count = 0;
     std::vector<VkFramebufferMixedSamplesCombinationNV> combinations;
 
-    vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu(), &combination_count, nullptr);
+    vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(Gpu(), &combination_count, nullptr);
     if (combination_count < 1) {
         GTEST_SKIP() << "No mixed sample combinations are supported";
     }
     combinations.resize(combination_count);
     // TODO this fill can be removed once https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/4138 merges
     std::fill(combinations.begin(), combinations.end(), vku::InitStruct<VkFramebufferMixedSamplesCombinationNV>());
-    vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(gpu(), &combination_count, &combinations[0]);
+    vk::GetPhysicalDeviceSupportedFramebufferMixedSamplesCombinationsNV(Gpu(), &combination_count, &combinations[0]);
 
     // Pick the first supported combination for a positive test.
     test_cases.push_back({combinations[0].rasterizationSamples, static_cast<VkSampleCountFlagBits>(combinations[0].colorSamples),
@@ -1311,7 +1311,7 @@ TEST_F(NegativePipeline, FramebufferMixedSamplesCoverageReduction) {
                           combinations[0].coverageReductionMode, true,
                           "VUID-VkGraphicsPipelineCreateInfo-coverageReductionMode-02722"});
 
-    VkSampleCountFlags fb_sample_counts = m_device->phy().limits_.framebufferDepthSampleCounts;
+    VkSampleCountFlags fb_sample_counts = m_device->Physical().limits_.framebufferDepthSampleCounts;
     int max_sample_count = VK_SAMPLE_COUNT_64_BIT;
     while (max_sample_count > VK_SAMPLE_COUNT_1_BIT) {
         if (fb_sample_counts & max_sample_count) {
@@ -1661,7 +1661,7 @@ TEST_F(NegativePipeline, LineRasterization) {
             kErrorBit, vuids);
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetLineStippleKHR-lineStippleFactor-02776");
     vk::CmdSetLineStippleEXT(m_command_buffer.handle(), 0, 0);
     m_errorMonitor->VerifyFound();
@@ -1710,14 +1710,14 @@ TEST_F(NegativePipeline, NotCompatibleForSet) {
     pipe.cp_ci_.layout = pipeline_layout.handle();
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, binding_pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-None-08600");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, MaxPerStageResources) {
@@ -1733,9 +1733,9 @@ TEST_F(NegativePipeline, MaxPerStageResources) {
     // Spec requires a minimum of 128 so know this is setting it lower than that
     const uint32_t maxPerStageResources = 4;
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxPerStageResources = maxPerStageResources;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     RETURN_IF_SKIP(InitState());
     // Adds the one color attachment
     InitRenderTarget();
@@ -1866,9 +1866,9 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
 
     // Remove format features want to test if missing
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), sampled_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), sampled_format, &formatProps);
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT);
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), sampled_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), sampled_format, formatProps);
 
     vkt::Image image(*m_device, 128, 128, 1, sampled_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_GENERAL);
@@ -1980,7 +1980,7 @@ TEST_F(NegativePipeline, SampledInvalidImageViews) {
                                                      VK_IMAGE_LAYOUT_UNDEFINED);
     seperate_descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Unused is a valid version of the combined pipeline/descriptors
@@ -2405,7 +2405,7 @@ TEST_F(NegativePipeline, ColorWriteCreateInfoEXTMaxAttachments) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    uint32_t max_color_attachments = m_device->phy().limits_.maxColorAttachments + 1;
+    uint32_t max_color_attachments = m_device->Physical().limits_.maxColorAttachments + 1;
 
     std::vector<VkBool32> enables(max_color_attachments, VK_TRUE);
     VkPipelineColorWriteCreateInfoEXT color_write = vku::InitStructHelper();
@@ -2477,7 +2477,7 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle());
 
     VkMultisamplePropertiesEXT multisample_prop = vku::InitStructHelper();
-    vk::GetPhysicalDeviceMultisamplePropertiesEXT(gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
+    vk::GetPhysicalDeviceMultisamplePropertiesEXT(Gpu(), VK_SAMPLE_COUNT_1_BIT, &multisample_prop);
     const uint32_t valid_count =
         multisample_prop.maxSampleLocationGridSize.width * multisample_prop.maxSampleLocationGridSize.height;
 
@@ -2540,7 +2540,7 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     begin_info.clearValueCount = 1;
     begin_info.pClearValues = &clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &begin_info, VK_SUBPASS_CONTENTS_INLINE);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-variableSampleLocations-01525");
@@ -2563,7 +2563,7 @@ TEST_F(NegativePipeline, VariableSampleLocations) {
     m_command_buffer.NextSubpass();
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, RasterizationConservativeStateCreateInfo) {
@@ -2633,7 +2633,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessWithoutFeature) {
     attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
     attachments[1].flags = 0;
-    attachments[1].format = FindSupportedDepthStencilFormat(this->gpu());
+    attachments[1].format = FindSupportedDepthStencilFormat(this->Gpu());
     attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
     attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
     attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -2733,7 +2733,7 @@ TEST_F(NegativePipeline, RasterizationOrderAttachmentAccessNoSubpassFlags) {
         attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         attachments[1].flags = 0;
-        attachments[1].format = FindSupportedDepthStencilFormat(this->gpu());
+        attachments[1].format = FindSupportedDepthStencilFormat(this->Gpu());
         attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
         attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -2882,7 +2882,7 @@ TEST_F(NegativePipeline, IncompatibleScissorCountAndViewportCount) {
     InitRenderTarget();
 
     VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     if (features.multiViewport == false) {
         GTEST_SKIP() << "multiViewport feature not supported by device";
     }
@@ -3211,7 +3211,7 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
     image_ci.initialLayout = VK_IMAGE_LAYOUT_UNDEFINED;
 
     VkImageFormatProperties formProps;
-    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(m_device->phy().handle(), image_ci.format, image_ci.imageType,
+    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(m_device->Physical().handle(), image_ci.format, image_ci.imageType,
                                                               image_ci.tiling, image_ci.usage, image_ci.flags, &formProps);
     if (res != VK_SUCCESS || (formProps.sampleCounts & VK_SAMPLE_COUNT_2_BIT) == 0) {
         GTEST_SKIP() << "Required format not supported";
@@ -3243,14 +3243,14 @@ TEST_F(NegativePipeline, MismatchedRasterizationSamples) {
     pipe.gp_ci_.renderPass = VK_NULL_HANDLE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-pNext-07935");
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, PipelineMissingFeatures) {
@@ -3260,7 +3260,7 @@ TEST_F(NegativePipeline, PipelineMissingFeatures) {
     VkPhysicalDeviceFeatures features = {};
     RETURN_IF_SKIP(InitState(&features));
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->phy().handle());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->Physical().handle());
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(ds_format, VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});
@@ -3299,7 +3299,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
 
     VkFormat undefined = VK_FORMAT_UNDEFINED;
     VkFormat color_format = VK_FORMAT_R8G8B8A8_UNORM;
-    VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image color_image(*m_device, 32, 32, 1, color_format, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     vkt::ImageView color_image_view = color_image.CreateView();
@@ -3385,7 +3385,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     color_pipe.cb_ci_ = color_blend_state;
     stencil_pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(rendering_info);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, color_pipe.Handle());
@@ -3404,7 +3404,7 @@ TEST_F(NegativePipeline, MissingPipelineFormat) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePipeline, MissingPipelineViewportState) {
@@ -3494,7 +3494,7 @@ TEST_F(NegativePipeline, GeometryShaderConservativeRasterization) {
     AddRequiredExtensions(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     if (features.geometryShader == VK_FALSE) {
         GTEST_SKIP() << "geometryShader not supported";
     }
@@ -3538,7 +3538,7 @@ TEST_F(NegativePipeline, VertexPointOutputConservativeRasterization) {
     AddRequiredExtensions(VK_EXT_CONSERVATIVE_RASTERIZATION_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     if (features.geometryShader == VK_FALSE) {
         GTEST_SKIP() << "geometryShader not supported";
     }

--- a/tests/unit/pipeline_binary.cpp
+++ b/tests/unit/pipeline_binary.cpp
@@ -32,7 +32,7 @@ TEST_F(NegativePipelineBinary, CacheControl) {
         GTEST_SKIP() << "pipelineBinaryInternalCacheControl is VK_TRUE";
     }
 
-    const auto q_props = vkt::PhysicalDevice(gpu()).queue_properties_;
+    const auto q_props = vkt::PhysicalDevice(Gpu()).queue_properties_;
     ASSERT_TRUE(q_props.size() > 0);
     ASSERT_TRUE(q_props[0].queueCount > 0);
 
@@ -59,7 +59,7 @@ TEST_F(NegativePipelineBinary, CacheControl) {
 
     m_errorMonitor->SetDesiredFailureMsg(kErrorBit,
                                          "VUID-VkDevicePipelineBinaryInternalCacheControlKHR-disableInternalCache-09602");
-    vk::CreateDevice(gpu(), &device_ci, nullptr, &testDevice);
+    vk::CreateDevice(Gpu(), &device_ci, nullptr, &testDevice);
     m_errorMonitor->VerifyFound();
 }
 
@@ -378,7 +378,7 @@ TEST_F(NegativePipelineBinary, GraphicsPipeline) {
     VkResult err = vk::CreatePipelineCache(device(), &cache_create_info, nullptr, &pipeline_cache);
     ASSERT_EQ(VK_SUCCESS, err);
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
 
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);

--- a/tests/unit/pipeline_layout.cpp
+++ b/tests/unit/pipeline_layout.cpp
@@ -36,7 +36,7 @@ TEST_F(NegativePipelineLayout, ExceedsSetLimit) {
     vkt::DescriptorSetLayout ds_layout(*m_device, ds_layout_ci);
 
     // Create an array of DSLs, one larger than the physical limit
-    const auto excess_layouts = 1 + m_device->phy().limits_.maxBoundDescriptorSets;
+    const auto excess_layouts = 1 + m_device->Physical().limits_.maxBoundDescriptorSets;
     std::vector<VkDescriptorSetLayout> dsl_array(excess_layouts, ds_layout.handle());
 
     VkPipelineLayoutCreateInfo pipeline_layout_ci = vku::InitStructHelper();
@@ -127,22 +127,22 @@ TEST_F(NegativePipelineLayout, ExcessPerStageDescriptors) {
     bool descriptor_indexing =
         IsExtensionsEnabled(VK_KHR_MAINTENANCE_3_EXTENSION_NAME) && IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
-    uint32_t max_uniform_buffers = m_device->phy().limits_.maxPerStageDescriptorUniformBuffers;
-    uint32_t max_storage_buffers = m_device->phy().limits_.maxPerStageDescriptorStorageBuffers;
-    uint32_t max_sampled_images = m_device->phy().limits_.maxPerStageDescriptorSampledImages;
-    uint32_t max_storage_images = m_device->phy().limits_.maxPerStageDescriptorStorageImages;
-    uint32_t max_samplers = m_device->phy().limits_.maxPerStageDescriptorSamplers;
+    uint32_t max_uniform_buffers = m_device->Physical().limits_.maxPerStageDescriptorUniformBuffers;
+    uint32_t max_storage_buffers = m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers;
+    uint32_t max_sampled_images = m_device->Physical().limits_.maxPerStageDescriptorSampledImages;
+    uint32_t max_storage_images = m_device->Physical().limits_.maxPerStageDescriptorStorageImages;
+    uint32_t max_samplers = m_device->Physical().limits_.maxPerStageDescriptorSamplers;
     uint32_t max_combined = std::min(max_samplers, max_sampled_images);
-    uint32_t max_input_attachments = m_device->phy().limits_.maxPerStageDescriptorInputAttachments;
+    uint32_t max_input_attachments = m_device->Physical().limits_.maxPerStageDescriptorInputAttachments;
 
-    uint32_t sum_dyn_uniform_buffers = m_device->phy().limits_.maxDescriptorSetUniformBuffersDynamic;
-    uint32_t sum_uniform_buffers = m_device->phy().limits_.maxDescriptorSetUniformBuffers;
-    uint32_t sum_dyn_storage_buffers = m_device->phy().limits_.maxDescriptorSetStorageBuffersDynamic;
-    uint32_t sum_storage_buffers = m_device->phy().limits_.maxDescriptorSetStorageBuffers;
-    uint32_t sum_sampled_images = m_device->phy().limits_.maxDescriptorSetSampledImages;
-    uint32_t sum_storage_images = m_device->phy().limits_.maxDescriptorSetStorageImages;
-    uint32_t sum_samplers = m_device->phy().limits_.maxDescriptorSetSamplers;
-    uint32_t sum_input_attachments = m_device->phy().limits_.maxDescriptorSetInputAttachments;
+    uint32_t sum_dyn_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffersDynamic;
+    uint32_t sum_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffers;
+    uint32_t sum_dyn_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffersDynamic;
+    uint32_t sum_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffers;
+    uint32_t sum_sampled_images = m_device->Physical().limits_.maxDescriptorSetSampledImages;
+    uint32_t sum_storage_images = m_device->Physical().limits_.maxDescriptorSetStorageImages;
+    uint32_t sum_samplers = m_device->Physical().limits_.maxDescriptorSetSamplers;
+    uint32_t sum_input_attachments = m_device->Physical().limits_.maxDescriptorSetInputAttachments;
 
     VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties =
         vku::InitStructHelper();
@@ -423,21 +423,21 @@ TEST_F(NegativePipelineLayout, ExcessDescriptorsOverall) {
     RETURN_IF_SKIP(Init());
     const bool descriptor_indexing = IsExtensionsEnabled(VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME);
 
-    uint32_t max_uniform_buffers = m_device->phy().limits_.maxPerStageDescriptorUniformBuffers;
-    uint32_t max_storage_buffers = m_device->phy().limits_.maxPerStageDescriptorStorageBuffers;
-    uint32_t max_sampled_images = m_device->phy().limits_.maxPerStageDescriptorSampledImages;
-    uint32_t max_storage_images = m_device->phy().limits_.maxPerStageDescriptorStorageImages;
-    uint32_t max_samplers = m_device->phy().limits_.maxPerStageDescriptorSamplers;
-    uint32_t max_input_attachments = m_device->phy().limits_.maxPerStageDescriptorInputAttachments;
+    uint32_t max_uniform_buffers = m_device->Physical().limits_.maxPerStageDescriptorUniformBuffers;
+    uint32_t max_storage_buffers = m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers;
+    uint32_t max_sampled_images = m_device->Physical().limits_.maxPerStageDescriptorSampledImages;
+    uint32_t max_storage_images = m_device->Physical().limits_.maxPerStageDescriptorStorageImages;
+    uint32_t max_samplers = m_device->Physical().limits_.maxPerStageDescriptorSamplers;
+    uint32_t max_input_attachments = m_device->Physical().limits_.maxPerStageDescriptorInputAttachments;
 
-    uint32_t sum_dyn_uniform_buffers = m_device->phy().limits_.maxDescriptorSetUniformBuffersDynamic;
-    uint32_t sum_uniform_buffers = m_device->phy().limits_.maxDescriptorSetUniformBuffers;
-    uint32_t sum_dyn_storage_buffers = m_device->phy().limits_.maxDescriptorSetStorageBuffersDynamic;
-    uint32_t sum_storage_buffers = m_device->phy().limits_.maxDescriptorSetStorageBuffers;
-    uint32_t sum_sampled_images = m_device->phy().limits_.maxDescriptorSetSampledImages;
-    uint32_t sum_storage_images = m_device->phy().limits_.maxDescriptorSetStorageImages;
-    uint32_t sum_samplers = m_device->phy().limits_.maxDescriptorSetSamplers;
-    uint32_t sum_input_attachments = m_device->phy().limits_.maxDescriptorSetInputAttachments;
+    uint32_t sum_dyn_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffersDynamic;
+    uint32_t sum_uniform_buffers = m_device->Physical().limits_.maxDescriptorSetUniformBuffers;
+    uint32_t sum_dyn_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffersDynamic;
+    uint32_t sum_storage_buffers = m_device->Physical().limits_.maxDescriptorSetStorageBuffers;
+    uint32_t sum_sampled_images = m_device->Physical().limits_.maxDescriptorSetSampledImages;
+    uint32_t sum_storage_images = m_device->Physical().limits_.maxDescriptorSetStorageImages;
+    uint32_t sum_samplers = m_device->Physical().limits_.maxDescriptorSetSamplers;
+    uint32_t sum_input_attachments = m_device->Physical().limits_.maxDescriptorSetInputAttachments;
 
     VkPhysicalDeviceDescriptorIndexingProperties descriptor_indexing_properties =
         vku::InitStructHelper();

--- a/tests/unit/pipeline_positive.cpp
+++ b/tests/unit/pipeline_positive.cpp
@@ -263,7 +263,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(Init());
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -369,7 +369,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineWithIgnoredPointers) {
 
         vkt::Pipeline pipeline(*m_device, graphics_pipeline_create_info);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.handle());
     }
 
@@ -855,7 +855,7 @@ TEST_F(PositivePipeline, SamplerDataForCombinedImageSampler) {
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -864,7 +864,7 @@ TEST_F(PositivePipeline, SamplerDataForCombinedImageSampler) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePipeline, ConditionalRendering) {
@@ -898,7 +898,7 @@ TEST_F(PositivePipeline, ConditionalRendering) {
 
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &imageView.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
 
     VkImageMemoryBarrier imb = vku::InitStructHelper();
@@ -919,7 +919,7 @@ TEST_F(PositivePipeline, ConditionalRendering) {
                            VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT, 0, 0, nullptr, 0, nullptr, 1, &imb);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePipeline, ShaderTileImage) {
@@ -1093,18 +1093,18 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     VkFormatProperties3 fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), image_format, &fmt_props);
+    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(Gpu(), image_format, &fmt_props);
     fmt_props.formatProperties.optimalTilingFeatures =
         (fmt_props.formatProperties.optimalTilingFeatures & ~VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT);
     fmt_props_3.optimalTilingFeatures = (fmt_props_3.optimalTilingFeatures & ~VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT);
     fmt_props_3.optimalTilingFeatures = (fmt_props_3.optimalTilingFeatures & ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT);
-    fpvkSetPhysicalDeviceFormatProperties2EXT(gpu(), image_format, fmt_props);
+    fpvkSetPhysicalDeviceFormatProperties2EXT(Gpu(), image_format, fmt_props);
 
-    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), image_view_format, &fmt_props);
+    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(Gpu(), image_view_format, &fmt_props);
     fmt_props.formatProperties.optimalTilingFeatures |= VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT;
     fmt_props_3.optimalTilingFeatures |= VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT;
     fmt_props_3.optimalTilingFeatures |= VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
-    fpvkSetPhysicalDeviceFormatProperties2EXT(gpu(), image_view_format, fmt_props);
+    fpvkSetPhysicalDeviceFormatProperties2EXT(Gpu(), image_view_format, fmt_props);
 
     // Make sure compute pipeline has a compute shader stage set
     const char *csSource = R"(
@@ -1158,7 +1158,7 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
 
     // Messing with format support, make sure device will handle the image combination
     VkImageFormatProperties format_props;
-    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(gpu(), image_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    if (VK_SUCCESS != vk::GetPhysicalDeviceImageFormatProperties(Gpu(), image_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                                  VK_IMAGE_USAGE_STORAGE_BIT, VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT,
                                                                  &format_props)) {
         GTEST_SKIP() << "Device will not be able to initialize buffer view skipped";
@@ -1180,8 +1180,8 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     ds.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     ds.UpdateDescriptorSets();
 
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = VK_ACCESS_HOST_READ_BIT;
@@ -1202,7 +1202,7 @@ TEST_F(PositivePipeline, MutableStorageImageFormatWriteForFormat) {
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_.handle(), 0,
                               1, &ds.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAccessFlags) {
@@ -1243,7 +1243,7 @@ TEST_F(PositivePipeline, CreateGraphicsPipelineRasterizationOrderAttachmentAcces
         attachments[0].finalLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
 
         attachments[1].flags = 0;
-        attachments[1].format = FindSupportedDepthStencilFormat(this->gpu());
+        attachments[1].format = FindSupportedDepthStencilFormat(this->Gpu());
         attachments[1].samples = VK_SAMPLE_COUNT_1_BIT;
         attachments[1].storeOp = VK_ATTACHMENT_STORE_OP_STORE;
         attachments[1].stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
@@ -1374,7 +1374,7 @@ TEST_F(PositivePipeline, DualBlendShader) {
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1382,7 +1382,7 @@ TEST_F(PositivePipeline, DualBlendShader) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // CTS was written, but may fail on older drivers
@@ -1684,7 +1684,7 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
         }
     } else {
         RETURN_IF_SKIP(InitState());
-        if (!m_device->phy().Features().sampleRateShading) {
+        if (!m_device->Physical().Features().sampleRateShading) {
             GTEST_SKIP() << "sampleRateShading not supported";
         }
     }
@@ -1714,12 +1714,12 @@ TEST_F(PositivePipeline, InterpolateAtSample) {
     pipe.shader_stages_ = {vs.GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePipeline, ShaderModuleIdentifierZeroLength) {
@@ -1869,7 +1869,7 @@ TEST_F(PositivePipeline, PipelineMissingFeaturesDynamic) {
     AddDisabledFeature(vkt::Feature::alphaToOne);
     RETURN_IF_SKIP(Init());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->phy().handle());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->Physical().handle());
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(ds_format, VK_IMAGE_LAYOUT_PREINITIALIZED, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL);
     rp.AddAttachmentReference({0, VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL});

--- a/tests/unit/pipeline_topology.cpp
+++ b/tests/unit/pipeline_topology.cpp
@@ -242,7 +242,7 @@ TEST_F(NegativePipelineTopology, PrimitiveTopologyListRestart) {
     topology = VK_PRIMITIVE_TOPOLOGY_POINT_LIST;
     CreatePipelineHelper::OneshotTest(*this, set_info, kErrorBit, "VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06252");
 
-    if (m_device->phy().Features().tessellationShader) {
+    if (m_device->Physical().Features().tessellationShader) {
         topology = VK_PRIMITIVE_TOPOLOGY_PATCH_LIST;
         constexpr std::array vuids = {"VUID-VkPipelineInputAssemblyStateCreateInfo-topology-06253",
                                       "VUID-VkGraphicsPipelineCreateInfo-topology-08889"};
@@ -310,7 +310,7 @@ TEST_F(NegativePipelineTopology, DynamicPrimitiveRestartEnable) {
     pipe.ia_ci_.topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetPrimitiveRestartEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -318,5 +318,5 @@ TEST_F(NegativePipelineTopology, DynamicPrimitiveRestartEnable) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/pipeline_topology_positive.cpp
+++ b/tests/unit/pipeline_topology_positive.cpp
@@ -313,11 +313,11 @@ TEST_F(PositivePipelineTopology, PolygonModeValid) {
     InitRenderTarget();
 
     std::vector<const char *> device_extension_names;
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     // Artificially disable support for non-solid fill modes
     features.fillModeNonSolid = false;
     // The sacrificial device object
-    vkt::Device test_device(gpu(), device_extension_names, &features);
+    vkt::Device test_device(Gpu(), device_extension_names, &features);
 
     VkAttachmentReference attach = {};
     attach.layout = VK_IMAGE_LAYOUT_GENERAL;
@@ -445,13 +445,13 @@ TEST_F(PositivePipelineTopology, Rasterizer) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_LINE_WIDTH);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
-    m_command_buffer.BeginRenderPass(renderPass(), framebuffer(), 32, 32, m_renderPassClearValues.size(),
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(RenderPass(), Framebuffer(), 32, 32, m_renderPassClearValues.size(),
                                      m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePipelineTopology, LineTopologyClasses) {
@@ -479,7 +479,7 @@ TEST_F(PositivePipelineTopology, LineTopologyClasses) {
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     vkt::CommandBuffer cb(*m_device, m_command_pool);
-    cb.begin();
+    cb.Begin();
     cb.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(cb.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -489,7 +489,7 @@ TEST_F(PositivePipelineTopology, LineTopologyClasses) {
 
     cb.EndRenderPass();
 
-    cb.end();
+    cb.End();
 }
 
 TEST_F(PositivePipelineTopology, PointSizeDynamicAndUnestricted) {

--- a/tests/unit/portability_subset.cpp
+++ b/tests/unit/portability_subset.cpp
@@ -21,7 +21,7 @@ TEST_F(NegativePortabilitySubset, Device) {
     AddRequiredExtensions(VK_KHR_PORTABILITY_SUBSET_EXTENSION_NAME);
     RETURN_IF_SKIP(InitFramework());
 
-    vkt::PhysicalDevice phys_device(gpu());
+    vkt::PhysicalDevice phys_device(Gpu());
 
     // request all queues
     const std::vector<VkQueueFamilyProperties> queue_props = phys_device.queue_properties_;
@@ -29,8 +29,8 @@ TEST_F(NegativePortabilitySubset, Device) {
 
     // Only request creation with queuefamilies that have at least one queue
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t j = 0; j < queue_info.size(); ++j) {
+    auto qci = queue_info.Data();
+    for (uint32_t j = 0; j < queue_info.Size(); ++j) {
         if (qci[j].queueCount) {
             create_queue_infos.push_back(qci[j]);
         }
@@ -47,7 +47,7 @@ TEST_F(NegativePortabilitySubset, Device) {
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pProperties-04451");
     VkDevice device;
-    vk::CreateDevice(gpu(), &dev_info, nullptr, &device);
+    vk::CreateDevice(Gpu(), &dev_info, nullptr, &device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -222,7 +222,7 @@ TEST_F(NegativePortabilitySubset, TriangleFans) {
     portability_feature.triangleFans = VK_FALSE;
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -255,7 +255,7 @@ TEST_F(NegativePortabilitySubset, VertexInputStride) {
     ASSERT_TRUE(portability_properties.minVertexInputBindingStrideAlignment > 0);
     auto vertex_stride = portability_properties.minVertexInputBindingStrideAlignment - 1;
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -289,7 +289,7 @@ TEST_F(NegativePortabilitySubset, VertexAttributes) {
     portability_feature.vertexAttributeAccessBeyondStride = VK_FALSE;
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -370,7 +370,7 @@ TEST_F(NegativePortabilitySubset, DepthStencilState) {
     portability_feature.separateStencilMaskRef = VK_FALSE;
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
-    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    m_depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     m_depthStencil->Init(*m_device, m_width, m_height, 1, m_depth_stencil_fmt, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
     m_depthStencil->SetLayout(VK_IMAGE_LAYOUT_GENERAL);
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -591,7 +591,7 @@ TEST_F(VkPortabilitySubsetTest, PortabilitySubsetColorBlendFactor) {
         VK_BLEND_FACTOR_ZERO,           VK_BLEND_OP_ADD,
     };
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkColorBlendEquationEXT-constantAlphaColorBlendFactors-07362");
     vk::CmdSetColorBlendEquationEXT(m_command_buffer.handle(), 0u, 1u, &color_blend_equation);
@@ -603,7 +603,7 @@ TEST_F(VkPortabilitySubsetTest, PortabilitySubsetColorBlendFactor) {
     vk::CmdSetColorBlendEquationEXT(m_command_buffer.handle(), 0u, 1u, &color_blend_equation);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(VkPortabilitySubsetTest, InstanceCreateEnumerate) {
@@ -641,22 +641,22 @@ TEST_F(VkPortabilitySubsetTest, FeatureWithoutExtension) {
 
     VkPhysicalDevicePortabilitySubsetFeaturesKHR feature = vku::InitStructHelper();
 
-    vkt::PhysicalDevice physical_device(gpu());
+    vkt::PhysicalDevice physical_device(Gpu());
     vkt::QueueCreateInfoArray queue_info(physical_device.queue_properties_);
     std::vector<VkDeviceQueueCreateInfo> create_queue_infos;
-    auto qci = queue_info.data();
-    for (uint32_t i = 0; i < queue_info.size(); ++i) {
+    auto qci = queue_info.Data();
+    for (uint32_t i = 0; i < queue_info.Size(); ++i) {
         if (qci[i].queueCount) {
             create_queue_infos.push_back(qci[i]);
         }
     }
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&feature);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     VkDevice testDevice;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-pNext-pNext");
-    vk::CreateDevice(gpu(), &device_create_info, NULL, &testDevice);
+    vk::CreateDevice(Gpu(), &device_create_info, NULL, &testDevice);
     m_errorMonitor->VerifyFound();
 }

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -36,9 +36,9 @@ TEST_F(NegativeProtectedMemory, Queue) {
     bool unprotected_queue = false;
     uint32_t queue_family_index = 0;
     uint32_t queue_family_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_families.data());
 
     // need to find a queue without protected support
     for (size_t i = 0; i < queue_families.size(); i++) {
@@ -70,7 +70,7 @@ TEST_F(NegativeProtectedMemory, Queue) {
     device_create_info.enabledExtensionCount = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-flags-06449");
-    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -114,7 +114,7 @@ TEST_F(NegativeProtectedMemory, Submit) {
     alloc_info.allocationSize = 4096;
 
     VkPhysicalDeviceMemoryProperties phys_mem_props;
-    vk::GetPhysicalDeviceMemoryProperties(gpu(), &phys_mem_props);
+    vk::GetPhysicalDeviceMemoryProperties(Gpu(), &phys_mem_props);
     alloc_info.memoryTypeIndex = phys_mem_props.memoryTypeCount + 1;
     for (uint32_t i = 0; i < phys_mem_props.memoryTypeCount; i++) {
         // Check just protected bit is in type at all
@@ -136,8 +136,8 @@ TEST_F(NegativeProtectedMemory, Submit) {
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_command_buffer.handle();
 
-    m_command_buffer.begin();
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-queue-06448");
     m_errorMonitor->SetUnexpectedError("VUID-VkSubmitInfo-pNext-04148");
@@ -152,7 +152,7 @@ TEST_F(NegativeProtectedMemory, Memory) {
     RETURN_IF_SKIP(InitFramework());
     RETURN_IF_SKIP(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_PROTECTED_BIT));
 
-    bool sparse_support = (m_device->phy().Features().sparseBinding == VK_TRUE);
+    bool sparse_support = (m_device->Physical().Features().sparseBinding == VK_TRUE);
 
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
     buffer_create_info.flags = VK_BUFFER_CREATE_PROTECTED_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
@@ -204,15 +204,16 @@ TEST_F(NegativeProtectedMemory, Memory) {
     vk::GetBufferMemoryRequirements(device(), buffer_unprotected.handle(), &mem_reqs_unprotected);
 
     alloc_info.allocationSize = mem_reqs_protected.size;
-    bool found = m_device->phy().SetMemoryType(mem_reqs_unprotected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+    bool found =
+        m_device->Physical().SetMemoryType(mem_reqs_unprotected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
     vkt::DeviceMemory memory_protected(*m_device, alloc_info);
 
     alloc_info.allocationSize = mem_reqs_unprotected.size;
-    found = m_device->phy().SetMemoryType(mem_reqs_unprotected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                          VK_MEMORY_PROPERTY_PROTECTED_BIT);
+    found = m_device->Physical().SetMemoryType(mem_reqs_unprotected.memoryTypeBits, &alloc_info,
+                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
@@ -263,9 +264,9 @@ TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
     VkQueueFamilyProperties queue_properties;  // selected queue family used
     uint32_t queue_family_index = 0;
     uint32_t queue_family_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_families.data());
 
     for (size_t i = 0; i < queue_families.size(); i++) {
         // need to have at least 2 queues to use
@@ -303,14 +304,14 @@ TEST_F(NegativeProtectedMemory, UniqueQueueDeviceCreationBothProtected) {
     device_create_info.enabledExtensionCount = 0;
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802");
-    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 
     // both protected
     queue_create_info[0].flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
     queue_create_info[1].flags = VK_DEVICE_QUEUE_CREATE_PROTECTED_BIT;
     m_errorMonitor->SetDesiredError("VUID-VkDeviceCreateInfo-queueFamilyIndex-02802");
-    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 }
 
@@ -331,7 +332,7 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     uint32_t queue_family_count = 1;
     uint32_t queue_family_index = 0;
     VkQueueFamilyProperties queue_properties;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, &queue_properties);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, &queue_properties);
 
     float queue_priority = 1.0;
     VkDeviceQueueCreateInfo queue_create_info = vku::InitStructHelper();
@@ -354,7 +355,7 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     // Protect feature not set
     m_errorMonitor->SetUnexpectedError("VUID-VkDeviceQueueCreateInfo-flags-06449");
     m_errorMonitor->SetDesiredError("VUID-VkDeviceQueueCreateInfo-flags-02861");
-    vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     m_errorMonitor->VerifyFound();
 
     GetPhysicalDeviceFeatures2(protect_features);
@@ -362,7 +363,7 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     if (protect_features.protectedMemory == VK_TRUE) {
         // Might not have protected queue support
         m_errorMonitor->SetUnexpectedError("VUID-VkDeviceQueueCreateInfo-flags-06449");
-        result = vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+        result = vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
         if (result != VK_SUCCESS) {
             GTEST_SKIP() << "CreateDevice returned back not VK_SUCCESS";
         }
@@ -387,7 +388,7 @@ TEST_F(NegativeProtectedMemory, GetDeviceQueue) {
     // Create device without protected queue
     protect_features.protectedMemory = VK_FALSE;
     queue_create_info.flags = 0;
-    result = vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device);
+    result = vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device);
     if (result != VK_SUCCESS) {
         GTEST_SKIP() << "CreateDevice returned back not VK_SUCCESS";
     }
@@ -459,7 +460,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
     pipe.gp_ci_.flags = VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07408");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_errorMonitor->VerifyFound();
@@ -471,13 +472,13 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccess) {
 
     vkt::CommandPool command_pool(*m_device, m_device->graphics_queue_node_index_);
     vkt::CommandBuffer unprotected_cmdbuf(*m_device, command_pool);
-    unprotected_cmdbuf.begin();
+    unprotected_cmdbuf.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipelineProtectedAccess-07409");
     vk::CmdBindPipeline(unprotected_cmdbuf.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, protected_pipe.Handle());
     m_errorMonitor->VerifyFound();
 
     // Create device without protected access features
-    vkt::Device test_device(gpu(), m_device_extension_names);
+    vkt::Device test_device(Gpu(), m_device_extension_names);
     VkShaderObj vs2(this, kVertexMinimalGlsl, VK_SHADER_STAGE_VERTEX_BIT, SPV_ENV_VULKAN_1_0, SPV_SOURCE_GLSL_TRY);
     vs2.InitFromGLSLTry(&test_device);
 
@@ -555,7 +556,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccessGPL) {
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07404");
     VkGraphicsPipelineCreateInfo lib_ci = vku::InitStructHelper(&link_info);
     lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR | VK_PIPELINE_CREATE_NO_PROTECTED_ACCESS_BIT_EXT;
-    lib_ci.renderPass = renderPass();
+    lib_ci.renderPass = RenderPass();
     lib_ci.layout = pre_raster_lib.gp_ci_.layout;
     vkt::Pipeline lib(*m_device, lib_ci);
     m_errorMonitor->VerifyFound();
@@ -572,7 +573,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccessGPL) {
     ASSERT_EQ(VK_SUCCESS, protected_pre_raster_lib.CreateGraphicsPipeline());
     libraries[0] = protected_pre_raster_lib.Handle();
     VkGraphicsPipelineCreateInfo protected_lib_ci = vku::InitStructHelper(&link_info);
-    protected_lib_ci.renderPass = renderPass();
+    protected_lib_ci.renderPass = RenderPass();
     protected_lib_ci.layout = pre_raster_lib.gp_ci_.layout;
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07407");
     lib_ci.flags = 0;
@@ -588,7 +589,7 @@ TEST_F(NegativeProtectedMemory, PipelineProtectedAccessGPL) {
     libraries[0] = unprotected_pre_raster_lib.Handle();
     VkGraphicsPipelineCreateInfo unprotected_lib_ci = vku::InitStructHelper(&link_info);
     unprotected_lib_ci.flags = VK_PIPELINE_CREATE_LIBRARY_BIT_KHR;
-    unprotected_lib_ci.renderPass = renderPass();
+    unprotected_lib_ci.renderPass = RenderPass();
     unprotected_lib_ci.layout = pre_raster_lib.gp_ci_.layout;
     m_errorMonitor->SetDesiredError("VUID-VkPipelineLibraryCreateInfoKHR-pipeline-07405");
     vkt::Pipeline lib4(*m_device, unprotected_lib_ci);
@@ -630,7 +631,7 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -660,7 +661,7 @@ TEST_F(NegativeProtectedMemory, UnprotectedCommands) {
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
@@ -728,15 +729,15 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     vk::GetImageMemoryRequirements(device(), image_unprotected.handle(), &mem_reqs_image_unprotected);
 
     bool found =
-        m_device->phy().SetMemoryType(mem_reqs_buffer_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+        m_device->Physical().SetMemoryType(mem_reqs_buffer_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
     alloc_info.allocationSize = mem_reqs_buffer_protected.size;
     vkt::DeviceMemory memory_buffer_protected(*m_device, alloc_info);
 
-    found = m_device->phy().SetMemoryType(mem_reqs_buffer_unprotected.memoryTypeBits, &alloc_info,
-                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+    found = m_device->Physical().SetMemoryType(mem_reqs_buffer_unprotected.memoryTypeBits, &alloc_info,
+                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
@@ -744,14 +745,15 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     vkt::DeviceMemory memory_buffer_unprotected(*m_device, alloc_info);
 
     alloc_info.allocationSize = mem_reqs_image_protected.size;
-    found = m_device->phy().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+    found =
+        m_device->Physical().SetMemoryType(mem_reqs_image_protected.memoryTypeBits, &alloc_info, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
     vkt::DeviceMemory memory_image_protected(*m_device, alloc_info);
 
-    found = m_device->phy().SetMemoryType(mem_reqs_image_unprotected.memoryTypeBits, &alloc_info,
-                                          VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_PROTECTED_BIT);
+    found = m_device->Physical().SetMemoryType(mem_reqs_image_unprotected.memoryTypeBits, &alloc_info,
+                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, VK_MEMORY_PROPERTY_PROTECTED_BIT);
     if (!found) {
         GTEST_SKIP() << "Memory type not found";
     }
@@ -857,7 +859,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
                                                      VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // will get undefined values, but not invalid if protectedNoFault is supported
     // Will still create an empty command buffer to test submit VUs if protectedNoFault is supported
     if (!protected_memory_properties.protectedNoFault) {
@@ -946,7 +948,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
 
         m_command_buffer.EndRenderPass();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Use unprotected resources in protected command buffer
     g_pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected.handle(), 0, 1024);
@@ -954,7 +956,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
                                                      VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    protectedCommandBuffer.begin();
+    protectedCommandBuffer.Begin();
     if (!protected_memory_properties.protectedNoFault) {
         m_errorMonitor->SetDesiredError("VUID-vkCmdBlitImage-commandBuffer-01836");
         vk::CmdBlitImage(protectedCommandBuffer.handle(), image_protected.handle(), VK_IMAGE_LAYOUT_GENERAL,
@@ -1014,7 +1016,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
 
         vk::CmdEndRenderPass(protectedCommandBuffer.handle());
     }
-    protectedCommandBuffer.end();
+    protectedCommandBuffer.End();
 
     // Try submitting together to test only 1 error occurs for the corresponding command buffer
     VkCommandBuffer comman_buffers[2] = {m_command_buffer.handle(), protectedCommandBuffer.handle()};
@@ -1096,11 +1098,11 @@ TEST_F(NegativeProtectedMemory, RayTracingPipeline) {
     vk::CreateRayTracingPipelinesKHR(m_device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &raytracing_pipeline_ci, nullptr,
                                      &raytracing_pipeline);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindPipeline-pipelineBindPoint-06721");
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, raytracing_pipeline);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyPipeline(device(), raytracing_pipeline, nullptr);
 }
@@ -1146,7 +1148,7 @@ TEST_F(NegativeProtectedMemory, RayQuery) {
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1156,7 +1158,7 @@ TEST_F(NegativeProtectedMemory, RayQuery) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeProtectedMemory, Usage) {
@@ -1211,7 +1213,7 @@ TEST_F(NegativeProtectedMemory, WriteToProtectedStorageBuffer) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer_unprotected, 0, 256, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -1221,5 +1223,5 @@ TEST_F(NegativeProtectedMemory, WriteToProtectedStorageBuffer) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/protected_memory_positive.cpp
+++ b/tests/unit/protected_memory_positive.cpp
@@ -36,9 +36,9 @@ TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
     VkQueueFamilyProperties queue_properties;  // selected queue family used
     uint32_t queue_family_index = 0;
     uint32_t queue_family_count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_families(queue_family_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_family_count, queue_families.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_family_count, queue_families.data());
 
     for (size_t i = 0; i < queue_families.size(); i++) {
         // need to have at least 2 queues to use
@@ -77,7 +77,7 @@ TEST_F(PositiveProtectedMemory, MixProtectedQueue) {
     device_create_info.pEnabledFeatures = nullptr;
     device_create_info.enabledLayerCount = 0;
     device_create_info.enabledExtensionCount = 0;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_create_info, nullptr, &test_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, nullptr, &test_device));
 
     VkQueue test_queue_protected = VK_NULL_HANDLE;
     VkQueue test_queue_unprotected = VK_NULL_HANDLE;

--- a/tests/unit/push_descriptor.cpp
+++ b/tests/unit/push_descriptor.cpp
@@ -38,7 +38,7 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
     // Create a buffer to be used for invalid updates
     VkBufferCreateInfo buff_ci = vku::InitStructHelper();
     buff_ci.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
-    buff_ci.size = m_device->phy().limits_.minUniformBufferOffsetAlignment;
+    buff_ci.size = m_device->Physical().limits_.minUniformBufferOffsetAlignment;
     vkt::Buffer buffer(*m_device, buff_ci);
 
     VkDescriptorBufferInfo buff_info = {};
@@ -103,10 +103,10 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredError(desired_failure);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout->handle(), 0, 1,
                                     &descriptor_write);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
 
         update_template_data.buff_info = buff_info;  // copy the test case information into our "pData"
@@ -115,10 +115,10 @@ TEST_F(NegativePushDescriptor, DSBufferInfo) {
         m_errorMonitor->VerifyFound();
 
         m_errorMonitor->SetDesiredError(desired_failure);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), push_template, pipeline_layout->handle(), 0,
                                                 &update_template_data);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     };
 
@@ -172,7 +172,7 @@ TEST_F(NegativePushDescriptor, DestroyDescriptorSetLayout) {
     descriptor_write.pImageInfo = nullptr;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::DestroyDescriptorSetLayout(device(), ds_layout, nullptr);
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-dstSet-00320");
@@ -180,7 +180,7 @@ TEST_F(NegativePushDescriptor, DestroyDescriptorSetLayout) {
                                 &descriptor_write);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePushDescriptor, TemplateDestroyDescriptorSetLayout) {
@@ -233,12 +233,12 @@ TEST_F(NegativePushDescriptor, TemplateDestroyDescriptorSetLayout) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::DestroyDescriptorSetLayout(device(), ds_layout, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetWithTemplateKHR-pData-01686");
     vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), update_template, pipeline_layout, 0, &update_template_data);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
     vk::DestroyPipelineLayout(device(), pipeline_layout, nullptr);
@@ -296,7 +296,7 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
     descriptor_write.dstBinding = 0;
 
     for (uint32_t i = 0; i < 2; i++) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         if (i == 1) {
             // Test path where image layout in command buffer is known at draw time
             image.ImageMemoryBarrier(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_ACCESS_SHADER_WRITE_BIT,
@@ -319,7 +319,7 @@ TEST_F(NegativePushDescriptor, ImageLayout) {
         m_errorMonitor->SetDesiredError("UNASSIGNED-CoreValidation-DrawState-InvalidImageLayout");
         vk::CmdDraw(m_command_buffer.handle(), 1, 1, 0, 0);
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
@@ -599,7 +599,7 @@ TEST_F(NegativePushDescriptor, DescriptorUpdateTemplateEntryWithInlineUniformBlo
         {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_ALL, nullptr}};
     OneOffDescriptorSet descriptor_set(m_device, ds_bindings);
 
-    vkt::Buffer buffer(*m_device, m_device->phy().limits_.minUniformBufferOffsetAlignment, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
+    vkt::Buffer buffer(*m_device, m_device->Physical().limits_.minUniformBufferOffsetAlignment, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
 
     struct SimpleTemplateData {
         VkDescriptorBufferInfo buff_info;
@@ -663,7 +663,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
         ASSERT_TRUE(command_pool.initialized());
         vkt::CommandBuffer command_buffer(*m_device, command_pool);
         ASSERT_TRUE(command_buffer.initialized());
-        command_buffer.begin();
+        command_buffer.Begin();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-00363");
         m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-00330");
@@ -674,7 +674,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
         vk::CmdPushDescriptorSetKHR(command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                     &descriptor_write);
         m_errorMonitor->VerifyFound();
-        command_buffer.end();
+        command_buffer.End();
 
         // If we succeed in testing only one condition above, we need to test the other below.
         if (transfer_qfi && err_qfi != transfer_qfi.value()) {
@@ -683,7 +683,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
             ASSERT_TRUE(tran_command_pool.initialized());
             vkt::CommandBuffer tran_command_buffer(*m_device, tran_command_pool);
             ASSERT_TRUE(tran_command_buffer.initialized());
-            tran_command_buffer.begin();
+            tran_command_buffer.Begin();
 
             // We can't avoid getting *both* errors in this case
             m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-pipelineBindPoint-00363");
@@ -692,12 +692,12 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
             vk::CmdPushDescriptorSetKHR(tran_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0,
                                         1, &descriptor_write);
             m_errorMonitor->VerifyFound();
-            tran_command_buffer.end();
+            tran_command_buffer.End();
         }
     }
 
     // Push to the non-push binding
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-set-00365");
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 1, 1,
                                 &descriptor_write);
@@ -708,7 +708,7 @@ TEST_F(NegativePushDescriptor, SetCmdPush) {
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 2, 1,
                                 &descriptor_write);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // TODO: Add VALIDATION_ERROR_ code support to core_validation::ValidateCmd
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-commandBuffer-recording");
@@ -728,7 +728,7 @@ TEST_F(NegativePushDescriptor, DestoryLayout) {
     VkWriteDescriptorSet descriptor_write =
         vkt::Device::WriteDescriptorSet(vkt::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkPipelineLayout invalid_layout = CastToHandle<VkPipelineLayout, uintptr_t>(0xbaadbeef);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-layout-parameter");
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, invalid_layout, 1, 1,
@@ -742,7 +742,7 @@ TEST_F(NegativePushDescriptor, SetCmdBufferOffsetUnaligned) {
 
     RETURN_IF_SKIP(Init());
 
-    auto const min_alignment = m_device->phy().limits_.minUniformBufferOffsetAlignment;
+    auto const min_alignment = m_device->Physical().limits_.minUniformBufferOffsetAlignment;
     if (min_alignment == 0) {
         GTEST_SKIP() << "minUniformBufferOffsetAlignment is zero";
     }
@@ -761,13 +761,13 @@ TEST_F(NegativePushDescriptor, SetCmdBufferOffsetUnaligned) {
     VkWriteDescriptorSet descriptor_write =
         vkt::Device::WriteDescriptorSet(vkt::DescriptorSet(), 0, 0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, &buffer_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkWriteDescriptorSet-descriptorType-00327");
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                 &descriptor_write);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePushDescriptor, DescriptorWriteMissingImageInfo) {
@@ -790,12 +790,12 @@ TEST_F(NegativePushDescriptor, DescriptorWriteMissingImageInfo) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE;
     descriptor_write.pImageInfo = nullptr;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetKHR-pDescriptorWrites-06494");
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0u, 1u,
                                 &descriptor_write);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativePushDescriptor, UnsupportedDescriptorTemplateBindPoint) {
@@ -849,12 +849,12 @@ TEST_F(NegativePushDescriptor, UnsupportedDescriptorTemplateBindPoint) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    command_buffer.begin();
+    command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetWithTemplateKHR-commandBuffer-00366");
     vk::CmdPushDescriptorSetWithTemplateKHR(command_buffer.handle(), update_template, pipeline_layout.handle(), 0,
                                             &update_template_data);
     m_errorMonitor->VerifyFound();
-    command_buffer.end();
+    command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
 }
@@ -902,12 +902,12 @@ TEST_F(NegativePushDescriptor, InvalidDescriptorUpdateTemplateType) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetWithTemplateKHR-descriptorUpdateTemplate-07994");
     vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), update_template, pipeline_layout.handle(), 0,
                                             &update_template_data);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
 }
@@ -964,7 +964,7 @@ TEST_F(NegativePushDescriptor, DescriptorTemplateIncompatibleLayout) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushDescriptorSetWithTemplateKHR-layout-07993");
     vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), update_template, pipeline_layout2.handle(), 0,
@@ -984,7 +984,7 @@ TEST_F(NegativePushDescriptor, DescriptorTemplateIncompatibleLayout) {
                                             &update_template_data);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template2, nullptr);

--- a/tests/unit/push_descriptor_positive.cpp
+++ b/tests/unit/push_descriptor_positive.cpp
@@ -58,7 +58,7 @@ TEST_F(PositivePushDescriptor, NullDstSet) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // In Intel GPU, it needs to bind pipeline before push descriptor set.
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
@@ -114,7 +114,7 @@ TEST_F(PositivePushDescriptor, UnboundSet) {
     descriptor_set.WriteDescriptorBufferInfo(2, buffer.handle(), 0, data_size);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -128,7 +128,7 @@ TEST_F(PositivePushDescriptor, UnboundSet) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
@@ -160,7 +160,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
                                                   VK_DESCRIPTOR_SET_LAYOUT_CREATE_PUSH_DESCRIPTOR_BIT_KHR);
     ASSERT_TRUE(push_ds_layout.initialized());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     CreatePipelineHelper pipe0(*this);
@@ -226,7 +226,7 @@ TEST_F(PositivePushDescriptor, SetUpdatingSetNumber) {
     }
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePushDescriptor, CreateDescriptorSetBindingWithIgnoredSamplers) {
@@ -312,10 +312,10 @@ TEST_F(PositivePushDescriptor, ImmutableSampler) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_SAMPLER;
     descriptor_write.dstSet = descriptor_set.set_;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                 &descriptor_write);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePushDescriptor, TemplateBasic) {
@@ -361,10 +361,10 @@ TEST_F(PositivePushDescriptor, TemplateBasic) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), update_template, pipeline_layout.handle(), 0,
                                             &update_template_data);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
 }
@@ -404,7 +404,7 @@ TEST_F(PositivePushDescriptor, WriteDescriptorSetNotAllocated) {
     descriptor_write.pImageInfo = nullptr;
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                 &descriptor_write);
 
@@ -412,7 +412,7 @@ TEST_F(PositivePushDescriptor, WriteDescriptorSetNotAllocated) {
     descriptor_write.dstSet = null_set;
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                                 &descriptor_write);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositivePushDescriptor, PushDescriptorWithTemplateMultipleSets) {
@@ -463,10 +463,10 @@ TEST_F(PositivePushDescriptor, PushDescriptorWithTemplateMultipleSets) {
     SimpleTemplateData update_template_data;
     update_template_data.buff_info = {buffer.handle(), 0, 32};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushDescriptorSetWithTemplateKHR(m_command_buffer.handle(), update_template, pipeline_layout.handle(), 1,
                                             &update_template_data);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyDescriptorUpdateTemplateKHR(device(), update_template, nullptr);
 }

--- a/tests/unit/query.cpp
+++ b/tests/unit/query.cpp
@@ -25,21 +25,21 @@ TEST_F(NegativeQuery, PerformanceCreation) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
 
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
         break;
     }
@@ -80,7 +80,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
     // Success
     query_pool.init(*m_device, query_pool_ci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Missing acquire lock
     {
@@ -89,7 +89,7 @@ TEST_F(NegativeQuery, PerformanceCreation) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
@@ -100,7 +100,7 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
     std::vector<uint32_t> counterIndices;
@@ -109,14 +109,14 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
 
         for (uint32_t counterIdx = 0; counterIdx < counters.size(); counterIdx++) {
@@ -158,7 +158,7 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     // Not the first command.
     {
         vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
         vk::CmdFillBuffer(m_command_buffer.handle(), buffer, 0, 4096, 0);
 
@@ -166,7 +166,7 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
 
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.waitSemaphoreCount = 0;
@@ -184,11 +184,11 @@ TEST_F(NegativeQuery, PerformanceCounterCommandbufferScope) {
     {
         vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
         vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
         vk::CmdFillBuffer(m_command_buffer.handle(), buffer, 0, 4096, 0);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.waitSemaphoreCount = 0;
@@ -214,7 +214,7 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
     std::vector<uint32_t> counterIndices;
@@ -223,14 +223,14 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
 
         for (uint32_t counterIdx = 0; counterIdx < counters.size(); counterIdx++) {
@@ -273,7 +273,7 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
 
     // Inside a render pass.
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryPool-03225");
@@ -281,7 +281,7 @@ TEST_F(NegativeQuery, PerformanceCounterRenderPassScope) {
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.waitSemaphoreCount = 0;
@@ -306,7 +306,7 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
     std::vector<uint32_t> counterIndices;
@@ -315,14 +315,14 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
 
         for (uint32_t counterIdx = 0; counterIdx < counters.size(); counterIdx++) {
@@ -364,10 +364,10 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
     }
 
     {
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.waitSemaphoreCount = 0;
@@ -385,8 +385,8 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
     {
         vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
 
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
 
@@ -400,7 +400,7 @@ TEST_F(NegativeQuery, PerformanceReleaseProfileLockBeforeSubmit) {
 
         vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
 
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.waitSemaphoreCount = 0;
@@ -442,7 +442,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
     VkPhysicalDevicePerformanceQueryPropertiesKHR perf_query_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(perf_query_props);
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
     std::vector<uint32_t> counterIndices;
@@ -452,14 +452,14 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
 
         for (uint32_t counterIdx = 0; counterIdx < counters.size(); counterIdx++) {
@@ -472,7 +472,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
         create_info.counterIndexCount = counterIndices.size();
         create_info.pCounterIndices = &counterIndices[0];
 
-        vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(gpu(), &create_info, &nPasses);
+        vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(Gpu(), &create_info, &nPasses);
 
         if (nPasses < 2) {
             counters.clear();
@@ -515,11 +515,11 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
 
         vk::ResetQueryPoolEXT(device(), query_pool.handle(), 0, 1);
 
-        m_command_buffer.begin(&command_buffer_begin_info);
+        m_command_buffer.Begin(&command_buffer_begin_info);
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
         vk::CmdFillBuffer(m_command_buffer.handle(), buffer, 0, buf_size, 0);
         vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Invalid pass index
         {
@@ -605,7 +605,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
 
         // Invalid flags for vkCmdCopyQueryPoolResults
         if (perf_query_props.allowCommandBufferQueryCopies) {
-            m_command_buffer.begin(&command_buffer_begin_info);
+            m_command_buffer.Begin(&command_buffer_begin_info);
             m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-queryType-09440");
             vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0, 1, buffer, 0,
                                         sizeof(VkPerformanceCounterResultKHR) * results.size(),
@@ -626,7 +626,7 @@ TEST_F(NegativeQuery, PerformanceIncompletePasses) {
                                             VK_QUERY_RESULT_WITH_STATUS_BIT_KHR);
                 m_errorMonitor->VerifyFound();
             }
-            m_command_buffer.end();
+            m_command_buffer.End();
         }
 
         // Invalid flags for vkGetQueryPoolResults
@@ -667,7 +667,7 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
     AddRequiredFeature(vkt::Feature::performanceCounterQueryPools);
     RETURN_IF_SKIP(Init());
 
-    auto queueFamilyProperties = m_device->phy().queue_properties_;
+    auto queueFamilyProperties = m_device->Physical().queue_properties_;
     uint32_t queueFamilyIndex = queueFamilyProperties.size();
     std::vector<VkPerformanceCounterKHR> counters;
     std::vector<uint32_t> counterIndices;
@@ -676,14 +676,14 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
     for (uint32_t idx = 0; idx < queueFamilyProperties.size(); idx++) {
         uint32_t nCounters;
 
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, nullptr, nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, nullptr, nullptr);
         if (nCounters == 0) continue;
 
         counters.resize(nCounters);
         for (auto &c : counters) {
             c = vku::InitStructHelper();
         }
-        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(gpu(), idx, &nCounters, &counters[0], nullptr);
+        vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(Gpu(), idx, &nCounters, &counters[0], nullptr);
         queueFamilyIndex = idx;
 
         for (uint32_t counterIdx = 0; counterIdx < counters.size(); counterIdx++) {
@@ -727,12 +727,12 @@ TEST_F(NegativeQuery, PerformanceResetAndBegin) {
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-None-02863");
 
-        m_command_buffer.reset();
-        m_command_buffer.begin(&command_buffer_begin_info);
+        m_command_buffer.Reset();
+        m_command_buffer.Begin(&command_buffer_begin_info);
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
         vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         {
             VkPerformanceQuerySubmitInfoKHR perf_submit_info = vku::InitStructHelper();
@@ -830,18 +830,18 @@ TEST_F(NegativeQuery, HostResetDevice) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
     // Create a second device with the feature enabled.
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
-    auto features = m_device->phy().Features();
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
+    auto features = m_device->Physical().Features();
 
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper(&host_query_reset_features);
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.pEnabledFeatures = &features;
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
     device_create_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     VkDevice second_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_create_info, nullptr, &second_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, nullptr, &second_device));
 
     m_errorMonitor->SetDesiredError("VUID-vkResetQueryPool-queryPool-parent");
     // Run vk::ResetQueryPoolExt on the wrong device.
@@ -857,9 +857,9 @@ TEST_F(NegativeQuery, CmdBufferQueryPoolDestroyed) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-pCommandBuffers-00070");
     // Destroy query pool dependency prior to submit to cause ERROR
@@ -891,7 +891,7 @@ TEST_F(NegativeQuery, InsideRenderPass) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -902,7 +902,7 @@ TEST_F(NegativeQuery, InsideRenderPass) {
 
     m_command_buffer.EndRenderPass();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, OutsideRenderPass) {
@@ -911,7 +911,7 @@ TEST_F(NegativeQuery, OutsideRenderPass) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -938,7 +938,7 @@ TEST_F(NegativeQuery, InsideRenderPassDynamicRendering) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_command_buffer.BeginRendering(begin_rendering_info);
@@ -949,7 +949,7 @@ TEST_F(NegativeQuery, InsideRenderPassDynamicRendering) {
 
     m_command_buffer.EndRendering();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, OutsideRenderPassDynamicRendering) {
@@ -969,7 +969,7 @@ TEST_F(NegativeQuery, OutsideRenderPassDynamicRendering) {
     begin_rendering_info.colorAttachmentCount = 1;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_command_buffer.BeginRendering(begin_rendering_info);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -984,21 +984,21 @@ TEST_F(NegativeQuery, PoolCreate) {
 
     RETURN_IF_SKIP(Init());
 
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
 
     VkDevice local_device;
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     // Intentionally disable pipeline stats
     features.pipelineStatisticsQuery = VK_FALSE;
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.enabledLayerCount = 0;
     device_create_info.ppEnabledLayerNames = NULL;
     device_create_info.pEnabledFeatures = &features;
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
     device_create_info.ppEnabledExtensionNames = m_device_extension_names.data();
-    VkResult err = vk::CreateDevice(gpu(), &device_create_info, nullptr, &local_device);
+    VkResult err = vk::CreateDevice(Gpu(), &device_create_info, nullptr, &local_device);
     ASSERT_EQ(VK_SUCCESS, err);
 
     VkQueryPoolCreateInfo qpci = vkt::QueryPool::CreateInfo(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1);
@@ -1031,7 +1031,7 @@ TEST_F(NegativeQuery, Sizes) {
     const uint32_t query_pool_size = 4;
     vkt::QueryPool occlusion_query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, query_pool_size);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // FirstQuery is too large
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-firstQuery-09436");
@@ -1090,7 +1090,7 @@ TEST_F(NegativeQuery, Sizes) {
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, occlusion_query_pool.handle(), 0);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const size_t out_data_size = 16;
     uint8_t data[out_data_size];
@@ -1113,7 +1113,7 @@ TEST_F(NegativeQuery, PreciseBit) {
     RETURN_IF_SKIP(Init());
 
     std::vector<const char *> device_extension_names;
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
 
     // Test for precise bit when query type is not OCCLUSION
     if (features.occlusionQueryPrecise) {
@@ -1125,20 +1125,20 @@ TEST_F(NegativeQuery, PreciseBit) {
                                                     VK_QUERY_PIPELINE_STATISTIC_VERTEX_SHADER_INVOCATIONS_BIT;
         vkt::QueryPool query_pool(*m_device, query_pool_create_info);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, query_pool_create_info.queryCount);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryType-00800");
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, VK_QUERY_CONTROL_PRECISE_BIT);
         m_errorMonitor->VerifyFound();
         // vk::CmdBeginQuery(m_command_buffer.handle(), query_pool, 0, VK_QUERY_CONTROL_PRECISE_BIT);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         const size_t out_data_size = 64;
         uint8_t data[out_data_size];
@@ -1150,7 +1150,7 @@ TEST_F(NegativeQuery, PreciseBit) {
 
     // Test for precise bit when precise feature is not available
     features.occlusionQueryPrecise = false;
-    vkt::Device test_device(gpu(), device_extension_names, &features);
+    vkt::Device test_device(Gpu(), device_extension_names, &features);
 
     VkCommandPoolCreateInfo pool_create_info = vku::InitStructHelper();
     pool_create_info.queueFamilyIndex = test_device.graphics_queue_node_index_;
@@ -1221,7 +1221,7 @@ TEST_F(NegativeQuery, PoolPartialTimestamp) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
     // Use setup as a positive test...
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool.handle(), 0);
 
@@ -1230,7 +1230,7 @@ TEST_F(NegativeQuery, PoolPartialTimestamp) {
                                 VK_QUERY_RESULT_PARTIAL_BIT);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submit cmd buffer and wait for it.
     VkSubmitInfo submit_info = vku::InitStructHelper();
@@ -1262,9 +1262,9 @@ TEST_F(NegativeQuery, PerformanceQueryIntel) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PERFORMANCE_QUERY_INTEL, 1);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-queryType-02734");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0, 1, buffer.handle(), 0, 8, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1283,11 +1283,11 @@ TEST_F(NegativeQuery, PoolInUseDestroyedSignaled) {
     query_pool_ci.queryCount = 1;
     vk::CreateQueryPool(device(), &query_pool_ci, nullptr, &query_pool);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Use query pool to create binding with cmd buffer
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0, 1);
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submit cmd buffer and then destroy query pool while in-flight
     m_default_queue->Submit(m_command_buffer);
@@ -1317,11 +1317,11 @@ TEST_F(NegativeQuery, WriteTimeStamp) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-query-04904");
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool.handle(), 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
@@ -1339,7 +1339,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTIndex) {
     vkt::QueryPool tf_query_pool(*m_device, VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT, 1);
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQueryIndexedEXT(m_command_buffer.handle(), tf_query_pool.handle(), 0, 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06694");
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQueryIndexedEXT-queryType-06696");
@@ -1381,7 +1381,7 @@ TEST_F(NegativeQuery, CmdEndQueryIndexedEXTPrimitiveGenerated) {
     vkt::QueryPool pg_query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-02339");
     vk::CmdBeginQueryIndexedEXT(m_command_buffer.handle(), tf_query_pool.handle(), 0, 0,
@@ -1426,12 +1426,12 @@ TEST_F(NegativeQuery, TransformFeedbackStream) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TRANSFORM_FEEDBACK_STREAM_EXT, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryType-02328");
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, GetResultsFlags) {
@@ -1501,10 +1501,10 @@ TEST_F(NegativeQuery, DestroyActiveQueryPool) {
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
     cmd_begin.flags = VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT;
-    m_command_buffer.begin(&cmd_begin);
+    m_command_buffer.Begin(&cmd_begin);
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0, 1);
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -1591,13 +1591,13 @@ TEST_F(NegativeQuery, MultiviewBeginQuery) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 2);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 64, 64);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-query-00808");
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 1, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, PipelineStatisticsQuery) {
@@ -1617,7 +1617,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
         vkt::CommandPool command_pool(*m_device, decode_queue_family_index.value());
 
         vkt::CommandBuffer command_buffer(*m_device, command_pool);
-        command_buffer.begin();
+        command_buffer.Begin();
 
         VkQueryPoolCreateInfo qpci = vkt::QueryPool::CreateInfo(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1);
         qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_COMPUTE_SHADER_INVOCATIONS_BIT;
@@ -1627,14 +1627,14 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
         vk::CmdBeginQuery(command_buffer.handle(), query_pool.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
 
-        command_buffer.end();
+        command_buffer.End();
     }
 
     if (compute_queue_family_index) {
         vkt::CommandPool command_pool(*m_device, compute_queue_family_index.value());
 
         vkt::CommandBuffer command_buffer(*m_device, command_pool);
-        command_buffer.begin();
+        command_buffer.Begin();
 
         VkQueryPoolCreateInfo qpci = vkt::QueryPool::CreateInfo(VK_QUERY_TYPE_PIPELINE_STATISTICS, 1);
         qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_FRAGMENT_SHADER_INVOCATIONS_BIT;
@@ -1644,7 +1644,7 @@ TEST_F(NegativeQuery, PipelineStatisticsQuery) {
         vk::CmdBeginQuery(command_buffer.handle(), query_pool.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
 
-        command_buffer.end();
+        command_buffer.End();
     }
 }
 
@@ -1689,7 +1689,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
     vkt::CommandPool command_pool(*m_device, compute_queue_family_index.value());
 
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
 
@@ -1701,7 +1701,7 @@ TEST_F(NegativeQuery, PrimitivesGenerated) {
     vk::CmdBeginQueryIndexedEXT(command_buffer.handle(), query_pool.handle(), 0, 0, 0);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-06690");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQueryIndexedEXT-queryType-06691");
     vk::CmdBeginQueryIndexedEXT(m_command_buffer.handle(), query_pool.handle(), 0, 0,
@@ -1731,7 +1731,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedFeature) {
         GTEST_SKIP() << "primitivesGeneratedQuery feature is not supported";
     }
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryType-06688");
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_errorMonitor->VerifyFound();
@@ -1770,7 +1770,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-primitivesGeneratedQueryWithRasterizerDiscard-06708");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -1779,7 +1779,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedDiscardEnabled) {
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1825,7 +1825,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-primitivesGeneratedQueryWithNonZeroStreams-06709");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -1834,7 +1834,7 @@ TEST_F(NegativeQuery, PrimitivesGeneratedStreams) {
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1853,7 +1853,7 @@ TEST_F(NegativeQuery, CommandBufferMissingOcclusion) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
+    cbii.framebuffer = Framebuffer();
     cbii.occlusionQueryEnable = VK_FALSE;  // Invalid
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
@@ -1864,11 +1864,11 @@ TEST_F(NegativeQuery, CommandBufferMissingOcclusion) {
     vk::EndCommandBuffer(secondary_handle);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-commandBuffer-00102");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_handle);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1884,7 +1884,7 @@ TEST_F(NegativeQuery, CommandBufferInheritanceFlags) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
+    cbii.framebuffer = Framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
     cbii.queryFlags = 0;
 
@@ -1896,11 +1896,11 @@ TEST_F(NegativeQuery, CommandBufferInheritanceFlags) {
     vk::EndCommandBuffer(secondary_handle);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-commandBuffer-00103");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, VK_QUERY_CONTROL_PRECISE_BIT);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_handle);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1947,7 +1947,7 @@ TEST_F(NegativeQuery, WriteTimestampWithoutQueryPool) {
 
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-queryPool-parameter");
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_VERTEX_INPUT_BIT, bad_query_pool, 0);
     m_errorMonitor->VerifyFound();
@@ -1955,7 +1955,7 @@ TEST_F(NegativeQuery, WriteTimestampWithoutQueryPool) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp2-queryPool-parameter");
     vk::CmdWriteTimestamp2KHR(m_command_buffer.handle(), VK_PIPELINE_STAGE_2_NONE_KHR, bad_query_pool, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, DestroyWithoutQueryPool) {
@@ -1985,7 +1985,7 @@ TEST_F(NegativeQuery, CmdEndQueryWithoutQueryPool) {
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQuery-queryPool-parameter");
@@ -1993,7 +1993,7 @@ TEST_F(NegativeQuery, CmdEndQueryWithoutQueryPool) {
     m_errorMonitor->VerifyFound();
 
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
@@ -2003,7 +2003,7 @@ TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
 
@@ -2013,18 +2013,18 @@ TEST_F(NegativeQuery, CmdCopyQueryPoolResultsWithoutQueryPool) {
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), bad_query_pool, 0, 1, buffer.handle(), 0, 0, VK_QUERY_RESULT_WAIT_BIT);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, CmdResetQueryPoolWithoutQueryPool) {
     TEST_DESCRIPTION("call vkCmdResetQueryPool with queryPool being invalid.");
     RETURN_IF_SKIP(Init());
     VkQueryPool bad_query_pool = CastFromUint64<VkQueryPool>(0xFFFFEEEE);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-queryPool-parameter");
     vk::CmdResetQueryPool(m_command_buffer.handle(), bad_query_pool, 0, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, ResetQueryPoolWithoutQueryPool) {
@@ -2043,12 +2043,12 @@ TEST_F(NegativeQuery, ActiveEndQuery) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndQuery-None-01923");
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, ActiveCmdResetQueryPool) {
@@ -2057,14 +2057,14 @@ TEST_F(NegativeQuery, ActiveCmdResetQueryPool) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdResetQueryPool-None-02841");
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, ActiveCmdCopyQueryPoolResults) {
@@ -2075,7 +2075,7 @@ TEST_F(NegativeQuery, ActiveCmdCopyQueryPoolResults) {
 
     vkt::Buffer buffer(*m_device, 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-None-07429");
@@ -2083,7 +2083,7 @@ TEST_F(NegativeQuery, ActiveCmdCopyQueryPoolResults) {
                                 VK_QUERY_RESULT_WAIT_BIT);
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, CmdExecuteCommandsActiveQueries) {
@@ -2119,14 +2119,14 @@ TEST_F(NegativeQuery, CmdExecuteCommandsActiveQueries) {
     vk::BeginCommandBuffer(secondary.handle(), &cmd_buf_info);
     vk::EndCommandBuffer(secondary.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-commandBuffer-07594");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &secondary.handle());
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, CmdExecuteBeginActiveQuery) {
@@ -2146,18 +2146,18 @@ TEST_F(NegativeQuery, CmdExecuteBeginActiveQuery) {
     cbbi.pInheritanceInfo = &cbii;
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary.begin(&cbbi);
+    secondary.Begin(&cbbi);
     vk::CmdBeginQuery(secondary.handle(), query_pool.handle(), 1u, 0u);
     vk::CmdEndQuery(secondary.handle(), query_pool.handle(), 1u);
-    secondary.end();
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0u, 0u);
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-00105");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &secondary.handle());
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, PerformanceQueryReset) {
@@ -2177,12 +2177,12 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     uint32_t counterCount = 0u;
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), m_device->graphics_queue_node_index_,
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), m_device->graphics_queue_node_index_,
                                                                       &counterCount, nullptr, nullptr);
     std::vector<VkPerformanceCounterKHR> counters(counterCount, vku::InitStruct<VkPerformanceCounterKHR>());
     std::vector<VkPerformanceCounterDescriptionKHR> counterDescriptions(counterCount,
                                                                         vku::InitStruct<VkPerformanceCounterDescriptionKHR>());
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), m_device->graphics_queue_node_index_,
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), m_device->graphics_queue_node_index_,
                                                                       &counterCount, counters.data(), counterDescriptions.data());
 
     uint32_t enabledCounter = counterCount;
@@ -2202,7 +2202,7 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
     query_pool_performance_ci.pCounterIndices = &enabledCounter;
 
     uint32_t num_passes = 0u;
-    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->phy(), &query_pool_performance_ci, &num_passes);
+    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->Physical(), &query_pool_performance_ci, &num_passes);
 
     auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>(&query_pool_performance_ci);
     query_pool_ci.queryType = VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR;
@@ -2215,22 +2215,22 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0u, 1u);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
     }
 
     vkt::CommandBuffer command_buffer(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    command_buffer.begin();
+    command_buffer.Begin();
     vk::CmdBeginQuery(command_buffer.handle(), query_pool, 0u, 0u);
     vk::CmdEndQuery(command_buffer.handle(), query_pool, 0u);
-    command_buffer.end();
+    command_buffer.End();
 
     for (uint32_t i = 0; i < 2; ++i) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         if (i == 0) {
             vk::CmdBeginQuery(m_command_buffer.handle(), query_pool, 0u, 0u);
             vk::CmdEndQuery(m_command_buffer.handle(), query_pool, 0u);
@@ -2238,7 +2238,7 @@ TEST_F(NegativeQuery, PerformanceQueryReset) {
             vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &command_buffer.handle());
         }
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0u, 1u);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         auto performance_query_submit_info = vku::InitStruct<VkPerformanceQuerySubmitInfoKHR>();
         performance_query_submit_info.counterPassIndex = 0u;
@@ -2269,9 +2269,9 @@ TEST_F(NegativeQuery, GetQueryPoolResultsWithoutReset) {
     vk::GetQueryPoolResults(*m_device, query_pool.handle(), 0u, 1u, sizeof(uint32_t), &data, sizeof(uint32_t), 0u);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0u, 1u, buffer.handle(), 0u, sizeof(uint32_t), 0u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-None-09402");
     m_default_queue->Submit(m_command_buffer);
@@ -2296,7 +2296,7 @@ TEST_F(NegativeQuery, InvalidMeshQueryAtDraw) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_MESH_PRIMITIVES_GENERATED_EXT, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0u, 0u);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -2305,7 +2305,7 @@ TEST_F(NegativeQuery, InvalidMeshQueryAtDraw) {
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, PipelineStatisticsQueryWithSecondaryCmdBuffer) {
@@ -2324,23 +2324,23 @@ TEST_F(NegativeQuery, PipelineStatisticsQueryWithSecondaryCmdBuffer) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
+    cbii.framebuffer = Framebuffer();
     cbii.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     cbbi.pInheritanceInfo = &cbii;
 
     vkt::CommandBuffer secondary(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary.begin(&cbbi);
-    secondary.end();
+    secondary.Begin(&cbbi);
+    secondary.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0u, 0u);
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-commandBuffer-00104");
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &secondary.handle());
     m_errorMonitor->VerifyFound();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, PipelineStatisticsZero) {
@@ -2401,7 +2401,7 @@ TEST_F(NegativeQuery, WriteTimestampInsideRenderPass) {
     render_pass_bi.clearValueCount = 1u;
     render_pass_bi.pClearValues = m_renderPassClearValues.data();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass_bi);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteTimestamp-query-00831");
@@ -2409,7 +2409,7 @@ TEST_F(NegativeQuery, WriteTimestampInsideRenderPass) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeQuery, Stride) {
@@ -2417,9 +2417,9 @@ TEST_F(NegativeQuery, Stride) {
     RETURN_IF_SKIP(Init());
 
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, queue_props.data());
     if (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
         GTEST_SKIP() << " Device graphic queue has timestampValidBits of 0, skipping.";
     }
@@ -2428,10 +2428,10 @@ TEST_F(NegativeQuery, Stride) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -2457,8 +2457,8 @@ TEST_F(NegativeQuery, Stride) {
 
     vkt::Buffer buffer(*m_device, 128, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyQueryPoolResults-flags-00822");
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0, 1, buffer.handle(), 1, 1, 0);
     m_errorMonitor->VerifyFound();
@@ -2488,11 +2488,11 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     assert(queue0->family_index != queue1_family.value());
 
     uint32_t counterCount = 0u;
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), 0, &counterCount, nullptr, nullptr);
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), 0, &counterCount, nullptr, nullptr);
     std::vector<VkPerformanceCounterKHR> counters(counterCount, vku::InitStruct<VkPerformanceCounterKHR>());
     std::vector<VkPerformanceCounterDescriptionKHR> counterDescriptions(counterCount,
                                                                         vku::InitStruct<VkPerformanceCounterDescriptionKHR>());
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), 0, &counterCount, counters.data(),
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), 0, &counterCount, counters.data(),
                                                                       counterDescriptions.data());
 
     std::vector<uint32_t> enabledCounters(128);
@@ -2507,7 +2507,7 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     query_pool_performance_ci.pCounterIndices = enabledCounters.data();
 
     uint32_t num_passes = 0;
-    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->phy(), &query_pool_performance_ci, &num_passes);
+    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->Physical(), &query_pool_performance_ci, &num_passes);
 
     auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>(&query_pool_performance_ci);
     query_pool_ci.queryType = VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR;
@@ -2525,15 +2525,15 @@ TEST_F(NegativeQuery, PerfQueryQueueFamilyIndex) {
     acquire_profiling_lock_info.timeout = std::numeric_limits<uint64_t>::max();
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
-    cb.begin();
+    cb.Begin();
     vk::CmdResetQueryPool(cb.handle(), query_pool.handle(), 0u, 1u);
-    cb.end();
+    cb.End();
 
-    cb.begin();
+    cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryPool-07289");
     vk::CmdBeginQuery(cb.handle(), query_pool, 0, 0);
     m_errorMonitor->VerifyFound();
-    cb.end();
+    cb.End();
     vk::ReleaseProfilingLockKHR(*m_device);
 }
 
@@ -2546,10 +2546,10 @@ TEST_F(NegativeQuery, NoInitReset) {
     qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-None-00807");
     m_default_queue->Submit(m_command_buffer);

--- a/tests/unit/query_positive.cpp
+++ b/tests/unit/query_positive.cpp
@@ -16,9 +16,9 @@
 
 bool QueryTest::HasZeroTimestampValidBits() {
     uint32_t queue_count;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, nullptr);
     std::vector<VkQueueFamilyProperties> queue_props(queue_count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queue_count, queue_props.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queue_count, queue_props.data());
     return (queue_props[m_device->graphics_queue_node_index_].timestampValidBits == 0);
 }
 
@@ -33,13 +33,13 @@ TEST_F(PositiveQuery, OutsideRenderPass) {
     qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_command_buffer.EndRenderPass();
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveQuery, InsideRenderPass) {
@@ -51,13 +51,13 @@ TEST_F(PositiveQuery, InsideRenderPass) {
     qpci.pipelineStatistics = VK_QUERY_PIPELINE_STATISTIC_INPUT_ASSEMBLY_VERTICES_BIT;
     vkt::QueryPool query_pool(*m_device, qpci);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveQuery, ResetQueryPoolFromDifferentCB) {
@@ -124,7 +124,7 @@ TEST_F(PositiveQuery, BasicQuery) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 2);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
@@ -136,7 +136,7 @@ TEST_F(PositiveQuery, BasicQuery) {
     m_command_buffer.EndRenderPass();
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0, 2, buffer.handle(), 0, sizeof(uint64_t),
                                 VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -146,16 +146,16 @@ TEST_F(PositiveQuery, BasicQuery) {
 
     // Now reset query pool in a different command buffer than the BeginQuery
     vk::ResetCommandBuffer(m_command_buffer.handle(), 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
     vk::ResetCommandBuffer(m_command_buffer.handle(), 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -183,7 +183,7 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
     // If VK_QUERY_RESULT_WAIT_BIT is not set, vkGetQueryPoolResults may return VK_NOT_READY
     constexpr VkQueryResultFlags query_flags = VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0, query_count);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool, 0, 0);
@@ -195,7 +195,7 @@ TEST_F(PositiveQuery, DestroyQueryPoolBasedOnQueryPoolResults) {
     m_command_buffer.EndRenderPass();
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool, 0, query_count, buffer.handle(), 0, sample_stride,
                                 query_flags);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -222,7 +222,7 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
 
     all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
-    if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
+    if ((m_device->Physical().queue_properties_.empty()) || (m_device->Physical().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
     if (HasZeroTimestampValidBits()) {
@@ -251,16 +251,16 @@ TEST_F(PositiveQuery, QueryAndCopySecondaryCommandBuffers) {
     {
         VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
         begin_info.pInheritanceInfo = &hinfo;
-        secondary_buffer.begin(&begin_info);
+        secondary_buffer.Begin(&begin_info);
         vk::CmdResetQueryPool(secondary_buffer.handle(), query_pool.handle(), 0, 1);
         vk::CmdWriteTimestamp(secondary_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool.handle(), 0);
-        secondary_buffer.end();
+        secondary_buffer.End();
 
-        primary_buffer.begin();
+        primary_buffer.Begin();
         vk::CmdExecuteCommands(primary_buffer.handle(), 1, &secondary_buffer.handle());
         vk::CmdCopyQueryPoolResults(primary_buffer.handle(), query_pool.handle(), 0, 1, buffer.handle(), 0, 0,
                                     VK_QUERY_RESULT_WAIT_BIT);
-        primary_buffer.end();
+        primary_buffer.End();
     }
 
     m_default_queue->Submit(primary_buffer);
@@ -273,7 +273,7 @@ TEST_F(PositiveQuery, QueryAndCopyMultipleCommandBuffers) {
 
     all_queue_count_ = true;
     RETURN_IF_SKIP(Init());
-    if ((m_device->phy().queue_properties_.empty()) || (m_device->phy().queue_properties_[0].queueCount < 2)) {
+    if ((m_device->Physical().queue_properties_.empty()) || (m_device->Physical().queue_properties_[0].queueCount < 2)) {
         GTEST_SKIP() << "Queue family needs to have multiple queues to run this test";
     }
     if (HasZeroTimestampValidBits()) {
@@ -336,10 +336,10 @@ TEST_F(PositiveQuery, DestroyQueryPoolAfterGetQueryPoolResults) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 1);
     vk::CmdWriteTimestamp(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -366,10 +366,10 @@ TEST_F(PositiveQuery, WriteTimestampNoneAndAll) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 2);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdWriteTimestamp2KHR(m_command_buffer.handle(), VK_PIPELINE_STAGE_2_NONE_KHR, query_pool.handle(), 0);
     vk::CmdWriteTimestamp2KHR(m_command_buffer.handle(), VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT_KHR, query_pool.handle(), 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
@@ -384,7 +384,7 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
 
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
     cbii.renderPass = m_renderPass;
-    cbii.framebuffer = framebuffer();
+    cbii.framebuffer = Framebuffer();
     cbii.occlusionQueryEnable = VK_TRUE;
     cbii.queryFlags = VK_QUERY_CONTROL_PRECISE_BIT;
 
@@ -396,7 +396,7 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
     vk::BeginCommandBuffer(secondary_handle, &cbbi);
     vk::EndCommandBuffer(secondary_handle);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_handle);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
@@ -406,7 +406,7 @@ TEST_F(PositiveQuery, CommandBufferInheritanceFlags) {
     vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, VK_QUERY_CONTROL_PRECISE_BIT);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_handle);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveQuery, PerformanceQueries) {
@@ -430,12 +430,12 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
 
     uint32_t counterCount = 0u;
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), m_device->graphics_queue_node_index_,
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), m_device->graphics_queue_node_index_,
                                                                       &counterCount, nullptr, nullptr);
     std::vector<VkPerformanceCounterKHR> counters(counterCount, vku::InitStruct<VkPerformanceCounterKHR>());
     std::vector<VkPerformanceCounterDescriptionKHR> counterDescriptions(counterCount,
                                                                         vku::InitStruct<VkPerformanceCounterDescriptionKHR>());
-    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->phy(), m_device->graphics_queue_node_index_,
+    vk::EnumeratePhysicalDeviceQueueFamilyPerformanceQueryCountersKHR(m_device->Physical(), m_device->graphics_queue_node_index_,
                                                                       &counterCount, counters.data(), counterDescriptions.data());
 
     std::vector<uint32_t> enabledCounters(128);
@@ -450,7 +450,7 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     query_pool_performance_ci.pCounterIndices = enabledCounters.data();
 
     uint32_t num_passes = 0u;
-    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->phy(), &query_pool_performance_ci, &num_passes);
+    vk::GetPhysicalDeviceQueueFamilyPerformanceQueryPassesKHR(m_device->Physical(), &query_pool_performance_ci, &num_passes);
 
     auto query_pool_ci = vku::InitStruct<VkQueryPoolCreateInfo>(&query_pool_performance_ci);
     query_pool_ci.queryType = VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR;
@@ -459,9 +459,9 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     vkt::QueryPool query_pool(*m_device, query_pool_ci);
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0u, 1u);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
@@ -475,7 +475,7 @@ TEST_F(PositiveQuery, PerformanceQueries) {
     vk::AcquireProfilingLockKHR(*m_device, &acquire_profiling_lock_info);
 
     VkCommandBufferBeginInfo info = vku::InitStructHelper();
-    cmd_buffer.begin(&info);
+    cmd_buffer.Begin(&info);
 
     vk::CmdBeginQuery(cmd_buffer.handle(), query_pool.handle(), 0u, 0u);
 
@@ -484,7 +484,7 @@ TEST_F(PositiveQuery, PerformanceQueries) {
 
     vk::CmdEndQuery(cmd_buffer.handle(), query_pool.handle(), 0u);
 
-    cmd_buffer.end();
+    cmd_buffer.End();
 
     for (uint32_t counterPass = 0u; counterPass < num_passes; ++counterPass) {
         auto performance_query_submit_info = vku::InitStruct<VkPerformanceQuerySubmitInfoKHR>();
@@ -531,14 +531,14 @@ TEST_F(PositiveQuery, ReuseSecondaryWithQueryCommand) {
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
     vkt::CommandBuffer secondary_buffer(*m_device, m_command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    secondary_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    secondary_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     vk::CmdWriteTimestamp(secondary_buffer.handle(), VK_PIPELINE_STAGE_ALL_GRAPHICS_BIT, query_pool, 0);
-    secondary_buffer.end();
+    secondary_buffer.End();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool, 0, 1);
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1, &secondary_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     // Submit the command buffer again.

--- a/tests/unit/ray_tracing.cpp
+++ b/tests/unit/ray_tracing.cpp
@@ -60,7 +60,7 @@ TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     mem_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_VERTEX_ATTRIBUTE_INPUT_BIT;
@@ -82,7 +82,7 @@ TEST_F(NegativeRayTracing, BarrierAccessAccelerationStructure) {
     m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-dstAccessMask-03928");
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -127,7 +127,7 @@ TEST_F(NegativeRayTracing, BarrierSync2AccessAccelerationStructureRayQueryDisabl
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = &image_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     mem_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
@@ -149,7 +149,7 @@ TEST_F(NegativeRayTracing, BarrierSync2AccessAccelerationStructureRayQueryDisabl
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier2-dstAccessMask-06256");
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -185,7 +185,7 @@ TEST_F(NegativeRayTracing, BarrierSync1AccessAccelerationStructureRayQueryDisabl
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // memory barrier
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcAccessMask-06257");
@@ -235,7 +235,7 @@ TEST_F(NegativeRayTracing, EventSync1AccessAccelerationStructureRayQueryDisabled
     image_barrier.image = image.handle();
     image_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // memory
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcAccessMask-06257");
@@ -518,7 +518,7 @@ TEST_F(NegativeRayTracing, BeginQueryQueryPoolType) {
                                                               auto vuid_begin_query_indexed) {
             vkt::QueryPool query_pool(*m_device, query_type, 1);
 
-            m_command_buffer.begin();
+            m_command_buffer.Begin();
             m_errorMonitor->SetDesiredError(vuid_begin_query);
             vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
             m_errorMonitor->VerifyFound();
@@ -528,7 +528,7 @@ TEST_F(NegativeRayTracing, BeginQueryQueryPoolType) {
                 vk::CmdBeginQueryIndexedEXT(m_command_buffer.handle(), query_pool.handle(), 0, 0, 0);
                 m_errorMonitor->VerifyFound();
             }
-            m_command_buffer.end();
+            m_command_buffer.End();
         };
 
         cmd_begin_query(VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, "VUID-vkCmdBeginQuery-queryType-04728",
@@ -546,7 +546,7 @@ TEST_F(NegativeRayTracing, BeginQueryQueryPoolType) {
     if (nv_ray_tracing) {
         vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_NV, 1);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_errorMonitor->SetDesiredError("VUID-vkCmdBeginQuery-queryType-04729");
         vk::CmdBeginQuery(m_command_buffer.handle(), query_pool.handle(), 0, 0);
         m_errorMonitor->VerifyFound();
@@ -556,7 +556,7 @@ TEST_F(NegativeRayTracing, BeginQueryQueryPoolType) {
             vk::CmdBeginQueryIndexedEXT(m_command_buffer.handle(), query_pool.handle(), 0, 0, 0);
             m_errorMonitor->VerifyFound();
         }
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -581,7 +581,7 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
     copy_info.dst = valid_blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
@@ -597,7 +597,7 @@ TEST_F(NegativeRayTracing, CopyUnboundAccelerationStructure) {
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer.handle(), &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CopyAccelerationStructureOverlappingMemory) {
@@ -627,9 +627,9 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureOverlappingMemory) {
 
     auto blas_1 = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas_1.GetDstAS()->SetDeviceBuffer(std::move(buffer_1));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas_1.BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_device->Wait();
 
@@ -642,13 +642,13 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureOverlappingMemory) {
     copy_info.dst = blas_2->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-dst-07791");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer.handle(), &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
@@ -666,14 +666,14 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT_KHR |
                       VK_BUFFER_USAGE_STORAGE_BUFFER_BIT;
     vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = buffer.MemoryRequirements();
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper(&alloc_flags);
     memory_alloc.allocationSize = memory_requirements.size;
     const bool memory_found =
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
+        m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                           VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     if (!memory_found) {
         GTEST_SKIP() << "Could not find suitable memory type, skipping test";
     }
@@ -694,24 +694,24 @@ TEST_F(NegativeRayTracing, CmdCopyUnboundAccelerationStructure) {
     copy_info.dst = blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03718");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03737");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer.handle(), &copy_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     copy_info.src = blas->handle();
     copy_info.dst = blas_no_mem->handle();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-buffer-03719");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureKHR-buffer-03738");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureInfoKHR-src-04963");
     vk::CmdCopyAccelerationStructureKHR(m_command_buffer.handle(), &copy_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CopyAccelerationStructureNoHostMem) {
@@ -729,11 +729,11 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureNoHostMem) {
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = buffer.MemoryRequirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
-    ASSERT_TRUE(
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0,
+                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory device_memory(*m_device, memory_alloc);
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), buffer.handle(), device_memory.handle(), 0);
@@ -794,15 +794,15 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructure) {
     blas->Build();
 
     VkCopyMemoryToAccelerationStructureInfoKHR copy_info = vku::InitStructHelper();
-    copy_info.src.deviceAddress = src_buffer.address();
+    copy_info.src.deviceAddress = src_buffer.Address();
     copy_info.dst = blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
 
     // Acceleration structure buffer is not bound to memory
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyMemoryToAccelerationStructureKHR-buffer-03745");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyMemoryToAccelerationStructureKHR(m_command_buffer.handle(), &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -822,11 +822,11 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructureKHR) {
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = non_host_visible_buffer.MemoryRequirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
-    ASSERT_TRUE(
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0,
+                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory device_memory(*m_device, memory_alloc);
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), non_host_visible_buffer.handle(), device_memory.handle(), 0);
@@ -882,11 +882,11 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructureMemory) {
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = non_host_visible_buffer.MemoryRequirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
-    ASSERT_TRUE(
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0,
+                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory device_memory(*m_device, memory_alloc);
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), non_host_visible_buffer.handle(), device_memory.handle(), 0);
@@ -947,11 +947,11 @@ TEST_F(NegativeRayTracing, CopyMemoryToAsBuffer) {
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     vkt::Buffer non_host_visible_buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = non_host_visible_buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = non_host_visible_buffer.MemoryRequirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
-    ASSERT_TRUE(
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0,
+                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory device_memory(*m_device, memory_alloc);
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), non_host_visible_buffer.handle(), device_memory.handle(), 0);
@@ -1134,7 +1134,7 @@ TEST_F(NegativeRayTracing, GetAccelerationStructureAddressBabBuffer) {
     blas->SetBufferUsageFlags(VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR);
     blas->Build();
 
-    blas->GetBuffer().memory().destroy();
+    blas->GetBuffer().Memory().destroy();
     m_errorMonitor->SetDesiredError("VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09541");
     m_errorMonitor->SetDesiredError("VUID-vkGetAccelerationStructureDeviceAddressKHR-pInfo-09542");
     (void)blas->GetAccelerationStructureDeviceAddress();
@@ -1212,12 +1212,12 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
-    const VkDeviceAddress device_address = buffer.address();
+    const VkDeviceAddress device_address = buffer.Address();
 
     const VkStridedDeviceAddressRegionKHR stridebufregion = {device_address, ray_tracing_properties.shaderGroupHandleAlignment,
                                                              ray_tracing_properties.shaderGroupHandleAlignment};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Invalid stride multiplier
     {
@@ -1269,7 +1269,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
         buffer_ci.usage = VK_BUFFER_USAGE_TRANSFER_DST_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
         vkt::Buffer buffer_missing_flag(*m_device, buffer_ci, vkt::no_mem);
         vk::BindBufferMemory(device(), buffer_missing_flag.handle(), mem.handle(), 0);
-        const VkDeviceAddress device_address_missing_flag = buffer_missing_flag.address();
+        const VkDeviceAddress device_address_missing_flag = buffer_missing_flag.Address();
 
         // buffer is missing flag VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR
         if (device_address_missing_flag == device_address) {
@@ -1316,7 +1316,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysKHR) {
                             100, 1);
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyPipeline(device(), raytracing_pipeline, nullptr);
 }
@@ -1335,14 +1335,14 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
-    const VkDeviceAddress device_address = buffer.address();
+    const VkDeviceAddress device_address = buffer.Address();
 
     VkStridedDeviceAddressRegionKHR stridebufregion = {};
     stridebufregion.deviceAddress = device_address;
     stridebufregion.stride = ray_tracing_properties.shaderGroupHandleAlignment;
     stridebufregion.size = stridebufregion.stride;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Invalid stride multiplier
     {
         VkStridedDeviceAddressRegionKHR invalid_stride = stridebufregion;
@@ -1394,7 +1394,7 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirectKHR) {
             m_errorMonitor->VerifyFound();
         }
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
@@ -1409,16 +1409,16 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRFeatureDisabled) {
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
-    const VkDeviceAddress device_address = buffer.address();
+    const VkDeviceAddress device_address = buffer.Address();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // No VkPhysicalDeviceRayTracingMaintenance1FeaturesKHR was in the device create info pNext chain
     {
         m_errorMonitor->SetDesiredError("VUID-vkCmdTraceRaysIndirect2KHR-rayTracingPipelineTraceRaysIndirect2-03637");
         vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), device_address);
         m_errorMonitor->VerifyFound();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
@@ -1433,16 +1433,16 @@ TEST_F(NegativeRayTracing, CmdTraceRaysIndirect2KHRAddress) {
     RETURN_IF_SKIP(InitState());
 
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_TRANSFER_DST_BIT, vkt::device_address);
-    const VkDeviceAddress device_address = buffer.address();
+    const VkDeviceAddress device_address = buffer.Address();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // indirectDeviceAddress is not a multiple of 4
     {
         m_errorMonitor->SetDesiredError("VUID-vkCmdTraceRaysIndirect2KHR-indirectDeviceAddress-03634");
         vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), device_address + 1);
         m_errorMonitor->VerifyFound();
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, AccelerationStructureVersionInfoKHR) {
@@ -1508,7 +1508,7 @@ TEST_F(NegativeRayTracing, IndirectStridesMultiple) {
     blas.SetIndirectStride(13);
     blas.SetIndirectDeviceAddress(13);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectStrides-03787");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresIndirectKHR-pIndirectDeviceAddresses-03648");
     blas.BuildCmdBufferIndirect(m_command_buffer);
@@ -1574,20 +1574,20 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
 
     // Positive build tests
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.BuildCmdBuffer(m_command_buffer.handle(), true);
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.BuildCmdBuffer(m_command_buffer.handle(), false);
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Invalid info count
     {
@@ -1809,7 +1809,7 @@ TEST_F(NegativeRayTracing, CmdBuildAccelerationStructuresKHR) {
         m_errorMonitor->VerifyFound();
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
@@ -1842,7 +1842,7 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         std::vector<vkt::Buffer> dst_blas_buffers(build_info_count);
         std::vector<vkt::as::BuildGeometryInfoKHR> build_infos;
         for (auto &dst_blas_buffer : dst_blas_buffers) {
-            dst_blas_buffer.init_no_mem(*m_device, dst_blas_buffer_ci);
+            dst_blas_buffer.InitNoMemory(*m_device, dst_blas_buffer_ci);
             vk::BindBufferMemory(device(), dst_blas_buffer.handle(), buffer_memory.handle(), 0);
 
             auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
@@ -1855,9 +1855,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03702");
         }
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), build_infos);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     }
 
@@ -1871,10 +1871,10 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         std::vector<vkt::Buffer> dst_blas_buffers(build_info_count);
         std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec;
         for (size_t i = 0; i < build_info_count; ++i) {
-            src_blas_buffers[i].init_no_mem(*m_device, blas_buffer_ci);
+            src_blas_buffers[i].InitNoMemory(*m_device, blas_buffer_ci);
             vk::BindBufferMemory(device(), src_blas_buffers[i].handle(), buffer_memory.handle(), 0);
 
-            dst_blas_buffers[i].init_no_mem(*m_device, blas_buffer_ci);
+            dst_blas_buffers[i].InitNoMemory(*m_device, blas_buffer_ci);
             vk::BindBufferMemory(device(), dst_blas_buffers[i].handle(), buffer_memory.handle(), 0);
 
             // 1st step: build destination acceleration struct
@@ -1882,9 +1882,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
             blas.GetDstAS()->SetDeviceBuffer(std::move(src_blas_buffers[i]));
             blas.GetDstAS()->SetSize(4096);
             blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
-            m_command_buffer.begin();
+            m_command_buffer.Begin();
             blas.BuildCmdBuffer(m_command_buffer.handle());
-            m_command_buffer.end();
+            m_command_buffer.End();
 
             // Possible 2nd step: insert memory barrier on acceleration structure buffer
             // => no need here since 2nd build call will not be executed by the driver
@@ -1908,9 +1908,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory) {
         for (size_t i = 0; i < build_info_count; ++i) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03668");
         }
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     }
 }
@@ -1953,9 +1953,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory2) {
             auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
             blas.SetScratchBuffer(std::move(scratch_buffer));
             if (ref_address == 0) {
-                ref_address = blas.GetScratchBuffer()->address();
+                ref_address = blas.GetScratchBuffer()->Address();
             } else {
-                if (blas.GetScratchBuffer()->address() != ref_address) {
+                if (blas.GetScratchBuffer()->Address() != ref_address) {
                     GTEST_SKIP()
                         << "Bounding two buffers to the same memory location does not result in identical buffer device addresses";
                 }
@@ -1968,9 +1968,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory2) {
         for (size_t i = 0; i < binom<size_t>(build_info_count, 2); ++i) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03704");
         }
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), build_infos);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     }
 }
@@ -2019,10 +2019,10 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory3) {
         std::vector<std::shared_ptr<vkt::Buffer>> scratch_buffers(build_info_count);
         std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec;
         for (size_t i = 0; i < build_info_count; ++i) {
-            dst_blas_buffers[i].init_no_mem(*m_device, dst_blas_buffer_ci);
+            dst_blas_buffers[i].InitNoMemory(*m_device, dst_blas_buffer_ci);
             vk::BindBufferMemory(device(), dst_blas_buffers[i].handle(), buffer_memory.handle(), 0);
             scratch_buffers[i] = std::make_shared<vkt::Buffer>();
-            scratch_buffers[i]->init_no_mem(*m_device, scratch_buffer_ci);
+            scratch_buffers[i]->InitNoMemory(*m_device, scratch_buffer_ci);
             vk::BindBufferMemory(device(), scratch_buffers[i]->handle(), buffer_memory.handle(), 0);
 
             auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
@@ -2042,9 +2042,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory3) {
         for (size_t i = 0; i < build_info_count; ++i) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-dstAccelerationStructure-03703");
         }
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     }
 }
@@ -2093,11 +2093,11 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory4) {
         std::vector<vkt::as::BuildGeometryInfoKHR> blas_vec;
 
         for (size_t i = 0; i < build_info_count; ++i) {
-            src_blas_buffers[i].init_no_mem(*m_device, blas_buffer_ci);
+            src_blas_buffers[i].InitNoMemory(*m_device, blas_buffer_ci);
             src_blas_buffers[i].BindMemory(buffer_memory, 0);
 
             scratch_buffers[i] = std::make_shared<vkt::Buffer>();
-            scratch_buffers[i]->init_no_mem(*m_device, scratch_buffer_ci);
+            scratch_buffers[i]->InitNoMemory(*m_device, scratch_buffer_ci);
             scratch_buffers[i]->BindMemory(buffer_memory, 0);
 
             // 1st step: build destination acceleration struct
@@ -2105,9 +2105,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory4) {
             blas.GetDstAS()->SetDeviceBuffer(std::move(src_blas_buffers[i]));
             blas.GetDstAS()->SetSize(4096);  // Do this to ensure dst accel struct buffer and scratch do overlap
             blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
-            m_command_buffer.begin();
+            m_command_buffer.Begin();
             blas.BuildCmdBuffer(m_command_buffer.handle());
-            m_command_buffer.end();
+            m_command_buffer.End();
             m_default_queue->Wait();
 
             // Possible 2nd step: insert memory barrier on acceleration structure buffer
@@ -2133,9 +2133,9 @@ TEST_F(NegativeRayTracing, AccelerationStructuresOverlappingMemory4) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-scratchData-03705");
         }
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_errorMonitor->VerifyFound();
     }
 }
@@ -2152,9 +2152,9 @@ TEST_F(NegativeRayTracing, ObjInUseCmdBuildAccelerationStructureKHR) {
     RETURN_IF_SKIP(InitState());
 
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     // This test used to destroy buffers used for building the acceleration structure,
@@ -2191,7 +2191,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     copy_info.dst = output_data;
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-pInfo-03739");
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureToMemoryKHR-None-03559");
@@ -2199,7 +2199,7 @@ TEST_F(NegativeRayTracing, CmdCopyAccelerationStructureToMemoryKHR) {
     vk::CmdCopyAccelerationStructureToMemoryKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CopyAccelerationStructureToMemoryKHR) {
@@ -2217,11 +2217,11 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureToMemoryKHR) {
     buffer_ci.size = 4096;
     buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR;
     vkt::Buffer buffer(*m_device, buffer_ci, vkt::no_mem);
-    VkMemoryRequirements memory_requirements = buffer.memory_requirements();
+    VkMemoryRequirements memory_requirements = buffer.MemoryRequirements();
     VkMemoryAllocateInfo memory_alloc = vku::InitStructHelper();
     memory_alloc.allocationSize = memory_requirements.size;
-    ASSERT_TRUE(
-        m_device->phy().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(memory_requirements.memoryTypeBits, &memory_alloc, 0,
+                                                   VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT));
     vkt::DeviceMemory device_memory(*m_device, memory_alloc);
     ASSERT_TRUE(device_memory.initialized());
     vk::BindBufferMemory(m_device->handle(), buffer.handle(), device_memory.handle(), 0);
@@ -2238,14 +2238,14 @@ TEST_F(NegativeRayTracing, CopyAccelerationStructureToMemoryKHR) {
     copy_info.dst = output_data;
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_SERIALIZE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCopyAccelerationStructureToMemoryKHR-buffer-03731");
     m_errorMonitor->SetDesiredError("VUID-VkCopyAccelerationStructureToMemoryInfoKHR-src-04959");
     vk::CopyAccelerationStructureToMemoryKHR(*m_device, VK_NULL_HANDLE, &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHRInvalidSrcBuffer) {
@@ -2265,13 +2265,13 @@ TEST_F(NegativeRayTracing, CmdCopyMemoryToAccelerationStructureKHRInvalidSrcBuff
     copy_info.dst = blas->handle();
     copy_info.mode = VK_COPY_ACCELERATION_STRUCTURE_MODE_DESERIALIZE_KHR;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyMemoryToAccelerationStructureKHR-pInfo-03742");
     vk::CmdCopyMemoryToAccelerationStructureKHR(m_command_buffer, &copy_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
@@ -2284,7 +2284,7 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
@@ -2293,7 +2293,7 @@ TEST_F(NegativeRayTracing, UpdateAccelerationStructureKHR) {
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
@@ -2348,8 +2348,8 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
 
         // Those calls to vkGetBufferDeviceAddressKHR will internally record vbo and ibo device addresses
         {
-            const VkDeviceAddress vbo_address = vbo.address();
-            const VkDeviceAddress ibo_address = ibo.address();
+            const VkDeviceAddress vbo_address = vbo.Address();
+            const VkDeviceAddress ibo_address = ibo.Address();
             if (vbo_address != ibo_address) {
                 GTEST_SKIP()
                     << "Bounding two buffers to the same memory location does not result in identical buffer device addresses";
@@ -2366,13 +2366,13 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
     // After deleting the valid vbo and ibo, calls are expected to fail.
 
     for (size_t i = 0; i < N; ++i) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         blas_vec[i]->BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     for (size_t i = 0; i < N; ++i) {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         if (i > 0) {
             // for vbo
             m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-geometry-03673");
@@ -2383,7 +2383,7 @@ TEST_F(NegativeRayTracing, BuffersAndBufferDeviceAddressesMapping) {
         if (i > 0) {
             m_errorMonitor->VerifyFound();
         }
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         blas_vec[i] = nullptr;
     }
@@ -2405,9 +2405,9 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesHost) {
     blas.GetDstAS()->SetDeviceBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
     blas.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_device->Wait();
 
@@ -2454,19 +2454,19 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDevice) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Incorrect query type
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryType-06742");
     vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer.handle(), 1, &blas.GetDstAS()->handle(),
                                                     VK_QUERY_TYPE_OCCLUSION, query_pool.handle(), 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesAccelStructDestroyedMemory) {
@@ -2486,22 +2486,22 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesAccelStructDestr
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_device->Wait();
 
-    blas.GetDstAS()->GetBuffer().memory().destroy();
+    blas.GetDstAS()->GetBuffer().Memory().destroy();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("vkCmdWriteAccelerationStructuresPropertiesKHR-buffer-03736");
     vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer.handle(), 1, &blas.GetDstAS()->handle(),
                                                     VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, query_pool.handle(),
                                                     0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDeviceBlasNotBuilt) {
@@ -2521,14 +2521,14 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDeviceBlasNotBui
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // blas not built
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-pAccelerationStructures-04964");
     vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer.handle(), 1, &blas.GetDstAS()->handle(),
                                                     VK_QUERY_TYPE_ACCELERATION_STRUCTURE_COMPACTED_SIZE_KHR, query_pool.handle(),
                                                     0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Host) {
@@ -2553,9 +2553,9 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Host
         blas.GetDstAS()->SetDeviceBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
         blas.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         blas.BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         // Incorrect query type
         m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-queryType-06742");
@@ -2571,9 +2571,9 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Host
         // missing flag
         blas.SetFlags(0);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         blas.BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-accelerationStructures-03431");
         vk::WriteAccelerationStructuresPropertiesKHR(m_device->handle(), 1, &blas.GetDstAS()->handle(),
@@ -2588,9 +2588,9 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Host
         blas.GetDstAS()->SetDeviceBufferMemoryPropertyFlags(VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT);
         blas.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         blas.BuildCmdBuffer(m_command_buffer.handle());
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_errorMonitor->SetDesiredError("VUID-vkWriteAccelerationStructuresPropertiesKHR-queryType-03448");
         vk::WriteAccelerationStructuresPropertiesKHR(m_device->handle(), 1, &blas.GetDstAS()->handle(),
@@ -2621,13 +2621,13 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Devi
     vkt::as::BuildGeometryInfoKHR blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.SetFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_COMPACTION_BIT_KHR);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Incorrect query type
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 1);
     m_errorMonitor->SetDesiredError("VUID-vkCmdWriteAccelerationStructuresPropertiesKHR-queryType-06742");
@@ -2635,7 +2635,7 @@ TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesMaintenance1Devi
                                                     VK_QUERY_TYPE_OCCLUSION, query_pool.handle(), 0);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, WriteAccelerationStructuresPropertiesDataSizeTooSmall) {
@@ -2728,11 +2728,11 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidMode) {
 
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.SetMode(static_cast<VkBuildAccelerationStructureModeKHR>(42));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-mode-04628");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryType) {
@@ -2748,7 +2748,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTy
     RETURN_IF_SKIP(InitState());
 
     // Invalid update to geometry type
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
@@ -2764,7 +2764,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTy
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03761");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryFlags) {
@@ -2781,7 +2781,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryFl
     RETURN_IF_SKIP(InitState());
 
     // Invalid update to geometry flags
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
@@ -2795,7 +2795,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryFl
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03762");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTrianglesFormat) {
@@ -2814,15 +2814,15 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     const VkFormat second_triangles_vertex_format = VK_FORMAT_R16G16B16_SFLOAT;
 
     // Invalid update to triangles vertex format
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
     blas.BuildCmdBuffer(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_device->Wait();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     blas.SetSrcAS(blas.GetDstAS());
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
@@ -2831,14 +2831,14 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     blas.GetGeometries()[0].SetTrianglesVertexFormat(second_triangles_vertex_format);
 
     VkFormatProperties vertex_format_props{};
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy(), second_triangles_vertex_format, &vertex_format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), second_triangles_vertex_format, &vertex_format_props);
     if (!(vertex_format_props.bufferFeatures & VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR)) {
         m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-03797");
     }
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03763");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesFormatMissingFeature) {
@@ -2854,21 +2854,21 @@ TEST_F(NegativeRayTracing, TrianglesFormatMissingFeature) {
 
     const VkFormat triangles_vertex_format = VK_FORMAT_R32_UINT;
     VkFormatProperties vertex_format_props{};
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy(), triangles_vertex_format, &vertex_format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical(), triangles_vertex_format, &vertex_format_props);
 
     if (vertex_format_props.bufferFeatures & VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR) {
         GTEST_SKIP()
             << "Hard coded vertex format has VK_FORMAT_FEATURE_ACCELERATION_STRUCTURE_VERTEX_BUFFER_BIT_KHR, skipping test.";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesVertexFormat(triangles_vertex_format);
 
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexFormat-03797");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesMisalignedVertexStride) {
@@ -2884,14 +2884,14 @@ TEST_F(NegativeRayTracing, TrianglesMisalignedVertexStride) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetStride(1);
 
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureGeometryTrianglesDataKHR-vertexStride-03735");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesMisalignedVertexBufferAddress) {
@@ -2907,7 +2907,7 @@ TEST_F(NegativeRayTracing, TrianglesMisalignedVertexBufferAddress) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesVertexBufferDeviceAddress(1);
 
@@ -2916,7 +2916,7 @@ TEST_F(NegativeRayTracing, TrianglesMisalignedVertexBufferAddress) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03711");  // misaligned device address
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTrianglesMaxVertex) {
@@ -2933,7 +2933,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles max vertex
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
@@ -2947,7 +2947,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03764");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTrianglesIndexType) {
@@ -2964,7 +2964,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles index type
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
@@ -2978,7 +2978,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03765");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTrianglesTransformData) {
@@ -2995,15 +2995,15 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     RETURN_IF_SKIP(InitState());
 
     // Invalid update to triangles transform data
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
     blas.GetGeometries()[0].SetTrianglesTransformatData(0);
     blas.BuildCmdBuffer(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_device->Wait();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     blas.SetSrcAS(blas.GetDstAS());
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
@@ -3015,7 +3015,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometryTr
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesVertexBufferNull) {
@@ -3032,11 +3032,11 @@ TEST_F(NegativeRayTracing, TrianglesVertexBufferNull) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesVertexBufferDeviceAddress(0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03804");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesIndexBufferNull) {
@@ -3053,11 +3053,11 @@ TEST_F(NegativeRayTracing, TrianglesIndexBufferNull) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesIndexBufferDeviceAddress(0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03806");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TrianglesIndexBufferInvalidAddress) {
@@ -3073,11 +3073,11 @@ TEST_F(NegativeRayTracing, TrianglesIndexBufferInvalidAddress) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesIndexBufferDeviceAddress(32);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03806");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, AabbBufferInvalidAddress) {
@@ -3094,11 +3094,11 @@ TEST_F(NegativeRayTracing, AabbBufferInvalidAddress) {
     blas.GetGeometries()[0] = vkt::as::blueprint::GeometrySimpleOnDeviceAABBInfo(*m_device);
     blas.GetGeometries()[0].SetAABBsDeviceAddress(32);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03811");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometry) {
@@ -3122,10 +3122,10 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometry) 
                                      VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
                                  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
-    blas.GetGeometries()[0].SetTrianglesTransformatData(transform_buffer.address());
+    blas.GetGeometries()[0].SetTrianglesTransformatData(transform_buffer.Address());
 
     blas.BuildCmdBuffer(m_command_buffer.handle());
 
@@ -3137,7 +3137,7 @@ TEST_F(NegativeRayTracing, BuildAccelerationStructuresInvalidUpdatesToGeometry) 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03767");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildNullGeometries) {
@@ -3153,7 +3153,7 @@ TEST_F(NegativeRayTracing, BuildNullGeometries) {
     AddRequiredFeature(vkt::Feature::rayQuery);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Build Bottom Level Acceleration Structure
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
@@ -3161,7 +3161,7 @@ TEST_F(NegativeRayTracing, BuildNullGeometries) {
     m_errorMonitor->SetDesiredError("VUID-VkAccelerationStructureBuildGeometryInfoKHR-pGeometries-03788");
     blas->GetSizeInfo();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TransformBufferInvalidDeviceAddress) {
@@ -3179,11 +3179,11 @@ TEST_F(NegativeRayTracing, TransformBufferInvalidDeviceAddress) {
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.GetGeometries()[0].SetTrianglesTransformatData(16);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03808");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TransformBufferInvalid) {
@@ -3204,15 +3204,15 @@ TEST_F(NegativeRayTracing, TransformBufferInvalid) {
                                  VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
 
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-    blas.GetGeometries()[0].SetTrianglesTransformatData(transform_buffer.address());
+    blas.GetGeometries()[0].SetTrianglesTransformatData(transform_buffer.Address());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.SetupBuild(*m_device, true);
-    transform_buffer.memory().destroy();
+    transform_buffer.Memory().destroy();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03809");
     blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, BuildAccelerationStructureMode) {
@@ -3248,16 +3248,16 @@ TEST_F(NegativeRayTracing, InstanceBufferBadAddress) {
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.SetupBuild(*m_device, true);
 
     tlas.GetGeometries()[0].SetInstancesDeviceAddress(0);
@@ -3265,7 +3265,7 @@ TEST_F(NegativeRayTracing, InstanceBufferBadAddress) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03813");
     tlas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, InstanceBufferBadMemory) {
@@ -3282,24 +3282,24 @@ TEST_F(NegativeRayTracing, InstanceBufferBadMemory) {
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.SetupBuild(*m_device, true);
 
-    tlas.GetGeometries()[0].GetInstance().buffer.memory().destroy();
+    tlas.GetGeometries()[0].GetInstance().buffer.Memory().destroy();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03814");
     tlas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, DynamicRayTracingPipelineStack) {
@@ -3319,14 +3319,14 @@ TEST_F(NegativeRayTracing, DynamicRayTracingPipelineStack) {
     pipeline.AddDynamicState(VK_DYNAMIC_STATE_RAY_TRACING_PIPELINE_STACK_SIZE_KHR);
     pipeline.Build();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdTraceRaysKHR-None-09458");
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, UpdatedFirstPrimitiveCount) {
@@ -3342,18 +3342,18 @@ TEST_F(NegativeRayTracing, UpdatedFirstPrimitiveCount) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
     blas.BuildCmdBuffer(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
     blas.SetSrcAS(blas.GetDstAS());
@@ -3366,7 +3366,7 @@ TEST_F(NegativeRayTracing, UpdatedFirstPrimitiveCount) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-primitiveCount-03769");
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpBuild) {
@@ -3400,12 +3400,12 @@ TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpBuild) {
     auto scratch_buffer = std::make_shared<vkt::Buffer>(*m_device, small_buffer_ci, vkt::no_mem);
     scratch_buffer->BindMemory(buffer_memory, 0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.SetScratchBuffer(scratch_buffer);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03671");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpUpdate) {
@@ -3434,21 +3434,21 @@ TEST_F(NegativeRayTracing, ScratchBufferBadAddressSpaceOpUpdate) {
         std::make_shared<vkt::Buffer>(*m_device, 64, VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_STORAGE_BUFFER_BIT,
                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT, &alloc_flags);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.SetScratchBuffer(scratch_buffer);
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
     blas.SetSrcAS(blas.GetDstAS());
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03672");
     blas.BuildCmdBuffer(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, ScratchBufferBadMemory) {
@@ -3476,12 +3476,12 @@ TEST_F(NegativeRayTracing, ScratchBufferBadMemory) {
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
     VkMemoryAllocateInfo alloc_info = vku::InitStructHelper(&alloc_flags);
-    alloc_info.allocationSize = scratch_buffer->memory_requirements().size;
+    alloc_info.allocationSize = scratch_buffer->MemoryRequirements().size;
     vkt::DeviceMemory buffer_memory(*m_device, alloc_info);
 
     scratch_buffer->BindMemory(buffer_memory, 0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.SetScratchBuffer(scratch_buffer);
     blas.SetupBuild(*m_device, true);
 
@@ -3490,7 +3490,7 @@ TEST_F(NegativeRayTracing, ScratchBufferBadMemory) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdBuildAccelerationStructuresKHR-pInfos-03803");
     blas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, DstAsTooSmall) {
@@ -3504,7 +3504,7 @@ TEST_F(NegativeRayTracing, DstAsTooSmall) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.SetUpdateDstAccelStructSizeBeforeBuild(false);
 
@@ -3513,7 +3513,7 @@ TEST_F(NegativeRayTracing, DstAsTooSmall) {
     blas.BuildCmdBuffer(m_command_buffer.handle());
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, TooManyInstances) {
@@ -3531,9 +3531,9 @@ TEST_F(NegativeRayTracing, TooManyInstances) {
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -3570,7 +3570,7 @@ TEST_F(NegativeRayTracing, PipelineNullMissShader) {
 
     pipeline.SetGlslRayGenShader(kRayTracingMinimalGlsl);
     pipeline.Build();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -3579,7 +3579,7 @@ TEST_F(NegativeRayTracing, PipelineNullMissShader) {
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRayTracing, HostInstanceInvalid) {

--- a/tests/unit/ray_tracing_nv.cpp
+++ b/tests/unit/ray_tracing_nv.cpp
@@ -27,7 +27,7 @@ void RayTracingTest::NvInitFrameworkForRayTracingTest(VkPhysicalDeviceFeatures2K
 
     if (features2) {
         // extension enabled as dependency of RT extension
-        vk::GetPhysicalDeviceFeatures2KHR(gpu(), features2);
+        vk::GetPhysicalDeviceFeatures2KHR(Gpu(), features2);
     }
 }
 
@@ -109,9 +109,9 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                      VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, nullptr,
                      {ray_tracing_queue_family_index});
 
-    uint8_t *mapped_aabb_buffer_data = (uint8_t *)aabb_buffer.memory().map();
+    uint8_t *mapped_aabb_buffer_data = (uint8_t *)aabb_buffer.Memory().Map();
     std::memcpy(mapped_aabb_buffer_data, (uint8_t *)aabbs.data(), static_cast<std::size_t>(aabb_buffer_size));
-    aabb_buffer.memory().unmap();
+    aabb_buffer.Memory().Unmap();
 
     VkGeometryNV geometry = {};
     geometry.sType = VK_STRUCTURE_TYPE_GEOMETRY_NV;
@@ -160,9 +160,9 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, nullptr,
                          {ray_tracing_queue_family_index});
 
-    uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.memory().map();
+    uint8_t *mapped_instance_buffer_data = (uint8_t *)instance_buffer.Memory().Map();
     std::memcpy(mapped_instance_buffer_data, (uint8_t *)instances.data(), static_cast<std::size_t>(instance_buffer_size));
-    instance_buffer.memory().unmap();
+    instance_buffer.Memory().Unmap();
 
     VkAccelerationStructureInfoNV top_level_as_info = vku::InitStructHelper();
     top_level_as_info.type = VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_NV;
@@ -179,7 +179,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     vkt::Buffer scratch_buffer(*m_device, scratch_buffer_size, VK_BUFFER_USAGE_RAY_TRACING_BIT_NV,
                                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    ray_tracing_command_buffer.begin();
+    ray_tracing_command_buffer.Begin();
 
     // Build bot level acceleration structure
     vk::CmdBuildAccelerationStructureNV(ray_tracing_command_buffer.handle(), &bot_level_as.Info(), VK_NULL_HANDLE, 0, VK_FALSE,
@@ -196,7 +196,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
     vk::CmdBuildAccelerationStructureNV(ray_tracing_command_buffer.handle(), &top_level_as.Info(), instance_buffer.handle(), 0,
                                         VK_FALSE, top_level_as.handle(), VK_NULL_HANDLE, scratch_buffer.handle(), 0);
 
-    ray_tracing_command_buffer.end();
+    ray_tracing_command_buffer.End();
 
     ray_tracing_queue->Submit(ray_tracing_command_buffer);
     ray_tracing_queue->Wait();
@@ -767,11 +767,11 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                                                     static_cast<std::size_t>(shader_binding_table_buffer_size),
                                                                     shader_binding_table_data.data()));
 
-        uint8_t *mapped_shader_binding_table_data = (uint8_t *)shader_binding_table_buffer.memory().map();
+        uint8_t *mapped_shader_binding_table_data = (uint8_t *)shader_binding_table_buffer.Memory().Map();
         std::memcpy(mapped_shader_binding_table_data, shader_binding_table_data.data(), shader_binding_table_data.size());
-        shader_binding_table_buffer.memory().unmap();
+        shader_binding_table_buffer.Memory().Unmap();
 
-        ray_tracing_command_buffer.begin();
+        ray_tracing_command_buffer.Begin();
 
         vk::CmdBindPipeline(ray_tracing_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, pipeline);
 
@@ -805,9 +805,9 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                /*width=*/1, /*height=*/1, /*depth=*/1);
         }
 
-        ray_tracing_command_buffer.end();
+        ray_tracing_command_buffer.End();
         // Update the index of the texture that the shaders should read
-        uint32_t *mapped_storage_buffer_data = (uint32_t *)storage_buffer.memory().map();
+        uint32_t *mapped_storage_buffer_data = (uint32_t *)storage_buffer.Memory().Map();
         mapped_storage_buffer_data[0] = test.rgen_index;
         mapped_storage_buffer_data[1] = test.ahit_index;
         mapped_storage_buffer_data[2] = test.chit_index;
@@ -820,23 +820,23 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
         mapped_storage_buffer_data[9] = 0;
         mapped_storage_buffer_data[10] = 0;
         mapped_storage_buffer_data[11] = 0;
-        storage_buffer.memory().unmap();
+        storage_buffer.Memory().Unmap();
 
         ray_tracing_queue->Submit(ray_tracing_command_buffer);
         ray_tracing_queue->Wait();
         m_errorMonitor->VerifyFound();
 
         if (gpu_assisted) {
-            mapped_storage_buffer_data = (uint32_t *)storage_buffer.memory().map();
+            mapped_storage_buffer_data = (uint32_t *)storage_buffer.Memory().Map();
             ASSERT_TRUE(mapped_storage_buffer_data[6] == 1);
             ASSERT_TRUE(mapped_storage_buffer_data[7] == 2);
             ASSERT_TRUE(mapped_storage_buffer_data[8] == 3);
             ASSERT_TRUE(mapped_storage_buffer_data[9] == 4);
             ASSERT_TRUE(mapped_storage_buffer_data[10] == 5);
             ASSERT_TRUE(mapped_storage_buffer_data[11] == 6);
-            storage_buffer.memory().unmap();
+            storage_buffer.Memory().Unmap();
         } else {
-            ray_tracing_command_buffer.begin();
+            ray_tracing_command_buffer.Begin();
             vk::CmdBindPipeline(ray_tracing_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, pipeline);
             vk::CmdBindDescriptorSets(ray_tracing_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV,
                                       test.variable_length ? pipeline_layout_variable.handle() : pipeline_layout.handle(), 0, 1,
@@ -954,7 +954,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                /*width=*/1, /*height=*/1, /*depth=*/1);
 
             m_errorMonitor->VerifyFound();
-            const auto &limits = m_device->phy().limits_;
+            const auto &limits = m_device->Physical().limits_;
 
             m_errorMonitor->SetDesiredError("VUID-vkCmdTraceRaysNV-width-02469");
             uint32_t invalid_width = limits.maxComputeWorkGroupCount[0] + 1;
@@ -989,7 +989,7 @@ void NegativeRayTracingNV::OOBRayTracingShadersTestBodyNV(bool gpu_assisted) {
                                /*width=*/1, /*height=*/1, /*depth=*/invalid_depth);
             m_errorMonitor->VerifyFound();
 
-            ray_tracing_command_buffer.end();
+            ray_tracing_command_buffer.End();
         }
         vk::DestroyPipeline(m_device->handle(), pipeline, nullptr);
     }
@@ -1079,21 +1079,21 @@ TEST_F(NegativeRayTracingNV, ValidateGeometry) {
     constexpr std::array aabbs = {0.0f, 0.0f, 0.0f, 1.0f, 1.0f, 1.0f};
     constexpr std::array transforms = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f};
 
-    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo.memory().map();
+    uint8_t *mapped_vbo_buffer_data = (uint8_t *)vbo.Memory().Map();
     std::memcpy(mapped_vbo_buffer_data, (uint8_t *)vertices.data(), sizeof(float) * vertices.size());
-    vbo.memory().unmap();
+    vbo.Memory().Unmap();
 
-    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo.memory().map();
+    uint8_t *mapped_ibo_buffer_data = (uint8_t *)ibo.Memory().Map();
     std::memcpy(mapped_ibo_buffer_data, (uint8_t *)indicies.data(), sizeof(uint32_t) * indicies.size());
-    ibo.memory().unmap();
+    ibo.Memory().Unmap();
 
-    uint8_t *mapped_tbo_buffer_data = (uint8_t *)tbo.memory().map();
+    uint8_t *mapped_tbo_buffer_data = (uint8_t *)tbo.Memory().Map();
     std::memcpy(mapped_tbo_buffer_data, (uint8_t *)transforms.data(), sizeof(float) * transforms.size());
-    tbo.memory().unmap();
+    tbo.Memory().Unmap();
 
-    uint8_t *mapped_aabbbo_buffer_data = (uint8_t *)aabbbo.memory().map();
+    uint8_t *mapped_aabbbo_buffer_data = (uint8_t *)aabbbo.Memory().Map();
     std::memcpy(mapped_aabbbo_buffer_data, (uint8_t *)aabbs.data(), sizeof(float) * aabbs.size());
-    aabbbo.memory().unmap();
+    aabbbo.Memory().Unmap();
 
     VkGeometryNV valid_geometry_triangles = vku::InitStructHelper();
     valid_geometry_triangles.geometryType = VK_GEOMETRY_TYPE_TRIANGLES_NV;
@@ -1417,7 +1417,7 @@ TEST_F(NegativeRayTracingNV, ValidateBindAccelerationStructure) {
 
     VkMemoryAllocateInfo as_memory_alloc = vku::InitStructHelper();
     as_memory_alloc.allocationSize = as_memory_requirements.size;
-    ASSERT_TRUE(m_device->phy().SetMemoryType(as_memory_requirements.memoryTypeBits, &as_memory_alloc, 0));
+    ASSERT_TRUE(m_device->Physical().SetMemoryType(as_memory_requirements.memoryTypeBits, &as_memory_alloc, 0));
 
     // Can not bind already freed memory
     {
@@ -1491,13 +1491,13 @@ TEST_F(NegativeRayTracingNV, ValidateBindAccelerationStructure) {
     // Can not bind with memory that has unsupported memory type
     {
         VkPhysicalDeviceMemoryProperties memory_properties = {};
-        vk::GetPhysicalDeviceMemoryProperties(m_device->phy().handle(), &memory_properties);
+        vk::GetPhysicalDeviceMemoryProperties(m_device->Physical().handle(), &memory_properties);
 
         uint32_t supported_memory_type_bits = as_memory_requirements.memoryTypeBits;
         uint32_t unsupported_mem_type_bits = ((1 << memory_properties.memoryTypeCount) - 1) & ~supported_memory_type_bits;
         if (unsupported_mem_type_bits != 0) {
             VkMemoryAllocateInfo as_memory_alloc_bad_type = as_memory_alloc;
-            ASSERT_TRUE(m_device->phy().SetMemoryType(unsupported_mem_type_bits, &as_memory_alloc_bad_type, 0));
+            ASSERT_TRUE(m_device->Physical().SetMemoryType(unsupported_mem_type_bits, &as_memory_alloc_bad_type, 0));
 
             VkDeviceMemory as_memory_bad_type = VK_NULL_HANDLE;
             ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &as_memory_alloc_bad_type, NULL, &as_memory_bad_type));
@@ -1598,7 +1598,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdBuildAccelerationStructure) {
                                         bot_level_as.handle(), VK_NULL_HANDLE, bot_level_as_scratch.handle(), 0);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Incompatible type
     VkAccelerationStructureInfoNV as_build_info_with_incompatible_type = bot_level_as_create_info.info;
@@ -1714,10 +1714,10 @@ TEST_F(NegativeRayTracingNV, ObjInUseCmdBuildAccelerationStructure) {
 
     const vkt::Buffer bot_level_as_scratch = bot_level_as.CreateScratchBuffer(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBuildAccelerationStructureNV(m_command_buffer.handle(), &bot_level_as_create_info.info, VK_NULL_HANDLE, 0, VK_FALSE,
                                         bot_level_as.handle(), VK_NULL_HANDLE, bot_level_as_scratch.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     m_errorMonitor->SetDesiredError("VUID-vkDestroyBuffer-buffer-00922");
@@ -1809,7 +1809,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
 
     const vkt::Buffer bot_level_as_scratch = src_as.CreateScratchBuffer(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureNV-src-04963");
     vk::CmdCopyAccelerationStructureNV(m_command_buffer.handle(), dst_as.handle(), src_as.handle(),
@@ -1818,7 +1818,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
 
     vk::CmdBuildAccelerationStructureNV(m_command_buffer.handle(), &bot_level_as_create_info.info, VK_NULL_HANDLE, 0, VK_FALSE,
                                         src_as.handle(), VK_NULL_HANDLE, bot_level_as_scratch.handle(), 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -1828,7 +1828,7 @@ TEST_F(NegativeRayTracingNV, ValidateCmdCopyAccelerationStructure) {
                                        VK_COPY_ACCELERATION_STRUCTURE_MODE_CLONE_NV);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Src must have been created with allow compaction flag
     m_errorMonitor->SetDesiredError("VUID-vkCmdCopyAccelerationStructureNV-src-03411");

--- a/tests/unit/ray_tracing_pipeline.cpp
+++ b/tests/unit/ray_tracing_pipeline.cpp
@@ -913,7 +913,7 @@ TEST_F(NegativeRayTracingPipeline, DeferredOp) {
     VkResult result = vk::CreateRayTracingPipelinesKHR(m_device->handle(), deferredOperation, VK_NULL_HANDLE, 1, &pipeline_ci,
                                                        nullptr, &pipeline);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     if (result == VK_OPERATION_DEFERRED_KHR) {
         result = vk::DeferredOperationJoinKHR(this->m_device->handle(), deferredOperation);
         ASSERT_EQ(result, VK_SUCCESS);
@@ -927,7 +927,7 @@ TEST_F(NegativeRayTracingPipeline, DeferredOp) {
     ASSERT_EQ(result, VK_SUCCESS);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::DestroyPipeline(m_device->handle(), pipeline, nullptr);
     vk::DestroyDeferredOperationKHR(m_device->handle(), deferredOperation, nullptr);
@@ -955,14 +955,14 @@ TEST_F(NegativeRayTracingPipeline, MaxResources) {
 
     const uint32_t maxPerStageResources = 4;
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxPerStageResources = maxPerStageResources;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState(nullptr, &ray_tracing_features));
 
     std::vector<VkDescriptorSetLayoutBinding> layout_bindings = {
-        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, m_device->phy().limits_.maxPerStageResources, VK_SHADER_STAGE_RAYGEN_BIT_KHR,
+        {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, m_device->Physical().limits_.maxPerStageResources, VK_SHADER_STAGE_RAYGEN_BIT_KHR,
          nullptr},
         {1, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1, VK_SHADER_STAGE_RAYGEN_BIT_KHR, nullptr}};
 

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -172,7 +172,7 @@ TEST_F(NegativeRayTracingPipelineNV, BindPoint) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_NV, pipe.Handle());
 
     m_errorMonitor->VerifyFound();

--- a/tests/unit/ray_tracing_positive.cpp
+++ b/tests/unit/ray_tracing_positive.cpp
@@ -66,22 +66,22 @@ TEST_F(PositiveRayTracing, AccelerationStructureReference) {
     AddRequiredFeature(vkt::Feature::rayQuery);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Build Bottom Level Acceleration Structure
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
     blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Build Top Level Acceleration Structure
     // ---
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
     tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -195,14 +195,14 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_tracing_properties = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(ray_tracing_properties);
 
-    const VkDeviceAddress device_address = buffer.address();
+    const VkDeviceAddress device_address = buffer.Address();
 
     VkStridedDeviceAddressRegionKHR stridebufregion = {};
     stridebufregion.deviceAddress = device_address;
     stridebufregion.stride = ray_tracing_properties.shaderGroupHandleAlignment;
     stridebufregion.size = stridebufregion.stride;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, raytracing_pipeline);
 
@@ -227,7 +227,7 @@ TEST_F(PositiveRayTracing, StridedDeviceAddressRegion) {
                             100, 1);
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -280,7 +280,7 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = &image_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     mem_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
@@ -296,7 +296,7 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT;
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabledRTXEnabled) {
@@ -345,7 +345,7 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = &image_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // specify VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR as srcStageMask and dstStageMask
     mem_barrier.srcAccessMask = VK_ACCESS_2_ACCELERATION_STRUCTURE_READ_BIT_KHR;
@@ -362,7 +362,7 @@ TEST_F(PositiveRayTracing, BarrierAccessMaskAccelerationStructureRayQueryEnabled
     image_barrier.dstStageMask = VK_PIPELINE_STAGE_2_RAY_TRACING_SHADER_BIT_KHR;
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, BarrierSync1NoCrash) {
@@ -378,10 +378,10 @@ TEST_F(PositiveRayTracing, BarrierSync1NoCrash) {
     barrier.srcAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
 
     m_errorMonitor->SetUnexpectedError("VUID-vkCmdPipelineBarrier-srcAccessMask-06257");
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer.handle(), invalid_src_stage, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, 1, &barrier, 0,
                            nullptr, 0, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
@@ -404,10 +404,10 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
         blas_vec.emplace_back(std::move(blas));
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
@@ -417,9 +417,9 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList) {
         blas.SetDstAS(vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, 4096));
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -442,7 +442,7 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList2) {
 
     VkPhysicalDeviceAccelerationStructurePropertiesKHR as_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 phys_dev_props = vku::InitStructHelper(&as_props);
-    vk::GetPhysicalDeviceProperties2(m_device->phy(), &phys_dev_props);
+    vk::GetPhysicalDeviceProperties2(m_device->Physical(), &phys_dev_props);
 
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
@@ -473,11 +473,11 @@ TEST_F(PositiveRayTracing, BuildAccelerationStructuresList2) {
     blas_vec.emplace_back(std::move(blas_0));
     blas_vec.emplace_back(std::move(blas_1));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -524,9 +524,9 @@ TEST_F(PositiveRayTracing, AccelerationStructuresOverlappingMemory) {
             blas_vec.emplace_back(std::move(blas));
         }
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vkt::as::BuildAccelerationStructuresKHR(m_command_buffer.handle(), blas_vec);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
@@ -576,7 +576,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_ci.size = alloc_info.allocationSize;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                   VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        scratch_buffer_frame_0->init_no_mem(*m_device, scratch_buffer_ci);
+        scratch_buffer_frame_0->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
         vk::BindBufferMemory(device(), scratch_buffer_frame_0->handle(), common_scratch_memory.handle(), 0);
@@ -585,7 +585,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_0);
         blas_vec_frame_0.emplace_back(std::move(blas));
-        cmd_buffer_frame_0.begin();
+        cmd_buffer_frame_0.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0.handle(), blas_vec_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -596,7 +596,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_0.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_0.end();
+        cmd_buffer_frame_0.End();
         m_default_queue->Submit(cmd_buffer_frame_0, fence_frame_0);
     }
 
@@ -609,7 +609,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_ci.size = alloc_info.allocationSize;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                   VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        scratch_buffer_frame_1->init_no_mem(*m_device, scratch_buffer_ci);
+        scratch_buffer_frame_1->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
         vk::BindBufferMemory(device(), scratch_buffer_frame_1->handle(), common_scratch_memory.handle(), 0);
@@ -618,7 +618,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_1);
         blas_vec_frame_1.emplace_back(std::move(blas));
-        cmd_buffer_frame_1.begin();
+        cmd_buffer_frame_1.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1.handle(), blas_vec_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -629,17 +629,17 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_1.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_1.end();
+        cmd_buffer_frame_1.End();
         m_default_queue->Submit(cmd_buffer_frame_1, fence_frame_1);
     }
 
     // Frame 2
     {
         // Free resources from frame 0
-        fence_frame_0.wait(kWaitTimeout);
+        fence_frame_0.Wait(kWaitTimeout);
         // Destroying buffer triggers VUID-vkDestroyBuffer-buffer-00922, it is still considered in use by cmd_buffer_frame_0 this
         // should not happen assuming synchronization is correct
-        // Adding "fence_frame_1.wait(kWaitTimeout);" used to solve this issue.
+        // Adding "fence_frame_1.Wait(kWaitTimeout);" used to solve this issue.
         // Using a dedicated memory chunk for each scratch buffer also used to solve it.
         // The issue was that when recording a acceleration structure build command,
         // any buffer indirectly mentioned through a device address used to be added using a call to GetBuffersByAddress.
@@ -657,7 +657,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         scratch_buffer_ci.size = alloc_info.allocationSize;
         scratch_buffer_ci.usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
                                   VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
-        scratch_buffer_frame_2->init_no_mem(*m_device, scratch_buffer_ci);
+        scratch_buffer_frame_2->InitNoMemory(*m_device, scratch_buffer_ci);
 
         // Bind memory to scratch buffer
         vk::BindBufferMemory(device(), scratch_buffer_frame_2->handle(), common_scratch_memory.handle(), 0);
@@ -666,7 +666,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas.SetScratchBuffer(scratch_buffer_frame_2);
         blas_vec_frame_2.emplace_back(std::move(blas));
-        cmd_buffer_frame_2.begin();
+        cmd_buffer_frame_2.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2.handle(), blas_vec_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -677,12 +677,12 @@ TEST_F(PositiveRayTracing, AccelerationStructuresReuseScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_2.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_2.end();
+        cmd_buffer_frame_2.End();
         m_default_queue->Submit(cmd_buffer_frame_2, fence_frame_2);
     }
 
-    fence_frame_1.wait(kWaitTimeout);
-    fence_frame_2.wait(kWaitTimeout);
+    fence_frame_1.Wait(kWaitTimeout);
+    fence_frame_2.Wait(kWaitTimeout);
 }
 
 TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
@@ -718,7 +718,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
 
         blas_vec_frame_0.emplace_back(std::move(blas));
-        cmd_buffer_frame_0.begin();
+        cmd_buffer_frame_0.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_0.handle(), blas_vec_frame_0);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -729,7 +729,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_0.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_0.end();
+        cmd_buffer_frame_0.End();
         m_default_queue->Submit(cmd_buffer_frame_0, fence_frame_0);
     }
 
@@ -740,7 +740,7 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         // Build a dummy acceleration structure
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas_vec_frame_1.emplace_back(std::move(blas));
-        cmd_buffer_frame_1.begin();
+        cmd_buffer_frame_1.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_1.handle(), blas_vec_frame_1);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -751,20 +751,20 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_1.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_1.end();
+        cmd_buffer_frame_1.End();
         m_default_queue->Submit(cmd_buffer_frame_1, fence_frame_1);
     }
 
     // Frame 2
     {
         // Free resources from frame 0
-        fence_frame_0.wait(kWaitTimeout);
+        fence_frame_0.Wait(kWaitTimeout);
         blas_vec_frame_0.clear();  // No validation error
 
         // Build a dummy acceleration structure
         auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
         blas_vec_frame_2.emplace_back(std::move(blas));
-        cmd_buffer_frame_2.begin();
+        cmd_buffer_frame_2.Begin();
         vkt::as::BuildAccelerationStructuresKHR(cmd_buffer_frame_2.handle(), blas_vec_frame_2);
 
         // Synchronize accesses to scratch buffer memory: next op will be a new acceleration structure build
@@ -775,12 +775,12 @@ TEST_F(PositiveRayTracing, AccelerationStructuresDedicatedScratchMemory) {
         barrier.dstAccessMask = VK_ACCESS_ACCELERATION_STRUCTURE_WRITE_BIT_KHR | VK_ACCESS_ACCELERATION_STRUCTURE_READ_BIT_KHR;
         vk::CmdPipelineBarrier(cmd_buffer_frame_2.handle(), VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR,
                                VK_PIPELINE_STAGE_ACCELERATION_STRUCTURE_BUILD_BIT_KHR, 0, 0, nullptr, 1, &barrier, 0, nullptr);
-        cmd_buffer_frame_2.end();
+        cmd_buffer_frame_2.End();
         m_default_queue->Submit(cmd_buffer_frame_2, fence_frame_2);
     }
 
-    fence_frame_1.wait(kWaitTimeout);
-    fence_frame_2.wait(kWaitTimeout);
+    fence_frame_1.Wait(kWaitTimeout);
+    fence_frame_2.Wait(kWaitTimeout);
 }
 
 TEST_F(PositiveRayTracing, CmdBuildAccelerationStructuresIndirect) {
@@ -794,9 +794,9 @@ TEST_F(PositiveRayTracing, CmdBuildAccelerationStructuresIndirect) {
     RETURN_IF_SKIP(InitState());
 
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBufferIndirect(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, ScratchBufferCorrectAddressSpaceOpBuild) {
@@ -840,15 +840,15 @@ TEST_F(PositiveRayTracing, ScratchBufferCorrectAddressSpaceOpBuild) {
     small_buffer_ci.size = alloc_info.allocationSize;
     auto big_scratch_buffer = std::make_shared<vkt::Buffer>(*m_device, small_buffer_ci, vkt::no_mem);
     big_scratch_buffer->BindMemory(buffer_memory, 0);
-    const VkDeviceAddress big_scratch_address = big_scratch_buffer->address();
-    if (big_scratch_address != small_scratch_buffer->address()) {
+    const VkDeviceAddress big_scratch_address = big_scratch_buffer->Address();
+    if (big_scratch_address != small_scratch_buffer->Address()) {
         GTEST_SKIP() << "Binding two buffers to the same memory does not yield identical buffer addresses, skipping test.";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.SetScratchBuffer(small_scratch_buffer);
     blas.BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, BasicTraceRays) {
@@ -918,14 +918,14 @@ TEST_F(PositiveRayTracing, BasicTraceRays) {
     pipeline.Build();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -999,14 +999,14 @@ TEST_F(PositiveRayTracing, BasicTraceRaysDeferredBuild) {
     RETURN_IF_SKIP(pipeline.Build());
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -1071,18 +1071,18 @@ TEST_F(PositiveRayTracing, UpdatedFirstVertex) {
     RETURN_IF_SKIP(InitFrameworkForRayTracingTest());
     RETURN_IF_SKIP(InitState());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     auto blas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device);
     blas.AddFlags(VK_BUILD_ACCELERATION_STRUCTURE_ALLOW_UPDATE_BIT_KHR);
 
     blas.BuildCmdBuffer(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     blas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_UPDATE_KHR);
     blas.SetSrcAS(blas.GetDstAS());
@@ -1093,7 +1093,7 @@ TEST_F(PositiveRayTracing, UpdatedFirstVertex) {
     blas.SetBuildRanges(build_range_infos);
 
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, BindGraphicsPipelineAfterRayTracingPipeline) {
@@ -1167,7 +1167,7 @@ TEST_F(PositiveRayTracing, BindGraphicsPipelineAfterRayTracingPipeline) {
     graphics_pipeline.CreateGraphicsPipeline();
 
     // Bind descriptor set, pipeline, and trace rays
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -1176,7 +1176,7 @@ TEST_F(PositiveRayTracing, BindGraphicsPipelineAfterRayTracingPipeline) {
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 }
@@ -1195,16 +1195,16 @@ TEST_F(PositiveRayTracing, InstanceBufferBadAddress) {
     auto blas =
         std::make_shared<vkt::as::BuildGeometryInfoKHR>(vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas->BuildCmdBuffer(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     auto tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     tlas.SetupBuild(*m_device, true);
 
     auto build_range_infos = tlas.GetBuildRangeInfosFromGeometries();
@@ -1214,7 +1214,7 @@ TEST_F(PositiveRayTracing, InstanceBufferBadAddress) {
     tlas.GetGeometries()[0].SetInstancesDeviceAddress(0);
 
     tlas.VkCmdBuildAccelerationStructuresKHR(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRayTracing, WriteAccelerationStructuresPropertiesDevice) {
@@ -1237,21 +1237,21 @@ TEST_F(PositiveRayTracing, WriteAccelerationStructuresPropertiesDevice) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     blas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0u, 1u);
     vk::CmdWriteAccelerationStructuresPropertiesKHR(m_command_buffer.handle(), 1, &blas.GetDstAS()->handle(),
                                                     VK_QUERY_TYPE_ACCELERATION_STRUCTURE_SIZE_KHR, query_pool.handle(), 0);
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0u, 1u, buffer, 0u, sizeof(uint64_t),
                                 VK_QUERY_RESULT_64_BIT | VK_QUERY_RESULT_WAIT_BIT);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();

--- a/tests/unit/render_pass.cpp
+++ b/tests/unit/render_pass.cpp
@@ -45,7 +45,7 @@ TEST_F(NegativeRenderPass, AttachmentReadOnlyButCleared) {
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     const bool maintenance2Supported = IsExtensionsEnabled(VK_KHR_MAINTENANCE_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkAttachmentDescription description = {0,
                                            ds_format,
@@ -160,9 +160,9 @@ TEST_F(NegativeRenderPass, AttachmentDescriptionFinalLayout) {
 
     attach_desc.finalLayout = VK_IMAGE_LAYOUT_GENERAL;
 
-    auto depth_format = FindSupportedDepthOnlyFormat(gpu());
-    auto depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
-    auto stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    auto depth_format = FindSupportedDepthOnlyFormat(Gpu());
+    auto depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
+    auto stencil_format = FindSupportedStencilOnlyFormat(Gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -396,7 +396,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
     RETURN_IF_SKIP(Init());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     std::vector<VkAttachmentDescription> attachments = {
         // input attachments
@@ -459,7 +459,7 @@ TEST_F(NegativeRenderPass, AttachmentsMisc) {
         vku::InitStruct<VkRenderPassCreateInfo>(nullptr, 0u, size32(attachments), attachments.data(), 1u, &subpass, 0u, nullptr);
 
     // Test too many color attachments
-    const uint32_t max_color_attachments = m_device->phy().limits_.maxColorAttachments;
+    const uint32_t max_color_attachments = m_device->Physical().limits_.maxColorAttachments;
     const uint32_t too_big_max_attachments = 65536 + 1;  // let's say this is too much to allocate
     if (max_color_attachments >= too_big_max_attachments) {
         printf("VkPhysicalDeviceLimits::maxColorAttachments is too large to practically test against -- skipping part of test.\n");
@@ -611,7 +611,7 @@ TEST_F(NegativeRenderPass, ShaderResolveQCOM) {
     RETURN_IF_SKIP(Init());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     std::vector<VkAttachmentDescription> attachments = {
         // input attachments
@@ -694,7 +694,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayout) {
     RETURN_IF_SKIP(Init());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     const std::array attachments = {
         VkAttachmentDescription{0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
@@ -771,7 +771,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceLayoutSeparateDepthStencilLayoutsF
     RETURN_IF_SKIP(Init());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
     const VkFormat stencil_format = VK_FORMAT_S8_UINT;
 
     const std::array attachments = {
@@ -930,7 +930,7 @@ TEST_F(NegativeRenderPass, AttachmentReferenceSync2Layout) {
     // synchronization2 not enabled
     RETURN_IF_SKIP(Init());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkAttachmentDescription attach[] = {
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
@@ -1083,7 +1083,7 @@ TEST_F(NegativeRenderPass, BeginWithinRenderPass) {
     InitRenderTarget();
 
     // Bind a BeginRenderPass within an active RenderPass
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Just use a dummy Renderpass
@@ -1168,7 +1168,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsFramebufferImageUsageMismatches) {
     vkt::ImageView iav = iai.CreateView();
 
     // Create an input depth attachment view
-    VkFormat dformat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat dformat = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image iadi(*m_device, 128, 128, 1, dformat, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
     vkt::ImageView iadv = iadi.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
 
@@ -1300,7 +1300,7 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
     auto test = [this](VkImageLayout depth_initial_layout, VkImageLayout stencil_initial_layout, const char *rp1_vuid,
                        const char *rp2_vuid) {
         // Create an input attachment with a depth stencil format, without VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT
-        VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(gpu());
+        VkFormat depth_stencil_format = FindSupportedDepthStencilFormat(Gpu());
         vkt::Image input_image(*m_device, 128, 128, 1, depth_stencil_format, VK_IMAGE_USAGE_INPUT_ATTACHMENT_BIT);
 
         vkt::ImageView input_view = input_image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
@@ -1320,8 +1320,8 @@ TEST_F(NegativeRenderPass, BeginLayoutsStencilBufferImageUsageMismatches) {
         rp.AddInputAttachment(0);
         rp.CreateRenderPass();
 
-        const uint32_t fb_width = input_image.width();
-        const uint32_t fb_height = input_image.height();
+        const uint32_t fb_width = input_image.Width();
+        const uint32_t fb_height = input_image.Height();
         vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &input_view.handle(), fb_width, fb_height);
 
         // Begin render pass and trigger errors
@@ -1388,9 +1388,9 @@ TEST_F(NegativeRenderPass, BeginStencilFormat) {
         m_errorMonitor->VerifyFound();
     };
 
-    test(FindSupportedDepthStencilFormat(gpu()), VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
+    test(FindSupportedDepthStencilFormat(Gpu()), VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL,
          "VUID-VkRenderPassCreateInfo2-attachment-06244");
-    test(FindSupportedDepthStencilFormat(gpu()), VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
+    test(FindSupportedDepthStencilFormat(Gpu()), VK_IMAGE_LAYOUT_STENCIL_ATTACHMENT_OPTIMAL,
          "VUID-VkRenderPassCreateInfo2-attachment-06245");
     test(VK_FORMAT_S8_UINT, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, "VUID-VkRenderPassCreateInfo2-attachment-06246");
 }
@@ -1427,8 +1427,8 @@ TEST_F(NegativeRenderPass, BeginClearOpMismatch) {
     vkt::RenderPass rp(*m_device, rpci);
 
     VkRenderPassBeginInfo rp_begin = vku::InitStructHelper();
-    rp_begin.renderPass = renderPass();
-    rp_begin.framebuffer = framebuffer();
+    rp_begin.renderPass = RenderPass();
+    rp_begin.framebuffer = Framebuffer();
     rp_begin.renderArea.extent = {1, 1};
     rp_begin.clearValueCount = 0;  // Should be 1
 
@@ -1511,10 +1511,10 @@ TEST_F(NegativeRenderPass, DestroyWhileInUse) {
     rp.AddColorAttachment(0);
     rp.CreateRenderPass();
 
-    m_command_buffer.begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer());
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp.Handle(), Framebuffer());
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 
@@ -1538,7 +1538,7 @@ TEST_F(NegativeRenderPass, FramebufferDepthStencilResolveAttachment) {
 
     uint32_t attachmentWidth = 512;
     uint32_t attachmentHeight = 512;
-    VkFormat attachmentFormat = FindSupportedDepthStencilFormat(gpu());
+    VkFormat attachmentFormat = FindSupportedDepthStencilFormat(Gpu());
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(attachmentFormat, VK_SAMPLE_COUNT_4_BIT);  // Depth/stencil
@@ -1611,14 +1611,14 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
-    cbii.renderPass = renderPass();
+    cbii.renderPass = RenderPass();
     cbii.framebuffer = fb.handle();
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cbbi.pInheritanceInfo = &cbii;
-    sec_cb.begin(&cbbi);
-    sec_cb.end();
+    sec_cb.Begin(&cbbi);
+    sec_cb.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdExecuteCommands-pCommandBuffers-00099");
@@ -1626,7 +1626,7 @@ TEST_F(NegativeRenderPass, FramebufferIncompatible) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, FramebufferIncompatibleNoHandle) {
@@ -1644,7 +1644,7 @@ TEST_F(NegativeRenderPass, FramebufferIncompatibleNoHandle) {
 
     VkCommandBufferBeginInfo cbbi = vku::InitStructHelper();
     VkCommandBufferInheritanceInfo cbii = vku::InitStructHelper();
-    cbii.renderPass = renderPass();
+    cbii.renderPass = RenderPass();
     cbii.framebuffer = CastFromUint64<VkFramebuffer>(0xFFFFEEEE);
     cbbi.flags = VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT | VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     cbbi.pInheritanceInfo = &cbii;
@@ -1660,14 +1660,14 @@ TEST_F(NegativeRenderPass, NullRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Don't care about RenderPass handle b/c error should be flagged before
     // that
     vk::CmdBeginRenderPass(m_command_buffer.handle(), NULL, VK_SUBPASS_CONTENTS_INLINE);
 
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, FramebufferAttachmentPointers) {
@@ -1715,7 +1715,7 @@ TEST_F(NegativeRenderPass, EndCommandBufferWithinRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::EndCommandBuffer(m_command_buffer.handle());
 
@@ -1724,7 +1724,7 @@ TEST_F(NegativeRenderPass, EndCommandBufferWithinRenderPass) {
     // End command buffer properly to avoid driver issues. This is safe -- the
     // previous vk::EndCommandBuffer should not have reached the driver.
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // TODO: Add test for VK_COMMAND_BUFFER_LEVEL_SECONDARY
     // TODO: Add test for VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT
@@ -1772,7 +1772,7 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPass) {
 
     // Finalize recording of the command buffer
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1854,7 +1854,7 @@ TEST_F(NegativeRenderPass, DrawWithPipelineIncompatibleWithRenderPassFragmentDen
 
     // Finalize recording of the command buffer
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1877,11 +1877,11 @@ TEST_F(NegativeRenderPass, MissingAttachment) {
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-parameter");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     // Don't call vk::CmdEndRenderPass; as the begin has been "skipped" based on the error condition
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 class RenderPassCreatePotentialFormatFeaturesTest : public NegativeRenderPass {
@@ -1921,14 +1921,14 @@ void RenderPassCreatePotentialFormatFeaturesTest::Test(bool const useLinearColor
     const VkFormat invalidColorFormat = VK_FORMAT_B8G8R8A8_UNORM;
     const VkFormat depthFormat = VK_FORMAT_D16_UNORM;
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), invalidColorFormat, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), invalidColorFormat, &formatProps);
     formatProps.linearTilingFeatures = 0;
     formatProps.optimalTilingFeatures = 0;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), invalidColorFormat, formatProps);
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), depthFormat, &formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), invalidColorFormat, formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), depthFormat, &formatProps);
     formatProps.linearTilingFeatures = 0;
     formatProps.optimalTilingFeatures = 0;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), depthFormat, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), depthFormat, formatProps);
 
     VkAttachmentDescription attachments[4] = {
         {0, validColorFormat, VK_SAMPLE_COUNT_1_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE,
@@ -2043,9 +2043,9 @@ TEST_F(NegativeRenderPass, DepthStencilResolveMode) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    VkFormat depthFormat = FindSupportedDepthOnlyFormat(gpu());
-    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(gpu());
-    VkFormat stencilFormat = FindSupportedStencilOnlyFormat(gpu());
+    VkFormat depthFormat = FindSupportedDepthOnlyFormat(Gpu());
+    VkFormat depthStencilFormat = FindSupportedDepthStencilFormat(Gpu());
+    VkFormat stencilFormat = FindSupportedStencilOnlyFormat(Gpu());
     if (stencilFormat == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -2202,7 +2202,7 @@ TEST_F(NegativeRenderPass, RenderArea) {
 
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper();
     rpbinfo.renderPass = m_renderPass;
-    rpbinfo.framebuffer = framebuffer();
+    rpbinfo.framebuffer = Framebuffer();
     rpbinfo.renderArea.extent.width = m_width;
     rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;
@@ -2210,7 +2210,7 @@ TEST_F(NegativeRenderPass, RenderArea) {
     rpbinfo.clearValueCount = 1;
     rpbinfo.pClearValues = m_renderPassClearValues.data();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-pNext-02850");
     m_command_buffer.BeginRenderPass(rpbinfo);
     m_errorMonitor->VerifyFound();
@@ -2236,7 +2236,7 @@ TEST_F(NegativeRenderPass, RenderArea) {
     m_command_buffer.BeginRenderPass(rpbinfo);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
@@ -2260,7 +2260,7 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
 
     VkRenderPassBeginInfo rpbinfo = vku::InitStructHelper(&device_group_render_pass_begin_info);
     rpbinfo.renderPass = m_renderPass;
-    rpbinfo.framebuffer = framebuffer();
+    rpbinfo.framebuffer = Framebuffer();
     rpbinfo.renderArea.extent.width = m_width;
     rpbinfo.renderArea.extent.height = m_height;
     rpbinfo.renderArea.offset.x = -32;
@@ -2268,7 +2268,7 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
     rpbinfo.clearValueCount = 1;
     rpbinfo.pClearValues = m_renderPassClearValues.data();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06166");
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupRenderPassBeginInfo-offset-06167");
@@ -2285,7 +2285,7 @@ TEST_F(NegativeRenderPass, DeviceGroupRenderArea) {
     m_command_buffer.BeginRenderPass(rpbinfo);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, RenderPassBeginNullValues) {
@@ -2308,7 +2308,7 @@ TEST_F(NegativeRenderPass, DepthStencilResolveAttachmentFormat) {
     AddRequiredExtensions(VK_KHR_DEPTH_STENCIL_RESOLVE_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     RenderPass2SingleSubpass rp(*this);
     rp.AddAttachmentDescription(VK_FORMAT_R8_UNORM, VK_SAMPLE_COUNT_1_BIT);  // Depth/stencil
@@ -2380,7 +2380,7 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
 
     const uint32_t width = 32;
     const uint32_t height = 32;
-    const VkFormat format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat format = FindSupportedDepthStencilFormat(Gpu());
 
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(format, VK_IMAGE_LAYOUT_DEPTH_STENCIL_READ_ONLY_OPTIMAL,
@@ -2435,14 +2435,14 @@ TEST_F(NegativeRenderPass, SamplingFromReadOnlyDepthStencilAttachment) {
     pipe.ds_ci_.stencilTestEnable = VK_TRUE;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), width, height, 1, m_renderPassClearValues.data());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, ColorAttachmentImageViewUsage) {
@@ -2489,7 +2489,7 @@ TEST_F(NegativeRenderPass, StencilLoadOp) {
     AddRequiredExtensions(VK_KHR_SEPARATE_DEPTH_STENCIL_LAYOUTS_EXTENSION_NAME);
     RETURN_IF_SKIP(Init());
 
-    const VkFormat stencil_format = FindSupportedStencilOnlyFormat(gpu());
+    const VkFormat stencil_format = FindSupportedStencilOnlyFormat(Gpu());
     if (stencil_format == VK_FORMAT_UNDEFINED) {
         GTEST_SKIP() << "Couldn't find a stencil only image format";
     }
@@ -2598,7 +2598,7 @@ TEST_F(NegativeRenderPass, AttachmentUndefinedLayout) {
     RETURN_IF_SKIP(Init());
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkSubpassDescription subpass = {};
     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
@@ -2820,13 +2820,13 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     begin_rendering_info.pColorAttachments = &color_attachment;
     begin_rendering_info.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(begin_rendering_info);
     // ms_render_to_ss.rasterizationSamples != ms_state.rasterizationSamples
     // Valid because never hit draw time
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_helper.Handle());
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     VkImageFormatProperties2 image_format_prop = vku::InitStructHelper();
     VkPhysicalDeviceImageFormatInfo2 image_format_info = vku::InitStructHelper();
@@ -2834,7 +2834,8 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     image_format_info.type = VK_IMAGE_TYPE_2D;
     image_format_info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     image_format_info.format = VK_FORMAT_B8G8R8A8_UNORM;
-    VkResult result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+    VkResult result =
+        vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
     if ((result != VK_SUCCESS) || !(image_format_prop.imageFormatProperties.sampleCounts & VK_SAMPLE_COUNT_2_BIT)) {
         GTEST_SKIP() << "Cannot create an image with format VK_FORMAT_B8G8R8A8_UNORM and sample count VK_SAMPLE_COUNT_2_BIT. "
                         "Skipping remainder of the test";
@@ -2856,7 +2857,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     vkt::ImageView two_count_image_view(*m_device, image_view_ci);
 
     color_attachment.imageView = two_count_image_view.handle();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Attachments must have a sample count that is either VK_SAMPLE_COUNT_1_BIT or
     // VkMultisampledRenderToSingleSampledInfoEXT::rasterizationSamples.
     m_errorMonitor->SetDesiredError("VUID-VkRenderingInfo-imageView-06858");
@@ -2940,7 +2941,7 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     VkSampleCountFlagBits unsampleable_count = VK_SAMPLE_COUNT_1_BIT;
     for (VkFormat format = VK_FORMAT_UNDEFINED; format <= VK_FORMAT_ASTC_12x12_SRGB_BLOCK; format = VkFormat(format + 1)) {
         image_format_info.format = format;
-        result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy().handle(), &image_format_info, &image_format_prop);
+        result = vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical().handle(), &image_format_info, &image_format_prop);
         if (result == VK_SUCCESS) {
             if (image_format_prop.imageFormatProperties.sampleCounts != 0x7f) {
                 unsampleable_format = format;
@@ -3055,16 +3056,16 @@ TEST_F(NegativeRenderPass, MultisampledRenderToSingleSampled) {
     vk::CreateImage(device(), &image_create_info, nullptr, &bad_flag_image);
     m_errorMonitor->VerifyFound();
 
-    vkt::QueueCreateInfoArray queue_info(m_device->phy().queue_properties_);
+    vkt::QueueCreateInfoArray queue_info(m_device->Physical().queue_properties_);
     VkDeviceCreateInfo device_create_info = vku::InitStructHelper();
-    device_create_info.queueCreateInfoCount = queue_info.size();
-    device_create_info.pQueueCreateInfos = queue_info.data();
+    device_create_info.queueCreateInfoCount = queue_info.Size();
+    device_create_info.pQueueCreateInfos = queue_info.Data();
     device_create_info.pEnabledFeatures = nullptr;
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
     device_create_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
     VkDevice second_device;
-    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(gpu(), &device_create_info, nullptr, &second_device));
+    ASSERT_EQ(VK_SUCCESS, vk::CreateDevice(Gpu(), &device_create_info, nullptr, &second_device));
     image_create_info.samples = VK_SAMPLE_COUNT_1_BIT;
     bad_flag_image = VK_NULL_HANDLE;
     // VK_IMAGE_CREATE_MULTISAMPLED_RENDER_TO_SINGLE_SAMPLED_BIT_EXT requires multisampledRenderToSingleSampled feature
@@ -3146,7 +3147,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     clear_values[0].color = {{0, 0, 0, 0}};
     clear_values[1].color = {{0, 0, 0, 0}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-renderPass-00904");
     m_command_buffer.BeginRenderPass(render_pass2.handle(), framebuffer.handle(), width, height, 2, clear_values);
@@ -3157,7 +3158,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass) {
     m_command_buffer.BeginRenderPass(render_pass3.handle(), framebuffer.handle(), width, height, 2, clear_values);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
@@ -3233,7 +3234,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     clear_values[0].color = {{0, 0, 0, 0}};
     clear_values[1].color = {{0, 0, 0, 0}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-renderPass-00904");
     m_command_buffer.BeginRenderPass(render_pass2.handle(), framebuffer.handle(), width, height, 2, clear_values);
@@ -3243,7 +3244,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPass2) {
     m_command_buffer.BeginRenderPass(render_pass3.handle(), framebuffer.handle(), width, height, 2, clear_values);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, IncompatibleRenderPassSubpassFlags) {
@@ -3307,7 +3308,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPassSubpassFlags) {
     pipe.gp_ci_.renderPass = render_pass2.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-renderPass-00904");
     m_command_buffer.BeginRenderPass(render_pass2.handle(), framebuffer.handle(), 32, 32, 2, clear_values);
@@ -3321,7 +3322,7 @@ TEST_F(NegativeRenderPass, IncompatibleRenderPassSubpassFlags) {
     m_errorMonitor->VerifyFound();
 
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
@@ -3338,7 +3339,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayout) {
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,
          VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL},
         // Depth stencil attachment
-        {0, FindSupportedDepthStencilFormat(m_device->phy()), VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        {0, FindSupportedDepthStencilFormat(m_device->Physical()), VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
          VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
          VK_IMAGE_LAYOUT_GENERAL},
     }};
@@ -3556,7 +3557,7 @@ TEST_F(NegativeRenderPass, SubpassAttachmentImageLayoutSeparateDepthStencil) {
         {0, VK_FORMAT_R8G8B8A8_UNORM, VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_STORE,
          VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_GENERAL},
         // Depth stencil attachment
-        {0, FindSupportedDepthStencilFormat(m_device->phy()), VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
+        {0, FindSupportedDepthStencilFormat(m_device->Physical()), VK_SAMPLE_COUNT_2_BIT, VK_ATTACHMENT_LOAD_OP_DONT_CARE,
          VK_ATTACHMENT_STORE_OP_STORE, VK_ATTACHMENT_LOAD_OP_DONT_CARE, VK_ATTACHMENT_STORE_OP_DONT_CARE, VK_IMAGE_LAYOUT_UNDEFINED,
          VK_IMAGE_LAYOUT_GENERAL},
     }};
@@ -3677,7 +3678,7 @@ TEST_F(NegativeRenderPass, BeginInfoWithoutRenderPass) {
     TEST_DESCRIPTION("call VkRenderPassBeginInfo with invalid renderpass");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-renderPass-parameter");
     m_renderPassBeginInfo.renderPass = CastFromUint64<VkRenderPass>(0xFFFFEEEE);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
@@ -3686,41 +3687,41 @@ TEST_F(NegativeRenderPass, BeginInfoWithoutRenderPass) {
     m_renderPassBeginInfo.renderPass = VK_NULL_HANDLE;
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, BeginInfoWithoutFramebuffer) {
     TEST_DESCRIPTION("call VkRenderPassBeginInfo with invalid framebuffer");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-parameter");
     m_renderPassBeginInfo.framebuffer = CastFromUint64<VkFramebuffer>(0xFFFFEEEE);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, EndWithoutRenderPass) {
     TEST_DESCRIPTION("call vkCmdEndRenderPass never starting a renderpass");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass-renderpass");
     m_command_buffer.EndRenderPass();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, RenderPassBegin) {
     TEST_DESCRIPTION("have an invalid pRenderPassBegin");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass-pRenderPassBegin-parameter");
     vk::CmdBeginRenderPass(m_command_buffer.handle(), nullptr, VK_SUBPASS_CONTENTS_INLINE);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, IncompatibleFramebuffer) {
@@ -3757,7 +3758,7 @@ TEST_F(NegativeRenderPass, ZeroRenderArea) {
     TEST_DESCRIPTION("renderArea set to zero");
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-None-08996");
     m_renderPassBeginInfo.renderArea.extent = {0, 64};
@@ -3769,7 +3770,7 @@ TEST_F(NegativeRenderPass, ZeroRenderArea) {
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, InvalidAttachmentDescriptionDSLayout) {
@@ -3778,7 +3779,7 @@ TEST_F(NegativeRenderPass, InvalidAttachmentDescriptionDSLayout) {
     AddRequiredFeature(vkt::Feature::separateDepthStencilLayouts);
     RETURN_IF_SKIP(Init());
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkAttachmentDescription description = {0,
                                            ds_format,
@@ -3960,13 +3961,13 @@ TEST_F(NegativeRenderPass, AttachmentLayout) {
     ImageMemoryBarrier.image = image.handle();
     ImageMemoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0u, 0u, nullptr, 0u, nullptr, 1u, &ImageMemoryBarrier);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass-initialLayout-00900");
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, ImageSubresourceOverlapBetweenCurrentRenderPassAndDescriptorSets) {
@@ -4011,9 +4012,9 @@ TEST_F(NegativeRenderPass, ImageSubresourceOverlapBetweenCurrentRenderPassAndDes
 
     VkClearValue clear_values[2] = {m_renderPassClearValues[0], m_renderPassClearValues[0]};
 
-    m_command_buffer.begin();
-    m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer(), width, height, 2, clear_values);
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(render_pass.handle(), Framebuffer(), width, height, 2, clear_values);
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -4048,11 +4049,11 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
     m_renderPassBeginInfo.pNext = &rp_stripe_info;
     m_renderPassBeginInfo.renderArea = {{0, 0}, {stripe_width * stripe_count, stripe_height}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeInfoCount-09450");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     stripe_count = 8;
     stripe_infos.resize(stripe_count);
@@ -4066,13 +4067,13 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t half_stripe_width = stripe_width / 2;
     for (uint32_t i = 0; i < stripe_count; ++i) {
@@ -4082,13 +4083,13 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09452");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09453");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t non_align_stripe_width = stripe_width - 12;
     m_renderPassBeginInfo.renderArea.extent.width = (stripe_width * (stripe_count - 1)) + non_align_stripe_width + 4;
@@ -4099,12 +4100,12 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09453");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-pNext-09539");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_renderPassBeginInfo.renderArea.extent = {stripe_width, stripe_height * stripe_count};
     const uint32_t half_stripe_height = stripe_height / 2;
@@ -4115,13 +4116,13 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = i == 2 ? half_stripe_height : stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeBeginInfoARM-stripeArea-09451");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09454");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09455");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     const uint32_t non_align_stripe_height = stripe_height - 12;
     m_renderPassBeginInfo.renderArea.extent.height = (stripe_height * (stripe_count - 1)) + non_align_stripe_height + 4;
@@ -4132,12 +4133,12 @@ TEST_F(NegativeRenderPass, BeginRenderPassWithRenderPassStriped) {
         stripe_infos[i].stripeArea.extent.height = i == 7 ? non_align_stripe_height : stripe_height;
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassStripeInfoARM-stripeArea-09455");
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-pNext-09539");
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, RenderPassWithRenderPassStripedQueueSubmit2) {
@@ -4179,10 +4180,10 @@ TEST_F(NegativeRenderPass, RenderPassWithRenderPassStripedQueueSubmit2) {
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
 
-    cmd_buffer.begin(&cmd_begin);
+    cmd_buffer.Begin(&cmd_begin);
     cmd_buffer.BeginRenderPass(m_renderPassBeginInfo);
     cmd_buffer.EndRenderPass();
-    cmd_buffer.end();
+    cmd_buffer.End();
 
     VkCommandBufferSubmitInfo cb_submit_info = vku::InitStructHelper();
     cb_submit_info.commandBuffer = cmd_buffer.handle();
@@ -4228,12 +4229,12 @@ TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginRenderPass-contents-09640");
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo,
                            VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_KHR);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature2) {
@@ -4247,9 +4248,9 @@ TEST_F(NegativeRenderPass, MissingNestedCommandBuffersFeature2) {
     auto subpassBeginInfo =
         vku::InitStruct<VkSubpassBeginInfoKHR>(nullptr, VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_KHR);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkSubpassBeginInfo-contents-09382");
     vk::CmdBeginRenderPass2KHR(m_command_buffer.handle(), &m_renderPassBeginInfo, &subpassBeginInfo);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/render_pass_positive.cpp
+++ b/tests/unit/render_pass_positive.cpp
@@ -54,13 +54,13 @@ TEST_F(PositiveRenderPass, InitialLayoutUndefined) {
     // Record a single command buffer which uses this renderpass twice. The
     // bug is triggered at the beginning of the second renderpass, when the
     // command buffer already has a layout recorded for the attachment.
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     m_command_buffer.EndRenderPass();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, AttachmentLayoutWithLoadOpThenReadOnly) {
@@ -68,7 +68,7 @@ TEST_F(PositiveRenderPass, AttachmentLayoutWithLoadOpThenReadOnly) {
         "Positive test where we create a renderpass with an attachment that uses LOAD_OP_CLEAR, the first subpass has a valid "
         "layout, and a second subpass then uses a valid *READ_ONLY* layout.");
     RETURN_IF_SKIP(Init());
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     VkAttachmentReference attach[2] = {};
     attach[0].attachment = 0;
@@ -124,7 +124,7 @@ TEST_F(PositiveRenderPass, BeginSubpassZeroTransitionsApplied) {
     // image memory barrier for the attachment. This detects the previously
     // missing tracking of the subpass layout by throwing a validation error
     // if it doesn't occur.
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
 
     image.ImageMemoryBarrier(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT,
@@ -132,7 +132,7 @@ TEST_F(PositiveRenderPass, BeginSubpassZeroTransitionsApplied) {
                              VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, BeginTransitionsAttachmentUnused) {
@@ -154,18 +154,18 @@ TEST_F(PositiveRenderPass, BeginTransitionsAttachmentUnused) {
 
     // Record a command buffer which just begins and ends the renderpass. The
     // bug manifests in BeginRenderPass.
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     TEST_DESCRIPTION("Create a stencil-only attachment with a LOAD_OP set to CLEAR. stencil[Load|Store]Op used to be ignored.");
     RETURN_IF_SKIP(Init());
-    VkFormat depth_stencil_fmt = FindSupportedDepthStencilFormat(gpu());
+    VkFormat depth_stencil_fmt = FindSupportedDepthStencilFormat(Gpu());
     VkImageFormatProperties formatProps;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), depth_stencil_fmt, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), depth_stencil_fmt, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_SRC_BIT, 0,
                                                &formatProps);
     if (formatProps.maxExtent.width < 100 || formatProps.maxExtent.height < 100) {
@@ -189,10 +189,10 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     vkt::ImageView depth_image_view = m_depthStencil->CreateView(VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT);
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_image_view.handle(), 100, 100);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 100, 100, 1, &clear);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -200,7 +200,7 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     vkt::Image destImage(*m_device, 100, 100, 1, depth_stencil_fmt,
                          VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT);
     vkt::CommandBuffer cmdbuf(*m_device, m_command_pool);
-    cmdbuf.begin();
+    cmdbuf.Begin();
 
     m_depthStencil->ImageMemoryBarrier(cmdbuf, VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT,
                                        VK_ACCESS_TRANSFER_READ_BIT | VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_READ_BIT,
@@ -218,7 +218,7 @@ TEST_F(PositiveRenderPass, BeginStencilLoadOp) {
     cregion.extent = {100, 100, 1};
     vk::CmdCopyImage(cmdbuf.handle(), m_depthStencil->handle(), VK_IMAGE_LAYOUT_TRANSFER_SRC_OPTIMAL, destImage.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &cregion);
-    cmdbuf.end();
+    cmdbuf.End();
     m_default_queue->Submit(cmdbuf);
     m_default_queue->Wait();
 }
@@ -227,14 +227,14 @@ TEST_F(PositiveRenderPass, BeginInlineAndSecondaryCommandBuffers) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     m_command_buffer.EndRenderPass();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
@@ -243,9 +243,9 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
         "by render pass and verify that transition has correctly occurred at queue submit time with no validation errors.");
 
     RETURN_IF_SKIP(Init());
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
     VkImageFormatProperties format_props;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), depth_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), depth_format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT, 0, &format_props);
     if (format_props.maxExtent.width < 32 || format_props.maxExtent.height < 32) {
         GTEST_SKIP() << "Depth extent too small";
@@ -266,10 +266,10 @@ TEST_F(PositiveRenderPass, BeginDepthStencilLayoutTransitionFromUndefined) {
     vkt::ImageView view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -291,7 +291,7 @@ TEST_F(PositiveRenderPass, DestroyPipeline) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     // Destroy renderPass before pipeline is used in Draw
@@ -300,7 +300,7 @@ TEST_F(PositiveRenderPass, DestroyPipeline) {
     rp.Destroy();
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -381,7 +381,7 @@ TEST_F(PositiveRenderPass, ImagelessFramebufferNonZeroBaseMip) {
     VkCommandBufferBeginInfo cmd_begin_info = {VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                                VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT, nullptr};
 
-    m_command_buffer.begin(&cmd_begin_info);
+    m_command_buffer.Begin(&cmd_begin_info);
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &rp_begin_info, VK_SUBPASS_CONTENTS_INLINE);
 }
 
@@ -524,7 +524,7 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
 
     // Start pushing commands.
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, NULL);
@@ -543,7 +543,7 @@ TEST_F(PositiveRenderPass, SingleMipTransition) {
 
     depthImage.Layout(VK_IMAGE_LAYOUT_GENERAL);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, ViewMasks) {
@@ -651,14 +651,14 @@ TEST_F(PositiveRenderPass, BeginWithViewMasks) {
     descriptor_write.descriptorType = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
     descriptor_write.dstSet = 0;  // Should not cause a validation error
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
     vk::CmdPushDescriptorSetKHR(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.pipeline_layout_.handle(), 0, 1,
                                 &descriptor_write);
     m_command_buffer.BeginRenderPass(render_pass.handle(), fb.handle(), 32, 32);
     m_command_buffer.NextSubpass();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
@@ -676,7 +676,7 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     RETURN_IF_SKIP(InitState(nullptr, &vulkan_12_features));
 
     // Create depth stencil image
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image ds_image(*m_device, 32, 32, 1, ds_format,
                         VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
@@ -696,7 +696,7 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     rp.AddDepthStencilAttachment(0);
     rp.CreateRenderPass();
 
-    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &ds_view.handle(), ds_image.width(), ds_image.height());
+    vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &ds_view.handle(), ds_image.Width(), ds_image.Height());
 
     // Use helper to create graphics pipeline
     VkPipelineDepthStencilStateCreateInfo ds_state = vku::InitStructHelper();
@@ -709,14 +709,14 @@ TEST_F(PositiveRenderPass, BeginDedicatedStencilLayout) {
     helper.gp_ci_.renderPass = rp.Handle();
     helper.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
-    m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), ds_image.width(), ds_image.height());
+    m_command_buffer.Begin();
+    m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), ds_image.Width(), ds_image.Height());
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, helper.Handle());
     // If the stencil layout was not specified separately using the separateDepthStencilLayouts feature,
     // and used in the validation code, 06887 would trigger with the following draw call
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, QueriesInMultiview) {
@@ -768,7 +768,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_OCCLUSION, 2);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetQueryPool(m_command_buffer.handle(), query_pool.handle(), 0, 2);
 
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
@@ -777,7 +777,7 @@ TEST_F(PositiveRenderPass, QueriesInMultiview) {
     m_command_buffer.EndRenderPass();
 
     vk::CmdCopyQueryPoolResults(m_command_buffer.handle(), query_pool.handle(), 0, 2, buffer.handle(), 0, 4, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -802,7 +802,7 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
 
     RETURN_IF_SKIP(Init());
     VkFormatProperties format_properties;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_D32_SFLOAT_S8_UINT, &format_properties);
     if (!(format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Image format does not support sampling";
     }
@@ -821,7 +821,7 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
     vkt::ImageView view = image.CreateView(VK_IMAGE_ASPECT_DEPTH_BIT);
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier imb = vku::InitStructHelper();
     imb.srcAccessMask = VK_ACCESS_DEPTH_STENCIL_ATTACHMENT_WRITE_BIT;
@@ -840,7 +840,7 @@ TEST_F(PositiveRenderPass, FramebufferCreateDepthStencilLayoutTransitionForDepth
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_EARLY_FRAGMENT_TESTS_BIT,
                            VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1, &imb);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -918,13 +918,13 @@ TEST_F(PositiveRenderPass, FramebufferWithAttachmentsTo3DImageMultipleSubpasses)
     vkt::Framebuffer framebuffer(*m_device, renderpass.handle(), depth_count, views, image_info.extent.width,
                                  image_info.extent.height);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(renderpass.handle(), framebuffer.handle(), image_info.extent.width, image_info.extent.height);
     for (unsigned i = 0; i < (depth_count - 1); ++i) {
         m_command_buffer.NextSubpass();
     }
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
@@ -1003,7 +1003,7 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
 
     vkt::Framebuffer framebuffer_2(*m_device, rp_2.Handle(), 1, &views[1], image_info.extent.width, image_info.extent.height);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BeginRenderPass(rp_1.Handle(), framebuffer_1.handle(), image_info.extent.width, image_info.extent.height);
     m_command_buffer.EndRenderPass();
@@ -1011,14 +1011,14 @@ TEST_F(PositiveRenderPass, ImageLayoutTransitionOf3dImageWith2dViews) {
     m_command_buffer.BeginRenderPass(rp_2.Handle(), framebuffer_2.handle(), image_info.extent.width, image_info.extent.height);
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, SubpassWithReadOnlyLayoutWithoutDependency) {
     TEST_DESCRIPTION("When both subpasses' attachments are the same and layouts are read-only, they don't need dependency.");
     RETURN_IF_SKIP(Init());
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     // A renderpass with one color attachment.
     VkAttachmentDescription attachment = {0,
@@ -1051,11 +1051,11 @@ TEST_F(PositiveRenderPass, SubpassWithReadOnlyLayoutWithoutDependency) {
 
     vkt::Framebuffer fb(*m_device, rp.handle(), size, views.data());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     m_command_buffer.NextSubpass();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
@@ -1069,10 +1069,10 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
 
     VkFormat ds_format = VK_FORMAT_D24_UNORM_S8_UINT;
     VkFormatProperties props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), ds_format, &props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), ds_format, &props);
     if ((props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) == 0) {
         ds_format = VK_FORMAT_D32_SFLOAT_S8_UINT;
-        vk::GetPhysicalDeviceFormatProperties(gpu(), ds_format, &props);
+        vk::GetPhysicalDeviceFormatProperties(Gpu(), ds_format, &props);
         ASSERT_TRUE((props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0);
     }
 
@@ -1101,7 +1101,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     std::vector<VkImageMemoryBarrier> barriers;
 
     {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         auto depth_barrier =
             image.ImageMemoryBarrier(0, 0, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_OPTIMAL, depth_range);
         auto stencil_barrier =
@@ -1110,13 +1110,13 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
                                0, nullptr, 0, nullptr, 1, &depth_barrier);
         vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
                                0, nullptr, 0, nullptr, 1, &stencil_barrier);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Test that we handle initial layout in command buffer.
     barriers.push_back(image.ImageMemoryBarrier(0, 0, VK_IMAGE_LAYOUT_DEPTH_ATTACHMENT_STENCIL_READ_ONLY_OPTIMAL,
@@ -1199,7 +1199,7 @@ TEST_F(PositiveRenderPass, SeparateDepthStencilSubresourceLayout) {
     m_command_buffer.BeginRenderPass(render_pass_combined.handle(), framebuffer_combined.handle());
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -1243,7 +1243,7 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
     }
     ASSERT_NO_FATAL_FAILURE(InitState(nullptr, nullptr, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT));
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->phy());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(m_device->Physical());
     vkt::Image depthImage(*m_device, 32, 32, 1, ds_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     for (size_t i = 0; i < 2; i++) {
@@ -1258,7 +1258,7 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
 
         const vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &depth_or_stencil_view.handle());
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
         m_command_buffer.EndRenderPass();
@@ -1276,7 +1276,7 @@ TEST_F(PositiveRenderPass, TestDepthStencilRenderPassTransition) {
         vk::CmdPipelineBarrier(m_command_buffer.handle(),
                                VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT | VK_PIPELINE_STAGE_LATE_FRAGMENT_TESTS_BIT,
                                VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr, 1, &img_barrier);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer);
         m_default_queue->Wait();
@@ -1319,10 +1319,10 @@ TEST_F(PositiveRenderPass, BeginRenderPassWithRenderPassStriped) {
     vkt::CommandBuffer cmd_buffer(*m_device, command_pool);
 
     VkCommandBufferBeginInfo cmd_begin = vku::InitStructHelper();
-    cmd_buffer.begin(&cmd_begin);
+    cmd_buffer.Begin(&cmd_begin);
     cmd_buffer.BeginRenderPass(m_renderPassBeginInfo);
     cmd_buffer.EndRenderPass();
-    cmd_buffer.end();
+    cmd_buffer.End();
 
     VkSemaphoreCreateInfo semaphore_create_info = vku::InitStructHelper();
     vkt::Semaphore semaphores[stripe_count];
@@ -1359,11 +1359,11 @@ TEST_F(PositiveRenderPass, NestedCommandBuffersFeatureMaintenance7) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRenderPass(m_command_buffer.handle(), &m_renderPassBeginInfo,
                            VK_SUBPASS_CONTENTS_INLINE_AND_SECONDARY_COMMAND_BUFFERS_KHR);
     vk::CmdEndRenderPass(m_command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRenderPass, RenderPassSampleLocationsBeginInfo) {
@@ -1463,12 +1463,12 @@ TEST_F(PositiveRenderPass, RenderPassSampleLocationsBeginInfo) {
     render_pass_begin_info.clearValueCount = 1;
     render_pass_begin_info.pClearValues = &color_clear_value;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass_begin_info);
 
     sample_location.x = 1.0f;
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/robustness_positive.cpp
+++ b/tests/unit/robustness_positive.cpp
@@ -79,12 +79,12 @@ TEST_F(PositiveRobustness, BindVertexBuffers2EXTNullDescriptors) {
     descriptor_set.UpdateDescriptorSets();
     descriptor_set.Clear();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkBuffer buffer = VK_NULL_HANDLE;
     VkDeviceSize offset = 0;
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer, &offset);
     vk::CmdBindVertexBuffers2EXT(m_command_buffer.handle(), 0, 1, &buffer, &offset, nullptr, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveRobustness, PipelineRobustnessRobustImageAccessExposed) {

--- a/tests/unit/sampler.cpp
+++ b/tests/unit/sampler.cpp
@@ -73,7 +73,7 @@ TEST_F(NegativeSampler, AnisotropyFeatureEnabled) {
     sampler_info.maxAnisotropy = sampler_info_ref.maxAnisotropy;
 
     // maxAnisotropy out-of-bounds high.
-    sampler_info.maxAnisotropy = NearestGreater(m_device->phy().limits_.maxSamplerAnisotropy);
+    sampler_info.maxAnisotropy = NearestGreater(m_device->Physical().limits_.maxSamplerAnisotropy);
     CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-anisotropyEnable-01071");
     sampler_info.maxAnisotropy = sampler_info_ref.maxAnisotropy;
 
@@ -175,7 +175,7 @@ TEST_F(NegativeSampler, BasicUsage) {
     sampler_info.maxLod = sampler_info_ref.maxLod;
 
     // Larger mipLodBias than max limit
-    sampler_info.mipLodBias = NearestGreater(m_device->phy().limits_.maxSamplerLodBias);
+    sampler_info.mipLodBias = NearestGreater(m_device->Physical().limits_.maxSamplerLodBias);
     CreateSamplerTest(*this, &sampler_info, "VUID-VkSamplerCreateInfo-mipLodBias-01069");
     sampler_info.mipLodBias = sampler_info_ref.mipLodBias;
 }
@@ -193,10 +193,10 @@ TEST_F(NegativeSampler, AllocationCount) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     if (props.limits.maxSamplerAllocationCount > max_samplers) {
         props.limits.maxSamplerAllocationCount = max_samplers;
-        fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+        fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     }
     RETURN_IF_SKIP(InitState());
     m_errorMonitor->SetDesiredError("VUID-vkCreateSampler-maxSamplerAllocationCount-04110");
@@ -317,7 +317,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
     for (auto &test_struct : tests) {
         for (std::pair<VkFormat, FormatTypes> cur_format_pair : formats_to_check) {
             VkFormatProperties props = {};
-            vk::GetPhysicalDeviceFormatProperties(gpu(), cur_format_pair.first, &props);
+            vk::GetPhysicalDeviceFormatProperties(Gpu(), cur_format_pair.first, &props);
             if (test_struct.format == VK_FORMAT_UNDEFINED && props.linearTilingFeatures != 0 &&
                 (props.linearTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) &&
                 !(props.linearTilingFeatures & test_struct.required_format_feature)) {
@@ -404,7 +404,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
         pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
         pipe.descriptor_set_->UpdateDescriptorSets();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -416,7 +416,7 @@ TEST_F(NegativeSampler, ImageViewFormatUnsupportedFilter) {
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         delete fs;
     }
@@ -435,10 +435,10 @@ TEST_F(NegativeSampler, LinearReductionModeMinMax) {
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UNORM;
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), format, &formatProps);
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_MINMAX_BIT);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), format, formatProps);
 
     vkt::Image image(*m_device, 128, 128, 1, format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView image_view = image.CreateView();
@@ -476,7 +476,7 @@ TEST_F(NegativeSampler, LinearReductionModeMinMax) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -531,7 +531,7 @@ TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -543,7 +543,7 @@ TEST_F(NegativeSampler, AddressModeWithCornerSampledNV) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
@@ -578,12 +578,12 @@ TEST_F(NegativeSampler, MultiplaneImageSamplerConversionMismatch) {
                                   VK_IMAGE_LAYOUT_UNDEFINED};
 
     // Verify formats
-    bool supported = ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT);
     if (!supported) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -710,10 +710,10 @@ TEST_F(NegativeSampler, ImageSamplerConversionNullImageView) {
                                   VK_IMAGE_USAGE_SAMPLED_BIT,
                                   VK_SHARING_MODE_EXCLUSIVE,
                                   VK_IMAGE_LAYOUT_UNDEFINED};
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -752,7 +752,7 @@ TEST_F(NegativeSampler, FilterMinmax) {
     ycbcr_features.samplerYcbcrConversion = VK_TRUE;
     RETURN_IF_SKIP(InitState(nullptr, &ycbcr_features));
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -906,7 +906,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -915,7 +915,7 @@ TEST_F(NegativeSampler, CustomBorderColorFormatUndefined) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
@@ -929,11 +929,11 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
     // This generates OpImage*Dref* instruction on R8G8B8A8_UNORM format.
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
         if (!(fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR)) {
             GTEST_SKIP() << "R8G8B8A8_UNORM does not support OpImage*Dref* operations";
@@ -996,7 +996,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1009,7 +1009,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCombinedSampler) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
@@ -1022,11 +1022,11 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
     // This generates OpImage*Dref* instruction on R8G8B8A8_UNORM format.
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
         if (!(fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR)) {
             GTEST_SKIP() << "R8G8B8A8_UNORM does not support OpImage*Dref* operations";
@@ -1103,7 +1103,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1116,7 +1116,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSampler) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
@@ -1171,7 +1171,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(2, image_view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1182,7 +1182,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedImage) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
@@ -1239,7 +1239,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1251,7 +1251,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesSeparateSamplerSharedSampler) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
@@ -1334,7 +1334,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 1);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1345,7 +1345,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesInBoundsAccess) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
@@ -1420,7 +1420,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1431,7 +1431,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesCopyObject) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, UnnormalizedCoordinatesLevelCount) {
@@ -1470,7 +1470,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesLevelCount) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -1481,7 +1481,7 @@ TEST_F(NegativeSampler, UnnormalizedCoordinatesLevelCount) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSampler, ReductionModeFeature) {

--- a/tests/unit/shader_compute.cpp
+++ b/tests/unit/shader_compute.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimit) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream csSource;
@@ -48,7 +48,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryBooleanOverLimit) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     // "Boolean values considered as 32-bit integer values for the purpose of this calculation."
     const uint32_t max_shared_bools = max_shared_memory_size / 4;
 
@@ -88,7 +88,7 @@ TEST_F(NegativeShaderCompute, SharedMemoryOverLimitWorkgroupMemoryExplicitLayout
         GTEST_SKIP() << "workgroupMemoryExplicitLayout feature not supported";
     }
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream csSource;
@@ -125,7 +125,7 @@ TEST_F(NegativeShaderCompute, SharedMemorySpecConstantDefault) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream cs_source;
@@ -152,7 +152,7 @@ TEST_F(NegativeShaderCompute, SharedMemorySpecConstantSet) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream cs_source;
@@ -192,7 +192,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeSpecConstant) {
     TEST_DESCRIPTION("Validate compute shader shared memory does not exceed maxComputeWorkGroupSize");
 
     RETURN_IF_SKIP(Init());
-    const VkPhysicalDeviceLimits limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits limits = m_device->Physical().limits_;
 
     // Make sure compute pipeline has a compute shader stage set
     const char *cs_source = R"glsl(
@@ -244,7 +244,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeConstantDefault) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -283,7 +283,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeSpecConstantDefault) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -328,7 +328,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeId) {
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     RETURN_IF_SKIP(InitState(nullptr, &features13));
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -369,7 +369,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantDefault) {
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     RETURN_IF_SKIP(InitState(nullptr, &features13));
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
@@ -415,7 +415,7 @@ TEST_F(NegativeShaderCompute, WorkGroupSizeLocalSizeIdSpecConstantSet) {
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     RETURN_IF_SKIP(InitState(nullptr, &features13));
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
@@ -741,16 +741,16 @@ TEST_F(NegativeShaderCompute, CmdDispatchExceedLimits) {
     RETURN_IF_SKIP(Init());
     const bool device_group_creation = IsExtensionsEnabled(VK_KHR_DEVICE_GROUP_EXTENSION_NAME);
 
-    uint32_t x_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[0];
-    uint32_t y_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[1];
-    uint32_t z_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[2];
+    uint32_t x_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[0];
+    uint32_t y_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[1];
+    uint32_t z_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[2];
     if (std::max({x_count_limit, y_count_limit, z_count_limit}) == vvl::kU32Max) {
         GTEST_SKIP() << "device maxComputeWorkGroupCount limit reports UINT32_MAX";
     }
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
-    uint32_t y_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[1];
-    uint32_t z_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[2];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
+    uint32_t y_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[1];
+    uint32_t z_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[2];
 
     std::string spv_source = R"(
         OpCapability Shader
@@ -783,7 +783,7 @@ TEST_F(NegativeShaderCompute, CmdDispatchExceedLimits) {
     y_size_limit = (y_size_limit > 1024) ? 1024 : y_size_limit;
     z_size_limit = (z_size_limit > 64) ? 64 : z_size_limit;
 
-    uint32_t invocations_limit = m_device->phy().limits_.maxComputeWorkGroupInvocations;
+    uint32_t invocations_limit = m_device->Physical().limits_.maxComputeWorkGroupInvocations;
     x_size_limit = (x_size_limit > invocations_limit) ? invocations_limit : x_size_limit;
     invocations_limit /= x_size_limit;
     y_size_limit = (y_size_limit > invocations_limit) ? invocations_limit : y_size_limit;
@@ -802,7 +802,7 @@ TEST_F(NegativeShaderCompute, CmdDispatchExceedLimits) {
     pipe.CreateComputePipeline();
 
     // Bind pipeline to command buffer
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
 
     // Dispatch counts that exceed device limits
@@ -867,10 +867,10 @@ TEST_F(NegativeShaderCompute, DispatchBaseFlag) {
     pipe.CreateComputePipeline();
 
     // Bind pipeline to command buffer
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchBase-baseGroupX-00427");
     vk::CmdDispatchBaseKHR(m_command_buffer.handle(), 1, 1, 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_compute_positive.cpp
+++ b/tests/unit/shader_compute_positive.cpp
@@ -23,9 +23,9 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSize) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
-    uint32_t y_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[1];
-    uint32_t z_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[2];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
+    uint32_t y_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[1];
+    uint32_t z_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[2];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -64,7 +64,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeSpecConstantUnder) {
 
     RETURN_IF_SKIP(Init());
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -157,7 +157,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizeLocalSizeIdSpecConstant) {
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     RETURN_IF_SKIP(InitState(nullptr, &features13));
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     // layout(local_size_x_id = 18, local_size_z_id = 19) in;
     // layout(local_size_x = 32) in;
@@ -215,7 +215,7 @@ TEST_F(PositiveShaderCompute, WorkGroupSizePrecedenceOverLocalSizeId) {
     features13.maintenance4 = VK_TRUE;  // required to be supported in 1.3
     RETURN_IF_SKIP(InitState(nullptr, &features13));
 
-    uint32_t x_size_limit = m_device->phy().limits_.maxComputeWorkGroupSize[0];
+    uint32_t x_size_limit = m_device->Physical().limits_.maxComputeWorkGroupSize[0];
 
     std::stringstream spv_source;
     spv_source << R"(
@@ -254,7 +254,7 @@ TEST_F(PositiveShaderCompute, SharedMemorySpecConstantOp) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     if (max_shared_ints < 16 * 7) {

--- a/tests/unit/shader_cooperative_matrix_positive.cpp
+++ b/tests/unit/shader_cooperative_matrix_positive.cpp
@@ -52,11 +52,11 @@ void CooperativeMatrixTest::InitCooperativeMatrixKHR() {
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
     RETURN_IF_SKIP(Init());
     uint32_t props_count = 0;
-    vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(gpu(), &props_count, nullptr);
+    vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(Gpu(), &props_count, nullptr);
     for (uint32_t i = 0; i < props_count; i++) {
         coop_matrix_props.emplace_back(vku::InitStruct<VkCooperativeMatrixPropertiesKHR>());
     }
-    vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(gpu(), &props_count, coop_matrix_props.data());
+    vk::GetPhysicalDeviceCooperativeMatrixPropertiesKHR(Gpu(), &props_count, coop_matrix_props.data());
 }
 
 bool CooperativeMatrixTest::HasValidProperty(VkScopeKHR scope, uint32_t m, uint32_t n, uint32_t k, VkComponentTypeKHR type) {

--- a/tests/unit/shader_image_access.cpp
+++ b/tests/unit/shader_image_access.cpp
@@ -89,7 +89,7 @@ TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -101,7 +101,7 @@ TEST_F(NegativeShaderImageAccess, FunctionOpImage) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
@@ -146,7 +146,7 @@ TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -158,7 +158,7 @@ TEST_F(NegativeShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
@@ -198,7 +198,7 @@ TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
                                                      VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL, 0);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -209,7 +209,7 @@ TEST_F(NegativeShaderImageAccess, UnnormalizedCoordinatesFunction) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
@@ -246,7 +246,7 @@ TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -258,7 +258,7 @@ TEST_F(NegativeShaderImageAccess, MultisampleMismatchWithPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
@@ -303,7 +303,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -315,7 +315,7 @@ TEST_F(NegativeShaderImageAccess, NonMultisampleMismatchWithPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
@@ -332,13 +332,13 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     const VkFormat bad_format = VK_FORMAT_B8G8R8A8_UNORM;
 
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), bad_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), bad_format, &formatProps);
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT);
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), bad_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), bad_format, formatProps);
 
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), good_format, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), good_format, formatProps);
 
     vkt::Image bad_image(*m_device, 128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView bad_view = bad_image.CreateView();
@@ -387,7 +387,7 @@ TEST_F(NegativeShaderImageAccess, MultipleFunctionCalls) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -443,14 +443,14 @@ TEST_F(NegativeShaderImageAccess, AliasImageBinding) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(1, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-format-07753");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderImageAccess, SampledImageShareBinding) {
@@ -502,7 +502,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBinding) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set_0.set_, 0, nullptr);
@@ -513,7 +513,7 @@ TEST_F(NegativeShaderImageAccess, SampledImageShareBinding) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // TODO - https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6944
@@ -572,7 +572,7 @@ TEST_F(NegativeShaderImageAccess, DISABLED_SampledImageShareBindingArray) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     const VkDescriptorSet sets[2] = {descriptor_set.set_, descriptor_set.set_};
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 2, sets, 0,
@@ -584,5 +584,5 @@ TEST_F(NegativeShaderImageAccess, DISABLED_SampledImageShareBindingArray) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_image_access_positive.cpp
+++ b/tests/unit/shader_image_access_positive.cpp
@@ -421,7 +421,7 @@ TEST_F(PositiveShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -431,7 +431,7 @@ TEST_F(PositiveShaderImageAccess, ComponentTypeMismatchFunctionTwoArgs) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
@@ -448,13 +448,13 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     const VkFormat bad_format = VK_FORMAT_B8G8R8A8_UNORM;
 
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), bad_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), bad_format, &formatProps);
     formatProps.optimalTilingFeatures = (formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT);
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), bad_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), bad_format, formatProps);
 
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), good_format, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), good_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), good_format, formatProps);
 
     vkt::Image bad_image(*m_device, 128, 128, 1, bad_format, VK_IMAGE_USAGE_SAMPLED_BIT);
     vkt::ImageView bad_view = bad_image.CreateView();
@@ -495,7 +495,7 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
@@ -503,7 +503,7 @@ TEST_F(PositiveShaderImageAccess, SamplerNeverAccessed) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderImageAccess, AliasImageBinding) {
@@ -548,10 +548,10 @@ TEST_F(PositiveShaderImageAccess, AliasImageBinding) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(1, buffer.handle(), 0, VK_WHOLE_SIZE, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_interface.cpp
+++ b/tests/unit/shader_interface.cpp
@@ -30,10 +30,10 @@ TEST_F(NegativeShaderInterface, MaxVertexComponentsWithBuiltins) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxVertexOutputComponents = 128;
     props.limits.maxFragmentInputComponents = 128;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -105,10 +105,10 @@ TEST_F(NegativeShaderInterface, MaxFragmentComponentsWithBuiltins) {
     }
 
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxVertexOutputComponents = 128;
     props.limits.maxFragmentInputComponents = 128;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -169,7 +169,7 @@ TEST_F(NegativeShaderInterface, MaxVertexOutputComponents) {
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
 
-        const uint32_t maxVsOutComp = m_device->phy().limits_.maxVertexOutputComponents + overflow;
+        const uint32_t maxVsOutComp = m_device->Physical().limits_.maxVertexOutputComponents + overflow;
         std::string vsSourceStr = "#version 450\n\n";
         const uint32_t numVec4 = maxVsOutComp / 4;
         uint32_t location = 0;
@@ -228,7 +228,8 @@ TEST_F(NegativeShaderInterface, MaxComponentsBlocks) {
     InitRenderTarget();
 
     // To make the test simple, just make sure max is 128 or less (most HW is 64 or 128)
-    if (m_device->phy().limits_.maxVertexOutputComponents > 128 || m_device->phy().limits_.maxFragmentInputComponents > 128) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents > 128 ||
+        m_device->Physical().limits_.maxFragmentInputComponents > 128) {
         GTEST_SKIP() << "maxVertexOutputComponents or maxFragmentInputComponents too high for test";
     }
     // vec4 == 4 components
@@ -288,7 +289,7 @@ TEST_F(NegativeShaderInterface, MaxFragmentInputComponents) {
     for (uint32_t overflow = 0; overflow < 3; ++overflow) {
         m_errorMonitor->Reset();
 
-        const uint32_t maxFsInComp = m_device->phy().limits_.maxFragmentInputComponents + overflow;
+        const uint32_t maxFsInComp = m_device->Physical().limits_.maxFragmentInputComponents + overflow;
         std::string fsSourceStr = "#version 450\n\n";
         const uint32_t numVec4 = maxFsInComp / 4;
         uint32_t location = 0;
@@ -689,7 +690,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructInnerArraySize) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -749,7 +750,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuterArraySize) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -808,7 +809,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructArraySizeVertex) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -868,7 +869,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchBlockStructOuter2DArraySize) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1136,7 +1137,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vsSource));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fsSource));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1144,7 +1145,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchShaderObject) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSizeShaderObject) {
@@ -1175,7 +1176,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSizeShaderObject) {
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, vsSource));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, fsSource));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1183,7 +1184,7 @@ TEST_F(NegativeShaderInterface, VsFsTypeMismatchVectorSizeShaderObject) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderInterface, InputOutputMismatch) {
@@ -1541,7 +1542,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1572,7 +1573,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArrayDim) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1605,7 +1606,7 @@ TEST_F(NegativeShaderInterface, MultidimensionalArray64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxFragmentOutputAttachments < 25) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments < 25) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 

--- a/tests/unit/shader_interface_positive.cpp
+++ b/tests/unit/shader_interface_positive.cpp
@@ -697,7 +697,7 @@ TEST_F(PositiveShaderInterface, InputAttachmentDepthStencil) {
     GetPhysicalDeviceFeatures2(features12);
     RETURN_IF_SKIP(InitState(nullptr, &features12));
 
-    const VkFormat ds_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat ds_format = FindSupportedDepthStencilFormat(Gpu());
 
     RenderPassSingleSubpass rp(*this);
     rp.AddAttachmentDescription(m_render_target_fmt);
@@ -907,7 +907,7 @@ TEST_F(PositiveShaderInterface, InputOutputMatch) {
     VkBuffer buffer_handle = buffer.handle();
     VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer_handle, &offset);
@@ -917,7 +917,7 @@ TEST_F(PositiveShaderInterface, InputOutputMatch) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderInterface, NestedStructs) {
@@ -1016,7 +1016,7 @@ TEST_F(PositiveShaderInterface, VsFsTypeMismatchBlockStructArray) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1219,7 +1219,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayVertex) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1250,7 +1250,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1281,7 +1281,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArrayDims2) {
 
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxVertexOutputComponents <= 64) {
+    if (m_device->Physical().limits_.maxVertexOutputComponents <= 64) {
         GTEST_SKIP() << "maxVertexOutputComponents is too low";
     }
 
@@ -1314,7 +1314,7 @@ TEST_F(PositiveShaderInterface, MultidimensionalArray64bit) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxFragmentOutputAttachments < 9) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments < 9) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is too low";
     }
 

--- a/tests/unit/shader_limits.cpp
+++ b/tests/unit/shader_limits.cpp
@@ -22,7 +22,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsInput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxSampleMaskWords > 1) {
+    if (m_device->Physical().limits_.maxSampleMaskWords > 1) {
         GTEST_SKIP() << "maxSampleMaskWords is greater than 1";
     }
 
@@ -84,7 +84,7 @@ TEST_F(NegativeShaderLimits, MaxSampleMaskWordsOutput) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxSampleMaskWords > 1) {
+    if (m_device->Physical().limits_.maxSampleMaskWords > 1) {
         GTEST_SKIP() << "maxSampleMaskWords is greater than 1";
     }
 
@@ -140,7 +140,7 @@ TEST_F(NegativeShaderLimits, MinAndMaxTexelGatherOffset) {
 
     RETURN_IF_SKIP(Init());
 
-    if (m_device->phy().limits_.minTexelGatherOffset <= -100 || m_device->phy().limits_.maxTexelGatherOffset >= 100) {
+    if (m_device->Physical().limits_.minTexelGatherOffset <= -100 || m_device->Physical().limits_.maxTexelGatherOffset >= 100) {
         GTEST_SKIP() << "test needs minTexelGatherOffset greater than -100 and maxTexelGatherOffset less than 100";
     }
 
@@ -209,7 +209,7 @@ TEST_F(NegativeShaderLimits, MinAndMaxTexelOffset) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.minTexelOffset <= -100 || m_device->phy().limits_.maxTexelOffset >= 100) {
+    if (m_device->Physical().limits_.minTexelOffset <= -100 || m_device->Physical().limits_.maxTexelOffset >= 100) {
         GTEST_SKIP() << "test needs minTexelGatherOffset greater than -100 and maxTexelGatherOffset less than 100";
     }
 
@@ -279,7 +279,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentDualSrcAttachments) {
     AddRequiredFeature(vkt::Feature::dualSrcBlend);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -307,7 +307,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentDualSrcAttachments) {
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -317,7 +317,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentDualSrcAttachments) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
@@ -329,7 +329,7 @@ TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
     AddRequiredFeature(vkt::Feature::workgroupMemoryExplicitLayout);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
 
     // layout(constant_id = 0) const uint value = 4;
     // shared X {
@@ -379,7 +379,7 @@ TEST_F(NegativeShaderLimits, OffsetMaxComputeSharedMemorySize) {
 
 TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachments) {
     RETURN_IF_SKIP(Init());
-    if (m_device->phy().limits_.maxFragmentOutputAttachments != 4) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments != 4) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
@@ -406,7 +406,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachments) {
 
 TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArray) {
     RETURN_IF_SKIP(Init());
-    if (m_device->phy().limits_.maxFragmentOutputAttachments != 4) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments != 4) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
@@ -425,7 +425,7 @@ TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArray) {
 
 TEST_F(NegativeShaderLimits, MaxFragmentOutputAttachmentsArrayAtEnd) {
     RETURN_IF_SKIP(Init());
-    if (m_device->phy().limits_.maxFragmentOutputAttachments != 4) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments != 4) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
@@ -450,9 +450,9 @@ TEST_F(NegativeShaderLimits, MaxFragmentCombinedOutputResources) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxFragmentCombinedOutputResources = 4;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     RETURN_IF_SKIP(InitState());
 
     char const *fsSource = R"glsl(

--- a/tests/unit/shader_limits_positive.cpp
+++ b/tests/unit/shader_limits_positive.cpp
@@ -61,7 +61,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryWorkgroupMemoryExplicitLayout) {
         GTEST_SKIP() << "workgroupMemoryExplicitLayout feature not supported.";
     }
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_vec4 = max_shared_memory_size / 16;
 
     std::stringstream csSource;
@@ -92,7 +92,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryAtLimit) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream csSource;
@@ -114,7 +114,7 @@ TEST_F(PositiveShaderLimits, ComputeSharedMemoryBooleanAtLimit) {
 
     RETURN_IF_SKIP(Init());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     // "Boolean values considered as 32-bit integer values for the purpose of this calculation."
     const uint32_t max_shared_bools = max_shared_memory_size / 4;
 
@@ -214,7 +214,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachments) {
     AddRequiredFeature(vkt::Feature::dualSrcBlend);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -243,12 +243,12 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachments) {
     pipe.shader_stages_ = {pipe.vs_->GetStageCreateInfo(), fs.GetStageCreateInfo()};
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachmentsDynamicEnabled) {
@@ -259,7 +259,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachmentsDynamicEnabled) {
     AddRequiredFeature(vkt::Feature::extendedDynamicState3ColorBlendEnable);
     RETURN_IF_SKIP(Init());
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -288,7 +288,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachmentsDynamicEnabled) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     VkBool32 color_blend_enabled[2] = {VK_FALSE, VK_FALSE};  // disable any blending
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0, 2, color_blend_enabled);
@@ -296,13 +296,13 @@ TEST_F(PositiveShaderLimits, MaxFragmentDualSrcAttachmentsDynamicEnabled) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachments) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
-    if (m_device->phy().limits_.maxFragmentOutputAttachments != 4) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments != 4) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 
@@ -330,7 +330,7 @@ TEST_F(PositiveShaderLimits, MaxFragmentOutputAttachmentsArray) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if (m_device->phy().limits_.maxFragmentOutputAttachments != 4) {
+    if (m_device->Physical().limits_.maxFragmentOutputAttachments != 4) {
         GTEST_SKIP() << "maxFragmentOutputAttachments is not 4";
     }
 

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -438,9 +438,9 @@ TEST_F(NegativeShaderObject, BindVertexAndTaskShaders) {
         VK_SHADER_STAGE_VERTEX_BIT,
         VK_SHADER_STAGE_TASK_BIT_EXT,
     };
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 2u, stages, shaderHandles);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -466,9 +466,9 @@ TEST_F(NegativeShaderObject, BindVertexAndMeshShaders) {
         VK_SHADER_STAGE_VERTEX_BIT,
         VK_SHADER_STAGE_MESH_BIT_EXT,
     };
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 2u, stages, shaderHandles);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -546,10 +546,10 @@ TEST_F(NegativeShaderObject, ComputeShaderNotSupportedByCommandPool) {
 
     vkt::CommandPool command_pool(*m_device, transfer_queue_family_index.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &create_info.stage, &shaderHandle);
-    command_buffer.end();
+    command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -574,10 +574,10 @@ TEST_F(NegativeShaderObject, GraphicsShadersNotSupportedByCommandPool) {
 
     vkt::CommandPool command_pool(*m_device, non_graphics_queue_family_index.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &create_info.stage, &shaderHandle);
-    command_buffer.end();
+    command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -602,10 +602,10 @@ TEST_F(NegativeShaderObject, GraphicsMeshShadersNotSupportedByCommandPool) {
 
     vkt::CommandPool command_pool(*m_device, non_graphics_queue_family_index.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool);
-    command_buffer.begin();
+    command_buffer.Begin();
 
     vk::CmdBindShadersEXT(command_buffer.handle(), 1u, &create_info.stage, &shaderHandle);
-    command_buffer.end();
+    command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -632,9 +632,9 @@ TEST_F(NegativeShaderObject, NonUniqueShadersBind) {
         VK_SHADER_STAGE_VERTEX_BIT,
     };
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 2u, stages, shaders);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -653,9 +653,9 @@ TEST_F(NegativeShaderObject, InvalidShaderStageBind) {
 
     VkShaderStageFlagBits stage = VK_SHADER_STAGE_ALL_GRAPHICS;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stage, &shaderHandle);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -696,11 +696,11 @@ TEST_F(NegativeShaderObject, DrawWithNoShadersBound) {
 
     InitDynamicRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -720,7 +720,7 @@ TEST_F(NegativeShaderObject, DrawWithMissingShaders) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
 
@@ -731,7 +731,7 @@ TEST_F(NegativeShaderObject, DrawWithMissingShaders) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -752,13 +752,13 @@ TEST_F(NegativeShaderObject, DrawWithoutBindingMeshShadersWhenEnabled) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1066,9 +1066,9 @@ TEST_F(NegativeShaderObject, BindInvalidShaderStage) {
 
     VkShaderStageFlagBits stage = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stage, &vertShader.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1084,11 +1084,11 @@ TEST_F(NegativeShaderObject, DrawWithShadersOutsideRenderPass) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1121,13 +1121,13 @@ TEST_F(NegativeShaderObject, DrawWithShadersInNonDynamicRenderPass) {
     clear_value.color.float32[2] = 0.25f;
     clear_value.color.float32[3] = 0.0f;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1162,13 +1162,13 @@ TEST_F(NegativeShaderObject, IncompatibleDescriptorSet) {
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentUniformGlsl),
                                  &descriptor_set.layout_.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1187,13 +1187,13 @@ TEST_F(NegativeShaderObject, NotSettingViewportAndScissor) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_VIEWPORT_WITH_COUNT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1210,7 +1210,7 @@ TEST_F(NegativeShaderObject, DifferentViewportAndScissorCount) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     VkViewport viewports[2];
@@ -1220,7 +1220,7 @@ TEST_F(NegativeShaderObject, DifferentViewportAndScissorCount) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1238,7 +1238,7 @@ TEST_F(NegativeShaderObject, InvalidViewportWScaling) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1255,7 +1255,7 @@ TEST_F(NegativeShaderObject, InvalidViewportWScaling) {
     vk::CmdSetViewportWScalingNV(m_command_buffer.handle(), 0u, 1u, &viewportWScaling);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1285,7 +1285,7 @@ TEST_F(NegativeShaderObject, InvalidShadingRatePaletteViewportCount) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1306,7 +1306,7 @@ TEST_F(NegativeShaderObject, InvalidShadingRatePaletteViewportCount) {
     vk::CmdSetCoarseSampleOrderNV(m_command_buffer.handle(), VK_COARSE_SAMPLE_ORDER_TYPE_DEFAULT_NV, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1325,13 +1325,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetExclusiveScissorEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1345,9 +1345,9 @@ TEST_F(NegativeShaderObject, InvalidExclusiveScissorCount) {
     AddRequiredFeature(vkt::Feature::exclusiveScissor);
     RETURN_IF_SKIP(InitBasicShaderObject());
     uint32_t count;
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, nullptr);
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, nullptr);
     std::vector<VkExtensionProperties> properties(count);
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, properties.data());
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, properties.data());
     for (const auto& p : properties) {
         if (std::strcmp(p.extensionName, VK_NV_SCISSOR_EXCLUSIVE_EXTENSION_NAME) == 0) {
             if (p.specVersion < 2) {
@@ -1361,7 +1361,7 @@ TEST_F(NegativeShaderObject, InvalidExclusiveScissorCount) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1377,7 +1377,7 @@ TEST_F(NegativeShaderObject, InvalidExclusiveScissorCount) {
     vk::CmdSetExclusiveScissorEnableNV(m_command_buffer.handle(), 0u, 1u, &exclusiveScissorEnable);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1394,13 +1394,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetRasterizerDiscardEnable) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_RASTERIZER_DISCARD_ENABLE});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1417,13 +1417,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthBiasEnable) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1445,14 +1445,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOp) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LOGIC_OP_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdSetLogicOpEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1465,7 +1465,7 @@ TEST_F(NegativeShaderObject, BlendEnabledWithNonBlendableFormat) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
     VkFormatProperties props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_R32_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_R32_UINT, &props);
 
     if ((props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) == 0 ||
         (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) != 0) {
@@ -1478,7 +1478,7 @@ TEST_F(NegativeShaderObject, BlendEnabledWithNonBlendableFormat) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1486,7 +1486,7 @@ TEST_F(NegativeShaderObject, BlendEnabledWithNonBlendableFormat) {
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0, 1, &enabled);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1503,14 +1503,14 @@ TEST_F(NegativeShaderObject, RasterizationSamplesMismatch) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdSetRasterizationSamplesEXT(m_command_buffer.handle(), VK_SAMPLE_COUNT_2_BIT);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1529,13 +1529,13 @@ TEST_F(NegativeShaderObject, MissingColorWriteEnable) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1580,7 +1580,7 @@ TEST_F(NegativeShaderObject, ColorWriteEnableAttachmentCount) {
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-None-08647");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1593,7 +1593,7 @@ TEST_F(NegativeShaderObject, ColorWriteEnableAttachmentCount) {
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 1u, 1u, &colorBlendEnable);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1611,13 +1611,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1630,9 +1630,9 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleModeEXT) {
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicShaderObject());
     uint32_t count;
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, nullptr);
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, nullptr);
     std::vector<VkExtensionProperties> properties(count);
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, properties.data());
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, properties.data());
     for (const auto& p : properties) {
         if (std::strcmp(p.extensionName, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME) == 0) {
             if (p.specVersion < 2) {
@@ -1647,7 +1647,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetDiscardRectangleEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -1658,7 +1658,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleModeEXT) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1671,9 +1671,9 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleEXT) {
     AddRequiredExtensions(VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME);
     RETURN_IF_SKIP(InitBasicShaderObject());
     uint32_t count;
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, nullptr);
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, nullptr);
     std::vector<VkExtensionProperties> properties(count);
-    vk::EnumerateDeviceExtensionProperties(m_device->phy(), nullptr, &count, properties.data());
+    vk::EnumerateDeviceExtensionProperties(m_device->Physical(), nullptr, &count, properties.data());
     for (const auto& p : properties) {
         if (std::strcmp(p.extensionName, VK_EXT_DISCARD_RECTANGLES_EXTENSION_NAME) == 0) {
             if (p.specVersion < 2) {
@@ -1688,7 +1688,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetDiscardRectangleEnableEXT(m_command_buffer.handle(), VK_TRUE);
@@ -1696,7 +1696,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetDiscardRectangleEXT) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1713,13 +1713,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthClampEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_CLAMP_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1736,13 +1736,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetPolygonModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_POLYGON_MODE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1759,13 +1759,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetRasterizationSamplesEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_RASTERIZATION_SAMPLES_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1782,13 +1782,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetSampleMaskEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_SAMPLE_MASK_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1805,13 +1805,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetAlphaToCoverageEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_ALPHA_TO_COVERAGE_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1828,13 +1828,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetAlphaToOneEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_ALPHA_TO_ONE_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1856,13 +1856,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetLogicOpEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LOGIC_OP_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1881,13 +1881,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEnableEXT) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1905,7 +1905,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEnableEXTForActiveAttachment
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1913,7 +1913,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEnableEXTForActiveAttachment
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 1u, 1u, &enable);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1931,7 +1931,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEquationEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1939,7 +1939,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEquationEXT) {
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0u, 1u, &colorBlendEnable);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1956,7 +1956,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEquationEXTActiveAttachments
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1968,7 +1968,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendEquationEXTActiveAttachments
     vk::CmdSetColorBlendEquationEXT(m_command_buffer.handle(), 1u, 1u, &colorBlendEquation);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1986,7 +1986,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendAdvancedEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT});
     VkBool32 colorBlendEnable = VK_TRUE;
@@ -2010,7 +2010,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorBlendAdvancedEXT) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2029,13 +2029,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetFragmentShadingRateKHR) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2053,13 +2053,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorWriteMaskEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2076,7 +2076,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorWriteMaskEXTActiveAttachments) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_WRITE_MASK_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -2084,7 +2084,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetColorWriteMaskEXTActiveAttachments) {
     vk::CmdSetColorWriteMaskEXT(m_command_buffer.handle(), 1u, 1u, &colorWriteMask);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2104,7 +2104,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetRasterizationStreamEXT) {
                                  GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, kGeometryMinimalGlsl));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -2114,7 +2114,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetRasterizationStreamEXT) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2132,13 +2132,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetConservativeRasterizationModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2156,14 +2156,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetExtraPrimitiveOverestimationSizeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetConservativeRasterizationModeEXT(m_command_buffer.handle(), VK_CONSERVATIVE_RASTERIZATION_MODE_OVERESTIMATE_EXT);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2182,13 +2182,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthClipEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2206,13 +2206,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetSampleLocationsEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2230,13 +2230,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetProvokingVertexModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2254,7 +2254,7 @@ TEST_F(NegativeShaderObject, MissingPolygonModeCmdSetLineRasterizationModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetPolygonModeEXT(m_command_buffer.handle(), VK_POLYGON_MODE_LINE);
@@ -2262,7 +2262,7 @@ TEST_F(NegativeShaderObject, MissingPolygonModeCmdSetLineRasterizationModeEXT) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2280,7 +2280,7 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyCmdSetLineRasterizationMode
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
@@ -2288,7 +2288,7 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyCmdSetLineRasterizationMode
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2306,7 +2306,7 @@ TEST_F(NegativeShaderObject, MissingPolygonModeCmdSetLineStippleEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetPolygonModeEXT(m_command_buffer.handle(), VK_POLYGON_MODE_LINE);
@@ -2314,7 +2314,7 @@ TEST_F(NegativeShaderObject, MissingPolygonModeCmdSetLineStippleEnableEXT) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2332,7 +2332,7 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyCmdSetLineStippleEnableEXT)
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
@@ -2340,7 +2340,7 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyCmdSetLineStippleEnableEXT)
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2358,14 +2358,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetLineStippleEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetLineStippleEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2384,13 +2384,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthClipNegativeOneToOneEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2408,13 +2408,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportWScalingEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2433,14 +2433,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportWScalingNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetViewportWScalingEnableNV(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2458,13 +2458,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportSwizzleNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2482,13 +2482,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageToColorEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2506,14 +2506,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageToColorLocationNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageToColorEnableNV(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2531,14 +2531,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageModulationModeNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageModulationTableEnableNV(m_command_buffer.handle(), VK_FALSE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2556,14 +2556,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageModulationTableEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageModulationModeNV(m_command_buffer.handle(), VK_COVERAGE_MODULATION_MODE_RGBA_NV);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2581,7 +2581,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageModulationTableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageModulationModeNV(m_command_buffer.handle(), VK_COVERAGE_MODULATION_MODE_NONE_NV);
@@ -2589,7 +2589,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageModulationTableNV) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2619,14 +2619,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetShadingRateImageEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoarseSampleOrderNV(m_command_buffer.handle(), VK_COARSE_SAMPLE_ORDER_TYPE_DEFAULT_NV, 0u, nullptr);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2655,7 +2655,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportShadingRatePaletteNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoarseSampleOrderNV(m_command_buffer.handle(), VK_COARSE_SAMPLE_ORDER_TYPE_DEFAULT_NV, 0u, nullptr);
@@ -2663,7 +2663,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetViewportShadingRatePaletteNV) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2692,14 +2692,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoarseSampleOrderNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetShadingRateImageEnableNV(m_command_buffer.handle(), VK_FALSE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2718,13 +2718,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetRepresentativeFragmentTestEnableNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2743,7 +2743,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageReductionModeNV) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageModulationModeNV(m_command_buffer.handle(), VK_COVERAGE_MODULATION_MODE_NONE_NV);
@@ -2751,7 +2751,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetCoverageReductionModeNV) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2767,7 +2767,7 @@ TEST_F(NegativeShaderObject, MissingVertexShaderBind) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
@@ -2776,7 +2776,7 @@ TEST_F(NegativeShaderObject, MissingVertexShaderBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 4u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2808,7 +2808,7 @@ TEST_F(NegativeShaderObject, MissingTessellationControlBind) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT,
@@ -2817,7 +2817,7 @@ TEST_F(NegativeShaderObject, MissingTessellationControlBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 4u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2849,7 +2849,7 @@ TEST_F(NegativeShaderObject, MissingTessellationEvaluationBind) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -2858,7 +2858,7 @@ TEST_F(NegativeShaderObject, MissingTessellationEvaluationBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 4u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2890,7 +2890,7 @@ TEST_F(NegativeShaderObject, MissingGeometryBind) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -2899,7 +2899,7 @@ TEST_F(NegativeShaderObject, MissingGeometryBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 4u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2914,7 +2914,7 @@ TEST_F(NegativeShaderObject, MissingFragmentShaderBind) {
     InitDynamicRenderTarget();
 
     const vkt::Shader vertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, GLSLToSPV(VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -2923,7 +2923,7 @@ TEST_F(NegativeShaderObject, MissingFragmentShaderBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 4u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2941,7 +2941,7 @@ TEST_F(NegativeShaderObject, MissingTaskShaderBind) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -2952,7 +2952,7 @@ TEST_F(NegativeShaderObject, MissingTaskShaderBind) {
     }
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2970,7 +2970,7 @@ TEST_F(NegativeShaderObject, MissingMeshShaderBind) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -2981,7 +2981,7 @@ TEST_F(NegativeShaderObject, MissingMeshShaderBind) {
     }
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3005,7 +3005,7 @@ TEST_F(NegativeShaderObject, VertAndMeshShaderBothBound) {
         ShaderCreateInfoFlag(mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT, VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT);
     const vkt::Shader meshShader(*m_device, mesh_create_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -3018,7 +3018,7 @@ TEST_F(NegativeShaderObject, VertAndMeshShaderBothBound) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &meshStage, &meshShader.handle());
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3037,7 +3037,7 @@ TEST_F(NegativeShaderObject, MeshShaderWithMissingTaskShader) {
     const vkt::Shader meshShader(*m_device, VK_SHADER_STAGE_MESH_BIT_EXT,
                                  GLSLToSPV(VK_SHADER_STAGE_MESH_BIT_EXT, kMeshMinimalGlsl, SPV_ENV_VULKAN_1_3));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3054,7 +3054,7 @@ TEST_F(NegativeShaderObject, MeshShaderWithMissingTaskShader) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3078,7 +3078,7 @@ TEST_F(NegativeShaderObject, TaskAndMeshShaderWithNoTaskFlag) {
         ShaderCreateInfoFlag(mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT, VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT);
     const vkt::Shader meshShader(*m_device, mesh_create_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3094,7 +3094,7 @@ TEST_F(NegativeShaderObject, TaskAndMeshShaderWithNoTaskFlag) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3117,7 +3117,7 @@ TEST_F(NegativeShaderObject, VertAndTaskShadersBound) {
         ShaderCreateInfoFlag(mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT, VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT);
     const vkt::Shader meshShader(*m_device, mesh_create_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3134,7 +3134,7 @@ TEST_F(NegativeShaderObject, VertAndTaskShadersBound) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3156,7 +3156,7 @@ TEST_F(NegativeShaderObject, MissingLinkedShaderBind) {
     VkShaderEXT shaders[2];
     vk::CreateShadersEXT(*m_device, 2u, createInfos, nullptr, shaders);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3166,7 +3166,7 @@ TEST_F(NegativeShaderObject, MissingLinkedShaderBind) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, bindShaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (uint32_t i = 0; i < 2; ++i) {
         vk::DestroyShaderEXT(*m_device, shaders[i], nullptr);
@@ -3194,7 +3194,7 @@ TEST_F(NegativeShaderObject, BindShaderBetweenLinkedShaders) {
 
     const vkt::Shader geomShader(*m_device, VK_SHADER_STAGE_GEOMETRY_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, kGeometryMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3204,7 +3204,7 @@ TEST_F(NegativeShaderObject, BindShaderBetweenLinkedShaders) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, bindShaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (uint32_t i = 0; i < 2; ++i) {
         vk::DestroyShaderEXT(*m_device, shaders[i], nullptr);
@@ -3231,13 +3231,13 @@ TEST_F(NegativeShaderObject, DifferentShaderPushConstantRanges) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3260,7 +3260,7 @@ TEST_F(NegativeShaderObject, DifferentShaderDescriptorLayouts) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -3268,7 +3268,7 @@ TEST_F(NegativeShaderObject, DifferentShaderDescriptorLayouts) {
                               &descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3287,13 +3287,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetAttachmentFeedbackLoopEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3310,13 +3310,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetPrimitiveTopologyEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_PRIMITIVE_TOPOLOGY_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3341,7 +3341,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetPatchControlPointsEXT) {
                                  GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_PATCH_CONTROL_POINTS_EXT});
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3352,7 +3352,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetPatchControlPointsEXT) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3377,7 +3377,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetTessellationDomainOriginEXT) {
                                  GLSLToSPV(VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, kTessellationEvalMinimalGlsl));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_TESSELLATION_DOMAIN_ORIGIN_EXT});
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3388,7 +3388,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetTessellationDomainOriginEXT) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 5u, stages, shaders);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3405,13 +3405,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetPrimitiveRestartEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_PRIMITIVE_RESTART_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3430,13 +3430,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetVertexInput) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_VERTEX_INPUT_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3457,7 +3457,7 @@ TEST_F(NegativeShaderObject, DrawWithGraphicsShadersWhenMeshShaderIsBound) {
         ShaderCreateInfoFlag(mesh_spv, VK_SHADER_STAGE_MESH_BIT_EXT, VK_SHADER_CREATE_NO_TASK_SHADER_BIT_EXT);
     const vkt::Shader meshShader(*m_device, mesh_create_info);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
@@ -3474,7 +3474,7 @@ TEST_F(NegativeShaderObject, DrawWithGraphicsShadersWhenMeshShaderIsBound) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &meshStage, &meshShader.handle());
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3491,14 +3491,14 @@ TEST_F(NegativeShaderObject, MissingPolygonLineCmdSetLineWidthEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_WIDTH});
     vk::CmdSetPolygonModeEXT(m_command_buffer.handle(), VK_POLYGON_MODE_LINE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3515,14 +3515,14 @@ TEST_F(NegativeShaderObject, MissingPrimitiveTopologyLineCmdSetLineWidthEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_WIDTH});
     vk::CmdSetPrimitiveTopologyEXT(m_command_buffer.handle(), VK_PRIMITIVE_TOPOLOGY_LINE_LIST);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3539,14 +3539,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthBiasEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BIAS});
     vk::CmdSetDepthBiasEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3563,7 +3563,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetBlendConstantsEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_BLEND_CONSTANTS});
     VkColorBlendEquationEXT colorBlendEquation = {
@@ -3587,7 +3587,7 @@ TEST_F(NegativeShaderObject, MissingCmdSetBlendConstantsEXT) {
     vk::CmdSetColorBlendAdvancedEXT(m_command_buffer.handle(), 0u, 1u, &colorBlendAdvanced);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3604,14 +3604,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthBoundsEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BOUNDS});
     vk::CmdSetDepthBoundsTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3628,14 +3628,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilCompareMaskEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_STENCIL_COMPARE_MASK});
     vk::CmdSetStencilTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3652,14 +3652,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilWriteMaskEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_STENCIL_WRITE_MASK});
     vk::CmdSetStencilTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3676,14 +3676,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilReferenceEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_STENCIL_REFERENCE});
     vk::CmdSetStencilTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3701,14 +3701,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetSampleLocationsEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_SAMPLE_LOCATIONS_EXT});
     vk::CmdSetSampleLocationsEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3725,13 +3725,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetCullModeEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_CULL_MODE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3748,14 +3748,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetFrontFaceEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_FRONT_FACE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdSetCullModeEXT(m_command_buffer.handle(), VK_CULL_MODE_BACK_BIT);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3772,13 +3772,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthTestEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_TEST_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3795,13 +3795,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthWriteEnableEXT) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_WRITE_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3818,14 +3818,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthCompareOp) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_COMPARE_OP_EXT});
     vk::CmdSetDepthTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3847,13 +3847,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetDepthBoundsTestEnable) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3875,13 +3875,13 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilTestEnable) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_STENCIL_TEST_ENABLE});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3903,14 +3903,14 @@ TEST_F(NegativeShaderObject, MissingCmdSetStencilOp) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_STENCIL_OP_EXT});
     vk::CmdSetStencilTestEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -3920,14 +3920,14 @@ TEST_F(NegativeShaderObject, ComputeShaderGroupCount) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    uint32_t x_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[0];
-    uint32_t y_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[1];
-    uint32_t z_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[2];
+    uint32_t x_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[0];
+    uint32_t y_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[1];
+    uint32_t z_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[2];
 
     const vkt::Shader compShader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_command_buffer.BindCompShader(compShader);
 
@@ -3943,7 +3943,7 @@ TEST_F(NegativeShaderObject, ComputeShaderGroupCount) {
     vk::CmdDispatch(m_command_buffer.handle(), 1u, 1u, z_count_limit + 1u);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderObject, ComputeShaderMissingPushConst) {
@@ -3985,12 +3985,12 @@ TEST_F(NegativeShaderObject, ComputeShaderMissingPushConst) {
     descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 32, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0u, 1u,
                               &descriptor_set.set_, 0u, nullptr);
     m_command_buffer.BindCompShader(compShader);
     vk::CmdDispatch(m_command_buffer.handle(), 1u, 1u, 1u);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -4002,7 +4002,7 @@ TEST_F(NegativeShaderObject, SharedMemoryOverLimit) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    const uint32_t max_shared_memory_size = m_device->phy().limits_.maxComputeSharedMemorySize;
+    const uint32_t max_shared_memory_size = m_device->Physical().limits_.maxComputeSharedMemorySize;
     const uint32_t max_shared_ints = max_shared_memory_size / 4;
 
     std::stringstream csSource;
@@ -4948,7 +4948,7 @@ TEST_F(NegativeShaderObject, MissingNonReadableDecorationFormatRead) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -5009,7 +5009,7 @@ TEST_F(NegativeShaderObject, MaxSampleMaskWords) {
     AddRequiredFeature(vkt::Feature::dynamicRendering);
     RETURN_IF_SKIP(Init());
 
-    if (m_device->phy().limits_.maxSampleMaskWords > 1) {
+    if (m_device->Physical().limits_.maxSampleMaskWords > 1) {
         GTEST_SKIP() << "maxSampleMaskWords is greater than 1";
     }
 
@@ -5132,7 +5132,7 @@ TEST_F(NegativeShaderObject, LocalSizeExceedLimits) {
 
     RETURN_IF_SKIP(InitBasicShaderObject());
 
-    uint32_t x_count_limit = m_device->phy().limits_.maxComputeWorkGroupCount[0];
+    uint32_t x_count_limit = m_device->Physical().limits_.maxComputeWorkGroupCount[0];
 
     std::string cs_src = R"asm(
                OpCapability Shader
@@ -5202,14 +5202,14 @@ TEST_F(NegativeShaderObject, MissingLineWidthSet) {
     const vkt::Shader geomShader(*m_device, stages[1], GLSLToSPV(stages[1], geom_src));
     const vkt::Shader fragShader(*m_device, stages[2], GLSLToSPV(stages[2], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_WIDTH});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stages[1], &geomShader.handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5242,7 +5242,7 @@ TEST_F(NegativeShaderObject, InvalidViewportCount) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], vsSource));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     VkViewport viewports[2];
@@ -5260,7 +5260,7 @@ TEST_F(NegativeShaderObject, InvalidViewportCount) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5285,14 +5285,14 @@ TEST_F(NegativeShaderObject, AlphaToCoverage) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], frag_src));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_WIDTH});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdSetAlphaToCoverageEnableEXT(m_command_buffer.handle(), VK_TRUE);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5326,7 +5326,7 @@ TEST_F(NegativeShaderObject, MissingLineRasterizationMode) {
     const vkt::Shader geomShader(*m_device, stages[1], GLSLToSPV(stages[1], geom_src));
     const vkt::Shader fragShader(*m_device, stages[2], GLSLToSPV(stages[2], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_RASTERIZATION_MODE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5334,7 +5334,7 @@ TEST_F(NegativeShaderObject, MissingLineRasterizationMode) {
     vk::CmdSetLineStippleEnableEXT(m_command_buffer.handle(), VK_FALSE);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5368,7 +5368,7 @@ TEST_F(NegativeShaderObject, MissingLineStippleEnable) {
     const vkt::Shader geomShader(*m_device, stages[1], GLSLToSPV(stages[1], geom_src));
     const vkt::Shader fragShader(*m_device, stages[2], GLSLToSPV(stages[2], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_LINE_STIPPLE_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5376,7 +5376,7 @@ TEST_F(NegativeShaderObject, MissingLineStippleEnable) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stages[1], &geomShader.handle());
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5390,7 +5390,7 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
 
     VkFormat format = VK_FORMAT_E5B9G9R9_UFLOAT_PACK32;
     VkFormatProperties props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), format, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), format, &props);
 
     if ((props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) == 0) {
         GTEST_SKIP() << "VK_FORMAT_E5B9G9R9_UFLOAT_PACK32 not supported as color attachment.";
@@ -5402,7 +5402,7 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
     imageFormatInfo.tiling = VK_IMAGE_TILING_OPTIMAL;
     imageFormatInfo.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     VkImageFormatProperties2 imageFormatProperties = vku::InitStructHelper();
-    auto res = vk::GetPhysicalDeviceImageFormatProperties2(m_device->phy(), &imageFormatInfo, &imageFormatProperties);
+    auto res = vk::GetPhysicalDeviceImageFormatProperties2(m_device->Physical(), &imageFormatInfo, &imageFormatProperties);
     if (res == VK_ERROR_FORMAT_NOT_SUPPORTED) {
         GTEST_SKIP() << "image format not supported as color attachment.";
     }
@@ -5415,7 +5415,7 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(image_view, GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5423,7 +5423,7 @@ TEST_F(NegativeShaderObject, InvalidColorWriteMask) {
     vk::CmdSetColorWriteMaskEXT(m_command_buffer.handle(), 0u, 1u, &colorWriteMask);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5439,7 +5439,7 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
     const VkFormat format = VK_FORMAT_R64_SINT;
 
     VkFormatProperties2 formatProperties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceFormatProperties2(m_device->phy(), format, &formatProperties);
+    vk::GetPhysicalDeviceFormatProperties2(m_device->Physical(), format, &formatProperties);
 
     if ((formatProperties.formatProperties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "format not supported.";
@@ -5457,7 +5457,7 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], vert_src));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5478,7 +5478,7 @@ TEST_F(NegativeShaderObject, Mismatched64BitAttributeType) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5504,7 +5504,7 @@ TEST_F(NegativeShaderObject, Mismatched32BitAttributeType) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], vert_src));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5525,7 +5525,7 @@ TEST_F(NegativeShaderObject, Mismatched32BitAttributeType) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5541,7 +5541,7 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
     const VkFormat format = VK_FORMAT_R64G64B64_SINT;
 
     VkFormatProperties2 formatProperties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceFormatProperties2(m_device->phy(), format, &formatProperties);
+    vk::GetPhysicalDeviceFormatProperties2(m_device->Physical(), format, &formatProperties);
 
     if ((formatProperties.formatProperties.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT) == 0) {
         GTEST_SKIP() << "format not supported.";
@@ -5560,7 +5560,7 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], vert_src));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5581,7 +5581,7 @@ TEST_F(NegativeShaderObject, MismatchedFormat64Components) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5606,7 +5606,7 @@ TEST_F(NegativeShaderObject, MismatchedAttributeType) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], vert_src));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5623,7 +5623,7 @@ TEST_F(NegativeShaderObject, MismatchedAttributeType) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5681,7 +5681,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
     vert_descriptor_set.WriteDescriptorBufferInfo(0, buffer.handle(), 0, 32, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     vert_descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5691,7 +5691,7 @@ TEST_F(NegativeShaderObject, DescriptorNotUpdated) {
                               &frag_descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -5779,7 +5779,7 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxOutputVertices) {
                OpExecutionMode %main Invocations 1
                OpExecutionMode %main OutputTriangleStrip
                OpExecutionMode %main OutputVertices )";
-    geom_src += std::to_string(m_device->phy().limits_.maxGeometryOutputVertices + 1);
+    geom_src += std::to_string(m_device->Physical().limits_.maxGeometryOutputVertices + 1);
     geom_src += R"(
                ; Debug Information
                OpSource GLSL 460
@@ -5853,7 +5853,7 @@ TEST_F(NegativeShaderObject, GeometryShaderMaxInvocations) {
                OpEntryPoint Geometry %main "main" %_
                OpExecutionMode %main Triangles
                OpExecutionMode %main Invocations )";
-    geom_src += std::to_string(m_device->phy().limits_.maxGeometryShaderInvocations + 1);
+    geom_src += std::to_string(m_device->Physical().limits_.maxGeometryShaderInvocations + 1);
     geom_src += R"(
                OpExecutionMode %main OutputTriangleStrip
                OpExecutionMode %main OutputVertices 2
@@ -5919,7 +5919,7 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
 
     VkFormat format = VK_FORMAT_R16_SINT;
     VkFormatProperties props = {};
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &props);
 
     if ((props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_FILTER_LINEAR_BIT) > 0 ||
         (props.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT) == 0) {
@@ -5960,7 +5960,7 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
     descriptor_set.WriteDescriptorImageInfo(0, image_view, sampler.handle());
     descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -5968,7 +5968,7 @@ TEST_F(NegativeShaderObject, MissingImageFilterLinearBit) {
                               &descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -6007,13 +6007,13 @@ TEST_F(NegativeShaderObject, MaxMultiviewInstanceIndex) {
     renderingInfo.pColorAttachments = &color_attachment;
     renderingInfo.viewMask = 0x1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, multiview_properties.maxMultiviewInstanceIndex);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -6025,7 +6025,7 @@ TEST_F(NegativeShaderObject, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     InitDynamicRenderTarget();
 
-    const uint32_t count = m_device->phy().limits_.maxFragmentDualSrcAttachments + 1;
+    const uint32_t count = m_device->Physical().limits_.maxFragmentDualSrcAttachments + 1;
     if (count != 2) {
         GTEST_SKIP() << "Test is designed for a maxFragmentDualSrcAttachments of 1";
     }
@@ -6069,7 +6069,7 @@ TEST_F(NegativeShaderObject, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     renderingInfo.colorAttachmentCount = 2u;
     renderingInfo.pColorAttachments = attachments;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
 
     SetDefaultDynamicStatesExclude();
@@ -6095,7 +6095,7 @@ TEST_F(NegativeShaderObject, MaxFragmentDualSrcAttachmentsDynamicBlendEnable) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
@@ -6134,7 +6134,7 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_PRIMITIVES_GENERATED_EXT, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -6143,7 +6143,7 @@ TEST_F(NegativeShaderObject, PrimitivesGeneratedQuery) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     vk::CmdEndQuery(m_command_buffer.handle(), query_pool.handle(), 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -6753,7 +6753,7 @@ TEST_F(NegativeShaderObject, CoverageToColorInvalidFormat) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetCoverageToColorEnableNV(m_command_buffer.handle(), VK_TRUE);
@@ -6761,7 +6761,7 @@ TEST_F(NegativeShaderObject, CoverageToColorInvalidFormat) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -6786,7 +6786,7 @@ TEST_F(NegativeShaderObject, InvalidViewportSwizzleCount) {
         VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_X_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Y_NV,
         VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_Z_NV, VK_VIEWPORT_COORDINATE_SWIZZLE_POSITIVE_W_NV};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     vk::CmdSetViewportWithCountEXT(m_command_buffer.handle(), 2u, viewports);
@@ -6795,7 +6795,7 @@ TEST_F(NegativeShaderObject, InvalidViewportSwizzleCount) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -7012,7 +7012,7 @@ TEST_F(NegativeShaderObject, TessellationPatchSize) {
                OpMemoryModel Logical GLSL450
                OpEntryPoint TessellationControl %main "main" %gl_TessLevelOuter %gl_TessLevelInner
                OpExecutionMode %main OutputVertices )";
-        tesc_src += i == 0 ? std::string("0") : std::to_string(m_device->phy().limits_.maxTessellationPatchSize + 1u);
+        tesc_src += i == 0 ? std::string("0") : std::to_string(m_device->Physical().limits_.maxTessellationPatchSize + 1u);
         tesc_src += R"(
                ; Debug Information
                OpSource GLSL 460
@@ -7077,10 +7077,10 @@ TEST_F(NegativeShaderObject, DispatchBaseFlag) {
     RETURN_IF_SKIP(InitBasicShaderObject());
     const vkt::Shader compShader(*m_device, VK_SHADER_STAGE_COMPUTE_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BindCompShader(compShader);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatchBase-baseGroupX-00427");
     vk::CmdDispatchBase(m_command_buffer.handle(), 1, 1, 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_object_positive.cpp
+++ b/tests/unit/shader_object_positive.cpp
@@ -68,9 +68,9 @@ TEST_F(PositiveShaderObject, BindShaderObject) {
     VkShaderStageFlagBits stage = VK_SHADER_STAGE_VERTEX_BIT;
     const vkt::Shader vertShader(*m_device, stage, GLSLToSPV(stage, kVertexMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &stage, &vertShader.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawWithVertAndFragShaderObjects) {
@@ -85,13 +85,13 @@ TEST_F(PositiveShaderObject, DrawWithVertAndFragShaderObjects) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawWithVertAndFragBinaryShaderObjects) {
@@ -122,13 +122,13 @@ TEST_F(PositiveShaderObject, DrawWithVertAndFragBinaryShaderObjects) {
     vkt::Shader binaryVertShader(*m_device, VK_SHADER_STAGE_VERTEX_BIT, vertData);
     vkt::Shader binaryFragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, fragData);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(binaryVertShader, binaryFragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, LinkedVertexAndFragmentShaders) {
@@ -188,14 +188,14 @@ TEST_F(PositiveShaderObject, MissingCmdSetDepthBiasEnable) {
     const vkt::Shader vertShader(*m_device, stages[0], GLSLToSPV(stages[0], kVertexMinimalGlsl));
     const vkt::Shader fragShader(*m_device, stages[1], GLSLToSPV(stages[1], kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BIAS_ENABLE});
     vk::CmdSetRasterizerDiscardEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, VertFragShaderDraw) {
@@ -248,7 +248,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
     begin_rendering_info.colorAttachmentCount = 1u;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
@@ -304,7 +304,7 @@ TEST_F(PositiveShaderObject, VertFragShaderDraw) {
 
     vk::CmdCopyImageToBuffer(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, buffer.handle(), 1u, &copyRegion);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -427,7 +427,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     begin_rendering_info.colorAttachmentCount = 1u;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
@@ -453,7 +453,7 @@ TEST_F(PositiveShaderObject, DrawWithAllGraphicsShaderStagesUsed) {
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     vk::CmdEndRenderingKHR(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -489,7 +489,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
 
     const vkt::Shader compShader(*m_device, shaderStages[0], GLSLToSPV(shaderStages[0], comp_src), &descriptorSetLayout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0u, 1u,
                               &descriptor_set.set_, 0u, nullptr);
@@ -497,7 +497,7 @@ TEST_F(PositiveShaderObject, ComputeShader) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, shaderStages, &compShader.handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -572,7 +572,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     begin_rendering_info.colorAttachmentCount = 1u;
     begin_rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         VkImageMemoryBarrier imageMemoryBarrier = vku::InitStructHelper();
@@ -611,7 +611,7 @@ TEST_F(PositiveShaderObject, TaskMeshShadersDraw) {
     vk::CmdDrawMeshTasksEXT(m_command_buffer.handle(), 1, 1, 1);
     vk::CmdEndRenderingKHR(m_command_buffer.handle());
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -754,7 +754,7 @@ TEST_F(PositiveShaderObject, DrawMinimalDynamicStates) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkViewport viewport = {0, 0, static_cast<float>(m_width), static_cast<float>(m_height), 0.0f, 1.0f};
@@ -789,7 +789,7 @@ TEST_F(PositiveShaderObject, DrawMinimalDynamicStates) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawMinimalDynamicStatesRasterizationDisabled) {
@@ -804,7 +804,7 @@ TEST_F(PositiveShaderObject, DrawMinimalDynamicStatesRasterizationDisabled) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     VkViewport viewport = {0, 0, static_cast<float>(m_width), static_cast<float>(m_height), 0.0f, 1.0f};
@@ -820,7 +820,7 @@ TEST_F(PositiveShaderObject, DrawMinimalDynamicStatesRasterizationDisabled) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
@@ -882,7 +882,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
     frag_descriptor_set.WriteDescriptorImageInfo(0, view, sampler.handle());
     frag_descriptor_set.UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -892,7 +892,7 @@ TEST_F(PositiveShaderObject, ShadersDescriptorSets) {
                               &frag_descriptor_set.set_, 0u, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DescriptorBuffer) {
@@ -910,7 +910,7 @@ TEST_F(PositiveShaderObject, DescriptorBuffer) {
     vkt::Buffer buffer(*m_device, 4096, VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT, vkt::device_address);
 
     VkDescriptorBufferBindingInfoEXT buffer_binding_info = vku::InitStructHelper();
-    buffer_binding_info.address = buffer.address();
+    buffer_binding_info.address = buffer.Address();
     buffer_binding_info.usage = VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT;
 
     const VkDescriptorSetLayoutBinding binding = {0, VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, 1, VK_SHADER_STAGE_FRAGMENT_BIT, nullptr};
@@ -931,14 +931,14 @@ TEST_F(PositiveShaderObject, DescriptorBuffer) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_spv),
                                  &set_layout.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdBindDescriptorBuffersEXT(m_command_buffer.handle(), 1, &buffer_binding_info);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, MultiplePushConstants) {
@@ -985,7 +985,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
     const vkt::Shader fragShader(*m_device,
                                  ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 0, nullptr, 2, push_constant_ranges));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     int pos = 1;
@@ -998,7 +998,7 @@ TEST_F(PositiveShaderObject, MultiplePushConstants) {
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
@@ -1051,14 +1051,14 @@ TEST_F(PositiveShaderObject, MultipleSpecializationConstants) {
     const vkt::Shader fragShader(
         *m_device, ShaderCreateInfo(frag_spv, VK_SHADER_STAGE_FRAGMENT_BIT, 0, nullptr, 0, nullptr, &specialization_info));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, IndirectDraw) {
@@ -1145,7 +1145,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
 
     vkt::Buffer indirect_buffer(*m_device, 32, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     SetDefaultDynamicStatesExclude();
@@ -1159,7 +1159,7 @@ TEST_F(PositiveShaderObject, IndirectDraw) {
 
     vk::CmdDrawIndirect(m_command_buffer.handle(), indirect_buffer.handle(), 0u, 1u, 0u);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffers) {
@@ -1178,7 +1178,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffers) {
 
     vkt::CommandPool command_pool(*m_device, graphics_queue_family_index.value());
     vkt::CommandBuffer command_buffer(*m_device, command_pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
-    command_buffer.begin();
+    command_buffer.Begin();
     command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
@@ -1188,11 +1188,11 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffers) {
     SetDefaultDynamicStatesExclude({}, true, command_buffer.handle());
     vk::CmdDraw(command_buffer.handle(), 4, 1, 0, 0);
     command_buffer.EndRendering();
-    command_buffer.end();
+    command_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &command_buffer.handle());
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, OutputToMultipleAttachments) {
@@ -1242,13 +1242,13 @@ TEST_F(PositiveShaderObject, OutputToMultipleAttachments) {
     renderingInfo.colorAttachmentCount = 2u;
     renderingInfo.pColorAttachments = attachments;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawWithNonBlendableFormat) {
@@ -1257,7 +1257,7 @@ TEST_F(PositiveShaderObject, DrawWithNonBlendableFormat) {
     RETURN_IF_SKIP(InitBasicShaderObject());
 
     VkFormatProperties props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_R32_UINT, &props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_R32_UINT, &props);
 
     if ((props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BIT) == 0 ||
         (props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT) != 0) {
@@ -1270,7 +1270,7 @@ TEST_F(PositiveShaderObject, DrawWithNonBlendableFormat) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1278,7 +1278,7 @@ TEST_F(PositiveShaderObject, DrawWithNonBlendableFormat) {
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0, 1, &enabled);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue) {
@@ -1306,7 +1306,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
     begin_info.flags = VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
     begin_info.pInheritanceInfo = &hinfo;
-    command_buffer.begin(&begin_info);
+    command_buffer.Begin(&begin_info);
     const VkShaderStageFlagBits stages[] = {VK_SHADER_STAGE_VERTEX_BIT, VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT,
                                             VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT, VK_SHADER_STAGE_GEOMETRY_BIT,
                                             VK_SHADER_STAGE_FRAGMENT_BIT};
@@ -1314,9 +1314,9 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
     vk::CmdBindShadersEXT(command_buffer.handle(), 5u, stages, shaders);
     SetDefaultDynamicStatesExclude({}, true, command_buffer.handle());
     vk::CmdDraw(command_buffer.handle(), 4, 1, 0, 0);
-    command_buffer.end();
+    command_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkRenderingAttachmentInfoKHR color_attachment = vku::InitStructHelper();
     color_attachment.imageView = GetDynamicRenderTarget();
@@ -1333,7 +1333,7 @@ TEST_F(PositiveShaderObject, DrawInSecondaryCommandBuffersWithRenderPassContinue
 
     vk::CmdExecuteCommands(m_command_buffer.handle(), 1u, &command_buffer.handle());
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawRebindingShaders) {
@@ -1358,7 +1358,7 @@ TEST_F(PositiveShaderObject, DrawRebindingShaders) {
 
     const VkShaderEXT nullShader = VK_NULL_HANDLE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
 
     SetDefaultDynamicStatesExclude();
@@ -1382,7 +1382,7 @@ TEST_F(PositiveShaderObject, DrawRebindingShaders) {
     vk::CmdDraw(m_command_buffer.handle(), 4u, 1u, 0u, 0u);
 
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
@@ -1431,7 +1431,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
         vk::CreateShadersEXT(*m_device, 1u, &createInfo, nullptr, &binaryShaders[i]);
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
 
@@ -1439,7 +1439,7 @@ TEST_F(PositiveShaderObject, DrawWithBinaryShaders) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (uint32_t i = 0; i < 5; ++i) {
         vk::DestroyShaderEXT(*m_device, shaders[i], nullptr);
@@ -1459,14 +1459,14 @@ TEST_F(PositiveShaderObject, NotSettingDepthBounds) {
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_DEPTH_BOUNDS_TEST_ENABLE, VK_DYNAMIC_STATE_DEPTH_BOUNDS});
     vk::CmdSetRasterizerDiscardEnableEXT(m_command_buffer.handle(), VK_TRUE);
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, CreateAndDrawLinkedAndUnlinkedShaders) {
@@ -1502,7 +1502,7 @@ TEST_F(PositiveShaderObject, CreateAndDrawLinkedAndUnlinkedShaders) {
         vk::CreateShadersEXT(*m_device, 1u, &createInfos[i], nullptr, &shaders[i]);
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
 
@@ -1510,7 +1510,7 @@ TEST_F(PositiveShaderObject, CreateAndDrawLinkedAndUnlinkedShaders) {
 
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     for (uint32_t i = 0; i < 5u; ++i) {
         vk::DestroyShaderEXT(*m_device, shaders[i], nullptr);
@@ -1530,14 +1530,14 @@ TEST_F(PositiveShaderObject, IgnoredColorAttachmentCount) {
     renderingInfo.layerCount = 1;
     renderingInfo.renderArea = {{0, 0}, {1, 1}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRendering(renderingInfo);
 
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_ENABLE_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1552,7 +1552,7 @@ TEST_F(PositiveShaderObject, DisabledColorBlend) {
 
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT,
                                  GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, kFragmentMinimalGlsl));
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude({VK_DYNAMIC_STATE_COLOR_BLEND_EQUATION_EXT});
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1560,7 +1560,7 @@ TEST_F(PositiveShaderObject, DisabledColorBlend) {
     vk::CmdSetColorBlendEnableEXT(m_command_buffer.handle(), 0u, 1u, &colorBlendEnable);
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
@@ -1622,7 +1622,7 @@ TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
     const vkt::Shader geomShader(*m_device, VK_SHADER_STAGE_GEOMETRY_BIT, GLSLToSPV(VK_SHADER_STAGE_GEOMETRY_BIT, geom_src));
     const vkt::Shader fragShader(*m_device, VK_SHADER_STAGE_FRAGMENT_BIT, GLSLToSPV(VK_SHADER_STAGE_FRAGMENT_BIT, frag_src));
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderingColor(GetDynamicRenderTarget(), GetRenderTargetArea());
     SetDefaultDynamicStatesExclude();
     m_command_buffer.BindVertFragShader(vertShader, fragShader);
@@ -1630,5 +1630,5 @@ TEST_F(PositiveShaderObject, DrawWithVertGeomFragShaderObjects) {
     vk::CmdBindShadersEXT(m_command_buffer.handle(), 1u, &geomStage, &geomShader.handle());
     vk::CmdDraw(m_command_buffer.handle(), 4, 1, 0, 0);
     m_command_buffer.EndRendering();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_push_constants.cpp
+++ b/tests/unit/shader_push_constants.cpp
@@ -58,7 +58,7 @@ TEST_F(NegativeShaderPushConstants, PipelineRange) {
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceProperties device_props = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &device_props);
+    vk::GetPhysicalDeviceProperties(Gpu(), &device_props);
     // will be at least 256 as required from the spec
     const uint32_t maxPushConstantsSize = device_props.limits.maxPushConstantsSize;
 
@@ -163,9 +163,9 @@ TEST_F(NegativeShaderPushConstants, Range) {
     // Set limit to be same max as the shader usages
     const uint32_t maxPushConstantsSize = 16;
     VkPhysicalDeviceProperties props;
-    fpvkGetOriginalPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkGetOriginalPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
     props.limits.maxPushConstantsSize = maxPushConstantsSize;
-    fpvkSetPhysicalDeviceLimitsEXT(gpu(), &props.limits);
+    fpvkSetPhysicalDeviceLimitsEXT(Gpu(), &props.limits);
 
     RETURN_IF_SKIP(InitState());
     InitRenderTarget();
@@ -192,7 +192,7 @@ TEST_F(NegativeShaderPushConstants, Range) {
 
     const float data[16] = {};  // dummy data to match shader size
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // size of 0
     m_errorMonitor->SetDesiredError("VUID-vkCmdPushConstants-size-arraylength");
@@ -226,7 +226,7 @@ TEST_F(NegativeShaderPushConstants, Range) {
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 0,
                          maxPushConstantsSize, data);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
@@ -308,7 +308,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     g_pipe_small_range.CreateGraphicsPipeline();
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-maintenance4-08602");  // vertex
@@ -341,7 +341,7 @@ TEST_F(NegativeShaderPushConstants, DrawWithoutUpdate) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderPushConstants, MultipleEntryPoint) {

--- a/tests/unit/shader_push_constants_positive.cpp
+++ b/tests/unit/shader_push_constants_positive.cpp
@@ -329,17 +329,17 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     // case 1 - bind different layout with the same range
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_b);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 2 - bind layout with same range then push different range
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_b, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
@@ -348,10 +348,10 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 3 - same range same layout then same range from a different layout and same range from the same layout
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
@@ -360,10 +360,10 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 4 - same range same layout then diff range and same range update
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
@@ -372,10 +372,10 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 5 - update push constant bind different layout with the same range then bind correct layout
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
@@ -383,10 +383,10 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_a);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 6 - update push constant then bind different layout with overlapping range then bind correct layout
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdPushConstants(m_command_buffer.handle(), layout_a, VK_SHADER_STAGE_VERTEX_BIT, 0, pc_size, data);
@@ -394,10 +394,10 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_a);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // case 7 - bind different layout with different range then update push constant and bind correct layout
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_c);
@@ -405,7 +405,7 @@ TEST_F(PositiveShaderPushConstants, CompatibilityGraphicsOnly) {
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_a);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
@@ -452,21 +452,21 @@ TEST_F(PositiveShaderPushConstants, StaticallyUnused) {
     vkt::Buffer vbo(*m_device, sizeof(float) * 3, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
 
     // Draw without ever pushing to the unused and empty pipelines
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_unused.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 1, 1, &vbo.handle(), &kZeroDeviceSize);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_empty.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderPushConstants, OffsetVector) {
@@ -501,9 +501,9 @@ TEST_F(PositiveShaderPushConstants, OffsetVector) {
 
     const float data[16] = {};  // dummy data to match shader size
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 16, 16, data);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
@@ -550,9 +550,9 @@ TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferBasic) {
 
     const float data[12] = {};  // dummy data to match shader size
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 16, 12, data);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderPushConstants, PhysicalStorageBufferVertFrag) {
@@ -686,13 +686,13 @@ TEST_F(PositiveShaderPushConstants, MultipleStructs) {
 
     const float data[16] = {};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdPushConstants(m_command_buffer.handle(), pipe.pipeline_layout_.handle(), VK_SHADER_STAGE_VERTEX_BIT, 32, 16, data);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderPushConstants, SpecConstantSizeDefault) {

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -58,7 +58,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
         std::vector<uint32_t> shader;
         VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
         VkShaderModule module;
-        this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
+        this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
         module_create_info.pCode = shader.data();
         // Introduce failure by making codeSize a non-multiple of 4
         module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -95,7 +95,7 @@ TEST_F(NegativeShaderSpirv, CodeSizeMaintenance5) {
     m_errorMonitor->VerifyFound();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -131,7 +131,7 @@ TEST_F(NegativeShaderSpirv, CodeSizeMaintenance5Compute) {
     m_errorMonitor->VerifyFound();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -634,7 +634,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
         }
     )glsl";
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->phy().limits_, VK_SHADER_STAGE_VERTEX_BIT, vsSource, shader);
+    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, vsSource, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();
@@ -1388,7 +1388,7 @@ TEST_F(NegativeShaderSpirv, SpecializationSizeMismatch) {
     RETURN_IF_SKIP(InitState(nullptr, &features2));
     InitRenderTarget();
 
-    if (m_device->phy().Features().shaderFloat64) {
+    if (m_device->Physical().Features().shaderFloat64) {
         float64_support = true;
     }
 
@@ -1688,7 +1688,7 @@ TEST_F(NegativeShaderSpirv, NonSemanticInfoEnabled) {
     TEST_DESCRIPTION("Test VK_KHR_shader_non_semantic_info.");
 
     RETURN_IF_SKIP(Init());
-    if (!DeviceExtensionSupported(gpu(), nullptr, VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME)) {
+    if (!DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_shader_non_semantic_info not supported";
     }
 

--- a/tests/unit/shader_spirv_positive.cpp
+++ b/tests/unit/shader_spirv_positive.cpp
@@ -157,9 +157,9 @@ TEST_F(PositiveShaderSpirv, GroupDecorations) {
         dslb[i].pImmutableSamplers = NULL;
         dslb[i].stageFlags = VK_SHADER_STAGE_COMPUTE_BIT | VK_SHADER_STAGE_ALL;
     }
-    if (m_device->phy().limits_.maxPerStageDescriptorStorageBuffers < dslb_size) {
+    if (m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers < dslb_size) {
         GTEST_SKIP() << "Needed storage buffer bindings (" << dslb_size << ") exceeds this devices limit of "
-                     << m_device->phy().limits_.maxPerStageDescriptorStorageBuffers;
+                     << m_device->Physical().limits_.maxPerStageDescriptorStorageBuffers;
     }
 
     CreateComputePipelineHelper pipe(*this);
@@ -575,26 +575,26 @@ TEST_F(PositiveShaderSpirv, SpecializationWordBoundryOffset) {
     pipe.descriptor_set_->WriteDescriptorBufferInfo(0, buffer.handle(), 0, 1024, VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
     pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &pipe.descriptor_set_->set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
     // Make sure spec constants were updated correctly
     void *pData;
-    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), buffer.memory().handle(), 0, VK_WHOLE_SIZE, 0, &pData));
+    ASSERT_EQ(VK_SUCCESS, vk::MapMemory(device(), buffer.Memory().handle(), 0, VK_WHOLE_SIZE, 0, &pData));
     uint32_t *ssbo_data = reinterpret_cast<uint32_t *>(pData);
     ASSERT_EQ(ssbo_data[0], 0x02);
     ASSERT_EQ(ssbo_data[1], 0x05040302);
     ASSERT_EQ(ssbo_data[2], 0x06050403);
     ASSERT_EQ(ssbo_data[3], 0x07060504);
     ASSERT_EQ(ssbo_data[4], 0x04);
-    vk::UnmapMemory(device(), buffer.memory().handle());
+    vk::UnmapMemory(device(), buffer.Memory().handle());
 }
 
 TEST_F(PositiveShaderSpirv, Spirv16Vulkan13) {
@@ -741,11 +741,11 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
     // This generates OpImage*Dref* instruction on R8G8B8A8_UNORM format.
     // Verify that it is allowed on this implementation if
     // VK_KHR_format_feature_flags2 is available.
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UNORM, &fmt_props);
 
         if (!(fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_SAMPLED_IMAGE_DEPTH_COMPARISON_BIT_KHR)) {
             GTEST_SKIP() << "R8G8B8A8_UNORM does not support OpImage*Dref* operations";
@@ -808,7 +808,7 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
     g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view, sampler.handle(), VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER);
     g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, g_pipe.pipeline_layout_.handle(), 0, 1,
@@ -816,7 +816,7 @@ TEST_F(PositiveShaderSpirv, UnnormalizedCoordinatesNotSampled) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderSpirv, GeometryShaderPassthroughNV) {

--- a/tests/unit/shader_storage_image.cpp
+++ b/tests/unit/shader_storage_image.cpp
@@ -24,7 +24,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.shaderStorageImageReadWithoutFormat = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
 
@@ -33,7 +33,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatRead) {
     //
     //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
     //
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -91,7 +91,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.shaderStorageImageWriteWithoutFormat = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
 
@@ -100,7 +100,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWrite) {
     //
     //   https://github.com/KhronosGroup/Vulkan-Docs/blob/6177645341afc/appendices/spirvenv.txt#L553
     //
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -166,7 +166,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2(gpu(), (VkFormat)fmt, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), (VkFormat)fmt, &fmt_props);
 
         const bool has_storage = (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR) != 0;
         const bool has_read_without_format =
@@ -260,8 +260,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
         ds.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
         ds.UpdateDescriptorSets();
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
 
         {
             VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
@@ -287,7 +287,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatReadForFormat) {
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07028");
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         if ((tests[t].props.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_READ_WITHOUT_FORMAT_BIT_KHR) == 0) {
             m_errorMonitor->VerifyFound();
@@ -315,7 +315,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
         VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
         VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
-        vk::GetPhysicalDeviceFormatProperties2(gpu(), (VkFormat)fmt, &fmt_props);
+        vk::GetPhysicalDeviceFormatProperties2(Gpu(), (VkFormat)fmt, &fmt_props);
 
         const bool has_storage = (fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_IMAGE_BIT_KHR) != 0;
         const bool has_write_without_format =
@@ -405,8 +405,8 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
         ds.WriteDescriptorImageInfo(0, view, VK_NULL_HANDLE, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, VK_IMAGE_LAYOUT_GENERAL);
         ds.UpdateDescriptorSets();
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
 
         {
             VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
@@ -434,7 +434,7 @@ TEST_F(NegativeShaderStorageImage, MissingFormatWriteForFormat) {
             m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07027");
         }
         vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         if ((tests[t].props.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) == 0) {
             m_errorMonitor->VerifyFound();
@@ -452,11 +452,11 @@ TEST_F(NegativeShaderStorageImage, MissingNonReadableDecorationFormatRead) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.shaderStorageImageReadWithoutFormat = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -513,11 +513,11 @@ TEST_F(NegativeShaderStorageImage, MissingNonWritableDecorationFormatWrite) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.shaderStorageImageWriteWithoutFormat = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -598,7 +598,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponent) {
         )";
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;  // Rgba8ui
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
     const auto set_info = [&](CreateComputePipelineHelper &helper) {
@@ -652,7 +652,7 @@ TEST_F(NegativeShaderStorageImage, WriteLessComponentCopyObject) {
         )";
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;  // Rgba8ui
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
     const auto set_info = [&](CreateComputePipelineHelper &helper) {
@@ -705,7 +705,7 @@ TEST_F(NegativeShaderStorageImage, WriteSpecConstantLessComponent) {
         )";
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;  // Rgba8ui
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
@@ -773,13 +773,13 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &fmt_props);
     if ((fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) == 0) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
@@ -796,14 +796,14 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteLessComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageWrite-08795");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
@@ -852,7 +852,7 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
                                      });
 
     const VkFormat format = VK_FORMAT_A8_UNORM_KHR;
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
@@ -868,12 +868,12 @@ TEST_F(NegativeShaderStorageImage, UnknownWriteComponentA8Unorm) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageWrite-08796");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_storage_image_positive.cpp
+++ b/tests/unit/shader_storage_image_positive.cpp
@@ -63,7 +63,7 @@ TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
@@ -79,12 +79,12 @@ TEST_F(PositiveShaderStorageImage, WriteMoreComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
@@ -137,13 +137,13 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &fmt_props);
     if ((fmt_props_3.optimalTilingFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) == 0) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
@@ -160,12 +160,12 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteMoreComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
@@ -217,7 +217,7 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
@@ -245,12 +245,12 @@ TEST_F(PositiveShaderStorageImage, WriteSpecConstantMoreComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
@@ -336,7 +336,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
                                      });
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;
-    if (!FormatFeaturesAreSupported(gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
+    if (!FormatFeaturesAreSupported(Gpu(), format, VK_IMAGE_TILING_OPTIMAL, VK_FORMAT_FEATURE_STORAGE_IMAGE_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage image";
     }
 
@@ -355,7 +355,7 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_.handle(), 0, 1,
@@ -363,5 +363,5 @@ TEST_F(PositiveShaderStorageImage, UnknownWriteLessComponentMultiEntrypoint) {
     // This does not invoke the Compute Entrypoint where the bad write would be
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_storage_texel.cpp
+++ b/tests/unit/shader_storage_texel.cpp
@@ -58,7 +58,7 @@ TEST_F(NegativeShaderStorageTexel, WriteLessComponent) {
         )";
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;  // Rgba8ui
-    if (!BufferFormatAndFeaturesSupported(gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
+    if (!BufferFormatAndFeaturesSupported(Gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
@@ -120,13 +120,13 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R8G8B8A8_UINT;  // Rgba8ui
-    if (!BufferFormatAndFeaturesSupported(gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
+    if (!BufferFormatAndFeaturesSupported(Gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
     VkFormatProperties3KHR fmt_props_3 = vku::InitStructHelper();
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), VK_FORMAT_R8G8B8A8_UINT, &fmt_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), VK_FORMAT_R8G8B8A8_UINT, &fmt_props);
     if ((fmt_props_3.bufferFeatures & VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT_KHR) == 0) {
         GTEST_SKIP() << "Format doesn't support storage write without format";
     }
@@ -147,14 +147,14 @@ TEST_F(NegativeShaderStorageTexel, UnknownWriteLessComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpImageWrite-04469");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
@@ -174,12 +174,12 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     VkFormatProperties2 fmt_props = vku::InitStructHelper(&fmt_props_3);
 
     // set so format can be used as a storage texel buffer, but no WITHOUT_FORMAT support
-    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(gpu(), format, &fmt_props);
+    fpvkGetOriginalPhysicalDeviceFormatProperties2EXT(Gpu(), format, &fmt_props);
     fmt_props.formatProperties.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
     fmt_props.formatProperties.bufferFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
     fmt_props_3.bufferFeatures |= VK_FORMAT_FEATURE_2_STORAGE_TEXEL_BUFFER_BIT;
     fmt_props_3.bufferFeatures &= ~VK_FORMAT_FEATURE_2_STORAGE_WRITE_WITHOUT_FORMAT_BIT;
-    fpvkSetPhysicalDeviceFormatProperties2EXT(gpu(), format, fmt_props);
+    fpvkSetPhysicalDeviceFormatProperties2EXT(Gpu(), format, fmt_props);
 
     const char *csSource = R"(
                   OpCapability Shader
@@ -244,8 +244,8 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     ds.WriteDescriptorBufferView(0, buffer_view);
     ds.UpdateDescriptorSets();
 
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
 
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipeline.pipeline_layout_.handle(), 0,
@@ -253,5 +253,5 @@ TEST_F(NegativeShaderStorageTexel, MissingFormatWriteForFormat) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdDispatch-OpTypeImage-07029");
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/shader_storage_texel_positive.cpp
+++ b/tests/unit/shader_storage_texel_positive.cpp
@@ -62,7 +62,7 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
                                      });
 
     const VkFormat format = VK_FORMAT_R32G32_UINT;  // Rg32ui
-    if (!BufferFormatAndFeaturesSupported(gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
+    if (!BufferFormatAndFeaturesSupported(Gpu(), format, VK_FORMAT_FEATURE_STORAGE_TEXEL_BUFFER_BIT)) {
         GTEST_SKIP() << "Format doesn't support storage texel buffer";
     }
 
@@ -82,11 +82,11 @@ TEST_F(PositiveShaderStorageTexel, BufferWriteMoreComponent) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_.handle(), 0, 1,
                               &ds.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 

--- a/tests/unit/sparse_buffer.cpp
+++ b/tests/unit/sparse_buffer.cpp
@@ -311,14 +311,14 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // This copy is not legal since both buffers share same device memory range, and none of them will be rebound
     // to non overlapping device memory ranges. Reported at queue submit
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -398,13 +398,13 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy2) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
                       copy_info_list.data());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -447,7 +447,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     }
     buffer_sparse.destroy();
     buffer_ci.size = 2 * buffer_mem_reqs.alignment;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    buffer_sparse.InitNoMemory(*m_device, buffer_ci);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -477,7 +477,7 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     vkt::Queue* sparse_queue = m_device->QueuesWithSparseCapability()[0];
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue->handle(), 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
     VkBufferCopy copy_info;
@@ -485,9 +485,9 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy3) {
     copy_info.dstOffset = buffer_mem_reqs.alignment / 2;  // dstOffset is the start of buffer_mem_2, or 0 in this space
                                                           // => since overlaps are computed in buffer space, none should be detected
     copy_info.size = buffer_mem_reqs.alignment;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -530,8 +530,8 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy4) {
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
-    VkMemoryRequirements buffer_sparse_mem_reqs = buffer_sparse.memory_requirements();
-    const VkMemoryRequirements buffer_not_sparse_mem_reqs = buffer_not_sparse.memory_requirements();
+    VkMemoryRequirements buffer_sparse_mem_reqs = buffer_sparse.MemoryRequirements();
+    const VkMemoryRequirements buffer_not_sparse_mem_reqs = buffer_not_sparse.MemoryRequirements();
 
     if ((buffer_sparse_mem_reqs.memoryTypeBits & buffer_not_sparse_mem_reqs.memoryTypeBits) == 0) {
         GTEST_SKIP() << "Could not find common memory type for sparse and not sparse buffer, skipping test";
@@ -564,14 +564,14 @@ TEST_F(NegativeSparseBuffer, OverlappingBufferCopy4) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // This copy is not legal since both buffers share same device memory range, and none of them will be rebound
     // to non overlapping device memory ranges. Reported at queue submit
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_not_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -625,7 +625,7 @@ TEST_F(NegativeSparseBuffer, VkSparseMemoryBindMemory) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buffer_create_info.size = 1024;
 
-    if (m_device->phy().Features().sparseResidencyBuffer) {
+    if (m_device->Physical().Features().sparseResidencyBuffer) {
         buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
@@ -661,7 +661,7 @@ TEST_F(NegativeSparseBuffer, VkSparseMemoryBindFlags) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buffer_create_info.size = 1024;
 
-    if (m_device->phy().Features().sparseResidencyBuffer) {
+    if (m_device->Physical().Features().sparseResidencyBuffer) {
         buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";

--- a/tests/unit/sparse_buffer_positive.cpp
+++ b/tests/unit/sparse_buffer_positive.cpp
@@ -73,11 +73,11 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy) {
     sparse_queue->Wait();
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // This copy is be completely legal as long as we change the memory for buffer_sparse to not overlap with
     // buffer_sparse2's memory on queue submission
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse2.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Rebind buffer_mem2 so it does not overlap
     buffer_memory_bind.memory = buffer_mem2.handle();
@@ -158,13 +158,13 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy2) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
                       copy_info_list.data());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -201,7 +201,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     vk::GetBufferMemoryRequirements(device(), buffer_sparse.handle(), &buffer_mem_reqs);
     buffer_sparse.destroy();
     buffer_ci.size = 2 * buffer_mem_reqs.alignment;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    buffer_sparse.InitNoMemory(*m_device, buffer_ci);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -235,12 +235,12 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy3) {
     vkt::Queue* sparse_queue = m_device->QueuesWithSparseCapability()[0];
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue->handle(), 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -281,7 +281,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     }
     buffer_sparse.destroy();
     buffer_ci.size = 2 * buffer_mem_reqs.alignment;
-    buffer_sparse.init_no_mem(*m_device, buffer_ci);
+    buffer_sparse.InitNoMemory(*m_device, buffer_ci);
     VkMemoryAllocateInfo buffer_mem_alloc =
         vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer_mem_reqs, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
 
@@ -309,7 +309,7 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     vkt::Queue* sparse_queue = m_device->QueuesWithSparseCapability()[0];
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue->handle(), 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
     VkBufferCopy copy_info;
@@ -317,9 +317,9 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy4) {
     copy_info.dstOffset = buffer_mem_reqs.alignment / 2;  // dstOffset is the start of buffer_mem_2, or 0 in this space
                                                           // => since overlaps are computed in buffer space, none should be detected
     copy_info.size = buffer_mem_reqs.alignment / 2;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -360,8 +360,8 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy5) {
     b_info.flags = VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     vkt::Buffer buffer_sparse(*m_device, b_info, vkt::no_mem);
 
-    VkMemoryRequirements buffer_sparse_mem_reqs = buffer_sparse.memory_requirements();
-    const VkMemoryRequirements buffer_not_sparse_mem_reqs = buffer_not_sparse.memory_requirements();
+    VkMemoryRequirements buffer_sparse_mem_reqs = buffer_sparse.MemoryRequirements();
+    const VkMemoryRequirements buffer_not_sparse_mem_reqs = buffer_not_sparse.MemoryRequirements();
 
     if ((buffer_sparse_mem_reqs.memoryTypeBits & buffer_not_sparse_mem_reqs.memoryTypeBits) == 0) {
         GTEST_SKIP() << "Could not find common memory type for sparse and not sparse buffer, skipping test";
@@ -395,12 +395,12 @@ TEST_F(PositiveSparseBuffer, NonOverlappingBufferCopy5) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_not_sparse.handle(), buffer_sparse.handle(), 1, &copy_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Submitting copy command with overlapping device memory regions
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
@@ -498,13 +498,13 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
                       copy_info_list.data());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     VkSubmitInfo submit_info = vku::InitStructHelper();
@@ -598,13 +598,13 @@ TEST_F(PositiveSparseBuffer, BufferCopiesValidationStressTest2) {
     VkQueue sparse_queue = m_device->QueuesWithSparseCapability()[0]->handle();
     vkt::Fence sparse_queue_fence(*m_device);
     vk::QueueBindSparse(sparse_queue, 1, &bind_info, sparse_queue_fence);
-    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.wait(kWaitTimeout));
+    ASSERT_EQ(VK_SUCCESS, sparse_queue_fence.Wait(kWaitTimeout));
     // Set up complete
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer.handle(), buffer_sparse.handle(), buffer_sparse.handle(), size32(copy_info_list),
                       copy_info_list.data());
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     VkPipelineStageFlags mask = VK_PIPELINE_STAGE_ALL_COMMANDS_BIT;
     VkSubmitInfo submit_info = vku::InitStructHelper();

--- a/tests/unit/sparse_image.cpp
+++ b/tests/unit/sparse_image.cpp
@@ -26,14 +26,14 @@ TEST_F(NegativeSparseImage, BindingImageBufferCreate) {
     buf_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buf_info.size = 2048;
 
-    if (m_device->phy().Features().sparseResidencyBuffer) {
+    if (m_device->Physical().Features().sparseResidencyBuffer) {
         buf_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT;
         CreateBufferTest(*this, &buf_info, "VUID-VkBufferCreateInfo-flags-00918");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
     }
 
-    if (m_device->phy().Features().sparseResidencyAliased) {
+    if (m_device->Physical().Features().sparseResidencyAliased) {
         buf_info.flags = VK_BUFFER_CREATE_SPARSE_ALIASED_BIT;
         CreateBufferTest(*this, &buf_info, "VUID-VkBufferCreateInfo-flags-00918");
     } else {
@@ -53,14 +53,14 @@ TEST_F(NegativeSparseImage, BindingImageBufferCreate) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    if (m_device->phy().Features().sparseResidencyImage2D) {
+    if (m_device->Physical().Features().sparseResidencyImage2D) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT;
         CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-00987");
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyImage2D feature";
     }
 
-    if (m_device->phy().Features().sparseResidencyAliased) {
+    if (m_device->Physical().Features().sparseResidencyAliased) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_ALIASED_BIT;
         CreateImageTest(*this, &image_create_info, "VUID-VkImageCreateInfo-flags-00987");
     } else {
@@ -222,7 +222,7 @@ TEST_F(NegativeSparseImage, MemoryBindOffset) {
     buffer_create_info.usage = VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     buffer_create_info.size = 0x10000;
 
-    if (m_device->phy().Features().sparseResidencyBuffer) {
+    if (m_device->Physical().Features().sparseResidencyBuffer) {
         buffer_create_info.flags = VK_BUFFER_CREATE_SPARSE_RESIDENCY_BIT | VK_BUFFER_CREATE_SPARSE_BINDING_BIT;
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyBuffer feature";
@@ -242,7 +242,7 @@ TEST_F(NegativeSparseImage, MemoryBindOffset) {
     image_create_info.initialLayout = VK_IMAGE_LAYOUT_PREINITIALIZED;
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
-    if (m_device->phy().Features().sparseResidencyImage2D) {
+    if (m_device->Physical().Features().sparseResidencyImage2D) {
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_RESIDENCY_BIT | VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
     } else {
         GTEST_SKIP() << "Test requires unsupported sparseResidencyImage2D feature";
@@ -322,7 +322,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    const uint32_t mem_types_mask = (1u << m_device->phy().memory_properties_.memoryTypeCount) - 1;
+    const uint32_t mem_types_mask = (1u << m_device->Physical().memory_properties_.memoryTypeCount) - 1;
 
     /// Create buffer whose memory has an incompatible type
     VkBufferCreateInfo buffer_create_info = vku::InitStructHelper();
@@ -339,13 +339,13 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
     buffer_mem_alloc.allocationSize = buffer_mem_reqs.size;
     buffer_mem_alloc.memoryTypeIndex = vvl::kU32Max;
     // Try to pick incompatible memory type
-    for (uint32_t memory_type_i = 0; memory_type_i < m_device->phy().memory_properties_.memoryTypeCount; ++memory_type_i) {
-        if (m_device->phy().memory_properties_.memoryTypes[memory_type_i].propertyFlags &
+    for (uint32_t memory_type_i = 0; memory_type_i < m_device->Physical().memory_properties_.memoryTypeCount; ++memory_type_i) {
+        if (m_device->Physical().memory_properties_.memoryTypes[memory_type_i].propertyFlags &
             VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD) {
             continue;
         }
 
-        if (m_device->phy().memory_properties_.memoryTypes[memory_type_i].propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) {
+        if (m_device->Physical().memory_properties_.memoryTypes[memory_type_i].propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) {
             continue;
         }
 
@@ -359,8 +359,9 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
         GTEST_SKIP() << "Could not find suitable memory type for buffer, skipping test";
     }
 
-    const bool buffer_mem_lazy = m_device->phy().memory_properties_.memoryTypes[buffer_mem_alloc.memoryTypeIndex].propertyFlags &
-                                 VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
+    const bool buffer_mem_lazy =
+        m_device->Physical().memory_properties_.memoryTypes[buffer_mem_alloc.memoryTypeIndex].propertyFlags &
+        VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
 
     vkt::DeviceMemory buffer_mem(*m_device, buffer_mem_alloc);
 
@@ -388,13 +389,13 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
     image_mem_alloc.allocationSize = image_mem_reqs.size;
     image_mem_alloc.memoryTypeIndex = vvl::kU32Max;
     // Try to pick incompatible memory type
-    for (uint32_t memory_type_i = 0; memory_type_i < m_device->phy().memory_properties_.memoryTypeCount; ++memory_type_i) {
-        if (m_device->phy().memory_properties_.memoryTypes[memory_type_i].propertyFlags &
+    for (uint32_t memory_type_i = 0; memory_type_i < m_device->Physical().memory_properties_.memoryTypeCount; ++memory_type_i) {
+        if (m_device->Physical().memory_properties_.memoryTypes[memory_type_i].propertyFlags &
             VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD) {
             continue;
         }
 
-        if (m_device->phy().memory_properties_.memoryTypes[memory_type_i].propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) {
+        if (m_device->Physical().memory_properties_.memoryTypes[memory_type_i].propertyFlags & VK_MEMORY_PROPERTY_PROTECTED_BIT) {
             continue;
         }
 
@@ -408,7 +409,7 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType) {
         GTEST_SKIP() << "Could not find suitable memory type for image, skipping test";
     }
 
-    const bool image_mem_lazy = m_device->phy().memory_properties_.memoryTypes[image_mem_alloc.memoryTypeIndex].propertyFlags &
+    const bool image_mem_lazy = m_device->Physical().memory_properties_.memoryTypes[image_mem_alloc.memoryTypeIndex].propertyFlags &
                                 VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT;
 
     vkt::DeviceMemory image_mem(*m_device, image_mem_alloc);
@@ -496,14 +497,15 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType2) {
         GTEST_SKIP() << "Required SPARSE_BINDING queue families not present";
     }
 
-    uint32_t lazily_allocated_index = m_device->phy().memory_properties_.memoryTypeCount;  // Set to an invalid value just in case
-    for (uint32_t i = 0; i < m_device->phy().memory_properties_.memoryTypeCount; ++i) {
-        if ((m_device->phy().memory_properties_.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) != 0) {
+    uint32_t lazily_allocated_index =
+        m_device->Physical().memory_properties_.memoryTypeCount;  // Set to an invalid value just in case
+    for (uint32_t i = 0; i < m_device->Physical().memory_properties_.memoryTypeCount; ++i) {
+        if ((m_device->Physical().memory_properties_.memoryTypes[i].propertyFlags & VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT) != 0) {
             lazily_allocated_index = i;
             break;
         }
     }
-    if (lazily_allocated_index == m_device->phy().memory_properties_.memoryTypeCount) {
+    if (lazily_allocated_index == m_device->Physical().memory_properties_.memoryTypeCount) {
         GTEST_SKIP() << "Did not find memory with VK_MEMORY_PROPERTY_LAZILY_ALLOCATED_BIT";
     }
 
@@ -629,13 +631,13 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
     buffer_create_info.size = 1024;
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
     const auto buffer_exportable_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), buffer_create_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), buffer_create_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!buffer_exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type for buffer, skipping test";
     }
     const auto buffer_exportable_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(buffer_exportable_types);
     VkExportMemoryAllocateInfo buffer_export_mem_alloc_info = vku::InitStructHelper();
-    buffer_export_mem_alloc_info.handleTypes = GetCompatibleHandleTypes(gpu(), buffer_create_info, buffer_exportable_type);
+    buffer_export_mem_alloc_info.handleTypes = GetCompatibleHandleTypes(Gpu(), buffer_create_info, buffer_exportable_type);
     VkMemoryRequirements buffer_mem_reqs{};
     vk::GetBufferMemoryRequirements(device(), buffer.handle(), &buffer_mem_reqs);
     const VkMemoryAllocateInfo buffer_mem_alloc = vkt::DeviceMemory::GetResourceAllocInfo(
@@ -659,14 +661,14 @@ TEST_F(NegativeSparseImage, QueueBindSparseMemoryType3) {
     vkt::Image image(*m_device, image_create_info, vkt::no_mem);
 
     const auto image_exportable_types =
-        FindSupportedExternalMemoryHandleTypes(gpu(), image_create_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
+        FindSupportedExternalMemoryHandleTypes(Gpu(), image_create_info, VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT);
     if (!image_exportable_types) {
         GTEST_SKIP() << "Unable to find exportable handle type for image, skipping test";
     }
     const auto image_exportable_type = LeastSignificantFlag<VkExternalMemoryHandleTypeFlagBits>(image_exportable_types);
 
     VkExportMemoryAllocateInfo image_export_mem_alloc_info = vku::InitStructHelper();
-    image_export_mem_alloc_info.handleTypes = GetCompatibleHandleTypes(gpu(), image_create_info, image_exportable_type);
+    image_export_mem_alloc_info.handleTypes = GetCompatibleHandleTypes(Gpu(), image_create_info, image_exportable_type);
     VkMemoryRequirements image_mem_reqs;
     vk::GetImageMemoryRequirements(device(), image.handle(), &image_mem_reqs);
     const VkMemoryAllocateInfo image_mem_alloc = vkt::DeviceMemory::GetResourceAllocInfo(
@@ -775,7 +777,7 @@ TEST_F(NegativeSparseImage, DISABLED_QueueBindSparseMemoryType4) {
         VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_EXTERNAL_BUFFER_INFO_KHR, nullptr, 0,
         VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, handle_type};
     VkExternalBufferPropertiesKHR external_buffer_props = {VK_STRUCTURE_TYPE_EXTERNAL_BUFFER_PROPERTIES_KHR, nullptr, {0, 0, 0}};
-    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(gpu(), &external_buffer_info, &external_buffer_props);
+    vk::GetPhysicalDeviceExternalBufferPropertiesKHR(Gpu(), &external_buffer_info, &external_buffer_props);
     if (!(external_buffer_props.externalMemoryProperties.compatibleHandleTypes & handle_type) ||
         !(external_buffer_props.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(external_buffer_props.externalMemoryProperties.externalMemoryFeatures & VK_EXTERNAL_MEMORY_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -799,7 +801,7 @@ TEST_F(NegativeSparseImage, DISABLED_QueueBindSparseMemoryType4) {
     buffer_create_info.size = 1024;
     vkt::Buffer buffer(*m_device, buffer_create_info, vkt::no_mem);
 
-    VkMemoryAllocateInfo buffer_mem_alloc = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.memory_requirements(), 0);
+    VkMemoryAllocateInfo buffer_mem_alloc = vkt::DeviceMemory::GetResourceAllocInfo(*m_device, buffer.MemoryRequirements(), 0);
     VkExportMemoryAllocateInfoKHR export_info = vku::InitStructHelper();
     export_info.handleTypes = handle_type;
     buffer_mem_alloc.pNext = &export_info;
@@ -867,7 +869,7 @@ TEST_F(NegativeSparseImage, DISABLED_QueueBindSparseMemoryType4) {
 
     // Setup memory bindings
     VkSparseMemoryBind buffer_memory_bind = {};
-    buffer_memory_bind.size = buffer.memory_requirements().size;
+    buffer_memory_bind.size = buffer.MemoryRequirements().size;
     buffer_memory_bind.memory = buffer_memory_imported.handle();
 
     VkSparseBufferMemoryBindInfo buffer_memory_bind_info = {};
@@ -1099,8 +1101,8 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidMemory) {
 
     VkMemoryAllocateInfo invalid_image_mem_alloc = vku::InitStructHelper();
     invalid_image_mem_alloc.allocationSize = invalid_image_mem_reqs.size;
-    if (!m_device->phy().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
-                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
+    if (!m_device->Physical().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 
@@ -1187,8 +1189,8 @@ TEST_F(NegativeSparseImage, ImageMemoryBindInvalidAlignment) {
 
     VkMemoryAllocateInfo invalid_image_mem_alloc = vku::InitStructHelper();
     invalid_image_mem_alloc.allocationSize = invalid_image_mem_reqs.size;
-    if (!m_device->phy().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
-                                       VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
+    if (!m_device->Physical().SetMemoryType(invalid_image_mem_reqs.memoryTypeBits, &invalid_image_mem_alloc,
+                                            VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT)) {
         GTEST_SKIP() << "Could not find required memory type";
     }
 
@@ -1316,7 +1318,7 @@ TEST_F(NegativeSparseImage, UnalignedBindOffsets) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if (!(m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+    if (!(m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
@@ -1347,14 +1349,14 @@ TEST_F(NegativeSparseImage, UnalignedBindOffsets) {
         image.destroy();
         image_create_info.extent.width *= 2;
         image_create_info.extent.height *= 2;
-        image.init_no_mem(*m_device, image_create_info);
+        image.InitNoMemory(*m_device, image_create_info);
         vk::GetImageMemoryRequirements(device(), image, &memory_reqs);
     }
     // Allocate 2 memory regions of minimum alignment size, bind one at 0, the other
     // at the end of the first
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = 2 * memory_reqs.alignment;
-    bool pass = m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
+    bool pass = m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory memory_one(*m_device, memory_info);
     vkt::DeviceMemory memory_two(*m_device, memory_info);

--- a/tests/unit/sparse_image_positive.cpp
+++ b/tests/unit/sparse_image_positive.cpp
@@ -24,7 +24,7 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if (!(m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+    if (!(m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
@@ -52,14 +52,14 @@ TEST_F(PositiveSparseImage, MultipleBinds) {
         image.destroy();
         image_create_info.extent.width *= 2;
         image_create_info.extent.height *= 2;
-        image.init_no_mem(*m_device, image_create_info);
+        image.InitNoMemory(*m_device, image_create_info);
         vk::GetImageMemoryRequirements(device(), image, &memory_reqs);
     }
     // Allocate 2 memory regions of minimum alignment size, bind one at 0, the other
     // at the end of the first
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs.alignment;
-    bool pass = m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
+    bool pass = m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
     vkt::DeviceMemory memory_one(*m_device, memory_info);
     vkt::DeviceMemory memory_two(*m_device, memory_info);
@@ -96,7 +96,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if (!(m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+    if (!(m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
@@ -119,7 +119,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     vk::GetImageMemoryRequirements(device(), image, &memory_reqs);
     VkMemoryAllocateInfo memory_info = vku::InitStructHelper();
     memory_info.allocationSize = memory_reqs.size;
-    bool pass = m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
+    bool pass = m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &memory_info, 0);
     ASSERT_TRUE(pass);
 
     vkt::DeviceMemory memory(*m_device, memory_info);
@@ -152,7 +152,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     // Free the memory, then use the image in a new command buffer
     memory.destroy();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -171,7 +171,7 @@ TEST_F(PositiveSparseImage, BindFreeMemory) {
     const VkClearColorValue clear_color = {{0.0f, 0.0f, 0.0f, 1.0f}};
     VkImageSubresourceRange range = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vk::CmdClearColorImage(m_command_buffer.handle(), image, VK_IMAGE_LAYOUT_GENERAL, &clear_color, 1, &range);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     // Wait for operations to finish before destroying anything
     m_default_queue->Wait();
@@ -184,7 +184,7 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if (!(m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+    if (!(m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
@@ -228,7 +228,7 @@ TEST_F(PositiveSparseImage, BindMetadata) {
     // Allocate memory for the metadata
     VkMemoryAllocateInfo metadata_memory_info = vku::InitStructHelper();
     metadata_memory_info.allocationSize = metadata_reqs->imageMipTailSize;
-    m_device->phy().SetMemoryType(memory_reqs.memoryTypeBits, &metadata_memory_info, 0);
+    m_device->Physical().SetMemoryType(memory_reqs.memoryTypeBits, &metadata_memory_info, 0);
     vkt::DeviceMemory metadata_memory(*m_device, metadata_memory_info);
 
     // Bind metadata
@@ -262,7 +262,7 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if (!(m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
+    if (!(m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT)) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
     InitRenderTarget();
@@ -317,14 +317,14 @@ TEST_F(PositiveSparseImage, OpImageSparse) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&ds.layout_});
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.pipeline_layout_, 0, 1, &ds.set_, 0,
                               nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSparseImage, BindImage) {

--- a/tests/unit/subgroups.cpp
+++ b/tests/unit/subgroups.cpp
@@ -26,7 +26,7 @@ TEST_F(NegativeSubgroup, Properties) {
     RETURN_IF_SKIP(InitFramework());
 
     VkPhysicalDeviceFeatures features{};
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     if (features.vertexPipelineStoresAndAtomics == VK_FALSE) {
         GTEST_SKIP() << "vertexPipelineStoresAndAtomics not supported";
     }
@@ -37,7 +37,7 @@ TEST_F(NegativeSubgroup, Properties) {
 
     // Don't enable the extension on purpose
     const bool extension_support_partitioned =
-        DeviceExtensionSupported(gpu(), nullptr, VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME);
+        DeviceExtensionSupported(Gpu(), nullptr, VK_NV_SHADER_SUBGROUP_PARTITIONED_EXTENSION_NAME);
     InitRenderTarget();
 
     // Gather all aspects supported
@@ -693,7 +693,7 @@ TEST_F(NegativeSubgroup, ComputeLocalWorkgroupSize) {
         pipe.cs_ = std::make_unique<VkShaderObj>(this, csSource.str().c_str(), VK_SHADER_STAGE_COMPUTE_BIT);
         pipe.LateBindPipelineInfo();
         pipe.cp_ci_.stage.pNext = &subgroup_size_control;
-        if (size * size * 2 > m_device->phy().limits_.maxComputeWorkGroupInvocations) {
+        if (size * size * 2 > m_device->Physical().limits_.maxComputeWorkGroupInvocations) {
             m_errorMonitor->SetDesiredError("VUID-RuntimeSpirv-x-06432");
         }
         m_errorMonitor->SetDesiredError("VUID-VkPipelineShaderStageCreateInfo-pNext-02756");

--- a/tests/unit/subpass.cpp
+++ b/tests/unit/subpass.cpp
@@ -313,7 +313,7 @@ TEST_F(NegativeSubpass, NextSubpassExcessive) {
     const bool rp2Supported = IsExtensionsEnabled(VK_KHR_CREATE_RENDERPASS_2_EXTENSION_NAME);
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdNextSubpass-None-00909");
@@ -331,7 +331,7 @@ TEST_F(NegativeSubpass, NextSubpassExcessive) {
     }
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
@@ -350,7 +350,7 @@ TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
     vkt::RenderPass rp(*m_device, rcpi);
     vkt::Framebuffer fb(*m_device, rp.handle(), 0u, nullptr, 16, 16);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 16, 16);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass-None-00910");
@@ -360,8 +360,8 @@ TEST_F(NegativeSubpass, RenderPassEndBeforeFinalSubpass) {
     if (rp2Supported) {
         VkSubpassEndInfoKHR subpassEndInfo = vku::InitStructHelper();
 
-        m_command_buffer.reset();
-        m_command_buffer.begin();
+        m_command_buffer.Reset();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 16, 16);
 
         m_errorMonitor->SetDesiredError("VUID-vkCmdEndRenderPass2-None-03103");
@@ -451,7 +451,7 @@ TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
     pipe.gp_ci_.renderPass = rp.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // subtest 1: bind in the wrong subpass
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
@@ -473,7 +473,7 @@ TEST_F(NegativeSubpass, DrawWithPipelineIncompatibleWithSubpass) {
 
     m_command_buffer.EndRenderPass();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
@@ -526,7 +526,7 @@ TEST_F(NegativeSubpass, ImageBarrierSubpassConflict) {
     img_barrier.subresourceRange.baseMipLevel = 0;
     img_barrier.subresourceRange.layerCount = 1;
     img_barrier.subresourceRange.levelCount = 1;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle(), 32, 32);
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-image-04073");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
@@ -626,7 +626,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
         g_pipe.descriptor_set_->WriteDescriptorImageInfo(0, view_input, sampler.handle(), VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT);
         g_pipe.descriptor_set_->UpdateDescriptorSets();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
 
         image_input.SetLayout(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
 
@@ -642,7 +642,7 @@ TEST_F(NegativeSubpass, SubpassInputNotBoundDescriptorSet) {
         vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 
@@ -752,7 +752,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     VkClearValue clear_value = {};
     clear_value.color = {{0, 0, 0, 0}};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass.handle(), framebuffer.handle(), 32, 32, 1, &clear_value);
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdDraw-subpass-02685");
@@ -772,7 +772,7 @@ TEST_F(NegativeSubpass, PipelineSubpassIndex) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSubpass, SubpassDependencyMasksSync2) {
@@ -1119,12 +1119,12 @@ TEST_F(NegativeSubpass, SubpassInputWithoutFormat) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitFramework());
     VkPhysicalDeviceFeatures features;
-    vk::GetPhysicalDeviceFeatures(gpu(), &features);
+    vk::GetPhysicalDeviceFeatures(Gpu(), &features);
     features.shaderStorageImageReadWithoutFormat = VK_FALSE;
     RETURN_IF_SKIP(InitState(&features));
     InitRenderTarget();
 
-    if (DeviceExtensionSupported(gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
+    if (DeviceExtensionSupported(Gpu(), nullptr, VK_KHR_FORMAT_FEATURE_FLAGS_2_EXTENSION_NAME)) {
         GTEST_SKIP() << "VK_KHR_format_feature_flags2 is supported";
     }
 
@@ -1181,7 +1181,7 @@ TEST_F(NegativeSubpass, NextSubpassNoRenderPass) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdNextSubpass-renderpass");
     m_command_buffer.NextSubpass();
     m_errorMonitor->VerifyFound();
@@ -1192,7 +1192,7 @@ TEST_F(NegativeSubpass, NextSubpassNoRenderPass) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdNextSubpass-renderpass");
     m_command_buffer.NextSubpass();
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSubpass, FramebufferNoAttachmentsSampleCounts) {
@@ -1200,7 +1200,7 @@ TEST_F(NegativeSubpass, FramebufferNoAttachmentsSampleCounts) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    if ((m_device->phy().limits_.framebufferNoAttachmentsSampleCounts & VK_SAMPLE_COUNT_8_BIT) != 0) {
+    if ((m_device->Physical().limits_.framebufferNoAttachmentsSampleCounts & VK_SAMPLE_COUNT_8_BIT) != 0) {
         GTEST_SKIP() << "Need framebufferNoAttachmentsSampleCounts with no support";
     }
 

--- a/tests/unit/subpass_positive.cpp
+++ b/tests/unit/subpass_positive.cpp
@@ -83,20 +83,20 @@ TEST_F(PositiveSubpass, SubpassImageBarrier) {
     dependency_info.pImageMemoryBarriers = safe_barrier2.ptr();
 
     // Test vkCmdPipelineBarrier subpass barrier
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
                            &barrier);
     vk::CmdEndRenderPass(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Test vkCmdPipelineBarrier2 subpass barrier
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
     vk::CmdPipelineBarrier2(m_command_buffer, &dependency_info);
     vk::CmdEndRenderPass(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSubpass, SubpassWithEventWait) {
@@ -163,25 +163,25 @@ TEST_F(PositiveSubpass, SubpassWithEventWait) {
     // vkCmdWaitEvents inside render pass
     {
         vkt::Event event(*m_device);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdSetEvent(m_command_buffer, event, VK_ACCESS_COLOR_ATTACHMENT_WRITE_BIT);
         m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
         vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                           VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, nullptr, 0, nullptr, 1, &barrier);
         vk::CmdEndRenderPass(m_command_buffer);
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     // vkCmdWaitEvents2 inside render pass.
     // It's also a regression test for https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/4258
     {
         vkt::Event event2(*m_device);
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdSetEvent2(m_command_buffer, event2, &dependency_info);
         m_command_buffer.BeginRenderPass(render_pass, framebuffer, 32, 32);
         vk::CmdWaitEvents2(m_command_buffer, 1, &event2.handle(), &dependency_info);
         vk::CmdEndRenderPass(m_command_buffer);
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 }
 

--- a/tests/unit/sync_object.cpp
+++ b/tests/unit/sync_object.cpp
@@ -53,7 +53,7 @@ TEST_F(NegativeSyncObject, ImageBarrierSubpassConflicts) {
     vkt::Framebuffer fb(*m_device, rp.handle(), 1, &imageView.handle());
     vkt::Framebuffer fb_noselfdep(*m_device, rp_noselfdep.handle(), 1, &imageView.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp_noselfdep.handle(), fb_noselfdep.handle(), 32, 32);
     VkMemoryBarrier mem_barrier = vku::InitStructHelper();
     mem_barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
@@ -194,7 +194,7 @@ TEST_F(NegativeSyncObject, BufferMemoryBarrierNoBuffer) {
     m_errorMonitor->SetDesiredError("UNASSIGNED-GeneralParameterError-RequiredHandle");
 
     RETURN_IF_SKIP(Init());
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkBufferMemoryBarrier buf_barrier = vku::InitStructHelper();
     buf_barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
@@ -265,13 +265,13 @@ TEST_F(NegativeSyncObject, Barriers) {
     rp.CreateRenderPass();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &color_view.handle());
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0) ||
-                                 ((m_device->phy().queue_properties_[other_family].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0) ||
+                                 ((m_device->Physical().queue_properties_[other_family].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0);
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
         qf_indices.resize(1);
@@ -303,7 +303,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     conc_test.image_barrier_.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     conc_test("");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
     // Can't send buffer memory barrier during a render pass
@@ -408,7 +408,7 @@ TEST_F(NegativeSyncObject, Barriers) {
 
     // Now test depth-only
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D16_UNORM, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D16_UNORM, &format_props);
     if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
         vkt::Image d_image(*m_device, 128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
@@ -426,7 +426,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     }
 
     // Now test stencil-only
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_S8_UINT, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_S8_UINT, &format_props);
     if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
         vkt::Image s_image(*m_device, 128, 128, 1, VK_FORMAT_S8_UINT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
@@ -460,7 +460,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     if (mp_extensions) {
         VkFormatProperties format_properties;
         VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &format_properties);
         constexpr VkImageAspectFlags disjoint_sampled = VK_FORMAT_FEATURE_DISJOINT_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
         if (disjoint_sampled == (format_properties.optimalTilingFeatures & disjoint_sampled)) {
             VkImageCreateInfo image_create_info = vku::InitStructHelper();
@@ -492,13 +492,13 @@ TEST_F(NegativeSyncObject, Barriers) {
             // Find a valid memory type index to memory to be allocated from
             VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
             alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-            ASSERT_TRUE(m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
+            ASSERT_TRUE(m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
             ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &alloc_info, NULL, &plane_0_memory));
 
             image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_1_BIT;
             vk::GetImageMemoryRequirements2KHR(device(), &mem_req_info2, &mem_req2);
             alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-            ASSERT_TRUE(m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
+            ASSERT_TRUE(m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
             ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &alloc_info, NULL, &plane_1_memory));
 
             VkBindImagePlaneMemoryInfo plane_0_memory_info = vku::InitStructHelper();
@@ -653,7 +653,7 @@ TEST_F(NegativeSyncObject, Barriers) {
                 continue;
             }
             conc_test.image_barrier_.image = test.image_obj.handle();
-            const VkImageUsageFlags usage = test.image_obj.usage();
+            const VkImageUsageFlags usage = test.image_obj.Usage();
             conc_test.image_barrier_.subresourceRange.aspectMask = (usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
                                                                        ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)
                                                                        : VK_IMAGE_ASPECT_COLOR_BIT;
@@ -695,7 +695,7 @@ TEST_F(NegativeSyncObject, Barriers) {
 
     // Attempt to mismatch barriers/waitEvents calls with incompatible queues
     // Create command pool with incompatible queueflags
-    const std::vector<VkQueueFamilyProperties> queue_props = m_device->phy().queue_properties_;
+    const std::vector<VkQueueFamilyProperties> queue_props = m_device->Physical().queue_properties_;
     const std::optional<uint32_t> queue_family_index = m_device->ComputeOnlyQueueFamily();
     if (!queue_family_index) {
         GTEST_SKIP() << "No compute-only queue found; skipped";
@@ -715,7 +715,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     vkt::CommandPool command_pool(*m_device, queue_family_index.value(), VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer bad_command_buffer(*m_device, command_pool);
 
-    bad_command_buffer.begin();
+    bad_command_buffer.Begin();
     // Set two bits that should both be supported as a bonus positive check
     buf_barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
     buf_barrier.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT | VK_ACCESS_TRANSFER_READ_BIT;
@@ -730,7 +730,7 @@ TEST_F(NegativeSyncObject, Barriers) {
     vk::CmdWaitEvents(bad_command_buffer.handle(), 1, &event.handle(), /*source stage mask*/ VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                       VK_PIPELINE_STAGE_TRANSFER_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    bad_command_buffer.end();
+    bad_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, Sync2Barriers) {
@@ -753,7 +753,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     GetPhysicalDeviceFeatures2(sync2_features);
     RETURN_IF_SKIP(InitState(nullptr, &sync2_features));
 
-    auto depth_format = FindSupportedDepthStencilFormat(gpu());
+    auto depth_format = FindSupportedDepthStencilFormat(Gpu());
 
     vkt::Image color_image(*m_device, m_width, m_height, 1, VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     auto color_view = color_image.CreateView();
@@ -778,9 +778,9 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &color_view.handle());
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
         qf_indices.resize(1);
@@ -812,7 +812,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     conc_test.image_barrier_.newLayout = VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL;
     conc_test("");
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
 
     // Can't send buffer memory barrier during a render pass
@@ -919,7 +919,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
 
     // Now test depth-only
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_D16_UNORM, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_D16_UNORM, &format_props);
     if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
         vkt::Image d_image(*m_device, 128, 128, 1, VK_FORMAT_D16_UNORM, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
@@ -937,7 +937,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
     }
 
     // Now test stencil-only
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), VK_FORMAT_S8_UINT, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), VK_FORMAT_S8_UINT, &format_props);
     if (format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_DEPTH_STENCIL_ATTACHMENT_BIT) {
         vkt::Image s_image(*m_device, 128, 128, 1, VK_FORMAT_S8_UINT, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
@@ -1081,7 +1081,7 @@ TEST_F(NegativeSyncObject, Sync2Barriers) {
                 continue;
             }
             conc_test.image_barrier_.image = test.image_obj.handle();
-            const VkImageUsageFlags usage = test.image_obj.usage();
+            const VkImageUsageFlags usage = test.image_obj.Usage();
             conc_test.image_barrier_.subresourceRange.aspectMask = (usage == VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT)
                                                                        ? (VK_IMAGE_ASPECT_DEPTH_BIT | VK_IMAGE_ASPECT_STENCIL_BIT)
                                                                        : VK_IMAGE_ASPECT_COLOR_BIT;
@@ -1130,9 +1130,9 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparate) {
     InitRenderTarget();
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
         qf_indices.resize(1);
@@ -1141,9 +1141,9 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparate) {
     BarrierQueueFamilyTestHelper conc_test(&test_context);
     conc_test.Init(nullptr, false, true);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
-    const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image ds_image(*m_device, 128, 128, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     conc_test.image_barrier_.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -1169,9 +1169,9 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparateSync2) {
     InitRenderTarget();
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
         qf_indices.resize(1);
@@ -1180,9 +1180,9 @@ TEST_F(NegativeSyncObject, DepthStencilImageNonSeparateSync2) {
     Barrier2QueueFamilyTestHelper conc_test(&test_context);
     conc_test.Init(nullptr, false, true);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
-    const VkFormat depth_format = FindSupportedDepthStencilFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthStencilFormat(Gpu());
     vkt::Image ds_image(*m_device, 128, 128, 1, depth_format, VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT);
 
     conc_test.image_barrier_.oldLayout = VK_IMAGE_LAYOUT_DEPTH_STENCIL_ATTACHMENT_OPTIMAL;
@@ -1206,10 +1206,11 @@ TEST_F(NegativeSyncObject, BarrierQueueFamily) {
 
     // Find queues of two families
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t queue_family_count = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t queue_family_count = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (queue_family_count == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0) ||
-                                 ((m_device->phy().queue_properties_[other_family].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0);
+    const bool only_one_family = (queue_family_count == 1) ||
+                                 (m_device->Physical().queue_properties_[other_family].queueCount == 0) ||
+                                 ((m_device->Physical().queue_properties_[other_family].queueFlags & VK_QUEUE_TRANSFER_BIT) == 0);
 
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
@@ -1299,7 +1300,7 @@ TEST_F(NegativeSyncObject, BarrierQueueFamily) {
         uint32_t third_family = VK_QUEUE_FAMILY_IGNORED;
         for (uint32_t candidate = 0; candidate < queue_family_count; ++candidate) {
             if (candidate != submit_family && candidate != other_family &&
-                m_device->phy().queue_properties_[candidate].queueCount != 0) {
+                m_device->Physical().queue_properties_[candidate].queueCount != 0) {
                 third_family = candidate;
                 break;
             }
@@ -1337,22 +1338,22 @@ TEST_F(NegativeSyncObject, BufferBarrierWithHostStage) {
     barrier.srcAccessMask = VK_ACCESS_2_HOST_WRITE_BIT;
     barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkBufferMemoryBarrier2-srcStageMask-03851");
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // HOST stage as destination
     barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
     barrier.dstStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_HOST_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkBufferMemoryBarrier2-srcStageMask-03851");
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, ImageBarrierWithHostStage) {
@@ -1381,29 +1382,29 @@ TEST_F(NegativeSyncObject, ImageBarrierWithHostStage) {
     barrier.srcAccessMask = VK_ACCESS_2_HOST_WRITE_BIT;
     barrier.dstStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_SHADER_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier2-srcStageMask-03854");
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // HOST stage as destination
     barrier.srcStageMask = VK_PIPELINE_STAGE_2_ALL_COMMANDS_BIT;
     barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
     barrier.dstStageMask = VK_PIPELINE_STAGE_2_HOST_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_HOST_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkImageMemoryBarrier2-srcStageMask-03854");
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, BufferBarrierWithHostStageSync1) {
     TEST_DESCRIPTION("Buffer barrier includes VK_PIPELINE_STAGE_HOST_BIT as srcStageMask or dstStageMask");
     RETURN_IF_SKIP(Init());
 
-    if (m_device->phy().queue_properties_.size() < 2) {
+    if (m_device->Physical().queue_properties_.size() < 2) {
         GTEST_SKIP() << "Two queue families are required";
     }
     vkt::Buffer buffer(*m_device, 32, VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT);
@@ -1417,29 +1418,29 @@ TEST_F(NegativeSyncObject, BufferBarrierWithHostStageSync1) {
     // HOST stage as source
     barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcStageMask-09634");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            1, &barrier, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // HOST stage as destination
     barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_HOST_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcStageMask-09634");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr,
                            1, &barrier, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, ImageBarrierWithHostStageSync1) {
     TEST_DESCRIPTION("Image barrier includes VK_PIPELINE_STAGE_HOST_BIT as srcStageMask or dstStageMask");
     RETURN_IF_SKIP(Init());
 
-    if (m_device->phy().queue_properties_.size() < 2) {
+    if (m_device->Physical().queue_properties_.size() < 2) {
         GTEST_SKIP() << "Two queue families are required";
     }
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -1455,22 +1456,22 @@ TEST_F(NegativeSyncObject, ImageBarrierWithHostStageSync1) {
     // HOST stage as source
     barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcStageMask-09633");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &barrier);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // HOST stage as destination
     barrier.srcAccessMask = VK_ACCESS_2_SHADER_WRITE_BIT;
     barrier.dstAccessMask = VK_ACCESS_2_HOST_READ_BIT;
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-srcStageMask-09633");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_HOST_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &barrier);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // TODO - Figure out if test or VU are bad
@@ -1481,9 +1482,9 @@ TEST_F(NegativeSyncObject, BarrierQueueFamilyWithMemExt) {
 
     // Find queues of two families
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
 
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
@@ -1545,9 +1546,9 @@ TEST_F(NegativeSyncObject, ImageBarrierWithBadRange) {
     img_barrier_template.subresourceRange.levelCount = 0;
 
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
         qf_indices.resize(1);
@@ -1616,7 +1617,7 @@ TEST_F(NegativeSyncObject, ImageBarrierWithBadRange) {
         }
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // try for vk::CmdWaitEvents
     {
         vkt::Event event(*m_device);
@@ -1723,9 +1724,9 @@ TEST_F(NegativeSyncObject, Sync2BarrierQueueFamily) {
 
     // Find queues of two families
     const uint32_t submit_family = m_device->graphics_queue_node_index_;
-    const uint32_t invalid = static_cast<uint32_t>(m_device->phy().queue_properties_.size());
+    const uint32_t invalid = static_cast<uint32_t>(m_device->Physical().queue_properties_.size());
     const uint32_t other_family = submit_family != 0 ? 0 : 1;
-    const bool only_one_family = (invalid == 1) || (m_device->phy().queue_properties_[other_family].queueCount == 0);
+    const bool only_one_family = (invalid == 1) || (m_device->Physical().queue_properties_[other_family].queueCount == 0);
 
     std::vector<uint32_t> qf_indices{{submit_family, other_family}};
     if (only_one_family) {
@@ -1760,12 +1761,12 @@ TEST_F(NegativeSyncObject, BarrierQueues) {
     bmb.offset = 0;
     bmb.size = VK_WHOLE_SIZE;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkBufferMemoryBarrier-srcQueueFamilyIndex-04087");
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT,
                            VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 1, &bmb, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, BarrierAccessSync2) {
@@ -1784,7 +1785,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // srcAccessMask and srcStageMask
     mem_barrier.srcAccessMask = VK_ACCESS_2_INDIRECT_COMMAND_READ_BIT;
@@ -1946,7 +1947,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2) {
     m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-dstAccessMask-03917");
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -1964,7 +1965,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2RtxMaintenance1) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     mem_barrier.srcAccessMask = VK_ACCESS_2_SHADER_BINDING_TABLE_READ_BIT_KHR;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
@@ -1982,7 +1983,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2RtxMaintenance1) {
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -1999,7 +2000,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2DescriptorBuffer) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     mem_barrier.srcAccessMask = VK_ACCESS_2_DESCRIPTOR_BUFFER_READ_BIT_EXT;
     mem_barrier.srcStageMask = VK_PIPELINE_STAGE_2_DRAW_INDIRECT_BIT;
@@ -2017,7 +2018,7 @@ TEST_F(NegativeSyncObject, BarrierAccessSync2DescriptorBuffer) {
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_errorMonitor->VerifyFound();
 }
 
@@ -2041,7 +2042,7 @@ TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-srcAccessMask-04858");
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
@@ -2058,7 +2059,7 @@ TEST_F(NegativeSyncObject, BarrierAccessVideoDecode) {
     m_errorMonitor->SetDesiredError("VUID-VkMemoryBarrier2-srcAccessMask-04861");
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->VerifyFound();
 }
@@ -2073,7 +2074,7 @@ TEST_F(NegativeSyncObject, Sync2LayoutFeature) {
     info.usage = VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT;
     vkt::Image image(*m_device, info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageMemoryBarrier2 img_barrier = vku::InitStructHelper();
     img_barrier.image = image.handle();
     img_barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
@@ -2099,8 +2100,8 @@ TEST_F(NegativeSyncObject, SubmitSignaledFence) {
     fenceInfo.flags = VK_FENCE_CREATE_SIGNALED_BIT;
     vkt::Fence testFence(*m_device, fenceInfo);
 
-    m_command_buffer.begin();
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkQueueSubmit-fence-00063");
     m_default_queue->Submit(m_command_buffer, testFence);
@@ -2135,7 +2136,7 @@ TEST_F(NegativeSyncObject, QueueSubmitWaitingSameSemaphore) {
         m_default_queue->Wait();
         m_second_queue->Wait();
     }
-    if (m_device->phy().queue_properties_[m_default_queue->family_index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
+    if (m_device->Physical().queue_properties_[m_default_queue->family_index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
         VkBindSparseInfo signal_bind = vku::InitStructHelper();
         signal_bind.signalSemaphoreCount = 1;
         signal_bind.pSignalSemaphores = &semaphore.handle();
@@ -2242,7 +2243,7 @@ TEST_F(NegativeSyncObject, WaitEventsDifferentQueueFamilies) {
     ImageMemoryBarrier.subresourceRange.layerCount = 1;
     ImageMemoryBarrier.subresourceRange.levelCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcQueueFamilyIndex-02803");
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
@@ -2252,7 +2253,7 @@ TEST_F(NegativeSyncObject, WaitEventsDifferentQueueFamilies) {
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                       VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 1, &ImageMemoryBarrier);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, SemaphoreTypeCreateInfoCore) {
@@ -2568,7 +2569,7 @@ TEST_F(NegativeSyncObject, QueueBindSparseTimelineSemaphoreValue) {
     RETURN_IF_SKIP(Init());
 
     auto index = m_device->graphics_queue_node_index_;
-    if ((m_device->phy().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) == 0) {
+    if ((m_device->Physical().queue_properties_[index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) == 0) {
         GTEST_SKIP() << "Graphics queue does not have sparse binding bit";
     }
 
@@ -2806,7 +2807,7 @@ TEST_F(NegativeSyncObject, QueueSubmitBinarySemaphoreNotSignaled) {
         ASSERT_EQ(VK_SUCCESS, vk::QueueSubmit(m_default_queue->handle(), 2, submit_info, VK_NULL_HANDLE));
         m_default_queue->Wait();
     }
-    if (m_device->phy().queue_properties_[m_default_queue->family_index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
+    if (m_device->Physical().queue_properties_[m_default_queue->family_index].queueFlags & VK_QUEUE_SPARSE_BINDING_BIT) {
         vkt::Semaphore semaphore[3];
         semaphore[0].init(*m_device, semaphore_create_info);
         semaphore[1].init(*m_device, semaphore_create_info);
@@ -3136,11 +3137,11 @@ TEST_F(NegativeSyncObject, EventStageMaskOneCommandBufferPass) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -3151,12 +3152,12 @@ TEST_F(NegativeSyncObject, EventStageMaskOneCommandBufferFail) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     // wrong srcStageMask
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-parameter");
     m_default_queue->Submit(m_command_buffer);
@@ -3171,15 +3172,15 @@ TEST_F(NegativeSyncObject, EventStageMaskTwoCommandBufferPass) {
     vkt::CommandBuffer commandBuffer2(*m_device, m_command_pool);
     vkt::Event event(*m_device);
 
-    commandBuffer1.begin();
+    commandBuffer1.Begin();
     vk::CmdSetEvent(commandBuffer1.handle(), event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
-    commandBuffer1.end();
+    commandBuffer1.End();
     m_default_queue->Submit(commandBuffer1);
 
-    commandBuffer2.begin();
+    commandBuffer2.Begin();
     vk::CmdWaitEvents(commandBuffer2.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT,
                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
-    commandBuffer2.end();
+    commandBuffer2.End();
     m_default_queue->Submit(commandBuffer2);
 
     m_default_queue->Wait();
@@ -3192,16 +3193,16 @@ TEST_F(NegativeSyncObject, EventStageMaskTwoCommandBufferFail) {
     vkt::CommandBuffer commandBuffer2(*m_device, m_command_pool);
     vkt::Event event(*m_device);
 
-    commandBuffer1.begin();
+    commandBuffer1.Begin();
     vk::CmdSetEvent(commandBuffer1.handle(), event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
-    commandBuffer1.end();
+    commandBuffer1.End();
     m_default_queue->Submit(commandBuffer1);
 
-    commandBuffer2.begin();
+    commandBuffer2.Begin();
     // wrong srcStageMask
     vk::CmdWaitEvents(commandBuffer2.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                       VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, nullptr, 0, nullptr, 0, nullptr);
-    commandBuffer2.end();
+    commandBuffer2.End();
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-srcStageMask-parameter");
     m_default_queue->Submit(commandBuffer2);
     m_errorMonitor->VerifyFound();
@@ -3220,16 +3221,16 @@ TEST_F(NegativeSyncObject, DetectInterQueueEventUsage) {
     const vkt::Event event(*m_device);
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetEvent(cb1, event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
-    cb1.end();
+    cb1.End();
 
     vkt::CommandPool pool2(*m_device, m_second_queue->family_index);
     vkt::CommandBuffer cb2(*m_device, pool2);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdWaitEvents(cb2, 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, 0, nullptr,
                       0, nullptr, 0, nullptr);
-    cb2.end();
+    cb2.End();
 
     m_default_queue->Submit(cb1);
     m_errorMonitor->SetDesiredError("UNASSIGNED-SubmitValidation-WaitEvents-WrongQueue");
@@ -3263,15 +3264,15 @@ TEST_F(NegativeSyncObject, DetectInterQueueEventUsage2) {
     const vkt::Event event(*m_device);
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetEvent2(cb1, event, &dependency_info);
-    cb1.end();
+    cb1.End();
 
     vkt::CommandPool pool2(*m_device, m_second_queue->family_index);
     vkt::CommandBuffer cb2(*m_device, pool2);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdWaitEvents2(cb2, 1, &event.handle(), &dependency_info);
-    cb2.end();
+    cb2.End();
 
     m_default_queue->Submit(cb1);
     m_errorMonitor->SetDesiredError("UNASSIGNED-SubmitValidation-WaitEvents-WrongQueue");
@@ -3288,14 +3289,14 @@ TEST_F(NegativeSyncObject, QueueForwardProgressFenceWait) {
     const char *queue_forward_progress_message = "VUID-vkQueueSubmit-pCommandBuffers-00065";
 
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
-    cb1.begin();
-    cb1.end();
+    cb1.Begin();
+    cb1.End();
 
     vkt::Semaphore semaphore(*m_device);
     m_default_queue->Submit(cb1, vkt::signal, semaphore);
 
-    m_command_buffer.begin();
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.End();
 
     m_errorMonitor->SetDesiredError(queue_forward_progress_message);
     m_default_queue->Submit(m_command_buffer, vkt::signal, semaphore);
@@ -3322,7 +3323,7 @@ TEST_F(NegativeSyncObject, PipelineStageConditionalRenderingWithWrongQueue) {
     vkt::CommandPool commandPool(*m_device, only_transfer_queueFamilyIndex.value());
     vkt::CommandBuffer commandBuffer(*m_device, commandPool);
 
-    commandBuffer.begin();
+    commandBuffer.Begin();
 
     VkImageMemoryBarrier imb = vku::InitStructHelper();
     imb.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
@@ -3344,18 +3345,18 @@ TEST_F(NegativeSyncObject, PipelineStageConditionalRenderingWithWrongQueue) {
                            VK_PIPELINE_STAGE_CONDITIONAL_RENDERING_BIT_EXT, 0, 0, nullptr, 0, nullptr, 1, &imb);
     m_errorMonitor->VerifyFound();
 
-    commandBuffer.end();
+    commandBuffer.End();
 }
 
 TEST_F(NegativeSyncObject, WaitOnNoEvent) {
     RETURN_IF_SKIP(Init());
     VkEvent bad_event = CastToHandle<VkEvent, uintptr_t>(0xbaadbeef);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdWaitEvents-pEvents-parameter");
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &bad_event, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0,
                       nullptr, 0, nullptr, 0, nullptr);
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, InvalidDeviceOnlyEvent) {
@@ -3394,7 +3395,7 @@ TEST_F(NegativeSyncObject, SetEvent2DependencyFlags) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkDependencyInfoKHR dependency_info = vku::InitStructHelper();
     dependency_info.dependencyFlags = VK_DEPENDENCY_BY_REGION_BIT;
@@ -3411,7 +3412,7 @@ TEST_F(NegativeSyncObject, SetEvent2HostStage) {
     AddRequiredFeature(vkt::Feature::synchronization2);
     RETURN_IF_SKIP(Init());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkMemoryBarrier2 barrier = vku::InitStructHelper();
     barrier.srcAccessMask = VK_ACCESS_HOST_WRITE_BIT;
@@ -3438,7 +3439,7 @@ TEST_F(NegativeSyncObject, WaitEventRenderPassHostBit) {
         GTEST_SKIP() << "VkPhysicalDevicePortabilitySubsetFeaturesKHR::events not supported";
     }
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     vkt::Event event(*m_device);
@@ -3449,7 +3450,7 @@ TEST_F(NegativeSyncObject, WaitEventRenderPassHostBit) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeSyncObject, StageMaskHost) {
@@ -3457,7 +3458,7 @@ TEST_F(NegativeSyncObject, StageMaskHost) {
     RETURN_IF_SKIP(Init());
 
     vkt::Event event(*m_device);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     m_errorMonitor->SetDesiredError("VUID-vkCmdSetEvent-stageMask-01149");
     vk::CmdSetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_HOST_BIT);
@@ -3467,7 +3468,7 @@ TEST_F(NegativeSyncObject, StageMaskHost) {
     vk::CmdResetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_HOST_BIT);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device);
     // Signal the semaphore so we can wait on it.
@@ -3486,9 +3487,9 @@ TEST_F(NegativeSyncObject, ResetEventThenSet) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdResetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     m_errorMonitor->SetDesiredError("VUID-vkSetEvent-event-09543");
@@ -3514,7 +3515,7 @@ TEST_F(NegativeSyncObject, RenderPassPipelineBarrierGraphicsStage) {
     vkt::ImageView view = image.CreateView();
     vkt::Framebuffer fb(*m_device, rp.Handle(), 1, &view.handle());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle());
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-None-07889");
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier-None-07889");
@@ -3559,7 +3560,7 @@ TEST_F(NegativeSyncObject, MemoryBarrierStageNotSupportedByQueue) {
     dep_info_dst_gfx.memoryBarrierCount = 1;
     dep_info_dst_gfx.pMemoryBarriers = &barrier_dst_gfx;
 
-    transfer_cb.begin();
+    transfer_cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-srcStageMask-09673");
     vk::CmdPipelineBarrier2(transfer_cb.handle(), &dep_info_src_gfx);
     m_errorMonitor->VerifyFound();
@@ -3567,7 +3568,7 @@ TEST_F(NegativeSyncObject, MemoryBarrierStageNotSupportedByQueue) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-dstStageMask-09674");
     vk::CmdPipelineBarrier2(transfer_cb.handle(), &dep_info_dst_gfx);
     m_errorMonitor->VerifyFound();
-    transfer_cb.end();
+    transfer_cb.End();
 }
 
 TEST_F(NegativeSyncObject, BufferBarrierStageNotSupportedByQueue) {
@@ -3611,7 +3612,7 @@ TEST_F(NegativeSyncObject, BufferBarrierStageNotSupportedByQueue) {
     dep_info_dst_gfx.bufferMemoryBarrierCount = 1;
     dep_info_dst_gfx.pBufferMemoryBarriers = &barrier_dst_gfx;
 
-    compute_cb.begin();
+    compute_cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-srcStageMask-09675");
     vk::CmdPipelineBarrier2(compute_cb.handle(), &dep_info_src_gfx);
     m_errorMonitor->VerifyFound();
@@ -3619,7 +3620,7 @@ TEST_F(NegativeSyncObject, BufferBarrierStageNotSupportedByQueue) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-dstStageMask-09676");
     vk::CmdPipelineBarrier2(compute_cb.handle(), &dep_info_dst_gfx);
     m_errorMonitor->VerifyFound();
-    compute_cb.end();
+    compute_cb.End();
 }
 
 TEST_F(NegativeSyncObject, ImageBarrierStageNotSupportedByQueue) {
@@ -3665,7 +3666,7 @@ TEST_F(NegativeSyncObject, ImageBarrierStageNotSupportedByQueue) {
     dep_info_dst_gfx.imageMemoryBarrierCount = 1;
     dep_info_dst_gfx.pImageMemoryBarriers = &barrier_dst_gfx;
 
-    compute_cb.begin();
+    compute_cb.Begin();
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-srcStageMask-09675");
     vk::CmdPipelineBarrier2(compute_cb.handle(), &dep_info_src_gfx);
     m_errorMonitor->VerifyFound();
@@ -3673,7 +3674,7 @@ TEST_F(NegativeSyncObject, ImageBarrierStageNotSupportedByQueue) {
     m_errorMonitor->SetDesiredError("VUID-vkCmdPipelineBarrier2-dstStageMask-09676");
     vk::CmdPipelineBarrier2(compute_cb.handle(), &dep_info_dst_gfx);
     m_errorMonitor->VerifyFound();
-    compute_cb.end();
+    compute_cb.End();
 }
 
 TEST_F(NegativeSyncObject, TimelineHostSignalAndInUseTracking) {

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -131,7 +131,7 @@ TEST_F(PositiveSyncObject, LayoutFromPresentWithoutAccessMemoryRead) {
     range.layerCount = 1;
     barrier.subresourceRange = range;
     vkt::CommandBuffer cmdbuf(*m_device, m_command_pool);
-    cmdbuf.begin();
+    cmdbuf.Begin();
     vk::CmdPipelineBarrier(cmdbuf.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &barrier);
     barrier.oldLayout = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR;
@@ -311,15 +311,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
                            0, nullptr);
     vk::CmdSetViewport(cb0, 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1, 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_second_queue->Submit(cb0, vkt::signal, semaphore);
     m_default_queue->Submit(cb1, vkt::wait, semaphore);
@@ -351,15 +351,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0, nullptr,
                            0, nullptr);
     vk::CmdSetViewport(cb0, 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1, 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_second_queue->Submit(cb0, vkt::signal, semaphore);
     m_default_queue->Submit(cb1, vkt::wait, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, fence);
@@ -391,15 +391,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_second_queue->Submit(cb0, vkt::signal, semaphore);
     m_default_queue->Submit(cb1, vkt::wait, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, fence);
@@ -417,8 +417,8 @@ TEST_F(PositiveSyncObject, TwoQueuesEnsureCorrectRetirementWithWorkStolen) {
 
     // An (empty) command buffer. We must have work in the first submission --
     // the layer treats unfenced work differently from fenced work.
-    m_command_buffer.begin();
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.End();
 
     vkt::Semaphore s(*m_device);
     m_default_queue->Submit(m_command_buffer, vkt::signal, s);
@@ -453,15 +453,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithSemaphoreAndOneFence
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_second_queue->Submit(cb0, vkt::signal, semaphore);
     m_default_queue->Submit(cb1, vkt::wait, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, fence);
@@ -495,15 +495,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsSeparateQueuesWithTimelineSemaphoreAnd
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_second_queue->SubmitWithTimelineSemaphore(cb0, vkt::signal, semaphore, 1);
     m_default_queue->SubmitWithTimelineSemaphore(cb1, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, fence);
@@ -529,15 +529,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueWithSemaphoreAndOneFence) {
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_default_queue->Submit(cb0, vkt::signal, semaphore);
     m_default_queue->Submit(cb1, vkt::wait, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, fence);
@@ -562,15 +562,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueNullQueueSubmitWithFence) {
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_default_queue->Submit(cb0);
     m_default_queue->Submit(cb1);
@@ -596,15 +596,15 @@ TEST_F(PositiveSyncObject, TwoQueueSubmitsOneQueueOneFence) {
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     m_default_queue->Submit(cb0);
     m_default_queue->Submit(cb1, fence);
@@ -629,15 +629,15 @@ TEST_F(PositiveSyncObject, TwoSubmitInfosWithSemaphoreOneQueueSubmitsOneFence) {
     viewport.x = 0;
     viewport.y = 0;
 
-    cb0.begin();
+    cb0.Begin();
     vk::CmdPipelineBarrier(cb0.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr, 0,
                            nullptr, 0, nullptr);
     vk::CmdSetViewport(cb0.handle(), 0, 1, &viewport);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdSetViewport(cb1.handle(), 0, 1, &viewport);
-    cb1.end();
+    cb1.End();
 
     VkSubmitInfo submit_info[2];
     VkPipelineStageFlags flags[]{VK_PIPELINE_STAGE_ALL_COMMANDS_BIT};
@@ -679,15 +679,15 @@ TEST_F(PositiveSyncObject, WaitBeforeSignalOnDifferentQueuesSignalLargerThanWait
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
     // Wait for value 1 (or greater)
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBuffer(m_command_buffer, buffer_a, buffer_b, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
 
     // Signal value 2
-    second_cb.begin();
+    second_cb.Begin();
     vk::CmdCopyBuffer(second_cb, buffer_a, buffer_b, 1, &region);
-    second_cb.end();
+    second_cb.End();
     m_second_queue->Submit2WithTimelineSemaphore(second_cb, vkt::signal, semaphore, 2, VK_PIPELINE_STAGE_2_COPY_BIT);
 
     m_device->Wait();
@@ -747,7 +747,7 @@ TEST_F(PositiveSyncObject, ExternalSemaphore) {
     VkPhysicalDeviceExternalSemaphoreInfoKHR esi = vku::InitStructHelper();
     esi.handleType = handle_type;
     VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -782,7 +782,7 @@ TEST_F(PositiveSyncObject, ExternalSemaphore) {
 
     vk::QueueSubmit(m_default_queue->handle(), si.size(), si.data(), VK_NULL_HANDLE);
 
-    if (m_device->phy().Features().sparseBinding) {
+    if (m_device->Physical().Features().sparseBinding) {
         // Signal the imported semaphore and wait on the exported semaphore
         std::vector<VkBindSparseInfo> bi(4, vku::InitStruct<VkBindSparseInfo>());
         bi[0].signalSemaphoreCount = 1;
@@ -829,7 +829,7 @@ TEST_F(PositiveSyncObject, ExternalTimelineSemaphore) {
 
     VkExternalSemaphorePropertiesKHR esp = vku::InitStructHelper();
 
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &esi, &esp);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &esi, &esp);
 
     if (!(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(esp.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -905,7 +905,7 @@ TEST_F(PositiveSyncObject, ExternalFence) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -960,7 +960,7 @@ TEST_F(PositiveSyncObject, ExternalFenceSyncFdLoop) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_IMPORTABLE_BIT_KHR)) {
@@ -983,10 +983,10 @@ TEST_F(PositiveSyncObject, ExternalFenceSyncFdLoop) {
     for (uint32_t i = 0; i < 1000; i++) {
         auto submitter = i & 1;
         auto waiter = (~i) & 1;
-        fences[submitter].reset();
+        fences[submitter].Reset();
         vk::QueueSubmit(m_default_queue->handle(), 0, nullptr, fences[submitter].handle());
 
-        fences[waiter].wait(kWaitTimeout);
+        fences[waiter].Wait(kWaitTimeout);
 
         vk::QueueSubmit(m_default_queue->handle(), 0, nullptr, export_fence.handle());
         int fd_handle = -1;
@@ -1015,7 +1015,7 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
     VkPhysicalDeviceExternalFenceInfoKHR efi = vku::InitStructHelper();
     efi.handleType = handle_type;
     VkExternalFencePropertiesKHR efp = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalFencePropertiesKHR(gpu(), &efi, &efp);
+    vk::GetPhysicalDeviceExternalFencePropertiesKHR(Gpu(), &efi, &efp);
 
     if (!(efp.externalFenceFeatures & VK_EXTERNAL_FENCE_FEATURE_EXPORTABLE_BIT_KHR)) {
         GTEST_SKIP() << "External fence does not support exporting, skipping test.";
@@ -1029,8 +1029,8 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
     vkt::Fence export_fence(*m_device, fci);
 
     for (uint32_t i = 0; i < 1000; i++) {
-        m_command_buffer.begin();
-        m_command_buffer.end();
+        m_command_buffer.Begin();
+        m_command_buffer.End();
 
         VkSubmitInfo submit_info = vku::InitStructHelper();
         submit_info.commandBufferCount = 1;
@@ -1066,7 +1066,7 @@ TEST_F(PositiveSyncObject, ExternalFenceSubmitCmdBuffer) {
         m_default_queue->Wait();
 #endif
 
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 
     m_default_queue->Wait();
@@ -1079,11 +1079,11 @@ TEST_F(PositiveSyncObject, BasicSetAndWaitEvent) {
     const vkt::Event event(*m_device);
 
     // Record time validation
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent(m_command_buffer, event, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
     vk::CmdWaitEvents(m_command_buffer, 1, &event.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT,
                       0, nullptr, 0, nullptr, 0, nullptr);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Also submit to the queue to test submit time validation
     m_default_queue->Submit(m_command_buffer);
@@ -1109,10 +1109,10 @@ TEST_F(PositiveSyncObject, BasicSetAndWaitEvent2) {
     const vkt::Event event(*m_device);
 
     // Record time validation
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdSetEvent2(m_command_buffer, event, &dependency_info);
     vk::CmdWaitEvents2(m_command_buffer, 1, &event.handle(), &dependency_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Also submit to the queue to test submit time validation
     m_default_queue->Submit(m_command_buffer);
@@ -1130,11 +1130,11 @@ TEST_F(PositiveSyncObject, WaitEventThenSet) {
 
     vkt::Event event(*m_device);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdWaitEvents(m_command_buffer.handle(), 1, &event.handle(), VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT,
                       0, nullptr, 0, nullptr, 0, nullptr);
     vk::CmdResetEvent(m_command_buffer.handle(), event.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     vk::SetEvent(device(), event.handle());
@@ -1162,7 +1162,7 @@ TEST_F(PositiveSyncObject, DoubleLayoutTransition) {
     VkImageSubresourceRange image_sub_range = vkt::Image::SubresourceRange(image_sub);
     vkt::Image image(*m_device, image_create_info, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     {
         VkImageMemoryBarrier image_barriers[] = {image.ImageMemoryBarrier(
@@ -1185,7 +1185,7 @@ TEST_F(PositiveSyncObject, DoubleLayoutTransition) {
                                0, nullptr, 0, nullptr, 2, image_barriers);
     }
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
@@ -1207,15 +1207,15 @@ TEST_F(PositiveSyncObject, QueueSubmitTimelineSemaphore2Queue) {
 
     vkt::CommandPool pool0(*m_device, m_default_queue->family_index);
     vkt::CommandBuffer cb0(*m_device, pool0);
-    cb0.begin();
+    cb0.Begin();
     vk::CmdCopyBuffer(cb0.handle(), buffer_a.handle(), buffer_b.handle(), 1, &region);
-    cb0.end();
+    cb0.End();
 
     vkt::CommandPool pool1(*m_device, m_second_queue->family_index);
     vkt::CommandBuffer cb1(*m_device, pool1);
-    cb1.begin();
+    cb1.Begin();
     vk::CmdCopyBuffer(cb1.handle(), buffer_c.handle(), buffer_b.handle(), 1, &region);
-    cb1.end();
+    cb1.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -1245,7 +1245,7 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
 
     RETURN_IF_SKIP(Init());
 
-    if (m_device->phy().queue_properties_[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
+    if (m_device->Physical().queue_properties_[m_device->graphics_queue_node_index_].timestampValidBits == 0) {
         GTEST_SKIP() << "Device graphic queue has timestampValidBits of 0, skipping.\n";
     }
 
@@ -1258,13 +1258,13 @@ TEST_F(PositiveSyncObject, ResetQueryPoolFromDifferentCBWithFenceAfter) {
 
     vkt::QueryPool query_pool(*m_device, VK_QUERY_TYPE_TIMESTAMP, 1);
 
-    cb0.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    cb0.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     vk::CmdResetQueryPool(cb0.handle(), query_pool.handle(), 0, 1);
-    cb0.end();
+    cb0.End();
 
-    cb1.begin();
+    cb1.Begin();
     vk::CmdWriteTimestamp(cb1.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, query_pool.handle(), 0);
-    cb1.end();
+    cb1.End();
 
     // Begin by resetting the query pool.
     m_default_queue->Submit(cb0);
@@ -1332,7 +1332,7 @@ TEST_F(PositiveSyncObject, FenceSemThreadRace) {
 
     for (uint32_t i = 0; i < data.iterations; i++, signal_value++) {
         m_default_queue->SubmitWithTimelineSemaphore(vkt::no_cmd, vkt::signal, sem, signal_value, fence);
-        fence.wait(data.timeout);
+        fence.Wait(data.timeout);
         vk::ResetFences(device(), 1, &fence.handle());
     }
     m_errorMonitor->SetBailout(nullptr);
@@ -1458,9 +1458,9 @@ struct SemBufferRaceData {
             gpu_signal_value = (i * 3) + 2;
             uint64_t host_wait_value = (i * 3) + 3;
 
-            cb.begin();
+            cb.Begin();
             vk::CmdFillBuffer(cb.handle(), buffer->handle(), 0, 12, 0x11111111);
-            cb.end();
+            cb.End();
             thread_buffer = std::move(buffer);
 
             err = queue->SubmitWithTimelineSemaphore(cb, sem, gpu_wait_value, sem, gpu_signal_value);
@@ -1510,7 +1510,7 @@ TEST_F(PositiveSyncObject, WaitTimelineSemaphoreWithWin32HandleRetrieved) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -1578,13 +1578,13 @@ TEST_F(PositiveSyncObject, SubpassBarrier) {
     barrier.image = image.handle();
     barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_DEPENDENCY_BY_REGION_BIT, 0, nullptr, 0, nullptr, 1,
                            &barrier);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, SubpassBarrier2) {
@@ -1625,11 +1625,11 @@ TEST_F(PositiveSyncObject, SubpassBarrier2) {
     dependency_info.imageMemoryBarrierCount = 1;
     dependency_info.pImageMemoryBarriers = &barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb.handle(), 32, 32);
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &dependency_info);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6204
@@ -1664,7 +1664,7 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
     barrier.srcAccessMask = VK_ACCESS_INDEX_READ_BIT;
     barrier.dstAccessMask = VK_ACCESS_INDEX_READ_BIT;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // The issue was that implementation expands *subpass* compound stages but did not expand *barrier* compound stages.
@@ -1674,7 +1674,7 @@ TEST_F(PositiveSyncObject, SubpassBarrierWithExpandableStages) {
                            &barrier, 0, nullptr, 0, nullptr);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, BarrierWithHostStage) {
@@ -1699,9 +1699,9 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     buffer_dependency.bufferMemoryBarrierCount = 1;
     buffer_dependency.pBufferMemoryBarriers = &buffer_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &buffer_dependency);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // HOST stage as destination
     vkt::Image image(*m_device, 128, 128, 1, VK_FORMAT_B8G8R8A8_UNORM, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
@@ -1722,9 +1722,9 @@ TEST_F(PositiveSyncObject, BarrierWithHostStage) {
     image_dependency.imageMemoryBarrierCount = 1;
     image_dependency.pImageMemoryBarriers = &image_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2(m_command_buffer.handle(), &image_dependency);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, BarrierASBuildWithShaderReadAccess) {
@@ -1743,9 +1743,9 @@ TEST_F(PositiveSyncObject, BarrierASBuildWithShaderReadAccess) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2KHR(m_command_buffer, &dependency_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, BarrierAccessSyncMicroMap) {
@@ -1767,9 +1767,9 @@ TEST_F(PositiveSyncObject, BarrierAccessSyncMicroMap) {
     dependency_info.memoryBarrierCount = 1;
     dependency_info.pMemoryBarriers = &mem_barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2KHR(m_command_buffer.handle(), &dependency_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncObject, DynamicRenderingLocalReadImageBarrier) {
@@ -1809,10 +1809,10 @@ TEST_F(PositiveSyncObject, DynamicRenderingLocalReadImageBarrier) {
     imageMemoryBarrier.image = image.handle();
     imageMemoryBarrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0u, 1u, 0u, 1u};
 
-    secondary.begin(&beginInfo);
+    secondary.Begin(&beginInfo);
     vk::CmdPipelineBarrier(secondary.handle(), VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, VK_PIPELINE_STAGE_FRAGMENT_SHADER_BIT,
                            VK_DEPENDENCY_BY_REGION_BIT, 0u, nullptr, 0u, nullptr, 1u, &imageMemoryBarrier);
-    secondary.end();
+    secondary.End();
 }
 
 // https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/6172
@@ -1908,7 +1908,7 @@ TEST_F(PositiveSyncObject, SubmitImportedBinarySemaphoreWithNonZeroValue) {
     VkPhysicalDeviceExternalSemaphoreInfoKHR semaphore_info = vku::InitStructHelper();
     semaphore_info.handleType = handle_type;
     VkExternalSemaphorePropertiesKHR semaphore_properties = vku::InitStructHelper();
-    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(gpu(), &semaphore_info, &semaphore_properties);
+    vk::GetPhysicalDeviceExternalSemaphorePropertiesKHR(Gpu(), &semaphore_info, &semaphore_properties);
     if (!(semaphore_properties.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_EXPORTABLE_BIT_KHR) ||
         !(semaphore_properties.externalSemaphoreFeatures & VK_EXTERNAL_SEMAPHORE_FEATURE_IMPORTABLE_BIT_KHR)) {
         GTEST_SKIP() << "Semaphore does not support import and/or export";
@@ -1979,9 +1979,9 @@ TEST_F(PositiveSyncObject, IgnoreAcquireOpSrcStage) {
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &acquire_barrier;
 
-    transfer_cb.begin();
+    transfer_cb.Begin();
     vk::CmdPipelineBarrier2(transfer_cb.handle(), &dep_info);
-    transfer_cb.end();
+    transfer_cb.End();
 }
 
 TEST_F(PositiveSyncObject, IgnoreReleaseOpDstStage) {
@@ -2015,9 +2015,9 @@ TEST_F(PositiveSyncObject, IgnoreReleaseOpDstStage) {
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &release_barrier;
 
-    release_cb.begin();
+    release_cb.Begin();
     vk::CmdPipelineBarrier2(release_cb.handle(), &dep_info);
-    release_cb.end();
+    release_cb.End();
 }
 
 #ifdef VK_USE_PLATFORM_WIN32_KHR
@@ -2033,7 +2033,7 @@ TEST_F(PositiveSyncObject, GetCounterValueOfExportedSemaphore) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -2070,7 +2070,7 @@ TEST_F(PositiveSyncObject, GetCounterValueOfExportedSemaphore2) {
         GTEST_SKIP() << "Test not supported by MockICD";
     }
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -160,7 +160,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     clear_rect.layerCount = 1;
     const VkClearAttachment clear_attachment = {VK_IMAGE_ASPECT_COLOR_BIT};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Write 1: Copy to render target's layer 0
     vk::CmdCopyImage(m_command_buffer, image, VK_IMAGE_LAYOUT_GENERAL, rt, VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -168,7 +168,7 @@ TEST_F(PositiveSyncVal, CmdClearAttachmentLayer) {
     // Write 2: Clear render target's layer 1
     vk::CmdClearAttachments(m_command_buffer, 1, &clear_attachment, 1, &clear_rect);
     vk::CmdEndRenderPass(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -207,11 +207,11 @@ TEST_F(PositiveSyncVal, WriteToImageAfterTransition) {
     region.imageExtent.height = height;
     region.imageExtent.depth = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_HOST_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0, nullptr,
                            1, &barrier);
     vk::CmdCopyBufferToImage(m_command_buffer, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // Regression test for vkWaitSemaphores timeout while waiting for vkSignalSemaphore.
@@ -392,7 +392,7 @@ TEST_F(PositiveSyncVal, ShaderReferencesNotBoundSet) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Bind set 0.
@@ -405,7 +405,7 @@ TEST_F(PositiveSyncVal, ShaderReferencesNotBoundSet) {
     vk::CmdDraw(m_command_buffer, 3, 1, 0, 0);
 
     vk::CmdEndRenderPass(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, SeparateAvailabilityAndVisibilityForBuffer) {
@@ -420,7 +420,7 @@ TEST_F(PositiveSyncVal, SeparateAvailabilityAndVisibilityForBuffer) {
     VkBufferCopy region = {};
     region.size = size;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Perform a copy
     vk::CmdCopyBuffer(m_command_buffer, staging_buffer, buffer, 1, &region);
 
@@ -444,7 +444,7 @@ TEST_F(PositiveSyncVal, SeparateAvailabilityAndVisibilityForBuffer) {
 
     // Perform one more copy. Should not generate WAW.
     vk::CmdCopyBuffer(m_command_buffer, staging_buffer, buffer, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, LayoutTransitionWithAlreadyAvailableImage) {
@@ -461,7 +461,7 @@ TEST_F(PositiveSyncVal, LayoutTransitionWithAlreadyAvailableImage) {
                      VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT);
     image.SetLayout(VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     // Copy data from buffer to image
     VkBufferImageCopy region = {};
@@ -493,7 +493,7 @@ TEST_F(PositiveSyncVal, LayoutTransitionWithAlreadyAvailableImage) {
     barrier_b.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &barrier_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
@@ -557,7 +557,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     cs_pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     cs_pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Graphics pipeline writes
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, gfx_pipe.Handle());
@@ -570,7 +570,7 @@ TEST_F(PositiveSyncVal, ImageArrayDynamicIndexing) {
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -628,7 +628,7 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     cs_pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     cs_pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Graphics pipeline writes
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, gfx_pipe.Handle());
@@ -641,7 +641,7 @@ TEST_F(PositiveSyncVal, ImageArrayConstantIndexing) {
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -661,8 +661,8 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
 
     const vkt::Buffer buffer0(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
     const vkt::Buffer buffer1(*m_device, 1024, VK_BUFFER_USAGE_STORAGE_TEXEL_BUFFER_BIT);
-    const vkt::BufferView buffer_view0(*m_device, vkt::BufferView::createInfo(buffer0, VK_FORMAT_R8G8B8A8_UINT));
-    const vkt::BufferView buffer_view1(*m_device, vkt::BufferView::createInfo(buffer1, VK_FORMAT_R8G8B8A8_UINT));
+    const vkt::BufferView buffer_view0(*m_device, vkt::BufferView::CreateInfo(buffer0, VK_FORMAT_R8G8B8A8_UINT));
+    const vkt::BufferView buffer_view1(*m_device, vkt::BufferView::CreateInfo(buffer1, VK_FORMAT_R8G8B8A8_UINT));
 
     const OneOffDescriptorSet::Bindings bindings = {
         {0, VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER, 2, VK_SHADER_STAGE_ALL, nullptr},
@@ -700,7 +700,7 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     cs_pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     cs_pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     // Graphics pipeline writes
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, gfx_pipe.Handle());
@@ -713,7 +713,7 @@ TEST_F(PositiveSyncVal, TexelBufferArrayConstantIndexing) {
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -781,11 +781,11 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     cs_pipe.CreateComputePipeline();
 
     vkt::CommandBuffer cb(*m_device, m_command_pool);
-    cb.begin();
+    cb.Begin();
     vk::CmdBindPipeline(cb, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.Handle());
     vk::CmdBindDescriptorSets(cb, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1, &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(cb, 1, 1, 1);
-    cb.end();
+    cb.End();
 
     m_default_queue->Submit2(cb, vkt::signal, semaphore);
 
@@ -807,9 +807,9 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     dep_info.pImageMemoryBarriers = &layout_transition;
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdPipelineBarrier2(cb2, &dep_info);
-    cb2.end();
+    cb2.End();
 
     m_default_queue->Submit2(cb2, vkt::wait, semaphore);
     m_default_queue->Wait();
@@ -846,16 +846,16 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage2) {
 
     // Submit 1: Clear image (WRITE access)
     vkt::CommandBuffer cb(*m_device, m_command_pool);
-    cb.begin();
+    cb.Begin();
     vk::CmdClearColorImage(cb, image, VK_IMAGE_LAYOUT_GENERAL, &m_clear_color, 1, &layout_transition.subresourceRange);
-    cb.end();
+    cb.End();
     m_default_queue->Submit2(cb, vkt::signal, semaphore);
 
     // Submit 2: Transition layout (WRITE access)
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdPipelineBarrier2(cb2, &dep_info);
-    cb2.end();
+    cb2.End();
     m_default_queue->Submit2(cb2, vkt::wait, semaphore);
     m_default_queue->Wait();
 }
@@ -889,9 +889,9 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     dep_info.pImageMemoryBarriers = &layout_transition;
 
     vkt::CommandBuffer cb(*m_device, m_command_pool);
-    cb.begin();
+    cb.Begin();
     vk::CmdPipelineBarrier2(cb, &dep_info);
-    cb.end();
+    cb.End();
     m_default_queue->Submit2(cb, vkt::signal, semaphore);
 
     // Submit1: wait for the semaphore and read image in the shader
@@ -914,12 +914,12 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     cs_pipe.CreateComputePipeline();
 
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdBindPipeline(cb2, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.Handle());
     vk::CmdBindDescriptorSets(cb2, VK_PIPELINE_BIND_POINT_COMPUTE, cs_pipe.pipeline_layout_, 0, 1, &descriptor_set.set_, 0,
                               nullptr);
     vk::CmdDispatch(cb2, 1, 1, 1);
-    cb2.end();
+    cb2.End();
     m_default_queue->Submit2(cb2, vkt::wait, semaphore);
     m_default_queue->Wait();
 }
@@ -966,10 +966,10 @@ TEST_F(PositiveSyncVal, DynamicRenderingColorResolve) {
     rendering_info.colorAttachmentCount = 1;
     rendering_info.pColorAttachments = &color_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRendering(m_command_buffer, &rendering_info);
     vk::CmdEndRendering(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
@@ -990,7 +990,7 @@ TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
 
     const uint32_t width = 64;
     const uint32_t height = 64;
-    const VkFormat depth_format = FindSupportedDepthOnlyFormat(gpu());
+    const VkFormat depth_format = FindSupportedDepthOnlyFormat(Gpu());
     const VkImageUsageFlags usage = VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 
     auto depth_ci = vkt::Image::ImageCreateInfo2D(width, height, 1, 1, depth_format, usage);
@@ -1019,10 +1019,10 @@ TEST_F(PositiveSyncVal, DynamicRenderingDepthResolve) {
     rendering_info.layerCount = 1;
     rendering_info.pDepthAttachment = &depth_attachment;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBeginRendering(m_command_buffer, &rendering_info);
     vk::CmdEndRendering(m_command_buffer);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, FillBuffer) {
@@ -1052,11 +1052,11 @@ TEST_F(PositiveSyncVal, FillBuffer) {
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdFillBuffer(m_command_buffer, src_buffer, 0, size, 42);
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
     vk::CmdCopyBuffer(m_command_buffer, src_buffer, dst_buffer, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, UpdateBuffer) {
@@ -1088,11 +1088,11 @@ TEST_F(PositiveSyncVal, UpdateBuffer) {
     dep_info.bufferMemoryBarrierCount = 1;
     dep_info.pBufferMemoryBarriers = &barrier;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdUpdateBuffer(m_command_buffer, src_buffer, 0, static_cast<VkDeviceSize>(data.size()), data.data());
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
     vk::CmdCopyBuffer(m_command_buffer, src_buffer, dst_buffer, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
@@ -1123,7 +1123,7 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
     // Submit 0: perform image layout transition on Graphics queue.
     // Image barrier synchronizes with COPY-WRITE access from Submit 2.
     vkt::CommandBuffer cb0(*m_device, m_command_pool);
-    cb0.begin();
+    cb0.Begin();
     VkImageMemoryBarrier2 image_barrier = vku::InitStructHelper();
     image_barrier.srcStageMask = VK_PIPELINE_STAGE_2_NONE;
     image_barrier.srcAccessMask = VK_ACCESS_2_NONE;
@@ -1137,7 +1137,7 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &image_barrier;
     vk::CmdPipelineBarrier2(cb0, &dep_info);
-    cb0.end();
+    cb0.End();
     m_default_queue->Submit2(cb0, vkt::signal, semaphore);
 
     // Submit 1: empty submit on Transfer queue that waits for Submit 0.
@@ -1145,9 +1145,9 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
 
     // Submit 2: copy to image on Graphics queue. No synchronization is needed because of COPY+WRITE barrier from Submit 0.
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
-    cb2.begin();
+    cb2.Begin();
     vk::CmdCopyBufferToImage(cb2, buffer, image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &region);
-    cb2.end();
+    cb2.End();
     m_default_queue->Submit2(cb2);
 
     m_default_queue->Wait();
@@ -1213,7 +1213,7 @@ TEST_F(PositiveSyncVal, DISABLED_RenderPassStoreOpNone) {
     pipe.gp_ci_.renderPass = rp.Handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp.Handle(), fb);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout, 0, 1, &descriptor_set.set_, 0,
@@ -1224,7 +1224,7 @@ TEST_F(PositiveSyncVal, DISABLED_RenderPassStoreOpNone) {
     // This waits for the FRAGMENT_SHADER read before starting with transition.
     // If storeOp other than NONE was used we had to wait for it instead.
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, ThreadedSubmitAndFenceWait) {
@@ -1251,13 +1251,13 @@ TEST_F(PositiveSyncVal, ThreadedSubmitAndFenceWait) {
     }
 
     vkt::CommandBuffer cmd(*m_device, m_command_pool);
-    cmd.begin();
+    cmd.Begin();
     vk::CmdCopyBuffer(cmd, src, dst, 1, &copy_info);
-    cmd.end();
+    cmd.End();
 
     vkt::CommandBuffer thread_cmd(*m_device, m_command_pool);
-    thread_cmd.begin();
-    thread_cmd.end();
+    thread_cmd.Begin();
+    thread_cmd.End();
 
     std::mutex queue_mutex;
     std::mutex queue_mutex2;
@@ -1303,7 +1303,7 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImage) {
 
     VkFormatProperties format_properties;
     VkFormat mp_format = VK_FORMAT_BC1_RGBA_UNORM_BLOCK;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), mp_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), mp_format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
         GTEST_SKIP()
             << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_BC1_RGBA_UNORM_BLOCK, skipping test.\n";
@@ -1321,10 +1321,10 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImage) {
     buffer_copy[1].imageOffset = {8, 0, 0};
     buffer_copy[1].imageExtent = {8, 8, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC) {
@@ -1335,7 +1335,7 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC) {
 
     VkFormatProperties format_properties;
     VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
         GTEST_SKIP()
             << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_ASTC_10x10_UNORM_BLOCK, skipping test.\n";
@@ -1353,10 +1353,10 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC) {
     buffer_copy[1].imageOffset = {10, 0, 0};
     buffer_copy[1].imageExtent = {10, 10, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC2) {
@@ -1367,7 +1367,7 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC2) {
 
     VkFormatProperties format_properties;
     VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
         GTEST_SKIP()
             << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_ASTC_10x10_UNORM_BLOCK, skipping test.\n";
@@ -1385,10 +1385,10 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC2) {
     buffer_copy[1].imageOffset = {0, 10, 0};
     buffer_copy[1].imageExtent = {10, 10, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC3) {
@@ -1399,7 +1399,7 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC3) {
 
     VkFormatProperties format_properties;
     VkFormat format = VK_FORMAT_ASTC_10x10_UNORM_BLOCK;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_properties);
     if ((format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_TRANSFER_DST_BIT) == 0) {
         GTEST_SKIP()
             << "Device does not support VK_FORMAT_FEATURE_TRANSFER_DST_BIT for VK_FORMAT_ASTC_10x10_UNORM_BLOCK, skipping test.\n";
@@ -1425,12 +1425,12 @@ TEST_F(PositiveSyncVal, CopyBufferToCompressedImageASTC3) {
     barrier.image = dst_image;
     barrier.subresourceRange = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 1, 0, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[0]);
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0, nullptr, 0,
                            nullptr, 1, &barrier);
     vk::CmdCopyBufferToImage(m_command_buffer, src_buffer, dst_image, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &buffer_copy[1]);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, SignalAndWaitSemaphoreOneQueueSubmit) {
@@ -1470,14 +1470,14 @@ TEST_F(PositiveSyncVal, SignalUnsignalSignalMultipleSubmits) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
-    command_buffer2.begin();
+    command_buffer2.Begin();
     command_buffer2.Copy(buffer_a, buffer_b);
-    command_buffer2.end();
+    command_buffer2.End();
 
     m_default_queue->Submit2(vkt::no_cmd, vkt::signal, semaphore);
     m_default_queue->Submit2(m_command_buffer, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, semaphore,
@@ -1496,14 +1496,14 @@ TEST_F(PositiveSyncVal, SignalUnsignalSignalSingleSubmit) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::CommandBuffer command_buffer2(*m_device, m_command_pool);
-    command_buffer2.begin();
+    command_buffer2.Begin();
     command_buffer2.Copy(buffer_a, buffer_b);
-    command_buffer2.end();
+    command_buffer2.End();
 
     VkSemaphoreSubmitInfo semaphore_info = vku::InitStructHelper();
     semaphore_info.semaphore = semaphore;
@@ -1546,7 +1546,8 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedUniformBufferRegions) {
     // 32 bytes
     const VkDeviceSize uniform_data_size = 8 * sizeof(uint32_t);
     // 128 bytes or more (depending on minUniformBufferOffsetAlignment)
-    const VkDeviceSize copy_dst_area_size = std::max((VkDeviceSize)128, m_device->phy().limits_.minUniformBufferOffsetAlignment);
+    const VkDeviceSize copy_dst_area_size =
+        std::max((VkDeviceSize)128, m_device->Physical().limits_.minUniformBufferOffsetAlignment);
     // 160 bytes or more (depending on minUniformBufferOffsetAlignment)
     const VkDeviceSize size = copy_dst_area_size + uniform_data_size;
 
@@ -1576,7 +1577,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedUniformBufferRegions) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
                               0, nullptr);
@@ -1588,7 +1589,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedUniformBufferRegions) {
 
     // Reads from region [128..159]
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions) {
@@ -1600,7 +1601,8 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions) {
     // 32 bytes
     const VkDeviceSize uniform_data_size = 8 * sizeof(uint32_t);
     // 128 bytes or more (depending on minUniformBufferOffsetAlignment)
-    const VkDeviceSize copy_dst_area_size = std::max((VkDeviceSize)128, m_device->phy().limits_.minUniformBufferOffsetAlignment);
+    const VkDeviceSize copy_dst_area_size =
+        std::max((VkDeviceSize)128, m_device->Physical().limits_.minUniformBufferOffsetAlignment);
     // 160 bytes or more (depending on minUniformBufferOffsetAlignment)
     const VkDeviceSize size = copy_dst_area_size + uniform_data_size;
 
@@ -1633,7 +1635,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions) {
     // this ensures copy region does not overlap with uniform data region
     uint32_t dynamic_offset = static_cast<uint32_t>(copy_dst_area_size);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
                               1, &dynamic_offset);
@@ -1645,7 +1647,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions) {
 
     // Reads from region [128..159]
     vk::CmdDispatch(m_command_buffer, 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions2) {
@@ -1659,7 +1661,8 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions2) {
     // 32 bytes
     const VkDeviceSize uniform_data_size = 8 * sizeof(uint32_t);
     // 128 bytes or more (depending on minUniformBufferOffsetAlignment)
-    const VkDeviceSize copy_dst_area_size = std::max((VkDeviceSize)128, m_device->phy().limits_.minUniformBufferOffsetAlignment);
+    const VkDeviceSize copy_dst_area_size =
+        std::max((VkDeviceSize)128, m_device->Physical().limits_.minUniformBufferOffsetAlignment);
     // 160 bytes or more (depending on minUniformBufferOffsetAlignment)
     const VkDeviceSize size = copy_dst_area_size + uniform_data_size;
 
@@ -1692,7 +1695,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions2) {
     // this ensures copy region does not overlap with uniform data region
     uint32_t dynamic_offset = static_cast<uint32_t>(copy_dst_area_size);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1, &descriptor_set.set_,
                               1, &dynamic_offset);
@@ -1705,7 +1708,7 @@ TEST_F(PositiveSyncVal, WriteAndReadNonOverlappedDynamicUniformBufferRegions2) {
     region.size = copy_dst_area_size;
     vk::CmdCopyBuffer(m_command_buffer, buffer_b, buffer_a, 1, &region);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveSyncVal, ImageUsedInShaderWithoutAccess) {
@@ -1738,14 +1741,14 @@ TEST_F(PositiveSyncVal, ImageUsedInShaderWithoutAccess) {
     region.imageSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     region.imageExtent = {32, 32, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     // this should not cause WRITE-AFTER-READ because previous dispatch reads only image descriptor
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), copy_source, image, VK_IMAGE_LAYOUT_GENERAL, 1, &region);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // WARNING: this test passes due to LUCK. Currently syncval does not know about atomic
@@ -1783,13 +1786,13 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoDispatches) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // WARNING: this test also passes due to LUCK. Same reason as the previous test.
@@ -1815,12 +1818,12 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoSubmits) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Submit(m_command_buffer);
@@ -1859,13 +1862,13 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoDispatches2) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 // Demostrates false-positive from the client's report.
@@ -1896,12 +1899,12 @@ TEST_F(PositiveSyncVal, AtomicAccessFromTwoSubmits2) {
     pipe.pipeline_layout_ = vkt::PipelineLayout(*m_device, {&descriptor_set.layout_});
     pipe.CreateComputePipeline();
 
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipe.pipeline_layout_, 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDispatch(m_command_buffer.handle(), 1, 1, 1);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
 

--- a/tests/unit/sync_val_semaphore.cpp
+++ b/tests/unit/sync_val_semaphore.cpp
@@ -25,9 +25,9 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitInitialValue) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
@@ -48,12 +48,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitInitialValueTwoQueues) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
@@ -71,9 +71,9 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitAfterSignalStageMismatch) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -95,12 +95,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitBeforeSignal) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -125,9 +125,9 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitBeforeSignalBatchFollowedByOneMoreB
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -148,12 +148,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitBeforeSignalEmptyWaitScope) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -179,12 +179,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, WaitBeforeSignalAfterNoDepsBatch) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -226,12 +226,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, HostSignal) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -254,12 +254,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, SignalResolvesTwoWaits) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -282,12 +282,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, SignalResolvesTwoWaits2) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 2);
@@ -310,12 +310,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, SignalResolvesTwoWaits3) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -338,12 +338,12 @@ TEST_F(NegativeSyncValTimelineSemaphore, SignalResolvesTwoWaits4) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     semaphore.Signal(1);

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -35,9 +35,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignal) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
@@ -51,9 +51,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSync1) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->SubmitWithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
@@ -70,12 +70,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalTwoQueues) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
@@ -89,9 +89,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSmallerValue) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 2);
@@ -108,12 +108,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSmallerValueTwoQueues) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 2);
@@ -127,9 +127,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStage) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -143,9 +143,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStage2) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -162,12 +162,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStageTwoQueues
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -184,12 +184,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignal) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -206,12 +206,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalSync1) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->SubmitWithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -228,12 +228,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitSmallerValueBeforeSignal) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
@@ -250,12 +250,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalNonDefaultStage) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -272,12 +272,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalNonDefaultStage2) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
@@ -292,9 +292,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitLatestSignal) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
@@ -314,12 +314,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitLatestSignalTwoQueues) {
     }
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
@@ -390,9 +390,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, SyncSubmitsWithSingleSemaphore) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
@@ -409,9 +409,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, FrameSynchronization) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     // Due to synchronization the copies from different frames do not collide
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
@@ -432,9 +432,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, FrameSynchronization2) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     // Due to synchronization the copies from different frames do not collide
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
@@ -496,12 +496,12 @@ TEST_F(PositiveSyncValTimelineSemaphore, HostWaitEmptyBatch) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_a, buffer_b);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -545,17 +545,17 @@ TEST_F(PositiveSyncValTimelineSemaphore, KhronosTimelineSemaphoreExample) {
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    if (!buffer_b.memory().initialized()) {
+    if (!buffer_b.Memory().initialized()) {
         GTEST_SKIP() << "Can't allocate host visible/coherent memory";
     }
-    uint8_t* bytes = static_cast<uint8_t*>(buffer_b.memory().map());
+    uint8_t* bytes = static_cast<uint8_t*>(buffer_b.Memory().Map());
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
-    m_second_command_buffer.begin();
+    m_command_buffer.End();
+    m_second_command_buffer.Begin();
     m_second_command_buffer.Copy(buffer_b, buffer_a);
-    m_second_command_buffer.end();
+    m_second_command_buffer.End();
 
     vkt::Semaphore timeline(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
@@ -625,7 +625,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
     }
 
     constexpr auto handle_type = VK_EXTERNAL_SEMAPHORE_HANDLE_TYPE_OPAQUE_WIN32_BIT;
-    if (!SemaphoreExportImportSupported(gpu(), handle_type)) {
+    if (!SemaphoreExportImportSupported(Gpu(), handle_type)) {
         GTEST_SKIP() << "Semaphore does not support export and import through Win32 handle";
     }
 
@@ -696,9 +696,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, ManyOrphanedSignals) {
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     VkCommandBufferSubmitInfo cbuf_info = vku::InitStructHelper();
     cbuf_info.commandBuffer = m_command_buffer;
@@ -746,9 +746,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitForFencesWithTimelineSignalBatches)
 
     vkt::Buffer buffer_a(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_SRC_BIT);
     vkt::Buffer buffer_b(*m_device, 256, VK_BUFFER_USAGE_TRANSFER_DST_BIT);
-    m_command_buffer.begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
+    m_command_buffer.Begin(VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT);
     m_command_buffer.Copy(buffer_a, buffer_b);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vkt::Fence fence(*m_device);
 
@@ -764,7 +764,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitForFencesWithTimelineSignalBatches)
     // The original omission was that iteration over all batch context did not take into account
     // batches associated with timeline signals. In the case of regression accesses in the first
     // batch (stored in timeline signal) will survive the fence wait.
-    fence.wait(kWaitTimeout);
+    fence.Wait(kWaitTimeout);
 
     // Waiting for timeline signal imports the first batch stored in that signal.
     // In case of regression the first batch will contain unprotected copy writes and

--- a/tests/unit/sync_val_wsi.cpp
+++ b/tests/unit/sync_val_wsi.cpp
@@ -61,9 +61,9 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     auto present_image = [this](uint32_t index, vkt::Semaphore* sem, vkt::Fence* fence) {
         VkResult result = VK_SUCCESS;
         if (fence) {
-            result = fence->wait(kWaitTimeout);
+            result = fence->Wait(kWaitTimeout);
             if (VK_SUCCESS == result) {
-                fence->reset();
+                fence->Reset();
             }
         }
 
@@ -110,10 +110,10 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
         image_barrier.image = h_image;
 
         image_barrier.subresourceRange = full_image;
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_TRANSFER_BIT, VK_PIPELINE_STAGE_TRANSFER_BIT, 0, 0,
                                nullptr, 0, nullptr, 1, &image_barrier);
-        m_command_buffer.end();
+        m_command_buffer.End();
     };
 
     // Transition swapchain images to PRESENT_SRC layout for presentation
@@ -121,7 +121,7 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
         write_barrier_cb(image, VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
         m_default_queue->Submit(m_command_buffer);
         m_device->Wait();
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 
     uint32_t acquired_index = 0;
@@ -143,7 +143,7 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
 
     // Finally we wait for the fence associated with the acquire
     REQUIRE_SUCCESS(vk::WaitForFences(m_device->handle(), 1, &fence.handle(), VK_TRUE, kWaitTimeout), "WaitForFences");
-    fence.reset();
+    fence.Reset();
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
@@ -153,7 +153,7 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     vkt::Semaphore sem(*m_device);
     REQUIRE_SUCCESS(acquire_used_image(&sem, nullptr, acquired_index), "acquire_used_image");
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     // The wait mask doesn't match the operations in the command buffer
@@ -174,12 +174,12 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     present_image(acquired_index, nullptr, nullptr);  // present without fence can't timeout
 
     REQUIRE_SUCCESS(acquire_used_image(VK_NULL_HANDLE, &fence, acquired_index), "acquire_used_index");
-    REQUIRE_SUCCESS(fence.wait(kWaitTimeout), "WaitForFences");
+    REQUIRE_SUCCESS(fence.Wait(kWaitTimeout), "WaitForFences");
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
-    fence.reset();
+    fence.Reset();
     m_default_queue->Submit(m_command_buffer, vkt::signal, sem);
 
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-PRESENT-AFTER-WRITE");
@@ -224,9 +224,9 @@ TEST_F(NegativeSyncValWsi, PresentDoesNotWaitForSubmit2) {
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &layout_transition;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit2(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore,
                              VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
@@ -271,10 +271,10 @@ TEST_F(NegativeSyncValWsi, PresentDoesNotWaitForSubmit) {
     layout_transition.subresourceRange.baseArrayLayer = 0;
     layout_transition.subresourceRange.layerCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &layout_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore);
 

--- a/tests/unit/sync_val_wsi_positive.cpp
+++ b/tests/unit/sync_val_wsi_positive.cpp
@@ -64,9 +64,9 @@ TEST_F(PositiveSyncValWsi, PresentAfterSubmit2AutomaticVisibility) {
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &layout_transition;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit2(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore,
                              VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
@@ -112,10 +112,10 @@ TEST_F(PositiveSyncValWsi, PresentAfterSubmitAutomaticVisibility) {
     layout_transition.subresourceRange.baseArrayLayer = 0;
     layout_transition.subresourceRange.layerCount = 1;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT,
                            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &layout_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore);
 
@@ -160,9 +160,9 @@ TEST_F(PositiveSyncValWsi, PresentAfterSubmitNoneDstStage) {
     dep_info.imageMemoryBarrierCount = 1;
     dep_info.pImageMemoryBarriers = &layout_transition;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // The goal of this test is to use QueueSubmit API (not QueueSubmit2) to
     // ensure syncval correctly converts SubmitInfo to SubmitInfo2 with
@@ -190,7 +190,7 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
     {
         vkt::CommandBuffer cmd(*m_device, m_command_pool);
-        cmd.begin();
+        cmd.Begin();
         for (VkImage image : swapchain_images) {
             VkImageMemoryBarrier transition = vku::InitStructHelper();
             transition.srcAccessMask = 0;
@@ -208,7 +208,7 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
             vk::CmdPipelineBarrier(cmd, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0, nullptr, 0,
                                    nullptr, 1, &transition);
         }
-        cmd.end();
+        cmd.End();
         m_default_queue->Submit(cmd);
         m_default_queue->Wait();
     }
@@ -226,9 +226,9 @@ TEST_F(PositiveSyncValWsi, ThreadedSubmitAndFenceWaitAndPresent) {
 
         vkt::Fence fence(*m_device);
         for (int i = 0; i < N; i++) {
-            m_command_buffer.begin();
+            m_command_buffer.Begin();
             vk::CmdCopyBuffer(m_command_buffer, src, dst, 1, &copy_info);
-            m_command_buffer.end();
+            m_command_buffer.End();
             {
                 std::unique_lock<std::mutex> lock(queue_mutex);
                 m_default_queue->Submit(m_command_buffer, fence);
@@ -279,7 +279,7 @@ static void SetImageLayoutPresentSrc(vkt::Queue& queue, vkt::Device& device, VkI
     vkt::CommandPool pool(device, device.graphics_queue_node_index_);
     vkt::CommandBuffer cmd_buf(device, pool);
 
-    cmd_buf.begin();
+    cmd_buf.Begin();
     VkImageMemoryBarrier layout_barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                         nullptr,
                                         0,
@@ -293,7 +293,7 @@ static void SetImageLayoutPresentSrc(vkt::Queue& queue, vkt::Device& device, VkI
 
     vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &layout_barrier);
-    cmd_buf.end();
+    cmd_buf.End();
     queue.Submit(cmd_buf);
     queue.Wait();
 }
@@ -335,9 +335,9 @@ TEST_F(PositiveSyncValWsi, WaitForFencesWithPresentBatches) {
         uint32_t image_index = 0;
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.Copy(src_buffer, buffer);
-        m_command_buffer.end();
+        m_command_buffer.End();
 
         m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, submit_semaphore, fence);
         present(submit_semaphore, image_index);
@@ -365,9 +365,9 @@ TEST_F(PositiveSyncValWsi, WaitForFencesWithPresentBatches) {
         vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index);
 
         // If WaitForFences leaks accesses from present batches the following copy will cause submit time hazard.
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.Copy(buffer, dst_buffer);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer, vkt::wait, acquire_semaphore);
     }
     m_default_queue->Wait();

--- a/tests/unit/threading.cpp
+++ b/tests/unit/threading.cpp
@@ -35,7 +35,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
     // Calls AllocateCommandBuffers
     vkt::CommandBuffer commandBuffer(*m_device, m_command_pool);
 
-    commandBuffer.begin();
+    commandBuffer.Begin();
 
     vkt::Event event(*m_device);
     VkResult err;
@@ -67,7 +67,7 @@ TEST_F(NegativeThreading, CommandBufferCollision) {
     AddToCommandBuffer(&data);
 
     thread2.join();
-    commandBuffer.end();
+    commandBuffer.End();
 
     m_errorMonitor->SetBailout(NULL);
 

--- a/tests/unit/threading_positive.cpp
+++ b/tests/unit/threading_positive.cpp
@@ -28,19 +28,19 @@ TEST_F(PositiveThreading, DisplayObjects) {
     RETURN_IF_SKIP(Init());
 
     uint32_t prop_count = 0;
-    vk::GetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, nullptr);
+    vk::GetPhysicalDeviceDisplayPropertiesKHR(Gpu(), &prop_count, nullptr);
     if (prop_count == 0) {
         GTEST_SKIP() << "No VkDisplayKHR properties to query";
     }
 
     std::vector<VkDisplayPropertiesKHR> display_props{prop_count};
     // Create a VkDisplayKHR object
-    vk::GetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, display_props.data());
+    vk::GetPhysicalDeviceDisplayPropertiesKHR(Gpu(), &prop_count, display_props.data());
     ASSERT_NE(prop_count, 0U);
 
     // Now use this new object in an API call that thread safety will track
     prop_count = 0;
-    vk::GetDisplayModePropertiesKHR(gpu(), display_props[0].display, &prop_count, nullptr);
+    vk::GetDisplayModePropertiesKHR(Gpu(), display_props[0].display, &prop_count, nullptr);
 }
 
 TEST_F(PositiveThreading, DisplayPlaneObjects) {
@@ -51,16 +51,16 @@ TEST_F(PositiveThreading, DisplayPlaneObjects) {
     RETURN_IF_SKIP(Init());
 
     uint32_t prop_count = 0;
-    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &prop_count, nullptr);
+    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(Gpu(), &prop_count, nullptr);
     if (prop_count != 0) {
         // only grab first plane property
         prop_count = 1;
         VkDisplayPlanePropertiesKHR display_plane_props = {};
         // Create a VkDisplayKHR object
-        vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &prop_count, &display_plane_props);
+        vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(Gpu(), &prop_count, &display_plane_props);
         // Now use this new object in an API call
         prop_count = 0;
-        vk::GetDisplayModePropertiesKHR(gpu(), display_plane_props.currentDisplay, &prop_count, nullptr);
+        vk::GetDisplayModePropertiesKHR(Gpu(), display_plane_props.currentDisplay, &prop_count, nullptr);
     }
 }
 
@@ -224,12 +224,12 @@ TEST_F(PositiveThreading, DebugObjectNames) {
         }
     };
     const auto bind_descriptor = [&]() {
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         for (uint32_t i = 0; i < count; ++i) {
             vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_COMPUTE, pipeline_layout.handle(), 0u, 1u,
                                       &descriptor_sets[i], 0u, nullptr);
         }
-        m_command_buffer.end();
+        m_command_buffer.End();
     };
 
     std::thread thread2(bind_descriptor);
@@ -271,8 +271,8 @@ TEST_F(PositiveThreading, Queue) {
     vkt::CommandBuffer mock_cmdbuff(*m_device, cbai);
     const VkCommandBufferBeginInfo cbbi{VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO, nullptr,
                                         VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT, nullptr};
-    mock_cmdbuff.begin(&cbbi);
-    mock_cmdbuff.end();
+    mock_cmdbuff.Begin(&cbbi);
+    mock_cmdbuff.End();
 
     std::mutex queue_mutex;
 

--- a/tests/unit/tooling.cpp
+++ b/tests/unit/tooling.cpp
@@ -48,11 +48,11 @@ TEST_F(NegativeTooling, PrivateDataSetNonDevice) {
 
     static const uint64_t data_value = 0x70AD;
     m_errorMonitor->SetDesiredError("VUID-vkSetPrivateData-objectHandle-04016");
-    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)gpu(), data_slot, data_value);
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)Gpu(), data_slot, data_value);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkSetPrivateData-objectHandle-04016");
-    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)gpu(), data_slot, data_value);
+    vk::SetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)Gpu(), data_slot, data_value);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);
@@ -83,7 +83,7 @@ TEST_F(NegativeTooling, PrivateDataSetSecondDevice) {
     AddRequiredFeature(vkt::Feature::privateData);
     RETURN_IF_SKIP(Init());
 
-    auto features = m_device->phy().Features();
+    auto features = m_device->Physical().Features();
     vkt::Device second_device(gpu_, m_device_extension_names, &features, nullptr);
 
     VkPrivateDataSlot data_slot;
@@ -119,11 +119,11 @@ TEST_F(NegativeTooling, PrivateDataGetNonDevice) {
 
     uint64_t data;
     m_errorMonitor->SetDesiredError("VUID-vkGetPrivateData-objectType-04018");
-    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)gpu(), data_slot, &data);
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_PHYSICAL_DEVICE, (uint64_t)Gpu(), data_slot, &data);
     m_errorMonitor->VerifyFound();
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPrivateData-objectType-04018");
-    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)gpu(), data_slot, &data);
+    vk::GetPrivateData(m_device->handle(), VK_OBJECT_TYPE_UNKNOWN, (uint64_t)Gpu(), data_slot, &data);
     m_errorMonitor->VerifyFound();
 
     vk::DestroyPrivateDataSlot(m_device->handle(), data_slot, nullptr);

--- a/tests/unit/tooling_positive.cpp
+++ b/tests/unit/tooling_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveTooling, InfoExt) {
     }
 
     uint32_t tool_count = 0;
-    auto result = vk::GetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, nullptr);
+    auto result = vk::GetPhysicalDeviceToolPropertiesEXT(Gpu(), &tool_count, nullptr);
 
     if (tool_count <= 0) {
         m_errorMonitor->SetError("Expected layer tooling data but received none");
@@ -39,7 +39,7 @@ TEST_F(PositiveTooling, InfoExt) {
     bool found_validation_layer = false;
 
     if (result == VK_SUCCESS) {
-        result = vk::GetPhysicalDeviceToolPropertiesEXT(gpu(), &tool_count, tool_properties.data());
+        result = vk::GetPhysicalDeviceToolPropertiesEXT(Gpu(), &tool_count, tool_properties.data());
 
         for (uint32_t i = 0; i < tool_count; i++) {
             if (strcmp(tool_properties[0].name, "Khronos Validation Layer") == 0) {
@@ -63,7 +63,7 @@ TEST_F(PositiveTooling, InfoCore) {
     }
 
     uint32_t tool_count = 0;
-    auto result = vk::GetPhysicalDeviceToolProperties(gpu(), &tool_count, nullptr);
+    auto result = vk::GetPhysicalDeviceToolProperties(Gpu(), &tool_count, nullptr);
 
     if (tool_count <= 0) {
         m_errorMonitor->SetError("Expected layer tooling data but received none");
@@ -77,7 +77,7 @@ TEST_F(PositiveTooling, InfoCore) {
     bool found_validation_layer = false;
 
     if (result == VK_SUCCESS) {
-        result = vk::GetPhysicalDeviceToolProperties(gpu(), &tool_count, tool_properties.data());
+        result = vk::GetPhysicalDeviceToolProperties(Gpu(), &tool_count, tool_properties.data());
 
         for (uint32_t i = 0; i < tool_count; i++) {
             if (strcmp(tool_properties[0].name, "Khronos Validation Layer") == 0) {

--- a/tests/unit/transform_feedback.cpp
+++ b/tests/unit/transform_feedback.cpp
@@ -72,7 +72,7 @@ TEST_F(NegativeTransformFeedback, FeatureEnabled) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -106,14 +106,14 @@ TEST_F(NegativeTransformFeedback, NoBoundPipeline) {
 
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-firstCounterBuffer-09630");
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-None-06233");
     vk::CmdBeginTransformFeedbackEXT(m_command_buffer.handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
@@ -127,7 +127,7 @@ TEST_F(NegativeTransformFeedback, CmdBindTransformFeedbackBuffersEXT) {
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -266,7 +266,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackEXT) {
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -349,7 +349,7 @@ TEST_F(NegativeTransformFeedback, CmdEndTransformFeedbackEXT) {
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
@@ -445,13 +445,13 @@ TEST_F(NegativeTransformFeedback, ExecuteSecondaryCommandBuffers) {
     hinfo.queryFlags = 0;
     hinfo.pipelineStatistics = 0;
 
-    secondary.begin(&info);
-    secondary.end();
+    secondary.Begin(&info);
+    secondary.End();
 
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
     m_errorMonitor->SetDesiredError("VUID-vkCmdBeginTransformFeedbackEXT-commandBuffer-recording");
@@ -477,7 +477,7 @@ TEST_F(NegativeTransformFeedback, BindPipeline) {
     CreatePipelineHelper pipe_two(*this);
     pipe_two.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
     VkDeviceSize offset = 0;
@@ -490,7 +490,7 @@ TEST_F(NegativeTransformFeedback, BindPipeline) {
     m_errorMonitor->VerifyFound();
     vk::CmdEndTransformFeedbackEXT(m_command_buffer.handle(), 0, 1, nullptr, nullptr);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeTransformFeedback, EndRenderPass) {
@@ -505,7 +505,7 @@ TEST_F(NegativeTransformFeedback, EndRenderPass) {
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo, VK_SUBPASS_CONTENTS_INLINE);
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
     VkDeviceSize offset = 0;
@@ -518,7 +518,7 @@ TEST_F(NegativeTransformFeedback, EndRenderPass) {
     m_errorMonitor->VerifyFound();
     vk::CmdEndTransformFeedbackEXT(m_command_buffer.handle(), 0, 1, nullptr, nullptr);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
@@ -539,7 +539,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
         CreatePipelineHelper pipeline(*this);
         pipeline.CreateGraphicsPipeline();
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
 
@@ -564,12 +564,12 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
         m_errorMonitor->VerifyFound();
 
         m_command_buffer.EndRenderPass();
-        m_command_buffer.end();
+        m_command_buffer.End();
     }
 
     std::vector<const char *> device_extension_names;
     device_extension_names.push_back(VK_EXT_TRANSFORM_FEEDBACK_EXTENSION_NAME);
-    vkt::Device test_device(gpu(), device_extension_names);
+    vkt::Device test_device(Gpu(), device_extension_names);
     vkt::CommandPool commandPool(test_device, 0);
     vkt::CommandBuffer commandBuffer(test_device, commandPool);
     vkt::Buffer counter_buffer2(test_device, 1024, VK_BUFFER_USAGE_INDIRECT_BUFFER_BIT);
@@ -600,7 +600,7 @@ TEST_F(NegativeTransformFeedback, DrawIndirectByteCountEXT) {
     m_renderPassBeginInfo.renderPass = renderpass.handle();
     m_renderPassBeginInfo.framebuffer = fb.handle();
     m_renderPassBeginInfo.renderPass = renderpass.handle();
-    commandBuffer.begin();
+    commandBuffer.Begin();
     vk::CmdBindPipeline(commandBuffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline.Handle());
     commandBuffer.BeginRenderPass(m_renderPassBeginInfo);
 
@@ -1063,7 +1063,7 @@ TEST_F(NegativeTransformFeedback, CmdNextSubpass) {
     pipe.shader_stages_[0] = vs->GetStageCreateInfo();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
@@ -1085,7 +1085,7 @@ TEST_F(NegativeTransformFeedback, CmdBeginTransformFeedbackOutsideRenderPass) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
     vkt::Buffer const buffer_obj(*m_device, 4, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_COUNTER_BUFFER_BIT_EXT);
@@ -1106,7 +1106,7 @@ TEST_F(NegativeTransformFeedback, XfbExecutionModeCommand) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vkt::Buffer buffer(*m_device, 16, VK_BUFFER_USAGE_TRANSFORM_FEEDBACK_BUFFER_BIT_EXT);
@@ -1116,7 +1116,7 @@ TEST_F(NegativeTransformFeedback, XfbExecutionModeCommand) {
     vk::CmdBeginTransformFeedbackEXT(m_command_buffer.handle(), 0, 1, nullptr, nullptr);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeTransformFeedback, XfbExecutionModePipeline) {

--- a/tests/unit/vertex_input.cpp
+++ b/tests/unit/vertex_input.cpp
@@ -60,7 +60,7 @@ TEST_F(NegativeVertexInput, DivisorExtension) {
     RETURN_IF_SKIP(InitState(nullptr, &pd_features2));
     InitRenderTarget();
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesEXT pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
@@ -213,7 +213,7 @@ TEST_F(NegativeVertexInput, DivisorExtensionKHR) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const VkPhysicalDeviceLimits &dev_limits = m_device->phy().limits_;
+    const VkPhysicalDeviceLimits &dev_limits = m_device->Physical().limits_;
     VkPhysicalDeviceVertexAttributeDivisorPropertiesKHR pdvad_props = vku::InitStructHelper();
     GetPhysicalDeviceProperties2(pdvad_props);
 
@@ -358,7 +358,7 @@ TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindings) {
 
     // Test when binding is greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings.
     VkVertexInputBindingDescription vertex_input_binding_description{};
-    vertex_input_binding_description.binding = m_device->phy().limits_.maxVertexInputBindings;
+    vertex_input_binding_description.binding = m_device->Physical().limits_.maxVertexInputBindings;
 
     const auto set_binding = [&](CreatePipelineHelper &helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
@@ -377,7 +377,7 @@ TEST_F(NegativeVertexInput, InputBindingMaxVertexInputBindingStride) {
 
     // Test when stride is greater than VkPhysicalDeviceLimits::maxVertexInputBindingStride.
     VkVertexInputBindingDescription vertex_input_binding_description{};
-    vertex_input_binding_description.stride = m_device->phy().limits_.maxVertexInputBindingStride + 1;
+    vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride + 1;
 
     const auto set_binding = [&](CreatePipelineHelper &helper) {
         helper.vi_ci_.pVertexBindingDescriptions = &vertex_input_binding_description;
@@ -396,7 +396,7 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputAttributes) {
 
     // Test when location is greater than or equal to VkPhysicalDeviceLimits::maxVertexInputAttributes.
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
-    vertex_input_attribute_description.location = m_device->phy().limits_.maxVertexInputAttributes;
+    vertex_input_attribute_description.location = m_device->Physical().limits_.maxVertexInputAttributes;
 
     const auto set_attribute = [&](CreatePipelineHelper &helper) {
         helper.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
@@ -418,7 +418,7 @@ TEST_F(NegativeVertexInput, InputAttributeMaxVertexInputBindings) {
 
     // Test when binding is greater than or equal to VkPhysicalDeviceLimits::maxVertexInputBindings.
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
-    vertex_input_attribute_description.binding = m_device->phy().limits_.maxVertexInputBindings;
+    vertex_input_attribute_description.binding = m_device->Physical().limits_.maxVertexInputBindings;
 
     const auto set_attribute = [&](CreatePipelineHelper &helper) {
         helper.vi_ci_.pVertexAttributeDescriptions = &vertex_input_attribute_description;
@@ -438,7 +438,7 @@ TEST_F(NegativeVertexInput, AttributeDescriptionOffset) {
     RETURN_IF_SKIP(Init());
 
     VkPhysicalDeviceProperties device_props = {};
-    vk::GetPhysicalDeviceProperties(gpu(), &device_props);
+    vk::GetPhysicalDeviceProperties(Gpu(), &device_props);
     const uint32_t maxVertexInputAttributeOffset = device_props.limits.maxVertexInputAttributeOffset;
     if (maxVertexInputAttributeOffset == 0xFFFFFFFF) {
         GTEST_SKIP() << "maxVertexInputAttributeOffset is max<uint32_t> already";
@@ -447,7 +447,7 @@ TEST_F(NegativeVertexInput, AttributeDescriptionOffset) {
 
     VkVertexInputBindingDescription vertex_input_binding_description{};
     vertex_input_binding_description.binding = 0;
-    vertex_input_binding_description.stride = m_device->phy().limits_.maxVertexInputBindingStride;
+    vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride;
     vertex_input_binding_description.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
     // Test when offset is greater than maximum.
     VkVertexInputAttributeDescription vertex_input_attribute_description{};
@@ -471,7 +471,7 @@ TEST_F(NegativeVertexInput, BindingDescriptions) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    const uint32_t binding_count = m_device->phy().limits_.maxVertexInputBindings + 1;
+    const uint32_t binding_count = m_device->Physical().limits_.maxVertexInputBindings + 1;
 
     std::vector<VkVertexInputBindingDescription> input_bindings(binding_count);
     for (uint32_t i = 0; i < binding_count; ++i) {
@@ -514,7 +514,7 @@ TEST_F(NegativeVertexInput, AttributeDescriptions) {
     input_binding.stride = 4;
     input_binding.inputRate = VK_VERTEX_INPUT_RATE_VERTEX;
 
-    const uint32_t attribute_count = m_device->phy().limits_.maxVertexInputAttributes + 1;
+    const uint32_t attribute_count = m_device->Physical().limits_.maxVertexInputAttributes + 1;
     std::vector<VkVertexInputAttributeDescription> input_attribs(attribute_count);
     for (uint32_t i = 0; i < attribute_count; ++i) {
         input_attribs[i].binding = 0;
@@ -591,7 +591,7 @@ TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
     CreatePipelineHelper pipe3(*this);
     pipe3.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe1.Handle());
 
@@ -608,7 +608,7 @@ TEST_F(NegativeVertexInput, ProvokingVertexModePerPipeline) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertextBinding) {
@@ -635,7 +635,7 @@ TEST_F(NegativeVertexInput, VertextBinding) {
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offset = 0;
@@ -648,7 +648,7 @@ TEST_F(NegativeVertexInput, VertextBinding) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
@@ -671,7 +671,7 @@ TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offset = 0;
@@ -685,7 +685,7 @@ TEST_F(NegativeVertexInput, VertextBindingNonLinear) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
@@ -726,7 +726,7 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     attributes[2].binding = 2;
     attributes[2].format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 5, 1, &buffer.handle(), &offset);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 3, 1, &buffer.handle(), &offset);
@@ -738,7 +738,7 @@ TEST_F(NegativeVertexInput, VertextBindingDynamicState) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, AttributeAlignment) {
@@ -813,7 +813,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     pipe2.vi_ci_ = vi_state;
     pipe2.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
 
     // Test with invalid buffer offset
@@ -837,7 +837,7 @@ TEST_F(NegativeVertexInput, AttributeAlignment) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, BindVertexOffset) {
@@ -858,7 +858,7 @@ TEST_F(NegativeVertexInput, BindVertexOffset) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -869,7 +869,7 @@ TEST_F(NegativeVertexInput, BindVertexOffset) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertexStride) {
@@ -890,7 +890,7 @@ TEST_F(NegativeVertexInput, VertexStride) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &input_attribs;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -901,7 +901,7 @@ TEST_F(NegativeVertexInput, VertexStride) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
@@ -929,7 +929,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
     attribute.binding = 0;
     attribute.format = VK_FORMAT_R16_UNORM;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -941,7 +941,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicInput) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
@@ -966,7 +966,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -978,7 +978,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStride) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
@@ -1003,7 +1003,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1016,7 +1016,7 @@ TEST_F(NegativeVertexInput, VertexStrideDynamicStrideArray) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
@@ -1047,7 +1047,7 @@ TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
     attribute.binding = 0;
     attribute.format = VK_FORMAT_R16_UNORM;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offset = 0;
@@ -1069,7 +1069,7 @@ TEST_F(NegativeVertexInput, VertexStrideDoubleDynamicStride) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, AttributeNotConsumed) {
@@ -1368,7 +1368,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatchDynamic) {
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, 1, &attribute);
@@ -1377,7 +1377,7 @@ TEST_F(NegativeVertexInput, AttributeTypeMismatchDynamic) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, AttributeBindingConflict) {
@@ -1527,7 +1527,7 @@ TEST_F(NegativeVertexInput, AttributeStructTypeBlockLocation64bit) {
     InitRenderTarget();
 
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
     if (!(format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_R64G64B64A64_SFLOAT vertex buffers";
     }
@@ -1625,7 +1625,7 @@ TEST_F(NegativeVertexInput, UnsupportedDivisor) {
     vkt::Buffer buffer(*m_device, 1027u, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &buffer.handle(), &offset);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1633,7 +1633,7 @@ TEST_F(NegativeVertexInput, UnsupportedDivisor) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 1u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, UnsupportedDynamicStateDivisor) {
@@ -1671,7 +1671,7 @@ TEST_F(NegativeVertexInput, UnsupportedDynamicStateDivisor) {
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &buffer.handle(), &offset);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1682,7 +1682,7 @@ TEST_F(NegativeVertexInput, UnsupportedDynamicStateDivisor) {
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 1u);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, BindVertexBufferNull) {
@@ -1690,7 +1690,7 @@ TEST_F(NegativeVertexInput, BindVertexBufferNull) {
     RETURN_IF_SKIP(Init());
     InitRenderTarget();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     VkDeviceSize offsets[2] = {0, 0};
     m_errorMonitor->SetDesiredError("VUID-vkCmdBindVertexBuffers-pBuffers-parameter");
@@ -1704,7 +1704,7 @@ TEST_F(NegativeVertexInput, BindVertexBufferNull) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, BindVertexBufferNullDraw) {
@@ -1725,7 +1725,7 @@ TEST_F(NegativeVertexInput, BindVertexBufferNullDraw) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -1739,7 +1739,7 @@ TEST_F(NegativeVertexInput, BindVertexBufferNullDraw) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeVertexInput, VertextBufferDestroyed) {
@@ -1753,7 +1753,7 @@ TEST_F(NegativeVertexInput, VertextBufferDestroyed) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offset = 0;
@@ -1797,7 +1797,7 @@ TEST_F(NegativeVertexInput, ResetCmdSetVertexInput) {
     attributes.binding = 0;
     attributes.format = VK_FORMAT_R8G8B8A8_UINT;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &vertex_buffer.handle(), &offset);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -1810,5 +1810,5 @@ TEST_F(NegativeVertexInput, ResetCmdSetVertexInput) {
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 1);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/vertex_input_positive.cpp
+++ b/tests/unit/vertex_input_positive.cpp
@@ -389,7 +389,7 @@ TEST_F(PositiveVertexInput, CreatePipeline64BitAttributes) {
     InitRenderTarget();
 
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
     if (!(format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_R64G64B64A64_SFLOAT vertex buffers";
     }
@@ -474,7 +474,7 @@ TEST_F(PositiveVertexInput, AttributeStructTypeBlockLocation64bit) {
     InitRenderTarget();
 
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_R64G64B64A64_SFLOAT, &format_props);
     if (!(format_props.bufferFeatures & VK_FORMAT_FEATURE_VERTEX_BUFFER_BIT)) {
         GTEST_SKIP() << "Device does not support VK_FORMAT_R64G64B64A64_SFLOAT vertex buffers";
     }
@@ -593,13 +593,13 @@ TEST_F(PositiveVertexInput, VertexAttributeDivisorFirstInstance) {
     vkt::Buffer vertex_buffer(*m_device, 256, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0u;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &vertex_buffer.handle(), &offset);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdDraw(m_command_buffer.handle(), 3u, 1u, 0u, 1u);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, VertextBindingNonLinear) {
@@ -622,7 +622,7 @@ TEST_F(PositiveVertexInput, VertextBindingNonLinear) {
     pipe.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     VkDeviceSize offsets[6] = {0, 0, 0, 0, 0, 0};
@@ -633,7 +633,7 @@ TEST_F(PositiveVertexInput, VertextBindingNonLinear) {
     m_errorMonitor->VerifyFound();
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, VertextBindingDynamicState) {
@@ -673,7 +673,7 @@ TEST_F(PositiveVertexInput, VertextBindingDynamicState) {
     attributes[2].binding = 2;
     attributes[2].format = VK_FORMAT_R8G8B8A8_UNORM;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     VkBuffer buffers[2] = {buffer.handle(), buffer.handle()};
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 5, 2, buffers, offsets);
@@ -684,7 +684,7 @@ TEST_F(PositiveVertexInput, VertextBindingDynamicState) {
 
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 1);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, VertexStrideDynamicStride) {
@@ -707,7 +707,7 @@ TEST_F(PositiveVertexInput, VertexStrideDynamicStride) {
     pipe.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -717,7 +717,7 @@ TEST_F(PositiveVertexInput, VertexStrideDynamicStride) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, VertexStrideDoubleDynamicStride) {
@@ -747,7 +747,7 @@ TEST_F(PositiveVertexInput, VertexStrideDoubleDynamicStride) {
     attribute.binding = 0;
     attribute.format = VK_FORMAT_R16_UNORM;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     const VkDeviceSize offset = 0;
@@ -765,7 +765,7 @@ TEST_F(PositiveVertexInput, VertexStrideDoubleDynamicStride) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, InputBindingMaxVertexInputBindingStrideDynamic) {
@@ -776,7 +776,7 @@ TEST_F(PositiveVertexInput, InputBindingMaxVertexInputBindingStrideDynamic) {
 
     // Test when stride is greater than VkPhysicalDeviceLimits::maxVertexInputBindingStride.
     VkVertexInputBindingDescription vertex_input_binding_description{};
-    vertex_input_binding_description.stride = m_device->phy().limits_.maxVertexInputBindingStride + 1;
+    vertex_input_binding_description.stride = m_device->Physical().limits_.maxVertexInputBindingStride + 1;
 
     const auto set_info = [&](CreatePipelineHelper &helper) {
         helper.AddDynamicState(VK_DYNAMIC_STATE_VERTEX_INPUT_BINDING_STRIDE);
@@ -802,7 +802,7 @@ TEST_F(PositiveVertexInput, BindVertexBufferNull) {
     pipe.vi_ci_.pVertexAttributeDescriptions = &attributes;
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
 
@@ -815,7 +815,7 @@ TEST_F(PositiveVertexInput, BindVertexBufferNull) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, InterleavedAttributes) {
@@ -846,7 +846,7 @@ TEST_F(PositiveVertexInput, InterleavedAttributes) {
     pipe1.vi_ci_.pVertexAttributeDescriptions = vtx_attri_des;
     pipe1.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     // We bind, but rebind with valid pipeline
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe0.Handle());  // invalid
@@ -856,7 +856,7 @@ TEST_F(PositiveVertexInput, InterleavedAttributes) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
 
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, LegacyVertexAttributes) {
@@ -895,14 +895,14 @@ TEST_F(PositiveVertexInput, LegacyVertexAttributes) {
     vkt::Buffer buffer(*m_device, 1024, VK_BUFFER_USAGE_VERTEX_BUFFER_BIT);
     VkDeviceSize offset = 0;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0, 1, &buffer.handle(), &offset);
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &binding, 1, &attribute);
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
@@ -949,7 +949,7 @@ TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
     attributes.binding = 0;
     attributes.format = VK_FORMAT_R8G8B8A8_UINT;
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindVertexBuffers(m_command_buffer.handle(), 0u, 1u, &vertex_buffer.handle(), &offset);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe_int.Handle());
@@ -963,5 +963,5 @@ TEST_F(PositiveVertexInput, ResetCmdSetVertexInput) {
     vk::CmdSetVertexInputEXT(m_command_buffer.handle(), 1, &bindings, 1, &attributes);
     vk::CmdDraw(m_command_buffer.handle(), 3, 1, 0, 1);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/viewport_inheritance.cpp
+++ b/tests/unit/viewport_inheritance.cpp
@@ -201,7 +201,7 @@ class ViewportInheritanceTestData {
         VkPhysicalDeviceInheritedViewportScissorFeaturesNV nv =
             vku::InitStructHelper(&ext);
         VkPhysicalDeviceFeatures2 features2 = vku::InitStructHelper(&nv);
-        VkPhysicalDevice gpu = p_framework->gpu();
+        VkPhysicalDevice gpu = p_framework->Gpu();
 
         // Enable extended dynamic state if requested.
         if (extended_dynamic_state_multi_viewport) {
@@ -416,7 +416,7 @@ TEST_F(NegativeViewportInheritance, BasicUsage) {
     AddRequiredFeature(vkt::Feature::nestedCommandBufferSimultaneousUse);
     RETURN_IF_SKIP(Init());
 
-    ViewportInheritanceTestData test_data(m_device, gpu());
+    ViewportInheritanceTestData test_data(m_device, Gpu());
     if (test_data.FailureReason()) {
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }
@@ -649,7 +649,7 @@ TEST_F(NegativeViewportInheritance, MissingFeature) {
         GTEST_SKIP() << missing_feature_string;
     }
 
-    ViewportInheritanceTestData test_data(m_device, gpu());
+    ViewportInheritanceTestData test_data(m_device, Gpu());
     if (test_data.FailureReason()) {
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }
@@ -677,7 +677,7 @@ TEST_F(NegativeViewportInheritance, MultiViewport) {
     AddRequiredFeature(vkt::Feature::nestedCommandBufferSimultaneousUse);
     RETURN_IF_SKIP(Init());
 
-    ViewportInheritanceTestData test_data(m_device, gpu());
+    ViewportInheritanceTestData test_data(m_device, Gpu());
     if (test_data.FailureReason()) {
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }
@@ -907,7 +907,7 @@ TEST_F(NegativeViewportInheritance, ScissorMissingFeature) {
         GTEST_SKIP() << missing_feature_string;
     }
 
-    ViewportInheritanceTestData test_data(m_device, gpu());
+    ViewportInheritanceTestData test_data(m_device, Gpu());
     if (test_data.FailureReason()) {
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }
@@ -945,7 +945,7 @@ TEST_F(NegativeViewportInheritance, PipelineMissingDynamicStateDiscardRectangle)
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_RESET_COMMAND_BUFFER_BIT);
     vkt::CommandBuffer secondary(*m_device, pool, VK_COMMAND_BUFFER_LEVEL_SECONDARY);
 
-    ViewportInheritanceTestData test_data(m_device, gpu());
+    ViewportInheritanceTestData test_data(m_device, Gpu());
     if (test_data.FailureReason()) {
         GTEST_SKIP() << "Test internal failure: " << test_data.FailureReason();
     }

--- a/tests/unit/wsi.cpp
+++ b/tests/unit/wsi.cpp
@@ -27,7 +27,7 @@ TEST_F(NegativeWsi, GetPhysicalDeviceDisplayPropertiesNull) {
     RETURN_IF_SKIP(Init());
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceDisplayPropertiesKHR-pPropertyCount-parameter");
-    vk::GetPhysicalDeviceDisplayPropertiesKHR(gpu(), nullptr, nullptr);
+    vk::GetPhysicalDeviceDisplayPropertiesKHR(Gpu(), nullptr, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -70,7 +70,7 @@ TEST_F(NegativeWsi, InitSwapchainPotentiallyIncompatibleFlag) {
         VkSurfaceProtectedCapabilitiesKHR surface_protected_capabilities = vku::InitStructHelper();
         VkSurfaceCapabilities2KHR surface_capabilities = vku::InitStructHelper();
         surface_capabilities.pNext = &surface_protected_capabilities;
-        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_capabilities);
+        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_capabilities);
 
         // Create swapchain, monitor potential validation error
         if (!surface_protected_capabilities.supportsProtected) {
@@ -91,7 +91,7 @@ TEST_F(NegativeWsi, InitSwapchainPotentiallyIncompatibleFlag) {
     // "split instance bind regions" not supported when there is only one device
     VkImageFormatProperties image_format_props{};
     if (vk::GetPhysicalDeviceImageFormatProperties(
-            gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
+            Gpu(), VK_FORMAT_R8G8B8A8_UNORM, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL, VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT,
             VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT, &image_format_props) == VK_SUCCESS) {
         swapchain_ci.flags = VK_SWAPCHAIN_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT_KHR;
 
@@ -147,7 +147,7 @@ TEST_F(NegativeWsi, BindImageMemorySwapchain) {
     }
 
     vkt::DeviceMemory mem;
-    bool pass = m_device->phy().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
+    bool pass = m_device->Physical().SetMemoryType(mem_reqs.memoryTypeBits, &alloc_info, 0);
     // some devices don't give us good memory requirements for the swapchain image
     if (pass) {
         mem.init(*m_device, alloc_info);
@@ -244,7 +244,7 @@ TEST_F(NegativeWsi, SwapchainImage) {
     CreateImageTest(*this, &image_create_info, vuid);
 
     // flags
-    if (m_device->phy().Features().sparseBinding) {
+    if (m_device->Physical().Features().sparseBinding) {
         image_create_info = good_create_info;
         image_create_info.flags = VK_IMAGE_CREATE_SPARSE_BINDING_BIT;
         CreateImageTest(*this, &image_create_info, vuid);
@@ -329,7 +329,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
 
     const auto swapchain_images = GetSwapchainImages(m_swapchain);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region = {};
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
@@ -340,7 +340,7 @@ TEST_F(NegativeWsi, TransferImageToSwapchainLayoutDeviceGroup) {
     vk::CmdCopyImage(m_command_buffer.handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     // Even though both peer_image and swapchain_images[0] use the same memory and are in an invalid layout,
     // only peer_image is referenced by the command buffer so there should only be one error reported.
@@ -362,7 +362,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
 
     VkDeviceGroupDeviceCreateInfo device_group_ci = vku::InitStructHelper();
     device_group_ci.physicalDeviceCount = 1;
-    VkPhysicalDevice pdev = gpu();
+    VkPhysicalDevice pdev = Gpu();
     device_group_ci.pPhysicalDevices = &pdev;
     RETURN_IF_SKIP(InitState(nullptr, &device_group_ci));
     InitRenderTarget();
@@ -400,7 +400,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
             for (size_t j = 0; j < m_surface_formats.size(); ++j) {
                 VkImageFormatProperties image_format_properties = {};
                 VkResult image_format_properties_result = vk::GetPhysicalDeviceImageFormatProperties(
-                    m_device->phy().handle(), m_surface_formats[j].format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+                    m_device->Physical().handle(), m_surface_formats[j].format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                     kImageUsageFlags[i], 0, &image_format_properties);
 
                 if (image_format_properties_result != VK_SUCCESS) {
@@ -413,7 +413,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
         }
     }
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -430,7 +430,7 @@ TEST_F(NegativeWsi, SwapchainImageParams) {
     vk::DestroySwapchainKHR(device(), m_swapchain, nullptr);
 
     VkImageFormatProperties props;
-    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(gpu(), good_create_info.imageFormat, VK_IMAGE_TYPE_2D,
+    VkResult res = vk::GetPhysicalDeviceImageFormatProperties(Gpu(), good_create_info.imageFormat, VK_IMAGE_TYPE_2D,
                                                               VK_IMAGE_TILING_OPTIMAL, good_create_info.imageUsage,
                                                               VK_IMAGE_CREATE_SPLIT_INSTANCE_BIND_REGIONS_BIT, &props);
     if (res != VK_SUCCESS) {
@@ -604,7 +604,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages) {
     uint32_t image_count;
     ASSERT_EQ(VK_SUCCESS, vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));
     VkSurfaceCapabilitiesKHR caps;
-    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &caps));
+    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(Gpu(), m_surface, &caps));
 
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
     std::vector<vkt::Fence> fences(acquirable_count);
@@ -659,15 +659,15 @@ TEST_F(NegativeWsi, SwapchainNotSupported) {
 
     std::vector<VkQueueFamilyProperties> queue_families;
     uint32_t count = 0;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &count, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &count, nullptr);
     queue_families.resize(count);
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &count, queue_families.data());
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &count, queue_families.data());
 
     bool found = false;
     uint32_t qfi = 0;
     for (uint32_t i = 0; i < queue_families.size(); i++) {
         VkBool32 supported = VK_FALSE;
-        vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), i, m_surface, &supported);
+        vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), i, m_surface, &supported);
         if (!supported) {
             found = true;
             qfi = i;
@@ -690,7 +690,7 @@ TEST_F(NegativeWsi, SwapchainNotSupported) {
     device_create_info.enabledExtensionCount = m_device_extension_names.size();
     device_create_info.ppEnabledExtensionNames = m_device_extension_names.data();
 
-    vkt::Device test_device(gpu(), device_create_info);
+    vkt::Device test_device(Gpu(), device_create_info);
 
     // Initialize extensions manually because we don't use InitState() in this test
     for (const char *device_ext_name : m_device_extension_names) {
@@ -729,7 +729,7 @@ TEST_F(NegativeWsi, SwapchainAcquireTooManyImages2KHR) {
     uint32_t image_count;
     ASSERT_EQ(VK_SUCCESS, vk::GetSwapchainImagesKHR(device(), m_swapchain, &image_count, nullptr));
     VkSurfaceCapabilitiesKHR caps;
-    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &caps));
+    ASSERT_EQ(VK_SUCCESS, vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(Gpu(), m_surface, &caps));
 
     const uint32_t acquirable_count = image_count - caps.minImageCount + 1;
     std::vector<vkt::Fence> fences(acquirable_count);
@@ -768,7 +768,7 @@ TEST_F(NegativeWsi, SwapchainImageFormatList) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -863,7 +863,7 @@ TEST_F(NegativeWsi, SwapchainMinImageCountNonShared) {
     }
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -904,7 +904,7 @@ TEST_F(NegativeWsi, SwapchainMinImageCountShared) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -926,7 +926,7 @@ TEST_F(NegativeWsi, SwapchainMinImageCountShared) {
     VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &capabilities);
 
     // This was recently added to CTS, but some drivers might not correctly advertise the flag
     if ((shared_present_capabilities.sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
@@ -966,7 +966,7 @@ TEST_F(NegativeWsi, SwapchainUsageNonShared) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -1009,7 +1009,7 @@ TEST_F(NegativeWsi, SwapchainUsageShared) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -1031,7 +1031,7 @@ TEST_F(NegativeWsi, SwapchainUsageShared) {
     VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &capabilities);
 
     // No implementation should support depth/stencil for swapchain
     if ((shared_present_capabilities.sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) != 0) {
@@ -1071,7 +1071,7 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -1093,7 +1093,7 @@ TEST_F(NegativeWsi, SwapchainPresentShared) {
     VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &capabilities);
 
     // This was recently added to CTS, but some drivers might not correctly advertise the flag
     if ((shared_present_capabilities.sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
@@ -1181,7 +1181,7 @@ TEST_F(NegativeWsi, DeviceMask) {
                                                              {VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_GROUP_PROPERTIES});
     err = vk::EnumeratePhysicalDeviceGroups(instance(), &pdev_group_count, &group_props[0]);
 
-    auto tgt = gpu();
+    auto tgt = Gpu();
     bool test_run = false;
     for (uint32_t i = 0; i < pdev_group_count; i++) {
         if ((group_props[i].physicalDeviceCount > 1) && !test_run) {
@@ -1209,20 +1209,20 @@ TEST_F(NegativeWsi, DeviceMask) {
     dev_grp_cmd_buf_info.deviceMask = 0xFFFFFFFF;
     VkCommandBufferBeginInfo cmd_buf_info = vku::InitStructHelper(&dev_grp_cmd_buf_info);
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupCommandBufferBeginInfo-deviceMask-00106");
     vk::BeginCommandBuffer(m_command_buffer.handle(), &cmd_buf_info);
     m_errorMonitor->VerifyFound();
 
     dev_grp_cmd_buf_info.deviceMask = 0;
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupCommandBufferBeginInfo-deviceMask-00107");
     vk::BeginCommandBuffer(m_command_buffer.handle(), &cmd_buf_info);
     m_errorMonitor->VerifyFound();
 
     // Test VkDeviceGroupRenderPassBeginInfo
     dev_grp_cmd_buf_info.deviceMask = 0x00000001;
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     vk::BeginCommandBuffer(m_command_buffer.handle(), &cmd_buf_info);
 
     VkDeviceGroupRenderPassBeginInfo dev_grp_rp_info = vku::InitStructHelper();
@@ -1297,7 +1297,7 @@ TEST_F(NegativeWsi, DeviceMask) {
     submit_info.commandBufferCount = 1;
     submit_info.pCommandBuffers = &m_command_buffer.handle();
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     vk::BeginCommandBuffer(m_command_buffer.handle(), &cmd_buf_info);
     vk::EndCommandBuffer(m_command_buffer.handle());
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupSubmitInfo-pCommandBufferDeviceMasks-00086");
@@ -1315,12 +1315,12 @@ TEST_F(NegativeWsi, DisplayPlaneSurface) {
     RETURN_IF_SKIP(InitSurface());
 
     uint32_t plane_prop_count = 0;
-    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &plane_prop_count, nullptr);
+    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(Gpu(), &plane_prop_count, nullptr);
     if (plane_prop_count == 0) {
         GTEST_SKIP() << "Test requires at least 1 supported display plane property";
     }
     std::vector<VkDisplayPlanePropertiesKHR> display_plane_props(plane_prop_count);
-    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(gpu(), &plane_prop_count, display_plane_props.data());
+    vk::GetPhysicalDeviceDisplayPlanePropertiesKHR(Gpu(), &plane_prop_count, display_plane_props.data());
     // using plane 0 for rest of test
     VkDisplayKHR current_display = display_plane_props[0].currentDisplay;
     if (current_display == VK_NULL_HANDLE) {
@@ -1328,24 +1328,24 @@ TEST_F(NegativeWsi, DisplayPlaneSurface) {
     }
 
     uint32_t mode_prop_count = 0;
-    vk::GetDisplayModePropertiesKHR(gpu(), current_display, &mode_prop_count, nullptr);
+    vk::GetDisplayModePropertiesKHR(Gpu(), current_display, &mode_prop_count, nullptr);
     if (plane_prop_count == 0) {
         GTEST_SKIP() << "test requires at least 1 supported display mode property";
     }
     std::vector<VkDisplayModePropertiesKHR> display_mode_props(mode_prop_count);
-    vk::GetDisplayModePropertiesKHR(gpu(), current_display, &mode_prop_count, display_mode_props.data());
+    vk::GetDisplayModePropertiesKHR(Gpu(), current_display, &mode_prop_count, display_mode_props.data());
 
     uint32_t plane_count;
     m_errorMonitor->SetDesiredError("VUID-vkGetDisplayPlaneSupportedDisplaysKHR-planeIndex-01249");
-    vk::GetDisplayPlaneSupportedDisplaysKHR(gpu(), plane_prop_count, &plane_count, nullptr);
+    vk::GetDisplayPlaneSupportedDisplaysKHR(Gpu(), plane_prop_count, &plane_count, nullptr);
     m_errorMonitor->VerifyFound();
-    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneSupportedDisplaysKHR(gpu(), 0, &plane_count, nullptr));
+    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneSupportedDisplaysKHR(Gpu(), 0, &plane_count, nullptr));
     if (plane_count == 0) {
         GTEST_SKIP() << "test requires at least 1 supported display plane";
     }
     std::vector<VkDisplayKHR> supported_displays(plane_count);
     plane_count = 1;
-    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneSupportedDisplaysKHR(gpu(), 0, &plane_count, supported_displays.data()));
+    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneSupportedDisplaysKHR(Gpu(), 0, &plane_count, supported_displays.data()));
     if (supported_displays[0] != current_display) {
         GTEST_SKIP() << "Current VkDisplayKHR used is not supported";
     }
@@ -1357,17 +1357,17 @@ TEST_F(NegativeWsi, DisplayPlaneSurface) {
     m_errorMonitor->SetDesiredError("VUID-VkDisplayModeParametersKHR-width-01990");
     m_errorMonitor->SetDesiredError("VUID-VkDisplayModeParametersKHR-height-01991");
     m_errorMonitor->SetDesiredError("VUID-VkDisplayModeParametersKHR-refreshRate-01992");
-    vk::CreateDisplayModeKHR(gpu(), current_display, &display_mode_info, nullptr, &display_mode);
+    vk::CreateDisplayModeKHR(Gpu(), current_display, &display_mode_info, nullptr, &display_mode);
     m_errorMonitor->VerifyFound();
     // Use the first good parameter queried
     display_mode_info.parameters = display_mode_props[0].parameters;
-    VkResult result = vk::CreateDisplayModeKHR(gpu(), current_display, &display_mode_info, nullptr, &display_mode);
+    VkResult result = vk::CreateDisplayModeKHR(Gpu(), current_display, &display_mode_info, nullptr, &display_mode);
     if (result != VK_SUCCESS) {
         GTEST_SKIP() << "test failed to create a display mode with vkCreateDisplayModeKHR";
     }
 
     VkDisplayPlaneCapabilitiesKHR plane_capabilities;
-    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneCapabilitiesKHR(gpu(), display_mode, 0, &plane_capabilities));
+    ASSERT_EQ(VK_SUCCESS, vk::GetDisplayPlaneCapabilitiesKHR(Gpu(), display_mode, 0, &plane_capabilities));
 
     VkSurfaceKHR surface;
     VkDisplaySurfaceCreateInfoKHR display_surface_info = vku::InitStructHelper();
@@ -1409,7 +1409,7 @@ TEST_F(NegativeWsi, DisplayPlaneSurface) {
     m_errorMonitor->VerifyFound();
     display_surface_info.planeIndex = 0;  // restore to good value
 
-    uint32_t bad_size = m_device->phy().limits_.maxImageDimension2D + 1;
+    uint32_t bad_size = m_device->Physical().limits_.maxImageDimension2D + 1;
     display_surface_info.imageExtent = {bad_size, bad_size};
     // one for height and width
     m_errorMonitor->SetDesiredError("VUID-VkDisplaySurfaceCreateInfoKHR-width-01256");
@@ -1472,7 +1472,7 @@ TEST_F(NegativeWsi, DeviceGroupSubmitInfoSemaphoreCount) {
     submit_info.signalSemaphoreCount = 1;
     submit_info.pSignalSemaphores = &semaphore.handle();
 
-    m_command_buffer.reset();
+    m_command_buffer.Reset();
     vk::BeginCommandBuffer(m_command_buffer.handle(), &cmd_buf_info);
     vk::EndCommandBuffer(m_command_buffer.handle());
     m_errorMonitor->SetDesiredError("VUID-VkDeviceGroupSubmitInfo-signalSemaphoreCount-00084");
@@ -1584,10 +1584,10 @@ TEST_F(NegativeWsi, DisplayPresentInfoSrcRect) {
     ASSERT_TRUE(image_acquired.initialized());
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, image_acquired.handle(), VK_NULL_HANDLE, &current_buffer);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     uint32_t swapchain_width = m_surface_capabilities.minImageExtent.width;
     uint32_t swapchain_height = m_surface_capabilities.minImageExtent.height;
@@ -1774,14 +1774,14 @@ TEST_F(NegativeWsi, GetSwapchainImagesCountButNotImages) {
     RETURN_IF_SKIP(InitSurface());
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present, skipping test";
     }
     InitSwapchainInfo();
 
     VkImageFormatProperties img_format_props;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), m_surface_formats[0].format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), m_surface_formats[0].format, VK_IMAGE_TYPE_2D, VK_IMAGE_TILING_OPTIMAL,
                                                VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT, 0, &img_format_props);
     VkExtent2D img_ext = {std::min(m_surface_capabilities.maxImageExtent.width, img_format_props.maxExtent.width),
                           std::min(m_surface_capabilities.maxImageExtent.height, img_format_props.maxExtent.height)};
@@ -1839,11 +1839,11 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
     RETURN_IF_SKIP(InitSurface());
 
     uint32_t queueFamilyPropertyCount;
-    vk::GetPhysicalDeviceQueueFamilyProperties(gpu(), &queueFamilyPropertyCount, nullptr);
+    vk::GetPhysicalDeviceQueueFamilyProperties(Gpu(), &queueFamilyPropertyCount, nullptr);
 
     VkBool32 supported = VK_FALSE;
     for (uint32_t i = 0; i < queueFamilyPropertyCount; ++i) {
-        vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), i, m_surface, &supported);
+        vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), i, m_surface, &supported);
         if (supported) {
             break;
         }
@@ -1863,7 +1863,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
         m_errorMonitor->VerifyFound();
 
         uint32_t count;
-        vk::GetPhysicalDeviceSurfacePresentModes2EXT(gpu(), &surface_info, &count, nullptr);
+        vk::GetPhysicalDeviceSurfacePresentModes2EXT(Gpu(), &surface_info, &count, nullptr);
     }
 #endif
 
@@ -1875,7 +1875,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
 
         uint32_t count;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDevicePresentRectanglesKHR-surface-06211");
-        vk::GetPhysicalDevicePresentRectanglesKHR(gpu(), m_surface, &count, nullptr);
+        vk::GetPhysicalDevicePresentRectanglesKHR(Gpu(), m_surface, &count, nullptr);
         m_errorMonitor->VerifyFound();
     }
 
@@ -1883,7 +1883,7 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
         VkSurfaceCapabilities2EXT capabilities = vku::InitStructHelper();
 
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2EXT-surface-06211");
-        vk::GetPhysicalDeviceSurfaceCapabilities2EXT(gpu(), m_surface, &capabilities);
+        vk::GetPhysicalDeviceSurfaceCapabilities2EXT(Gpu(), m_surface, &capabilities);
         m_errorMonitor->VerifyFound();
     }
 
@@ -1893,14 +1893,14 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
         VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper();
 
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pSurfaceInfo-06522");
-        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
+        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &capabilities);
         m_errorMonitor->VerifyFound();
     }
 
     {
         VkSurfaceCapabilitiesKHR capabilities;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilitiesKHR-surface-06211");
-        vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &capabilities);
+        vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(Gpu(), m_surface, &capabilities);
         m_errorMonitor->VerifyFound();
     }
 
@@ -1909,20 +1909,20 @@ TEST_F(NegativeWsi, SurfaceSupportByPhysicalDevice) {
         surface_info.surface = m_surface;
         uint32_t count;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceFormats2KHR-pSurfaceInfo-06522");
-        vk::GetPhysicalDeviceSurfaceFormats2KHR(gpu(), &surface_info, &count, nullptr);
+        vk::GetPhysicalDeviceSurfaceFormats2KHR(Gpu(), &surface_info, &count, nullptr);
         m_errorMonitor->VerifyFound();
     }
 
     {
         uint32_t count;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceFormatsKHR-surface-06525");
-        vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &count, nullptr);
+        vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &count, nullptr);
         m_errorMonitor->VerifyFound();
     }
 
     {
         uint32_t count;
-        vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, nullptr);
+        vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, nullptr);
     }
 }
 
@@ -1968,9 +1968,9 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     const std::array defined_present_modes{VK_PRESENT_MODE_IMMEDIATE_KHR, VK_PRESENT_MODE_MAILBOX_KHR, VK_PRESENT_MODE_FIFO_KHR,
                                            VK_PRESENT_MODE_FIFO_RELAXED_KHR};
 
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, nullptr);
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, nullptr);
     std::vector<VkPresentModeKHR> pdev_surface_present_modes(count);
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, pdev_surface_present_modes.data());
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, pdev_surface_present_modes.data());
 
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
@@ -1992,21 +1992,21 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     surface_info.pNext = &present_mode;
     m_errorMonitor->SetDesiredError("VUID-VkSurfacePresentModeEXT-presentMode-07780");
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkSurfacePresentModeEXT-presentMode-parameter");
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
 
     VkSurfacePresentModeCompatibilityEXT present_mode_compatibility = vku::InitStructHelper();
     present_mode.presentMode = pdev_surface_present_modes[0];
     surface_caps.pNext = &present_mode_compatibility;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     std::vector<VkPresentModeKHR> compatible_present_modes(present_mode_compatibility.presentModeCount);
     present_mode_compatibility.pPresentModes = compatible_present_modes.data();
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities = vku::InitStructHelper();
     surface_caps.pNext = &scaling_capabilities;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     mismatched_present_mode = VK_PRESENT_MODE_MAX_ENUM_KHR;
 
@@ -2065,7 +2065,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
         VkSurfacePresentModeCompatibilityEXT present_mode_compatibility2 = vku::InitStructHelper();
         present_mode2.presentMode = swapchain_create_info.presentMode;
         VkSurfaceCapabilities2KHR surface_caps2 = vku::InitStructHelper(&present_mode_compatibility2);
-        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info2, &surface_caps2);
+        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info2, &surface_caps2);
 
         swapchain_create_info.minImageCount = surface_caps2.surfaceCapabilities.minImageCount;
         m_errorMonitor->SetDesiredError("VUID-VkSwapchainPresentModesCreateInfoEXT-presentMode-07764");
@@ -2166,7 +2166,7 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionAcquire) {
     // If the swapchain is created with VkSwapchainPresentModesCreateInfoEXT,
     present_mode.presentMode = present_modes_ci.pPresentModes[0];
     surface_caps.pNext = &scaling_capabilities;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     // presentScaling must be a valid scaling method for the surface
     // as returned in VkSurfacePresentScalingCapabilitiesEXT::supportedPresentScaling,
@@ -2331,9 +2331,9 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
     vk::BindImageMemory2(device(), 1, &bind_info);
     m_errorMonitor->VerifyFound();
 
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, nullptr);
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, nullptr);
     std::vector<VkPresentModeKHR> present_modes(count);
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, present_modes.data());
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, present_modes.data());
 
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
@@ -2346,33 +2346,33 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionCaps) {
 
     // Leave VkSurfacePresentMode off of the pNext chain
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07776");
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
 
     surface_info.pNext = &present_mode;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     std::vector<VkPresentModeKHR> compatible_present_modes(present_mode_compatibility.presentModeCount);
     present_mode_compatibility.pPresentModes = compatible_present_modes.data();
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
 
     VkSurfacePresentScalingCapabilitiesEXT scaling_capabilities = vku::InitStructHelper();
     surface_caps.pNext = &scaling_capabilities;
     surface_info.pNext = nullptr;
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07777");
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
 
     if (IsExtensionsEnabled(VK_GOOGLE_SURFACELESS_QUERY_EXTENSION_NAME)) {
         surface_info.pNext = &present_mode;
         surface_info.surface = VK_NULL_HANDLE;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07778");
-        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
         m_errorMonitor->VerifyFound();
 
         surface_caps.pNext = &present_mode_compatibility;
         m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-07779");
-        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+        vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
         m_errorMonitor->VerifyFound();
     }
 }
@@ -2429,10 +2429,10 @@ TEST_F(NegativeWsi, SwapchainMaintenance1ExtensionRelease) {
 
     const VkImageMemoryBarrier present_transition =
         TransitionToPresent(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                            0, nullptr, 0, nullptr, 1, &present_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, submit_semaphore);
 
@@ -2647,7 +2647,7 @@ TEST_F(NegativeWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
 
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceSurfaceInfo2KHR-pNext-02672");
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->Physical(), &surface_info, &surface_caps);
     m_errorMonitor->VerifyFound();
 }
 #endif
@@ -2889,7 +2889,7 @@ TEST_F(NegativeWsi, CreatingSwapchainWithExtent) {
     m_errorMonitor->SetAllowedFailureMsg("VUID-VkSwapchainCreateInfoKHR-imageFormat-01778");
 
     VkSurfaceCapabilitiesKHR surface_capabilities;
-    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(gpu(), m_surface, &surface_capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilitiesKHR(Gpu(), m_surface, &surface_capabilities);
 
     VkSwapchainCreateInfoKHR swapchain_ci = vku::InitStructHelper();
     swapchain_ci.surface = m_surface;
@@ -2930,7 +2930,7 @@ TEST_F(NegativeWsi, SurfaceQueryImageCompressionControlWithoutExtension) {
 
     // get compression control properties even of VK_EXT_image_compression_control extension is disabled(or is not supported).
     m_errorMonitor->SetDesiredError("VUID-VkPhysicalDeviceSurfaceInfo2KHR-pNext-pNext");
-    vk::GetPhysicalDeviceSurfaceFormats2KHR(gpu(), &surface_info, &count, nullptr);
+    vk::GetPhysicalDeviceSurfaceFormats2KHR(Gpu(), &surface_info, &count, nullptr);
     m_errorMonitor->VerifyFound();
 }
 
@@ -2953,7 +2953,7 @@ TEST_F(NegativeWsi, PhysicalDeviceSurfaceCapabilities) {
     surface_capabilities.surfaceCapabilities = m_surface_capabilities;
 
     m_errorMonitor->SetDesiredError("VUID-vkGetPhysicalDeviceSurfaceCapabilities2KHR-pNext-02671");
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_capabilities);
     m_errorMonitor->VerifyFound();
 }
 #endif  // VK_USE_PLATFORM_WIN32_KHR
@@ -2978,7 +2978,7 @@ TEST_F(NegativeWsi, QueuePresentWaitingSameSemaphore) {
 
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, semaphore.handle(), fence.handle(), &image_index);
 
-    fence.wait(kWaitTimeout);
+    fence.Wait(kWaitTimeout);
     SetImageLayoutPresentSrc(images[image_index]);
 
     vkt::Queue *other = m_device->QueuesWithGraphicsCapability()[1];
@@ -3022,7 +3022,7 @@ TEST_F(NegativeWsi, QueuePresentBinarySemaphoreNotSignaled) {
 
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, semaphore.handle(), fence.handle(), &image_index);
 
-    fence.wait(kWaitTimeout);
+    fence.Wait(kWaitTimeout);
     SetImageLayoutPresentSrc(images[image_index]);
 
     m_default_queue->Submit(vkt::no_cmd, vkt::wait, semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT);
@@ -3086,8 +3086,8 @@ TEST_F(NegativeWsi, MissingWaitForImageAcquireSemaphore_2) {
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, semaphore, VK_NULL_HANDLE, &image_index);
 
     // Dummy submit that signals semaphore that will be waited by the present. Does not wait on the acquire semaphore.
-    m_command_buffer.begin();
-    m_command_buffer.end();
+    m_command_buffer.Begin();
+    m_command_buffer.End();
     const vkt::Semaphore submit_semaphore(*m_device);
     m_default_queue->Submit(m_command_buffer, vkt::signal, submit_semaphore);
 
@@ -3294,7 +3294,7 @@ TEST_F(NegativeWsi, UseDestroyedSwapchain) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -3363,11 +3363,11 @@ TEST_F(NegativeWsi, UseDestroyedSwapchain) {
     vk::CreateSwapchainKHR(device(), &swapchain_create_info, nullptr, &m_swapchain);
     vk::DestroySwapchainKHR(device(), oldSwapchain, nullptr);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_errorMonitor->SetDesiredError("VUID-VkRenderPassBeginInfo-framebuffer-parameter");
     m_command_buffer.BeginRenderPass(rp.handle(), fb.handle());
     m_errorMonitor->VerifyFound();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeWsi, ImageCompressionControlSwapchainWithoutFeature) {
@@ -3409,7 +3409,7 @@ TEST_F(NegativeWsi, PresentDuplicatedSwapchain) {
     RETURN_IF_SKIP(InitSurface());
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -3542,9 +3542,9 @@ TEST_F(NegativeWsi, NonSupportedPresentMode) {
     RETURN_IF_SKIP(InitSurface());
 
     uint32_t count;
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, nullptr);
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, nullptr);
     std::vector<VkPresentModeKHR> present_modes(count);
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), m_surface, &count, present_modes.data());
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), m_surface, &count, present_modes.data());
     for (auto present_mode : present_modes) {
         if (present_mode == VK_PRESENT_MODE_IMMEDIATE_KHR) {
             GTEST_SKIP() << "Need no support for VK_PRESENT_MODE_IMMEDIATE_KHR";
@@ -3552,7 +3552,7 @@ TEST_F(NegativeWsi, NonSupportedPresentMode) {
     }
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Surface not supported.";
     }

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -15,7 +15,7 @@ void WsiTest::SetImageLayoutPresentSrc(VkImage image) {
     vkt::CommandPool pool(*m_device, m_device->graphics_queue_node_index_);
     vkt::CommandBuffer cmd_buf(*m_device, pool);
 
-    cmd_buf.begin();
+    cmd_buf.Begin();
     VkImageMemoryBarrier layout_barrier{VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER,
                                         nullptr,
                                         0,
@@ -29,7 +29,7 @@ void WsiTest::SetImageLayoutPresentSrc(VkImage image) {
 
     vk::CmdPipelineBarrier(cmd_buf.handle(), VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, 0, 0, nullptr,
                            0, nullptr, 1, &layout_barrier);
-    cmd_buf.end();
+    cmd_buf.End();
     m_default_queue->Submit(cmd_buf);
     m_default_queue->Wait();
 }
@@ -225,7 +225,7 @@ TEST_F(PositiveWsi, GetPhysicalDeviceSurfaceCapabilities2KHRWithFullScreenEXT) {
     surface_info.surface = m_surface;
 
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->Physical(), &surface_info, &surface_caps);
 }
 #endif
 
@@ -287,7 +287,7 @@ TEST_F(PositiveWsi, CmdCopySwapchainImage) {
     copy_region.extent = {std::min(10u, m_surface_capabilities.minImageExtent.width),
                           std::min(10u, m_surface_capabilities.minImageExtent.height), 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     vk::CmdCopyImage(m_command_buffer.handle(), srcImage.handle(), VK_IMAGE_LAYOUT_GENERAL, image_from_swapchain.handle(),
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
@@ -382,7 +382,7 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
     vk::AcquireNextImageKHR(m_device->handle(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
     vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
@@ -407,7 +407,7 @@ TEST_F(PositiveWsi, TransferImageToSwapchainDeviceGroup) {
     vk::CmdCopyImage(m_command_buffer.handle(), src_Image.handle(), VK_IMAGE_LAYOUT_GENERAL, peer_image.handle(),
                      VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy_region);
 
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -428,10 +428,10 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
 
     const VkImageMemoryBarrier present_transition =
         TransitionToPresent(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &present_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, submit_semaphore);
 
@@ -567,8 +567,8 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
         vk::ResetFences(device(), 1, &acquire_fence.handle());
 
         // There should not be in-use errors when we re-use command buffer that corresponds to the acquired image index.
-        command_buffers[image_index].begin();
-        command_buffers[image_index].end();
+        command_buffers[image_index].Begin();
+        command_buffers[image_index].End();
 
         m_default_queue->Submit(command_buffers[image_index], vkt::signal, submit_semaphores[image_index]);
 
@@ -605,8 +605,8 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence2) {
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, acquire_fence, &image_index);
     vk::WaitForFences(device(), 1, &acquire_fence.handle(), VK_TRUE, kWaitTimeout);
     vk::ResetFences(device(), 1, &acquire_fence.handle());
-    command_buffers[image_index].begin();
-    command_buffers[image_index].end();
+    command_buffers[image_index].Begin();
+    command_buffers[image_index].End();
 
     m_default_queue->Submit(command_buffers[image_index], vkt::signal, submit_semaphores[image_index]);
 
@@ -640,8 +640,8 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence2) {
     vk::WaitForFences(device(), 1, &acquire_fence.handle(), VK_TRUE, kWaitTimeout);
     vk::ResetFences(device(), 1, &acquire_fence.handle());
 
-    command_buffers[image_index].begin();
-    command_buffers[image_index].end();
+    command_buffers[image_index].Begin();
+    command_buffers[image_index].End();
     m_default_queue->Wait();
 }
 
@@ -656,7 +656,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     {
         auto result = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
         ASSERT_TRUE(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
-        fence.wait(vvl::kU32Max);
+        fence.Wait(vvl::kU32Max);
     }
 
     VkAttachmentDescription attach[] = {
@@ -691,7 +691,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
     vkt::Framebuffer fb1(*m_device, rp1.handle(), 1, &view.handle(), 1, 1);
     vkt::Framebuffer fb2(*m_device, rp2.handle(), 1, &view.handle(), 1, 1);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(rp1.handle(), fb1.handle());
     m_command_buffer.EndRenderPass();
     m_command_buffer.BeginRenderPass(rp2.handle(), fb2.handle());
@@ -701,7 +701,7 @@ TEST_F(PositiveWsi, SwapchainImageLayout) {
         TransitionToPresent(swapchainImages[image_index], VK_IMAGE_LAYOUT_COLOR_ATTACHMENT_OPTIMAL, 0);
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                            0, nullptr, 0, nullptr, 1, &present_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     vk::WaitForFences(device(), 1, &fence.handle(), VK_TRUE, kWaitTimeout);
     vk::ResetFences(device(), 1, &fence.handle());
@@ -721,7 +721,7 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -743,7 +743,7 @@ TEST_F(PositiveWsi, SwapchainPresentShared) {
     VkSurfaceCapabilities2KHR capabilities = vku::InitStructHelper(&shared_present_capabilities);
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = m_surface;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &capabilities);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &capabilities);
 
     // This was recently added to CTS, but some drivers might not correctly advertise the flag
     if ((shared_present_capabilities.sharedPresentSupportedUsageFlags & VK_IMAGE_USAGE_COLOR_ATTACHMENT_BIT) == 0) {
@@ -907,13 +907,13 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     VkSurfaceFormatKHR format_tmp;
     {
         uint32_t format_count = 1;
-        const VkResult err = vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &format_count, &format_tmp);
+        const VkResult err = vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &format_count, &format_tmp);
         ASSERT_TRUE(err == VK_SUCCESS || err == VK_INCOMPLETE) << string_VkResult(err);
     }
     const VkFormat format = format_tmp.format;
 
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), format, &format_props);
     if (!(format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT)) {
         GTEST_SKIP() << "We need VK_FORMAT_FEATURE_COLOR_ATTACHMENT_BLEND_BIT feature";
     }
@@ -958,7 +958,7 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     {
         auto result = vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, VK_NULL_HANDLE, fence.handle(), &image_index);
         ASSERT_TRUE(result == VK_SUCCESS || result == VK_SUBOPTIMAL_KHR);
-        fence.wait(vvl::kU32Max);
+        fence.Wait(vvl::kU32Max);
     }
 
     VkImageViewCreateInfo ivci = vku::InitStructHelper();
@@ -970,7 +970,7 @@ TEST_F(PositiveWsi, SwapchainImageFormatProps) {
     vkt::Framebuffer framebuffer(*m_device, render_pass.handle(), 1, &image_view.handle(), 1, 1);
 
     vkt::CommandBuffer cmdbuff(*m_device, m_command_pool);
-    cmdbuff.begin();
+    cmdbuff.Begin();
     cmdbuff.BeginRenderPass(render_pass.handle(), framebuffer.handle());
 
     vk::CmdBindPipeline(cmdbuff.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
@@ -985,7 +985,7 @@ TEST_F(PositiveWsi, SwapchainExclusiveModeQueueFamilyPropertiesReferences) {
     InitSwapchainInfo();
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present";
     }
@@ -1054,7 +1054,7 @@ TEST_F(PositiveWsi, DestroySwapchainWithBoundImages) {
 
     int i = 0;
     for (auto &image : images) {
-        image.init_no_mem(*m_device, image_create_info);
+        image.InitNoMemory(*m_device, image_create_info);
         VkBindImageMemorySwapchainInfoKHR bind_swapchain_info = vku::InitStructHelper();
         bind_swapchain_info.swapchain = m_swapchain;
         bind_swapchain_info.imageIndex = i++;
@@ -1099,7 +1099,7 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
 
     // Create protected swapchain
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Graphics queue does not support present, skipping test";
     }
@@ -1183,7 +1183,7 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
     vkt::CommandPool protectedCommandPool(*m_device, m_device->graphics_queue_node_index_, VK_COMMAND_POOL_CREATE_PROTECTED_BIT);
     vkt::CommandBuffer protectedCommandBuffer(*m_device, protectedCommandPool);
 
-    protectedCommandBuffer.begin();
+    protectedCommandBuffer.Begin();
     VkRect2D render_area = {{0, 0}, swapchain_create_info.imageExtent};
     VkRenderPassBeginInfo render_pass_begin =
         vku::InitStruct<VkRenderPassBeginInfo>(nullptr, m_renderPass, fb.handle(), render_area, 0u, nullptr);
@@ -1192,7 +1192,7 @@ TEST_F(PositiveWsi, ProtectedSwapchainImageColorAttachment) {
     // This should be valid since the framebuffer color attachment is a protected swapchain image
     vk::CmdDraw(protectedCommandBuffer.handle(), 3, 1, 0, 0);
     vk::CmdEndRenderPass(protectedCommandBuffer.handle());
-    protectedCommandBuffer.end();
+    protectedCommandBuffer.End();
 }
 
 TEST_F(PositiveWsi, CreateSwapchainWithPresentModeInfo) {
@@ -1215,7 +1215,7 @@ TEST_F(PositiveWsi, CreateSwapchainWithPresentModeInfo) {
     surface_info.surface = m_surface;
 
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->phy(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(m_device->Physical(), &surface_info, &surface_caps);
 
     VkSwapchainPresentModesCreateInfoEXT swapchain_present_mode_create_info = vku::InitStructHelper();
     swapchain_present_mode_create_info.presentModeCount = 1;
@@ -1245,13 +1245,13 @@ TEST_F(PositiveWsi, RegisterDisplayEvent) {
     RETURN_IF_SKIP(Init());
 
     uint32_t prop_count = 0;
-    vk::GetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, nullptr);
+    vk::GetPhysicalDeviceDisplayPropertiesKHR(Gpu(), &prop_count, nullptr);
     if (prop_count == 0) {
         GTEST_SKIP() << "No VkDisplayKHR properties to query";
     }
 
     std::vector<VkDisplayPropertiesKHR> display_props{prop_count};
-    vk::GetPhysicalDeviceDisplayPropertiesKHR(gpu(), &prop_count, display_props.data());
+    vk::GetPhysicalDeviceDisplayPropertiesKHR(Gpu(), &prop_count, display_props.data());
     VkDisplayKHR display = display_props[0].display;
 
     VkDisplayEventInfoEXT event_info = vku::InitStructHelper();
@@ -1276,13 +1276,13 @@ TEST_F(PositiveWsi, SurfacelessQueryTest) {
     // Use the VK_GOOGLE_surfaceless_query extension to query the available formats and
     // colorspaces by using a VK_NULL_HANDLE for the VkSurfaceKHR handle.
     uint32_t count;
-    vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), VK_NULL_HANDLE, &count, nullptr);
+    vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), VK_NULL_HANDLE, &count, nullptr);
     std::vector<VkSurfaceFormatKHR> surface_formats(count);
-    vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), VK_NULL_HANDLE, &count, surface_formats.data());
+    vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), VK_NULL_HANDLE, &count, surface_formats.data());
 
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), VK_NULL_HANDLE, &count, nullptr);
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), VK_NULL_HANDLE, &count, nullptr);
     std::vector<VkPresentModeKHR> present_modes(count);
-    vk::GetPhysicalDeviceSurfacePresentModesKHR(gpu(), VK_NULL_HANDLE, &count, present_modes.data());
+    vk::GetPhysicalDeviceSurfacePresentModesKHR(Gpu(), VK_NULL_HANDLE, &count, present_modes.data());
 }
 
 TEST_F(PositiveWsi, PhysicalDeviceSurfaceSupport) {
@@ -1293,11 +1293,11 @@ TEST_F(PositiveWsi, PhysicalDeviceSurfaceSupport) {
     RETURN_IF_SKIP(InitSurface());
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), 0, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), 0, m_surface, &supported);
 
     if (supported) {
         uint32_t count;
-        vk::GetPhysicalDeviceSurfaceFormatsKHR(gpu(), m_surface, &count, nullptr);
+        vk::GetPhysicalDeviceSurfaceFormatsKHR(Gpu(), m_surface, &count, nullptr);
     }
 }
 
@@ -1310,7 +1310,7 @@ TEST_F(PositiveWsi, AcquireImageBeforeGettingSwapchainImages) {
     RETURN_IF_SKIP(InitSurface());
 
     VkBool32 supported;
-    vk::GetPhysicalDeviceSurfaceSupportKHR(gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
+    vk::GetPhysicalDeviceSurfaceSupportKHR(Gpu(), m_device->graphics_queue_node_index_, m_surface, &supported);
     if (!supported) {
         GTEST_SKIP() << "Surface not supported.";
     }
@@ -1349,10 +1349,10 @@ TEST_F(PositiveWsi, AcquireImageBeforeGettingSwapchainImages) {
     vk::GetSwapchainImagesKHR(device(), swapchain, &imageCount, images.data());
 
     const VkImageMemoryBarrier present_transition = TransitionToPresent(images[imageIndex], VK_IMAGE_LAYOUT_UNDEFINED, 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer.handle(), VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0,
                            0, nullptr, 0, nullptr, 1, &present_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
 
     VkPresentInfoKHR present = vku::InitStructHelper();
@@ -1376,8 +1376,8 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
 
     // Warm up. Show that we can reset command buffer after waiting on **submit** fence
     {
-        m_command_buffer.begin();
-        m_command_buffer.end();
+        m_command_buffer.Begin();
+        m_command_buffer.End();
 
         vkt::Fence submit_fence(*m_device);
         m_default_queue->Submit(m_command_buffer, submit_fence);
@@ -1385,7 +1385,7 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
         vk::WaitForFences(device(), 1, &submit_fence.handle(), VK_TRUE, kWaitTimeout);
 
         // It's safe to reset command buffer because we waited on the fence
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
 
     // Main performance. Show that we can reset command buffer after waiting on **present** fence
@@ -1399,10 +1399,10 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
         const VkImageMemoryBarrier present_transition =
             TransitionToPresent(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, 0);
 
-        m_command_buffer.begin();
+        m_command_buffer.Begin();
         vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                                nullptr, 0, nullptr, 1, &present_transition);
-        m_command_buffer.end();
+        m_command_buffer.End();
         m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, submit_semaphore);
 
         vkt::Fence present_fence(*m_device);
@@ -1426,7 +1426,7 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
         //      submit semaphore signaled ->
         //      QueueSubmit workload has completed ->
         //      command buffer is no longer in use and we can reset it.
-        m_command_buffer.reset();
+        m_command_buffer.Reset();
     }
     m_default_queue->Wait();
 }
@@ -1471,7 +1471,7 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
     for (uint32_t i = 0; i < 500; i++) {
         // Remove completed frames
         for (auto it = frames.begin(); it != frames.end();) {
-            if (it->present_finished_fence.status() == VK_SUCCESS) {
+            if (it->present_finished_fence.GetStatus() == VK_SUCCESS) {
                 // NOTE: Root cause of the issue. The present fence processed regular queue submissions,
                 // but not the one associated with a present operation. The present batch usually was
                 // lucky enough to get through, before we start the following "erase", which deletes the
@@ -1524,10 +1524,10 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence) {
     vk::AcquireNextImageKHR(device(), m_swapchain, kWaitTimeout, acquire_semaphore, VK_NULL_HANDLE, &image_index);
     const auto present_transition = TransitionToPresent(swapchain_images[image_index], VK_IMAGE_LAYOUT_UNDEFINED, 0);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &present_transition);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, submit_semaphore);
 
     vkt::Fence present_fence(*m_device);
@@ -1547,7 +1547,7 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence) {
     m_default_queue->Wait();
 
     // This should not report in-use error
-    present_fence.reset();
+    present_fence.Reset();
 }
 
 TEST_F(PositiveWsi, QueueWaitsForPresentFence2) {
@@ -1597,8 +1597,8 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence2) {
 
     m_default_queue->Wait();
 
-    present_fence.reset();
-    present_fence2.reset();
+    present_fence.Reset();
+    present_fence2.Reset();
 
     vk::DestroySwapchainKHR(device(), swapchain2, nullptr);
     DestroySurface(surface2);
@@ -1631,13 +1631,13 @@ TEST_F(PositiveWsi, DifferentPerPresentModeImageCount) {
     VkSurfaceCapabilities2KHR surface_caps = vku::InitStructHelper();
     VkPhysicalDeviceSurfaceInfo2KHR surface_info = vku::InitStructHelper();
     surface_info.surface = surface;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
     const uint32_t general_min_image_count = surface_caps.surfaceCapabilities.minImageCount;
 
     VkSurfacePresentModeEXT surface_present_mode = vku::InitStructHelper();
     surface_present_mode.presentMode = present_mode;
     surface_info.pNext = &surface_present_mode;
-    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(gpu(), &surface_info, &surface_caps);
+    vk::GetPhysicalDeviceSurfaceCapabilities2KHR(Gpu(), &surface_info, &surface_caps);
     const uint32_t per_present_mode_min_image_count = surface_caps.surfaceCapabilities.minImageCount;
 
     if (per_present_mode_min_image_count >= general_min_image_count) {

--- a/tests/unit/ycbcr.cpp
+++ b/tests/unit/ycbcr.cpp
@@ -55,10 +55,10 @@ TEST_F(NegativeYcbcr, Sampler) {
     // Force the multi-planar format support desired format features
     VkFormat mp_format = VK_FORMAT_G16_B16_R16_3PLANE_420_UNORM;
     VkFormatProperties formatProps;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, &formatProps);
     formatProps.linearTilingFeatures = 0;
     formatProps.optimalTilingFeatures = 0;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, formatProps);
 
     // Check that errors are caught when format feature don't exist
     sycci.format = mp_format;
@@ -74,7 +74,7 @@ TEST_F(NegativeYcbcr, Sampler) {
     // Cosited feature supported, but midpoint samples set
     formatProps.linearTilingFeatures = 0;
     formatProps.optimalTilingFeatures = VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, formatProps);
     sycci.xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
     sycci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     m_errorMonitor->SetDesiredError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652");
@@ -84,7 +84,7 @@ TEST_F(NegativeYcbcr, Sampler) {
     // Moving support to Linear to test that it checks either linear or optimal
     formatProps.linearTilingFeatures = VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT;
     formatProps.optimalTilingFeatures = 0;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, formatProps);
     sycci.xChromaOffset = VK_CHROMA_LOCATION_MIDPOINT;
     sycci.yChromaOffset = VK_CHROMA_LOCATION_COSITED_EVEN;
     m_errorMonitor->SetDesiredError("VUID-VkSamplerYcbcrConversionCreateInfo-xChromaOffset-01652");
@@ -109,7 +109,7 @@ TEST_F(NegativeYcbcr, Sampler) {
     // Add linear feature bit so can create valid SamplerYcbcrConversion
     formatProps.linearTilingFeatures = VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT;
     formatProps.optimalTilingFeatures = VK_FORMAT_FEATURE_SAMPLED_IMAGE_YCBCR_CONVERSION_LINEAR_FILTER_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, formatProps);
     vkt::SamplerYcbcrConversion conversion(*m_device, sycci);
 
     // Try to create a Sampler with non-matching filters without feature bit set
@@ -135,7 +135,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
 
     // Make sure components doesn't affect _444 formats
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(gpu(), mp_format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), mp_format, &format_props);
     if ((format_props.optimalTilingFeatures &
          (VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT | VK_FORMAT_FEATURE_MIDPOINT_CHROMA_SAMPLES_BIT)) == 0) {
         GTEST_SKIP() << "Device does not support chroma sampling of 3plane 420 format";
@@ -242,7 +242,7 @@ TEST_F(NegativeYcbcr, Swizzle) {
     sycci.ycbcrModel = VK_SAMPLER_YCBCR_MODEL_CONVERSION_RGB_IDENTITY;  // reset
 
     // Make sure components doesn't affect _444 formats
-    vk::GetPhysicalDeviceFormatProperties(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM, &format_props);
     if ((format_props.optimalTilingFeatures & VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT) != 0) {
         sycci.format = VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM;
         sycci.components = identity;
@@ -284,17 +284,17 @@ TEST_F(NegativeYcbcr, Formats) {
         GTEST_SKIP() << "Failed to load device profile layer.";
     }
 
-    if (!FormatIsSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM)) {
+    if (!FormatIsSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM)) {
         GTEST_SKIP() << "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM is unsupported";
     }
 
     // Set format features as needed for tests
     VkFormatProperties formatProps;
     const VkFormat mp_format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM;
-    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, &formatProps);
+    fpvkGetOriginalPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, &formatProps);
     formatProps.optimalTilingFeatures |= VK_FORMAT_FEATURE_TRANSFER_SRC_BIT;
     formatProps.optimalTilingFeatures = formatProps.optimalTilingFeatures & ~VK_FORMAT_FEATURE_DISJOINT_BIT;
-    fpvkSetPhysicalDeviceFormatPropertiesEXT(gpu(), mp_format, formatProps);
+    fpvkSetPhysicalDeviceFormatPropertiesEXT(Gpu(), mp_format, formatProps);
 
     // Create ycbcr image with all valid values
     // Each test changes needed values and returns them back after
@@ -312,7 +312,7 @@ TEST_F(NegativeYcbcr, Formats) {
     VkImageCreateInfo reset_create_info = image_create_info;
 
     VkImageFormatProperties img_limits;
-    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(gpu(), &image_create_info, &img_limits));
+    ASSERT_EQ(VK_SUCCESS, GPDIFPHelper(Gpu(), &image_create_info, &img_limits));
 
     // invalid mipLevels
     if (img_limits.maxMipLevels == 1) {
@@ -330,7 +330,7 @@ TEST_F(NegativeYcbcr, Formats) {
     image_create_info.samples = VK_SAMPLE_COUNT_4_BIT;
     // Might need to add extra validation because implementation probably doesn't support YUV
     VkImageFormatProperties image_format_props;
-    vk::GetPhysicalDeviceImageFormatProperties(gpu(), mp_format, image_create_info.imageType, image_create_info.tiling,
+    vk::GetPhysicalDeviceImageFormatProperties(Gpu(), mp_format, image_create_info.imageType, image_create_info.tiling,
                                                image_create_info.usage, image_create_info.flags, &image_format_props);
     if ((image_format_props.sampleCounts & VK_SAMPLE_COUNT_4_BIT) == 0) {
         m_errorMonitor->SetDesiredError("VUID-VkImageCreateInfo-samples-02258");
@@ -351,7 +351,7 @@ TEST_F(NegativeYcbcr, Formats) {
     // invalid imageType
     image_create_info.imageType = VK_IMAGE_TYPE_1D;
     // Check that image format is valid
-    if (vk::GetPhysicalDeviceImageFormatProperties(gpu(), mp_format, image_create_info.imageType, image_create_info.tiling,
+    if (vk::GetPhysicalDeviceImageFormatProperties(Gpu(), mp_format, image_create_info.imageType, image_create_info.tiling,
                                                    image_create_info.usage, image_create_info.flags,
                                                    &image_format_props) == VK_SUCCESS) {
         // Can't just set height to 1 as stateless validation will hit 04713 first
@@ -372,7 +372,7 @@ TEST_F(NegativeYcbcr, ImageViewFormat) {
     RETURN_IF_SKIP(InitBasicYcbcr());
     InitRenderTarget();
 
-    if (!FormatIsSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM)) {
+    if (!FormatIsSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM)) {
         GTEST_SKIP() << "VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM is unsupported";
     }
     VkImageCreateInfo image_create_info = vku::InitStructHelper();
@@ -425,7 +425,7 @@ TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    bool supported = ImageFormatIsSupported(instance(), gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Single-plane _422 image format not supported";
@@ -439,7 +439,7 @@ TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
     ci.format = VK_FORMAT_R8G8B8A8_UNORM;
     vkt::Image image_ucmp(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {48, 48, 1};
@@ -480,7 +480,7 @@ TEST_F(NegativeYcbcr, CopyImageSinglePlane422Alignment) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     copy_region.dstOffset = {0, 0, 0};
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
@@ -504,11 +504,11 @@ TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
 
     // Verify formats
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    bool supported = ImageFormatIsSupported(instance(), gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
     ci.format = VK_FORMAT_D24_UNORM_S8_UINT;
-    supported = supported && ImageFormatIsSupported(instance(), gpu(), ci, features);
+    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, features);
     ci.format = mp3_format;
-    supported = supported && ImageFormatIsSupported(instance(), gpu(), ci, features);
+    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, features);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image formats or optimally tiled depth-stencil buffers not supported";
@@ -523,7 +523,7 @@ TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
     ci.format = VK_FORMAT_D24_UNORM_S8_UINT;
     vkt::Image sp_image(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkImageCopy copy_region;
     copy_region.extent = {128, 128, 1};
@@ -572,7 +572,7 @@ TEST_F(NegativeYcbcr, CopyImageMultiplaneAspectBits) {
                      VK_IMAGE_LAYOUT_GENERAL, 1, &copy_region);
     m_errorMonitor->VerifyFound();
 
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeYcbcr, SamplerYcbcrConversionEnable) {
@@ -624,13 +624,13 @@ TEST_F(NegativeYcbcr, ClearColorImageFormat) {
     image_create_info.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     image_create_info.arrayLayers = 1;
 
-    bool supported = ImageFormatIsSupported(instance(), gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), image_create_info, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     if (supported == false) {
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
     vkt::Image mp_image(*m_device, image_create_info, vkt::set_layout);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
 
     VkClearColorValue color_clear_value = {};
     VkImageSubresourceRange clear_range;
@@ -650,7 +650,7 @@ TEST_F(NegativeYcbcr, WriteDescriptorSet) {
     TEST_DESCRIPTION("Attempt to use VkSamplerYcbcrConversion ImageView to update descriptors that are not allowed.");
     RETURN_IF_SKIP(InitBasicYcbcr());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -700,9 +700,9 @@ TEST_F(NegativeYcbcr, MultiplaneImageLayoutAspectFlags) {
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
 
     // Verify formats
-    bool supported = ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     ci.format = VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM_KHR;
-    supported = supported && ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
+    supported = supported && ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT);
     if (!supported) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
@@ -745,7 +745,7 @@ TEST_F(NegativeYcbcr, BindMemory) {
     // Try to bind an image created with Disjoint bit
     VkFormatProperties format_properties;
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &format_properties);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &format_properties);
     // Need to make sure disjoint is supported for format
     // Also need to support an arbitrary image usage feature
     constexpr VkFormatFeatureFlags disjoint_sampled = VK_FORMAT_FEATURE_DISJOINT_BIT | VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
@@ -779,7 +779,7 @@ TEST_F(NegativeYcbcr, BindMemory) {
         // Find a valid memory type index to memory to be allocated from
         VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
 
         VkDeviceMemory image_memory;
         ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &alloc_info, NULL, &image_memory));
@@ -843,7 +843,7 @@ TEST_F(NegativeYcbcr, BindMemory) {
         // Find a valid memory type index to memory to be allocated from
         VkMemoryAllocateInfo alloc_info = vku::InitStructHelper();
         alloc_info.allocationSize = mem_req2.memoryRequirements.size;
-        ASSERT_TRUE(m_device->phy().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
+        ASSERT_TRUE(m_device->Physical().SetMemoryType(mem_req2.memoryRequirements.memoryTypeBits, &alloc_info, 0));
 
         VkDeviceMemory image_memory;
         ASSERT_EQ(VK_SUCCESS, vk::AllocateMemory(device(), &alloc_info, NULL, &image_memory));
@@ -900,7 +900,7 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     bool mp_disjoint_support = false;
     if (mp_supported) {
         VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &mp_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
         if ((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
             (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
             mp_disjoint_support = true;
@@ -915,7 +915,7 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
     // Leave some extra space for alignment wiggle room
     image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
-    m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
+    m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
     vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
 
     // Keep values outside scope so multiple tests cases can reuse
@@ -924,7 +924,7 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
     VkMemoryRequirements2 mp_image_mem_reqs2[2];
     VkMemoryAllocateInfo mp_image_alloc_info[2];
     if (mp_disjoint_support) {
-        mp_image.init_no_mem(*m_device, mp_image_create_info);
+        mp_image.InitNoMemory(*m_device, mp_image_create_info);
 
         VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -944,11 +944,11 @@ TEST_F(NegativeYcbcr, BindMemory2Disjoint) {
         // plane 0
         mp_image_alloc_info[0].allocationSize =
             mp_image_mem_reqs2[0].memoryRequirements.size + mp_image_mem_reqs2[0].memoryRequirements.alignment;
-        m_device->phy().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0);
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0);
         // Exact size as VU will always be for plane 1
         // plane 1
         mp_image_alloc_info[1].allocationSize = mp_image_mem_reqs2[1].memoryRequirements.size;
-        m_device->phy().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
 
         mp_image_mem[0].init(*m_device, mp_image_alloc_info[0]);
         mp_image_mem[1].init(*m_device, mp_image_alloc_info[1]);
@@ -1100,7 +1100,7 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
     bool mp_disjoint_support = false;
     if (mp_supported) {
         VkFormatProperties mp_format_properties;
-        vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &mp_format_properties);
+        vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &mp_format_properties);
         if ((mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_DISJOINT_BIT) &&
             (mp_format_properties.optimalTilingFeatures & VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
             mp_disjoint_support = true;
@@ -1115,7 +1115,7 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
     VkMemoryAllocateInfo image_alloc_info = vku::InitStructHelper();
     // Leave some extra space for alignment wiggle room
     image_alloc_info.allocationSize = image_mem_reqs.size + image_mem_reqs.alignment;
-    m_device->phy().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
+    m_device->Physical().SetMemoryType(image_mem_reqs.memoryTypeBits, &image_alloc_info, 0);
     vkt::DeviceMemory image_mem(*m_device, image_alloc_info);
 
     // Keep values outside scope so multiple tests cases can reuse
@@ -1124,7 +1124,7 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
     VkMemoryRequirements2 mp_image_mem_reqs2[2];
     VkMemoryAllocateInfo mp_image_alloc_info[2];
     if (mp_disjoint_support) {
-        mp_image.init_no_mem(*m_device, mp_image_create_info);
+        mp_image.InitNoMemory(*m_device, mp_image_create_info);
 
         VkImagePlaneMemoryRequirementsInfo image_plane_req = vku::InitStructHelper();
         image_plane_req.planeAspect = VK_IMAGE_ASPECT_PLANE_0_BIT;
@@ -1144,11 +1144,11 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
         // plane 0
         mp_image_alloc_info[0].allocationSize =
             mp_image_mem_reqs2[0].memoryRequirements.size + mp_image_mem_reqs2[0].memoryRequirements.alignment;
-        m_device->phy().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0);
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[0], 0);
         // Exact size as VU will always be for plane 1
         // plane 1
         mp_image_alloc_info[1].allocationSize = mp_image_mem_reqs2[1].memoryRequirements.size;
-        m_device->phy().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
+        m_device->Physical().SetMemoryType(mp_image_mem_reqs2[1].memoryRequirements.memoryTypeBits, &mp_image_alloc_info[1], 0);
 
         mp_image_mem[0].init(*m_device, mp_image_alloc_info[0]);
         mp_image_mem[1].init(*m_device, mp_image_alloc_info[1]);
@@ -1165,7 +1165,7 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
 
     // Create a mask of available memory types *not* supported by these resources, and try to use one of them.
     VkPhysicalDeviceMemoryProperties memory_properties = {};
-    vk::GetPhysicalDeviceMemoryProperties(m_device->phy().handle(), &memory_properties);
+    vk::GetPhysicalDeviceMemoryProperties(m_device->Physical().handle(), &memory_properties);
 
     // single-plane image
     VkBindImageMemoryInfo bind_image_info = vku::InitStructHelper();
@@ -1181,8 +1181,8 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
         uint32_t image2_unsupported_mem_type_bits =
             ((1 << memory_properties.memoryTypeCount) - 1) & ~mem_req2.memoryRequirements.memoryTypeBits;
         bool found_type =
-            m_device->phy().SetMemoryType(image2_unsupported_mem_type_bits, &image_alloc_info, 0,
-                                          VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
+            m_device->Physical().SetMemoryType(image2_unsupported_mem_type_bits, &image_alloc_info, 0,
+                                               VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
         if (image2_unsupported_mem_type_bits != 0 && found_type) {
             vkt::DeviceMemory image_mem_tmp(*m_device, image_alloc_info);
             bind_image_info.memory = image_mem_tmp.handle();
@@ -1194,8 +1194,8 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
         // Same as 01047 but with bindImageMemory2 call
         uint32_t image_unsupported_mem_type_bits = ((1 << memory_properties.memoryTypeCount) - 1) & ~image_mem_reqs.memoryTypeBits;
         bool found_type =
-            m_device->phy().SetMemoryType(image_unsupported_mem_type_bits, &image_alloc_info, 0,
-                                          VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
+            m_device->Physical().SetMemoryType(image_unsupported_mem_type_bits, &image_alloc_info, 0,
+                                               VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
         if (image_unsupported_mem_type_bits != 0 && found_type) {
             vkt::DeviceMemory image_mem_tmp(*m_device, image_alloc_info);
             bind_image_info.memory = image_mem_tmp.handle();
@@ -1218,8 +1218,8 @@ TEST_F(NegativeYcbcr, BindMemory2DisjointUnsupported) {
         uint32_t mp_image_unsupported_mem_type_bits =
             ((1 << memory_properties.memoryTypeCount) - 1) & ~mp_image_mem_reqs2[0].memoryRequirements.memoryTypeBits;
         bool found_type =
-            m_device->phy().SetMemoryType(mp_image_unsupported_mem_type_bits, &mp_image_alloc_info[0], 0,
-                                          VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
+            m_device->Physical().SetMemoryType(mp_image_unsupported_mem_type_bits, &mp_image_alloc_info[0], 0,
+                                               VK_MEMORY_PROPERTY_PROTECTED_BIT | VK_MEMORY_PROPERTY_DEVICE_COHERENT_BIT_AMD);
         if (mp_image_unsupported_mem_type_bits != 0 && found_type) {
             mp_image_alloc_info[0].allocationSize = mp_image_mem_reqs2[0].memoryRequirements.size;
             vkt::DeviceMemory mp_image_mem_tmp(*m_device, mp_image_alloc_info[0]);
@@ -1284,7 +1284,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     RETURN_IF_SKIP(InitBasicYcbcr());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -1317,7 +1317,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     const VkFormatFeatureFlags features = VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT;
-    bool supported = ImageFormatIsSupported(instance(), gpu(), ci, features);
+    bool supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
     // Verify format 3 Plane format
     if (!supported) {
         printf("Multiplane image format not supported.  Skipping test.\n");
@@ -1355,7 +1355,7 @@ TEST_F(NegativeYcbcr, MultiplaneIncompatibleViewFormat) {
     }
 
     ci.format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;
-    supported = ImageFormatIsSupported(instance(), gpu(), ci, features);
+    supported = ImageFormatIsSupported(instance(), Gpu(), ci, features);
     // Verify format 2 Plane format
     if (!supported) {
         printf("Multiplane image format not supported.  Skipping test.\n");
@@ -1463,14 +1463,14 @@ TEST_F(NegativeYcbcr, MultiplaneAspectBits) {
     SetTargetApiVersion(VK_API_VERSION_1_1);
     RETURN_IF_SKIP(InitBasicYcbcr());
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8R8_2PLANE_420_UNORM, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
 
     VkFormat mp_format = VK_FORMAT_G8_B8R8_2PLANE_420_UNORM;  // commonly supported multi-planar format
     VkFormatProperties format_props;
-    vk::GetPhysicalDeviceFormatProperties(m_device->phy().handle(), mp_format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties(m_device->Physical().handle(), mp_format, &format_props);
     if (!vkt::Image::IsCompatible(*m_device, VK_IMAGE_USAGE_SAMPLED_BIT, format_props.optimalTilingFeatures)) {
         GTEST_SKIP() << "multi-planar format cannot be sampled for optimalTiling.";
     }
@@ -1537,14 +1537,14 @@ TEST_F(NegativeYcbcr, DisjointImageWithDrmFormatModifier) {
     std::vector<uint64_t> mods;
     VkDrmFormatModifierPropertiesListEXT mod_props = vku::InitStructHelper();
     VkFormatProperties2 format_props = vku::InitStructHelper(&mod_props);
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
     if (mod_props.drmFormatModifierCount == 0) {
         GTEST_SKIP() << "drmFormatModifierCount is 0.";
     }
 
     std::vector<VkDrmFormatModifierPropertiesEXT> mod_props_length(mod_props.drmFormatModifierCount);
     mod_props.pDrmFormatModifierProperties = mod_props_length.data();
-    vk::GetPhysicalDeviceFormatProperties2(gpu(), format, &format_props);
+    vk::GetPhysicalDeviceFormatProperties2(Gpu(), format, &format_props);
 
     for (uint32_t i = 0; i < mod_props.drmFormatModifierCount; ++i) {
         auto &mod = mod_props.pDrmFormatModifierProperties[i];
@@ -1603,7 +1603,7 @@ TEST_F(NegativeYcbcr, DrawFetch) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -1644,7 +1644,7 @@ TEST_F(NegativeYcbcr, DrawFetch) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1653,7 +1653,7 @@ TEST_F(NegativeYcbcr, DrawFetch) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(NegativeYcbcr, DrawConstOffset) {
@@ -1672,7 +1672,7 @@ TEST_F(NegativeYcbcr, DrawConstOffset) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -1743,7 +1743,7 @@ TEST_F(NegativeYcbcr, DrawConstOffset) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
@@ -1752,5 +1752,5 @@ TEST_F(NegativeYcbcr, DrawConstOffset) {
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_errorMonitor->VerifyFound();
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }

--- a/tests/unit/ycbcr_positive.cpp
+++ b/tests/unit/ycbcr_positive.cpp
@@ -69,7 +69,7 @@ TEST_F(PositiveYcbcr, MultiplaneGetImageSubresourceLayout) {
     ci.tiling = VK_IMAGE_TILING_LINEAR;
     ci.usage = VK_IMAGE_USAGE_TRANSFER_SRC_BIT;
     // Verify format
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_TRANSFER_SRC_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -102,14 +102,14 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
 
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
     vkt::Image image(*m_device, ci, vkt::set_layout);
 
-    m_command_buffer.reset();
-    m_command_buffer.begin();
+    m_command_buffer.Reset();
+    m_command_buffer.Begin();
     image.ImageMemoryBarrier(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, 0, VK_ACCESS_TRANSFER_WRITE_BIT,
                              VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
 
@@ -129,7 +129,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopyBufferToImage) {
         vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffers[i].handle(), image.handle(),
                                  VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1, &copy);
     }
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
@@ -139,7 +139,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
     RETURN_IF_SKIP(InitBasicYcbcr());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -157,14 +157,14 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
 
     // Verify format
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
 
     vkt::Image image(*m_device, ci, vkt::no_mem);
     vkt::DeviceMemory mem_obj;
-    mem_obj.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.memory_requirements(), 0));
+    mem_obj.init(*m_device, vkt::DeviceMemory::GetResourceAllocInfo(*m_device, image.MemoryRequirements(), 0));
 
     vk::BindImageMemory(device(), image, mem_obj, 0);
 
@@ -176,11 +176,11 @@ TEST_F(PositiveYcbcr, MultiplaneImageCopy) {
     copyRegion.dstOffset = {0, 0, 0};
     copyRegion.extent = {128, 128, 1};
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     image.ImageMemoryBarrier(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, VK_IMAGE_LAYOUT_GENERAL);
     vk::CmdCopyImage(m_command_buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_GENERAL, image.handle(), VK_IMAGE_LAYOUT_GENERAL, 1,
                      &copyRegion);
-    m_command_buffer.end();
+    m_command_buffer.End();
 
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -192,7 +192,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
     RETURN_IF_SKIP(InitBasicYcbcr());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -211,7 +211,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
     // Verify format
     VkFormatFeatureFlags features =
         VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT | VK_FORMAT_FEATURE_DISJOINT_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -232,7 +232,7 @@ TEST_F(PositiveYcbcr, MultiplaneImageBindDisjoint) {
     vk::GetImageMemoryRequirements2(device(), &mem_req_info2, &mem_reqs2);
     uint32_t mem_type = 0;
     auto phys_mem_props2 = vku::InitStruct<VkPhysicalDeviceMemoryProperties2>();
-    vk::GetPhysicalDeviceMemoryProperties2(gpu(), &phys_mem_props2);
+    vk::GetPhysicalDeviceMemoryProperties2(Gpu(), &phys_mem_props2);
     for (mem_type = 0; mem_type < phys_mem_props2.memoryProperties.memoryTypeCount; mem_type++) {
         if ((mem_reqs2.memoryRequirements.memoryTypeBits & (1 << mem_type)) &&
             ((phys_mem_props2.memoryProperties.memoryTypes[mem_type].propertyFlags & mem_props) == mem_props)) {
@@ -279,7 +279,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     RETURN_IF_SKIP(InitBasicYcbcr());
     InitRenderTarget();
 
-    if (!FormatFeaturesAreSupported(gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
+    if (!FormatFeaturesAreSupported(Gpu(), VK_FORMAT_G8_B8_R8_3PLANE_444_UNORM_KHR, VK_IMAGE_TILING_OPTIMAL,
                                     VK_FORMAT_FEATURE_COSITED_CHROMA_SAMPLES_BIT)) {
         GTEST_SKIP() << "Required formats/features not supported";
     }
@@ -297,7 +297,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
 
     // Verify format
     VkFormatFeatureFlags features = VK_FORMAT_FEATURE_TRANSFER_SRC_BIT | VK_FORMAT_FEATURE_TRANSFER_DST_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, features)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, features)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -314,11 +314,11 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     copy_region.imageExtent.depth = 1;
 
     vk::ResetCommandBuffer(m_command_buffer.handle(), 0);
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     image.ImageMemoryBarrier(m_command_buffer, VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL);
     vk::CmdCopyBufferToImage(m_command_buffer.handle(), buffer.handle(), image.handle(), VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, 1,
                              &copy_region);
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -352,7 +352,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
     CreatePipelineHelper pipe(*this);
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     VkImageMemoryBarrier img_barrier = vku::InitStructHelper();
     img_barrier.srcAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
     img_barrier.dstAccessMask = VK_ACCESS_INPUT_ATTACHMENT_READ_BIT | VK_ACCESS_SHADER_READ_BIT;
@@ -375,7 +375,7 @@ TEST_F(PositiveYcbcr, ImageLayout) {
 
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 }
@@ -396,7 +396,7 @@ TEST_F(PositiveYcbcr, DrawCombinedImageSampler) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -437,14 +437,14 @@ TEST_F(PositiveYcbcr, DrawCombinedImageSampler) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }
 
 TEST_F(PositiveYcbcr, ImageQuerySizeLod) {
@@ -463,7 +463,7 @@ TEST_F(PositiveYcbcr, ImageQuerySizeLod) {
     ci.mipLevels = 1;
     ci.arrayLayers = 1;
     ci.samples = VK_SAMPLE_COUNT_1_BIT;
-    if (!ImageFormatIsSupported(instance(), gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
+    if (!ImageFormatIsSupported(instance(), Gpu(), ci, VK_FORMAT_FEATURE_SAMPLED_IMAGE_BIT)) {
         // Assume there's low ROI on searching for different mp formats
         GTEST_SKIP() << "Multiplane image format not supported";
     }
@@ -505,12 +505,12 @@ TEST_F(PositiveYcbcr, ImageQuerySizeLod) {
     pipe.gp_ci_.layout = pipeline_layout.handle();
     pipe.CreateGraphicsPipeline();
 
-    m_command_buffer.begin();
+    m_command_buffer.Begin();
     m_command_buffer.BeginRenderPass(m_renderPassBeginInfo);
     vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipe.Handle());
     vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline_layout.handle(), 0, 1,
                               &descriptor_set.set_, 0, nullptr);
     vk::CmdDraw(m_command_buffer.handle(), 1, 0, 0, 0);
     m_command_buffer.EndRenderPass();
-    m_command_buffer.end();
+    m_command_buffer.End();
 }


### PR DESCRIPTION
The final (for near future) of these (like https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8631)

For the more "probably going to break someone rebasing" I did

```c++
void End();
// Deprecated, use End()
void end() { End() };
```