### PR TITLE
gpuav: Create VMA wrappers for DeviceMemoryBlock

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.cpp
@@ -19,9 +19,9 @@
 
 #include "gpu/core/gpuav.h"
 #include "gpu/core/gpuav_constants.h"
+#include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/shaders/gpuav_shaders_constants.h"
 
-#include "state_tracker/descriptor_sets.h"
 #include "state_tracker/shader_object_state.h"
 
 namespace gpuav {

--- a/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
+++ b/layers/gpu/cmd_validation/gpuav_cmd_validation_common.h
@@ -17,13 +17,13 @@
 
 #pragma once
 
-#include "gpu/resources/gpuav_subclasses.h"
-
 #include <utility>
 #include <vector>
+#include "state_tracker/cmd_buffer_state.h"
 
 namespace gpuav {
 class Validator;
+class CommandBuffer;
 
 class RestorablePipelineState {
   public:

--- a/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
@@ -203,7 +203,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
         VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &copy_src_regions_mem_block.buffer,
                                           &copy_src_regions_mem_block.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to allocate device memory for GPU copy of pRegions.", true);
+            gpuav.InternalVmaError(cb_state.VkHandle(), loc, "Unable to allocate device memory for GPU copy of pRegions.");
             return;
         }
         cb_state.gpu_resources_manager.ManageDeviceMemoryBlock(copy_src_regions_mem_block);
@@ -213,7 +213,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
                               reinterpret_cast<void **>(&gpu_regions_u32_ptr));
 
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to map device memory for GPU copy of pRegions.", true);
+            gpuav.InternalVmaError(cb_state.VkHandle(), loc, "Unable to map device memory for GPU copy of pRegions.");
             return;
         }
 

--- a/layers/gpu/cmd_validation/gpuav_draw.cpp
+++ b/layers/gpu/cmd_validation/gpuav_draw.cpp
@@ -19,10 +19,11 @@
 #include "gpu/cmd_validation/gpuav_cmd_validation_common.h"
 #include "gpu/error_message/gpuav_vuids.h"
 #include "gpu/resources/gpuav_subclasses.h"
-#include "state_tracker/render_pass_state.h"
 #include "gpu/shaders/gpuav_error_header.h"
 #include "gpu/shaders/gpuav_shaders_constants.h"
 #include "generated/cmd_validation_draw_vert.h"
+
+#include "state_tracker/render_pass_state.h"
 
 // See gpu/shaders/cmd_validation/draw.vert
 constexpr uint32_t kPushConstantDWords = 11u;

--- a/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
+++ b/layers/gpu/cmd_validation/gpuav_trace_rays.cpp
@@ -132,14 +132,14 @@ struct SharedTraceRaysValidationResources final {
         pool_create_info.flags = VMA_POOL_CREATE_LINEAR_ALGORITHM_BIT;
         result = vmaCreatePool(vma_allocator, &pool_create_info, &sbt_pool);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to create VMA memory pool for SBT.", true);
+            gpuav.InternalVmaError(gpuav.device, loc, "Unable to create VMA memory pool for SBT.");
             return;
         }
 
         alloc_info.pool = sbt_pool;
         result = vmaCreateBuffer(vma_allocator, &buffer_info, &alloc_info, &sbt_buffer, &sbt_allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for shader binding table.", true);
+            gpuav.InternalVmaError(gpuav.device, loc, "Unable to allocate device memory for shader binding table.");
             return;
         }
 
@@ -147,8 +147,8 @@ struct SharedTraceRaysValidationResources final {
         result = vmaMapMemory(vma_allocator, sbt_allocation, reinterpret_cast<void **>(&mapped_sbt));
 
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc,
-                                "Failed to map shader binding table when creating trace rays validation resources.", true);
+            gpuav.InternalVmaError(gpuav.device, loc,
+                                   "Failed to map shader binding table when creating trace rays validation resources.");
             return;
         }
 

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -84,6 +84,8 @@ class Validator : public GpuShaderInstrumentor {
                                    vku::safe_VkDeviceCreateInfo* modified_create_info) final;
     void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
+    void InternalVmaError(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
+
   private:
     void InitSettings(const Location& loc);
 
@@ -409,6 +411,7 @@ class Validator : public GpuShaderInstrumentor {
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
     SharedResourcesManager shared_resources_manager;
 
+    VmaAllocator vma_allocator_ = {};
     VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
     std::unique_ptr<DescriptorSetManager> desc_set_manager_;
 

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -88,6 +88,7 @@ class Validator : public GpuShaderInstrumentor {
     void PostCreateDevice(const VkDeviceCreateInfo* pCreateInfo, const Location& loc) final;
 
     void InternalVmaError(LogObjectList objlist, const Location& loc, const char* const specific_message) const;
+    VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer) const;
 
   private:
     void InitSettings(const Location& loc);

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -78,6 +78,9 @@ class Validator : public GpuShaderInstrumentor {
     std::shared_ptr<vvl::DescriptorSet> CreateDescriptorSet(VkDescriptorSet handle, vvl::DescriptorPool* pool,
                                                             const std::shared_ptr<vvl::DescriptorSetLayout const>& layout,
                                                             uint32_t variable_count) final;
+    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
+                                            VkDeviceQueueCreateFlags flags,
+                                            const VkQueueFamilyProperties& queueFamilyProperties) override;
 
     void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo* pCreateInfo,
                                    const VkAllocationCallbacks* pAllocator, VkDevice* pDevice, const RecordObject& record_obj,
@@ -420,6 +423,9 @@ class Validator : public GpuShaderInstrumentor {
 
   private:
     std::string instrumented_shader_cache_path_{};
+
+    // Make sure we call the right versions of any timeline semaphore functions.
+    bool timeline_khr_{false};
 };
 
 }  // namespace gpuav

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -409,6 +409,9 @@ class Validator : public GpuShaderInstrumentor {
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
     SharedResourcesManager shared_resources_manager;
 
+    VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
+    std::unique_ptr<DescriptorSetManager> desc_set_manager_;
+
     DeviceMemoryBlock indices_buffer_{};
     unsigned int indices_buffer_alignment_ = 0;
 

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -409,6 +409,9 @@ class Validator : public GpuShaderInstrumentor {
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
     SharedResourcesManager shared_resources_manager;
 
+    DeviceMemoryBlock indices_buffer_{};
+    unsigned int indices_buffer_alignment_ = 0;
+
   private:
     std::string instrumented_shader_cache_path_{};
 };

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -414,6 +414,8 @@ class Validator : public GpuShaderInstrumentor {
     std::optional<DescriptorHeap> desc_heap_{};  // optional only to defer construction
     SharedResourcesManager shared_resources_manager;
 
+    PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
+
     VmaAllocator vma_allocator_ = {};
     VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
     std::unique_ptr<DescriptorSetManager> desc_set_manager_;

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -55,7 +55,7 @@ class Validator : public GpuShaderInstrumentor {
     using Field = vvl::Field;
 
   public:
-    Validator() { container_type = LayerObjectTypeGpuAssisted; }
+    Validator() : indices_buffer_(*this) { container_type = LayerObjectTypeGpuAssisted; }
 
     // gpuav_setup.cpp
     // -------------
@@ -421,7 +421,7 @@ class Validator : public GpuShaderInstrumentor {
     VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
     std::unique_ptr<DescriptorSetManager> desc_set_manager_;
 
-    DeviceMemoryBlock indices_buffer_{};
+    DeviceMemoryBlock indices_buffer_;
     unsigned int indices_buffer_alignment_ = 0;
 
   private:

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -115,6 +115,17 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
     indices_buffer_.DestroyBuffer(vma_allocator_);
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
+
+    // State Tracker (BaseClass) can end up making vma calls through callbacks - so destroy allocator last
+    if (output_buffer_pool_ != VK_NULL_HANDLE) {
+        vmaDestroyPool(vma_allocator_, output_buffer_pool_);
+        output_buffer_pool_ = VK_NULL_HANDLE;
+    }
+    if (vma_allocator_) {
+        vmaDestroyAllocator(vma_allocator_);
+    }
+
+    desc_set_manager_.reset();
 }
 
 void Validator::RecordCmdBeginRenderPassLayouts(VkCommandBuffer commandBuffer, const VkRenderPassBeginInfo *pRenderPassBegin,

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -111,6 +111,9 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
             file_stream.close();
         }
     }
+
+    indices_buffer_.DestroyBuffer(vma_allocator_);
+
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 }
 

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -112,7 +112,7 @@ void Validator::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCa
         }
     }
 
-    indices_buffer_.DestroyBuffer(vma_allocator_);
+    indices_buffer_.DestroyBuffer();
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
 

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -374,9 +374,9 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     VmaAllocationCreateInfo alloc_create_info = {};
     alloc_create_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
     uint32_t mem_type_index;
-    VkResult result = vmaFindMemoryTypeIndexForBufferInfo(vma_allocator_, &error_buffer_ci, &alloc_create_info, &mem_type_index);
+    result = vmaFindMemoryTypeIndexForBufferInfo(vma_allocator_, &error_buffer_ci, &alloc_create_info, &mem_type_index);
     if (result != VK_SUCCESS) {
-        InternalError(device, loc, "Unable to find memory type index.", true);
+        InternalVmaError(device, loc, "Unable to find memory type index.");
         return;
     }
     VmaPoolCreateInfo vma_pool_ci = {};
@@ -388,7 +388,7 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
     }
     result = vmaCreatePool(vma_allocator_, &vma_pool_ci, &output_buffer_pool_);
     if (result != VK_SUCCESS) {
-        InternalError(device, loc, "Unable to create VMA memory pool.", true);
+        InternalVmaError(device, loc, "Unable to create VMA memory pool.");
         return;
     }
 
@@ -436,14 +436,14 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         result = vmaCreateBuffer(vma_allocator_, &buffer_info, &alloc_info, &indices_buffer_.buffer, &indices_buffer_.allocation,
                                  nullptr);
         if (result != VK_SUCCESS) {
-            InternalError(device, loc, "Unable to allocate device memory for command indices.", true);
+            InternalVmaError(device, loc, "Unable to allocate device memory for command indices.");
             return;
         }
 
         uint32_t *indices_ptr = nullptr;
         result = vmaMapMemory(vma_allocator_, indices_buffer_.allocation, reinterpret_cast<void **>(&indices_ptr));
         if (result != VK_SUCCESS) {
-            InternalError(device, loc, "Unable to map device memory for command indices buffer.", true);
+            InternalVmaError(device, loc, "Unable to map device memory for command indices buffer.");
             return;
         }
 

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -504,25 +504,16 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         assert(output_buffer_pool_);
         alloc_info.pool = output_buffer_pool_;
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
-        result = vmaCreateBuffer(vma_allocator_, &buffer_info, &alloc_info, &indices_buffer_.buffer, &indices_buffer_.allocation,
-                                 nullptr);
-        if (result != VK_SUCCESS) {
-            InternalVmaError(device, loc, "Unable to allocate device memory for command indices.");
-            return;
-        }
+        indices_buffer_.CreateBuffer(loc, &buffer_info, &alloc_info);
 
         uint32_t *indices_ptr = nullptr;
-        result = vmaMapMemory(vma_allocator_, indices_buffer_.allocation, reinterpret_cast<void **>(&indices_ptr));
-        if (result != VK_SUCCESS) {
-            InternalVmaError(device, loc, "Unable to map device memory for command indices buffer.");
-            return;
-        }
+        indices_buffer_.MapMemory(loc, reinterpret_cast<void **>(&indices_ptr));
 
         for (uint32_t i = 0; i < buffer_info.size / sizeof(uint32_t); ++i) {
             indices_ptr[i] = i / (indices_buffer_alignment_ / sizeof(uint32_t));
         }
 
-        vmaUnmapMemory(vma_allocator_, indices_buffer_.allocation);
+        indices_buffer_.UnmapMemory();
     }
 }
 

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -628,4 +628,15 @@ void Validator::InternalVmaError(LogObjectList objlist, const Location &loc, con
     ReleaseDeviceDispatchObject(LayerObjectTypeGpuAssisted);
 }
 
+VkDeviceAddress Validator::GetBufferDeviceAddressHelper(VkBuffer buffer) const {
+    VkBufferDeviceAddressInfo address_info = vku::InitStructHelper();
+    address_info.buffer = buffer;
+
+    if (api_version >= VK_API_VERSION_1_2) {
+        return DispatchGetBufferDeviceAddress(device, &address_info);
+    } else {
+        return DispatchGetBufferDeviceAddressKHR(device, &address_info);
+    }
+}
+
 }  // namespace gpuav

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -419,6 +419,13 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
 
     desc_set_manager_ = std::make_unique<DescriptorSetManager>(device, static_cast<uint32_t>(instrumentation_bindings_.size()));
 
+    // If api version 1.1 or later, SetDeviceLoaderData will be in the loader
+    {
+        auto chain_info = GetChainInfo(pCreateInfo, VK_LOADER_DATA_CALLBACK);
+        assert(chain_info->u.pfnSetDeviceLoaderData);
+        vk_set_device_loader_data_ = chain_info->u.pfnSetDeviceLoaderData;
+    }
+
     if (gpuav_settings.shader_instrumentation.bindless_descriptor) {
         VkPhysicalDeviceDescriptorIndexingProperties desc_indexing_props = vku::InitStructHelper();
         VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&desc_indexing_props);

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -536,4 +536,25 @@ void Validator::InitSettings(const Location &loc) {
     }
 }
 
+void Validator::InternalVmaError(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
+    aborted_ = true;
+    std::string error_message = specific_message;
+
+    char *stats_string;
+    vmaBuildStatsString(vma_allocator_, &stats_string, false);
+    error_message += " VMA statistics = ";
+    error_message += stats_string;
+    vmaFreeStatsString(vma_allocator_, stats_string);
+
+    char const *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
+    char const *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
+
+    LogError(vuid, objlist, loc, "Internal VMA Error, %s is being disabled. Details:\n%s", layer_name, error_message.c_str());
+
+    // Once we encounter an internal issue disconnect everything.
+    // This prevents need to check "if (aborted)" (which is awful when we easily forget to check somewhere and the user gets spammed
+    // with errors making it hard to see the first error with the real source of the problem).
+    ReleaseDeviceDispatchObject(LayerObjectTypeGpuAssisted);
+}
+
 }  // namespace gpuav

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -370,7 +370,7 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &debug_printf_output_buffer.buffer,
                                       &debug_printf_output_buffer.allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state.Handle(), loc, "Unable to allocate device memory.", true);
+        gpuav.InternalVmaError(cb_state.Handle(), loc, "Unable to allocate device memory.");
         return false;
     }
 
@@ -378,7 +378,7 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     uint32_t *data;
     result = vmaMapMemory(gpuav.vma_allocator_, debug_printf_output_buffer.allocation, reinterpret_cast<void **>(&data));
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state.Handle(), loc, "Unable to allocate map memory.", true);
+        gpuav.InternalVmaError(cb_state.Handle(), loc, "Unable to allocate map memory.");
         return false;
     }
     memset(data, 0, gpuav.gpuav_settings.debug_printf_buffer_size);

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -15,16 +15,14 @@
  * limitations under the License.
  */
 
+#include <vulkan/vulkan.h>
 #include "gpu/debug_printf/debug_printf.h"
-#include "gpu/instrumentation/gpuav_shader_instrumentor.h"
-#include "error_message/log_message_type.h"
-#include "error_message/logging.h"
 #include "generated/layer_chassis_dispatch.h"
-#include "chassis/chassis_modification_state.h"
 #include "gpu/shaders/gpuav_error_header.h"
 #include "gpu/shaders/gpuav_shaders_constants.h"
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/core/gpuav.h"
+#include "gpu/spirv/instruction.h"
 
 #include <iostream>
 

--- a/layers/gpu/debug_printf/debug_printf.h
+++ b/layers/gpu/debug_printf/debug_printf.h
@@ -21,9 +21,6 @@
 
 struct Location;
 namespace gpuav {
-struct DeviceMemoryBlock;
-}
-namespace gpuav {
 struct DebugPrintfBufferInfo;
 class CommandBuffer;
 class Validator;

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -44,8 +44,8 @@ DescriptorSet::~DescriptorSet() {
 
 VkDeviceAddress DescriptorSet::GetLayoutState(Validator &gpuav, const Location &loc) {
     auto guard = Lock();
-    if (layout_.device_addr != 0) {
-        return layout_.device_addr;
+    if (layout_.device_address != 0) {
+        return layout_.device_address;
     }
     uint32_t num_bindings = (GetBindingCount() > 0) ? GetLayout()->GetMaxBinding() + 1 : 0;
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
@@ -97,7 +97,7 @@ VkDeviceAddress DescriptorSet::GetLayoutState(Validator &gpuav, const Location &
 
     layout_.FlushAllocation(loc);
     layout_.UnmapMemory();
-    return layout_.device_addr;
+    return layout_.device_address;
 }
 
 static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -26,47 +26,6 @@ using vvl::DescriptorClass;
 
 namespace gpuav {
 
-void AddressBuffer::MapMemory(const Location &loc, void **data) const {
-    VkResult result = vmaMapMemory(gpuav.vma_allocator_, allocation, data);
-    if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to map device memory.", true);
-    }
-}
-
-void AddressBuffer::UnmapMemory() const { vmaUnmapMemory(gpuav.vma_allocator_, allocation); }
-
-void AddressBuffer::FlushAllocation(const Location &loc, VkDeviceSize offset, VkDeviceSize size) const {
-    VkResult result = vmaFlushAllocation(gpuav.vma_allocator_, allocation, offset, size);
-    if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to flush device memory.", true);
-    }
-}
-
-void AddressBuffer::InvalidateAllocation(const Location &loc, VkDeviceSize offset, VkDeviceSize size) const {
-    VkResult result = vmaInvalidateAllocation(gpuav.vma_allocator_, allocation, offset, size);
-    if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to invalidate device memory.", true);
-    }
-}
-
-void AddressBuffer::CreateBuffer(const Location &loc, const VkBufferCreateInfo *buffer_create_info,
-                                 const VmaAllocationCreateInfo *allocation_create_info) {
-    VkResult result =
-        vmaCreateBuffer(gpuav.vma_allocator_, buffer_create_info, allocation_create_info, &buffer, &allocation, nullptr);
-    if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.", true);
-    }
-
-    assert(buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT);
-    // After creating the buffer, get the address right away
-    device_addr = gpuav.GetBufferDeviceAddressHelper(buffer);
-    if (device_addr == 0) {
-        gpuav.InternalError(gpuav.device, loc, "Failed to get address with DispatchGetBufferDeviceAddress.");
-    }
-}
-
-void AddressBuffer::DestroyBuffer() { vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation); }
-
 // Returns the number of bytes to hold 32 bit aligned array of bits.
 static uint32_t BitBufferSize(uint32_t num_bits) {
     static constexpr uint32_t kBitsPerWord = 32;

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.cpp
@@ -44,8 +44,8 @@ DescriptorSet::~DescriptorSet() {
 
 VkDeviceAddress DescriptorSet::GetLayoutState(Validator &gpuav, const Location &loc) {
     auto guard = Lock();
-    if (layout_.device_address != 0) {
-        return layout_.device_address;
+    if (layout_.Address() != 0) {
+        return layout_.Address();
     }
     uint32_t num_bindings = (GetBindingCount() > 0) ? GetLayout()->GetMaxBinding() + 1 : 0;
     VkBufferCreateInfo buffer_info = vku::InitStruct<VkBufferCreateInfo>();
@@ -97,7 +97,7 @@ VkDeviceAddress DescriptorSet::GetLayoutState(Validator &gpuav, const Location &
 
     layout_.FlushAllocation(loc);
     layout_.UnmapMemory();
-    return layout_.device_address;
+    return layout_.Address();
 }
 
 static glsl::DescriptorState GetInData(const vvl::BufferDescriptor &desc) {

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -72,7 +72,7 @@ class DescriptorHeap {
     DescriptorId NextId(const VulkanTypedHandle &handle);
     void DeleteId(DescriptorId id);
 
-    VkDeviceAddress GetDeviceAddress() const { return buffer_.device_address; }
+    VkDeviceAddress GetDeviceAddress() const { return buffer_.Address(); }
 
   private:
     std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(lock_); }

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -38,7 +38,7 @@ class DescriptorSet : public vvl::DescriptorSet {
 
         const VkDescriptorSet set;
         const uint32_t version;
-        AddressMemoryBlock buffer;
+        DeviceMemoryBlock buffer;
 
         std::map<uint32_t, std::vector<uint32_t>> UsedDescriptors(const Location &loc, const DescriptorSet &set,
                                                                   uint32_t shader_set) const;
@@ -57,7 +57,7 @@ class DescriptorSet : public vvl::DescriptorSet {
   private:
     std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(state_lock_); }
 
-    AddressMemoryBlock layout_;
+    DeviceMemoryBlock layout_;
     std::atomic<uint32_t> current_version_{0};
     std::shared_ptr<State> last_used_state_;
     std::shared_ptr<State> output_state_;
@@ -83,7 +83,7 @@ class DescriptorHeap {
     DescriptorId next_id_{1};
     vvl::unordered_map<DescriptorId, VulkanTypedHandle> alloc_map_;
 
-    AddressMemoryBlock buffer_;
+    DeviceMemoryBlock buffer_;
     uint32_t *gpu_heap_state_{nullptr};
 };
 

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -72,7 +72,7 @@ class DescriptorHeap {
     DescriptorId NextId(const VulkanTypedHandle &handle);
     void DeleteId(DescriptorId id);
 
-    VkDeviceAddress GetDeviceAddress() const { return buffer_.device_addr; }
+    VkDeviceAddress GetDeviceAddress() const { return buffer_.device_address; }
 
   private:
     std::lock_guard<std::mutex> Lock() const { return std::lock_guard<std::mutex>(lock_); }

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -89,13 +89,13 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
     VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &di_buffers.bindless_state.buffer,
                                       &di_buffers.bindless_state.allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to allocate device memory.", true);
+        gpuav.InternalVmaError(cb_state.VkHandle(), loc, "Unable to allocate device memory.");
         return;
     }
     glsl::BindlessStateBuffer *bindless_state{nullptr};
     result = vmaMapMemory(gpuav.vma_allocator_, di_buffers.bindless_state.allocation, reinterpret_cast<void **>(&bindless_state));
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(cb_state.VkHandle(), loc, "Unable to map device memory.", true);
+        gpuav.InternalVmaError(cb_state.VkHandle(), loc, "Unable to map device memory.");
         return;
     }
     memset(bindless_state, 0, static_cast<size_t>(buffer_info.size));
@@ -143,7 +143,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
         VkResult result =
             vmaMapMemory(gpuav.vma_allocator_, cmd_info.bindless_state.allocation, reinterpret_cast<void **>(&bindless_state));
         if (result != VK_SUCCESS) {
-            gpuav.InternalError(gpuav.device, loc, "Unable to map device memory allocated for error output buffer.", true);
+            gpuav.InternalVmaError(gpuav.device, loc, "Unable to map device memory allocated for error output buffer.");
             return false;
         }
         for (size_t i = 0; i < cmd_info.descriptor_set_buffers.size(); i++) {

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -115,13 +115,13 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
         }
         if (!desc_set_state.state->IsUpdateAfterBind()) {
             desc_set_state.gpu_state = desc_set_state.state->GetCurrentState(gpuav, loc);
-            bindless_state->desc_sets[i].in_data = desc_set_state.gpu_state->buffer.device_address;
+            bindless_state->desc_sets[i].in_data = desc_set_state.gpu_state->buffer.Address();
             desc_set_state.output_state = desc_set_state.state->GetOutputState(gpuav, loc);
             if (!desc_set_state.output_state) {
                 di_buffers.bindless_state.UnmapMemory();
                 return;
             }
-            bindless_state->desc_sets[i].out_data = desc_set_state.output_state->buffer.device_address;
+            bindless_state->desc_sets[i].out_data = desc_set_state.output_state->buffer.Address();
         }
         di_buffers.descriptor_set_buffers.emplace_back(std::move(desc_set_state));
     }
@@ -141,7 +141,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
             bindless_state->desc_sets[i].layout_data = set_buffer.state->GetLayoutState(gpuav, loc);
             if (!set_buffer.gpu_state) {
                 set_buffer.gpu_state = set_buffer.state->GetCurrentState(gpuav, loc);
-                bindless_state->desc_sets[i].in_data = set_buffer.gpu_state->buffer.device_address;
+                bindless_state->desc_sets[i].in_data = set_buffer.gpu_state->buffer.Address();
             }
             if (!set_buffer.output_state) {
                 set_buffer.output_state = set_buffer.state->GetOutputState(gpuav, loc);
@@ -149,7 +149,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
                     cmd_info.bindless_state.UnmapMemory();
                     return false;
                 }
-                bindless_state->desc_sets[i].out_data = set_buffer.output_state->buffer.device_address;
+                bindless_state->desc_sets[i].out_data = set_buffer.output_state->buffer.Address();
             }
         }
         cmd_info.bindless_state.UnmapMemory();

--- a/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_image_layout.cpp
@@ -22,6 +22,7 @@
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/cmd_validation/gpuav_copy_buffer_to_image.h"
 #include "utils/image_layout_utils.h"
+
 #include "state_tracker/render_pass_state.h"
 
 using LayoutRange = image_layout_map::ImageSubresourceLayoutMap::RangeType;

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -21,8 +21,10 @@
 #include "gpu/core/gpuav.h"
 #include "gpu/error_message/gpuav_vuids.h"
 #include "gpu/resources/gpuav_shader_resources.h"
+#include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/shaders/gpuav_error_header.h"
 #include "gpu/debug_printf/debug_printf.h"
+
 #include "state_tracker/shader_object_state.h"
 
 namespace gpuav {

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -17,11 +17,16 @@
 
 #pragma once
 
-#include "gpu/resources/gpuav_subclasses.h"
+#include <vulkan/vulkan.h>
+#include <string>
+#include <vector>
 
+struct Location;
+struct LogObjectList;
 namespace gpuav {
-
 struct DescSetState;
+class Validator;
+class CommandBuffer;
 
 void UpdateInstrumentationDescSet(Validator& gpuav, CommandBuffer& cb_state, VkDescriptorSet instrumentation_desc_set,
                                   const Location& loc);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -342,7 +342,7 @@ void GpuShaderInstrumentor::Cleanup() {
 
 void GpuShaderInstrumentor::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                                        const RecordObject &record_obj) {
-    indices_buffer_.Destroy(vma_allocator_);
+    indices_buffer_.DestroyBuffer(vma_allocator_);
 
     Cleanup();
 

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -79,11 +79,6 @@ void GpuShaderInstrumentor::PostCreateDevice(const VkDeviceCreateInfo *pCreateIn
         return;
     }
 
-    // If api version 1.1 or later, SetDeviceLoaderData will be in the loader
-    auto chain_info = GetChainInfo(pCreateInfo, VK_LOADER_DATA_CALLBACK);
-    assert(chain_info->u.pfnSetDeviceLoaderData);
-    vk_set_device_loader_data_ = chain_info->u.pfnSetDeviceLoaderData;
-
     // maxBoundDescriptorSets limit, but possibly adjusted
     const uint32_t adjusted_max_desc_sets_limit =
         std::min(kMaxAdjustedBoundDescriptorSet, phys_dev_props.limits.maxBoundDescriptorSets);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -342,8 +342,6 @@ void GpuShaderInstrumentor::Cleanup() {
 
 void GpuShaderInstrumentor::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                                        const RecordObject &record_obj) {
-    indices_buffer_.DestroyBuffer(vma_allocator_);
-
     Cleanup();
 
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -60,33 +60,6 @@ WriteLockGuard GpuShaderInstrumentor::WriteLock() {
     }
 }
 
-// These are the common things required for anything that deals with shader instrumentation
-void GpuShaderInstrumentor::PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                                      const VkAllocationCallbacks *pAllocator, VkDevice *pDevice,
-                                                      const RecordObject &record_obj,
-                                                      vku::safe_VkDeviceCreateInfo *modified_create_info) {
-    // Force enable required features
-    // If the features are not supported, can't internal error until post device creation
-    VkPhysicalDeviceFeatures supported_features{};
-    DispatchGetPhysicalDeviceFeatures(physicalDevice, &supported_features);
-
-    if (auto enabled_features = const_cast<VkPhysicalDeviceFeatures *>(modified_create_info->pEnabledFeatures)) {
-        if (supported_features.fragmentStoresAndAtomics && !enabled_features->fragmentStoresAndAtomics) {
-            InternalWarning(device, record_obj.location, "Forcing VkPhysicalDeviceFeatures::fragmentStoresAndAtomics to VK_TRUE");
-            enabled_features->fragmentStoresAndAtomics = VK_TRUE;
-        }
-        if (supported_features.vertexPipelineStoresAndAtomics && !enabled_features->vertexPipelineStoresAndAtomics) {
-            InternalWarning(device, record_obj.location,
-                            "Forcing VkPhysicalDeviceFeatures::vertexPipelineStoresAndAtomics to VK_TRUE");
-            enabled_features->vertexPipelineStoresAndAtomics = VK_TRUE;
-        }
-        if (supported_features.shaderInt64 && !enabled_features->shaderInt64) {
-            InternalWarning(device, record_obj.location, "Forcing VkPhysicalDeviceFeatures::shaderInt64 to VK_TRUE");
-            enabled_features->shaderInt64 = VK_TRUE;
-        }
-    }
-}
-
 // In charge of getting things for shader instrumentation that both GPU-AV and DebugPrintF will need
 void GpuShaderInstrumentor::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) {
     BaseClass::PostCreateDevice(pCreateInfo, loc);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -24,9 +24,10 @@
 #include "gpu/shaders/gpuav_error_codes.h"
 #include "spirv-tools/optimizer.hpp"
 #include "utils/vk_layer_utils.h"
+#include "gpu/resources/gpuav_subclasses.h"
+
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/shader_object_state.h"
-#include "gpu/resources/gpuav_subclasses.h"
 
 #include <cassert>
 #include <regex>

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "gpu/instrumentation/gpuav_shader_instrumentor.h"
+#include <vulkan/vulkan_core.h>
 
 #include "gpu/shaders/gpuav_shaders_constants.h"
 #include "gpu/spirv/module.h"
@@ -32,112 +33,6 @@
 #include <fstream>
 
 namespace gpuav {
-// Trampolines to make VMA call Dispatch for Vulkan calls
-static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetInstanceProcAddr(VkInstance inst, const char *name) {
-    return DispatchGetInstanceProcAddr(inst, name);
-}
-static VKAPI_ATTR PFN_vkVoidFunction VKAPI_CALL gpuVkGetDeviceProcAddr(VkDevice dev, const char *name) {
-    return DispatchGetDeviceProcAddr(dev, name);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkGetPhysicalDeviceProperties(VkPhysicalDevice physicalDevice,
-                                                                   VkPhysicalDeviceProperties *pProperties) {
-    DispatchGetPhysicalDeviceProperties(physicalDevice, pProperties);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkGetPhysicalDeviceMemoryProperties(VkPhysicalDevice physicalDevice,
-                                                                         VkPhysicalDeviceMemoryProperties *pMemoryProperties) {
-    DispatchGetPhysicalDeviceMemoryProperties(physicalDevice, pMemoryProperties);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkAllocateMemory(VkDevice device, const VkMemoryAllocateInfo *pAllocateInfo,
-                                                          const VkAllocationCallbacks *pAllocator, VkDeviceMemory *pMemory) {
-    return DispatchAllocateMemory(device, pAllocateInfo, pAllocator, pMemory);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkFreeMemory(VkDevice device, VkDeviceMemory memory, const VkAllocationCallbacks *pAllocator) {
-    DispatchFreeMemory(device, memory, pAllocator);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkMapMemory(VkDevice device, VkDeviceMemory memory, VkDeviceSize offset, VkDeviceSize size,
-                                                     VkMemoryMapFlags flags, void **ppData) {
-    return DispatchMapMemory(device, memory, offset, size, flags, ppData);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkUnmapMemory(VkDevice device, VkDeviceMemory memory) { DispatchUnmapMemory(device, memory); }
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkFlushMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                                   const VkMappedMemoryRange *pMemoryRanges) {
-    return DispatchFlushMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkInvalidateMappedMemoryRanges(VkDevice device, uint32_t memoryRangeCount,
-                                                                        const VkMappedMemoryRange *pMemoryRanges) {
-    return DispatchInvalidateMappedMemoryRanges(device, memoryRangeCount, pMemoryRanges);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkBindBufferMemory(VkDevice device, VkBuffer buffer, VkDeviceMemory memory,
-                                                            VkDeviceSize memoryOffset) {
-    return DispatchBindBufferMemory(device, buffer, memory, memoryOffset);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkBindImageMemory(VkDevice device, VkImage image, VkDeviceMemory memory,
-                                                           VkDeviceSize memoryOffset) {
-    return DispatchBindImageMemory(device, image, memory, memoryOffset);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkGetBufferMemoryRequirements(VkDevice device, VkBuffer buffer,
-                                                                   VkMemoryRequirements *pMemoryRequirements) {
-    DispatchGetBufferMemoryRequirements(device, buffer, pMemoryRequirements);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkGetImageMemoryRequirements(VkDevice device, VkImage image,
-                                                                  VkMemoryRequirements *pMemoryRequirements) {
-    DispatchGetImageMemoryRequirements(device, image, pMemoryRequirements);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateBuffer(VkDevice device, const VkBufferCreateInfo *pCreateInfo,
-                                                        const VkAllocationCallbacks *pAllocator, VkBuffer *pBuffer) {
-    return DispatchCreateBuffer(device, pCreateInfo, pAllocator, pBuffer);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyBuffer(VkDevice device, VkBuffer buffer, const VkAllocationCallbacks *pAllocator) {
-    return DispatchDestroyBuffer(device, buffer, pAllocator);
-}
-static VKAPI_ATTR VkResult VKAPI_CALL gpuVkCreateImage(VkDevice device, const VkImageCreateInfo *pCreateInfo,
-                                                       const VkAllocationCallbacks *pAllocator, VkImage *pImage) {
-    return DispatchCreateImage(device, pCreateInfo, pAllocator, pImage);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkDestroyImage(VkDevice device, VkImage image, const VkAllocationCallbacks *pAllocator) {
-    DispatchDestroyImage(device, image, pAllocator);
-}
-static VKAPI_ATTR void VKAPI_CALL gpuVkCmdCopyBuffer(VkCommandBuffer commandBuffer, VkBuffer srcBuffer, VkBuffer dstBuffer,
-                                                     uint32_t regionCount, const VkBufferCopy *pRegions) {
-    DispatchCmdCopyBuffer(commandBuffer, srcBuffer, dstBuffer, regionCount, pRegions);
-}
-
-static VkResult UtilInitializeVma(VkInstance instance, VkPhysicalDevice physical_device, VkDevice device,
-                                  bool use_buffer_device_address, VmaAllocator *pAllocator) {
-    VmaVulkanFunctions functions;
-    VmaAllocatorCreateInfo allocator_info = {};
-    allocator_info.instance = instance;
-    allocator_info.device = device;
-    allocator_info.physicalDevice = physical_device;
-
-    if (use_buffer_device_address) {
-        allocator_info.flags |= VMA_ALLOCATOR_CREATE_BUFFER_DEVICE_ADDRESS_BIT;
-    }
-
-    functions.vkGetInstanceProcAddr = static_cast<PFN_vkGetInstanceProcAddr>(gpuVkGetInstanceProcAddr);
-    functions.vkGetDeviceProcAddr = static_cast<PFN_vkGetDeviceProcAddr>(gpuVkGetDeviceProcAddr);
-    functions.vkGetPhysicalDeviceProperties = static_cast<PFN_vkGetPhysicalDeviceProperties>(gpuVkGetPhysicalDeviceProperties);
-    functions.vkGetPhysicalDeviceMemoryProperties =
-        static_cast<PFN_vkGetPhysicalDeviceMemoryProperties>(gpuVkGetPhysicalDeviceMemoryProperties);
-    functions.vkAllocateMemory = static_cast<PFN_vkAllocateMemory>(gpuVkAllocateMemory);
-    functions.vkFreeMemory = static_cast<PFN_vkFreeMemory>(gpuVkFreeMemory);
-    functions.vkMapMemory = static_cast<PFN_vkMapMemory>(gpuVkMapMemory);
-    functions.vkUnmapMemory = static_cast<PFN_vkUnmapMemory>(gpuVkUnmapMemory);
-    functions.vkFlushMappedMemoryRanges = static_cast<PFN_vkFlushMappedMemoryRanges>(gpuVkFlushMappedMemoryRanges);
-    functions.vkInvalidateMappedMemoryRanges = static_cast<PFN_vkInvalidateMappedMemoryRanges>(gpuVkInvalidateMappedMemoryRanges);
-    functions.vkBindBufferMemory = static_cast<PFN_vkBindBufferMemory>(gpuVkBindBufferMemory);
-    functions.vkBindImageMemory = static_cast<PFN_vkBindImageMemory>(gpuVkBindImageMemory);
-    functions.vkGetBufferMemoryRequirements = static_cast<PFN_vkGetBufferMemoryRequirements>(gpuVkGetBufferMemoryRequirements);
-    functions.vkGetImageMemoryRequirements = static_cast<PFN_vkGetImageMemoryRequirements>(gpuVkGetImageMemoryRequirements);
-    functions.vkCreateBuffer = static_cast<PFN_vkCreateBuffer>(gpuVkCreateBuffer);
-    functions.vkDestroyBuffer = static_cast<PFN_vkDestroyBuffer>(gpuVkDestroyBuffer);
-    functions.vkCreateImage = static_cast<PFN_vkCreateImage>(gpuVkCreateImage);
-    functions.vkDestroyImage = static_cast<PFN_vkDestroyImage>(gpuVkDestroyImage);
-    functions.vkCmdCopyBuffer = static_cast<PFN_vkCmdCopyBuffer>(gpuVkCmdCopyBuffer);
-    allocator_info.pVulkanFunctions = &functions;
-
-    return vmaCreateAllocator(&allocator_info, pAllocator);
-}
 
 void SpirvCache::Add(uint32_t hash, std::vector<uint32_t> spirv) { spirv_shaders_.emplace(hash, std::move(spirv)); }
 
@@ -275,19 +170,11 @@ void GpuShaderInstrumentor::PostCreateDevice(const VkDeviceCreateInfo *pCreateIn
         return;
     }
 
-    VkResult result = UtilInitializeVma(instance, physical_device, device, enabled_features.bufferDeviceAddress, &vma_allocator_);
-    if (result != VK_SUCCESS) {
-        InternalError(device, loc, "Could not initialize VMA", true);
-        return;
-    }
-
-    desc_set_manager_ = std::make_unique<DescriptorSetManager>(device, static_cast<uint32_t>(instrumentation_bindings_.size()));
-
     const VkDescriptorSetLayoutCreateInfo debug_desc_layout_info = {VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, nullptr, 0,
                                                                     static_cast<uint32_t>(instrumentation_bindings_.size()),
                                                                     instrumentation_bindings_.data()};
 
-    result = DispatchCreateDescriptorSetLayout(device, &debug_desc_layout_info, nullptr, &instrumentation_desc_layout_);
+    VkResult result = DispatchCreateDescriptorSetLayout(device, &debug_desc_layout_info, nullptr, &instrumentation_desc_layout_);
     if (result != VK_SUCCESS) {
         InternalError(device, loc, "vkCreateDescriptorSetLayout failed for internal descriptor set");
         Cleanup();
@@ -343,17 +230,7 @@ void GpuShaderInstrumentor::Cleanup() {
 void GpuShaderInstrumentor::PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                                        const RecordObject &record_obj) {
     Cleanup();
-
     BaseClass::PreCallRecordDestroyDevice(device, pAllocator, record_obj);
-    // State Tracker can end up making vma calls through callbacks - don't destroy allocator until ST is done
-    if (output_buffer_pool_ != VK_NULL_HANDLE) {
-        vmaDestroyPool(vma_allocator_, output_buffer_pool_);
-        output_buffer_pool_ = VK_NULL_HANDLE;
-    }
-    if (vma_allocator_) {
-        vmaDestroyAllocator(vma_allocator_);
-    }
-    desc_set_manager_.reset();
 }
 
 void GpuShaderInstrumentor::ReserveBindingSlot(VkPhysicalDevice physicalDevice, VkPhysicalDeviceLimits &limits,

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1344,27 +1344,6 @@ VkDeviceAddress GpuShaderInstrumentor::GetBufferDeviceAddressHelper(VkBuffer buf
     }
 }
 
-void GpuShaderInstrumentor::InternalVmaError(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
-    aborted_ = true;
-    std::string error_message = specific_message;
-
-    char *stats_string;
-    vmaBuildStatsString(vma_allocator_, &stats_string, false);
-    error_message += " VMA statistics = ";
-    error_message += stats_string;
-    vmaFreeStatsString(vma_allocator_, stats_string);
-
-    char const *layer_name = gpuav_settings.debug_printf_only ? "DebugPrintf" : "GPU-AV";
-    char const *vuid = gpuav_settings.debug_printf_only ? "UNASSIGNED-DEBUG-PRINTF" : "UNASSIGNED-GPU-Assisted-Validation";
-
-    LogError(vuid, objlist, loc, "Internal VMA Error, %s is being disabled. Details:\n%s", layer_name, error_message.c_str());
-
-    // Once we encounter an internal issue disconnect everything.
-    // This prevents need to check "if (aborted)" (which is awful when we easily forget to check somewhere and the user gets spammed
-    // with errors making it hard to see the first error with the real source of the problem).
-    ReleaseDeviceDispatchObject(LayerObjectTypeGpuAssisted);
-}
-
 void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
     aborted_ = true;
     std::string error_message = specific_message;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -1256,17 +1256,6 @@ bool GpuShaderInstrumentor::InstrumentShader(const vvl::span<const uint32_t> &in
     return true;
 }
 
-VkDeviceAddress GpuShaderInstrumentor::GetBufferDeviceAddressHelper(VkBuffer buffer) const {
-    VkBufferDeviceAddressInfo address_info = vku::InitStructHelper();
-    address_info.buffer = buffer;
-
-    if (api_version >= VK_API_VERSION_1_2) {
-        return DispatchGetBufferDeviceAddress(device, &address_info);
-    } else {
-        return DispatchGetBufferDeviceAddressKHR(device, &address_info);
-    }
-}
-
 void GpuShaderInstrumentor::InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const {
     aborted_ = true;
     std::string error_message = specific_message;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -167,7 +167,8 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer) const;
 
-    void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message, bool vma_fail = false) const;
+    void InternalVmaError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
+    void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -211,7 +211,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     // sense too)
     mutable bool aborted_ = false;
 
-    PFN_vkSetDeviceLoaderData vk_set_device_loader_data_;
     std::atomic<uint32_t> unique_shader_module_id_ = 1;  // zero represents no shader module found
     // The descriptor slot we will be injecting our error buffer into
     uint32_t instrumentation_desc_set_bind_index_ = 0;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -18,10 +18,8 @@
 
 #include "containers/custom_containers.h"
 #include "generated/chassis.h"
-#include "state_tracker/cmd_buffer_state.h"
-#include "gpu/resources/gpuav_resources.h"
+#include "state_tracker/state_tracker.h"
 #include "gpu/spirv/instruction.h"
-#include "vma/vma.h"
 
 #include <vector>
 

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -73,9 +73,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     ReadLockGuard ReadLock() const override;
     WriteLockGuard WriteLock() override;
-    void PreCallRecordCreateDevice(VkPhysicalDevice physicalDevice, const VkDeviceCreateInfo *pCreateInfo,
-                                   const VkAllocationCallbacks *pAllocator, VkDevice *pDevice, const RecordObject &record_obj,
-                                   vku::safe_VkDeviceCreateInfo *modified_create_info) override;
     void PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Location &loc) override;
     void PreCallRecordDestroyDevice(VkDevice device, const VkAllocationCallbacks *pAllocator,
                                     const RecordObject &record_obj) override;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -179,10 +179,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
                                          uint32_t operation_index) const;
 
   protected:
-    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
-                                            VkDeviceQueueCreateFlags flags,
-                                            const VkQueueFamilyProperties &queueFamilyProperties) override;
-
     bool NeedPipelineCreationShaderInstrumentation(vvl::Pipeline &pipeline_state);
     bool HasBindlessDescriptors(vvl::Pipeline &pipeline_state);
     bool HasBindlessDescriptors(VkShaderCreateInfoEXT &create_info);
@@ -233,8 +229,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     // These are objects used to inject our descriptor set into the command buffer
     VkDescriptorSetLayout instrumentation_desc_layout_ = VK_NULL_HANDLE;
     VkPipelineLayout instrumentation_pipeline_layout_ = VK_NULL_HANDLE;
-    // Make sure we call the right versions of any timeline semaphore functions.
-    bool timeline_khr_{false};
 
     // Pass select_instrumented_shaders from vkCreateShaderModule to CreatePipeline time
     vvl::unordered_set<VkShaderModule> selected_instrumented_shaders;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -230,8 +230,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     vvl::concurrent_unordered_map<uint32_t, GpuAssistedShaderTracker> shader_map_;
     std::vector<VkDescriptorSetLayoutBinding> instrumentation_bindings_;
     SpirvCache instrumented_shaders_cache_;
-    DeviceMemoryBlock indices_buffer_{};
-    unsigned int indices_buffer_alignment_ = 0;
 
   private:
     void Cleanup();

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -225,8 +225,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     // This is a layout used to "pad" a pipeline layout to fill in any gaps to the selected bind index
     VkDescriptorSetLayout dummy_desc_layout_ = VK_NULL_HANDLE;
     VmaAllocator vma_allocator_ = {};
-    VmaPool output_buffer_pool_ = VK_NULL_HANDLE;
-    std::unique_ptr<DescriptorSetManager> desc_set_manager_;
     vvl::concurrent_unordered_map<uint32_t, GpuAssistedShaderTracker> shader_map_;
     std::vector<VkDescriptorSetLayoutBinding> instrumentation_bindings_;
     SpirvCache instrumented_shaders_cache_;

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -162,8 +162,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     void PreCallRecordDestroyPipeline(VkDevice device, VkPipeline pipeline, const VkAllocationCallbacks *pAllocator,
                                       const RecordObject &record_obj) override;
 
-    VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer) const;
-
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
 

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -167,7 +167,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     VkDeviceAddress GetBufferDeviceAddressHelper(VkBuffer buffer) const;
 
-    void InternalVmaError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalError(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
     void InternalWarning(LogObjectList objlist, const Location &loc, const char *const specific_message) const;
 
@@ -225,7 +224,6 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
     uint32_t instrumentation_desc_set_bind_index_ = 0;
     // This is a layout used to "pad" a pipeline layout to fill in any gaps to the selected bind index
     VkDescriptorSetLayout dummy_desc_layout_ = VK_NULL_HANDLE;
-    VmaAllocator vma_allocator_ = {};
     vvl::concurrent_unordered_map<uint32_t, GpuAssistedShaderTracker> shader_map_;
     std::vector<VkDescriptorSetLayoutBinding> instrumentation_bindings_;
     SpirvCache instrumented_shaders_cache_;

--- a/layers/gpu/resources/gpuav_resources.cpp
+++ b/layers/gpu/resources/gpuav_resources.cpp
@@ -174,6 +174,14 @@ void DeviceMemoryBlock::CreateBuffer(const Location &loc, const VkBufferCreateIn
     if (result != VK_SUCCESS) {
         gpuav.InternalVmaError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.");
     }
+
+    if (buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT) {
+        // After creating the buffer, get the address right away
+        device_address = gpuav.GetBufferDeviceAddressHelper(buffer);
+        if (device_address == 0) {
+            gpuav.InternalError(gpuav.device, loc, "Failed to get address with DispatchGetBufferDeviceAddress.");
+        }
+    }
 }
 
 void DeviceMemoryBlock::DestroyBuffer() {
@@ -181,22 +189,6 @@ void DeviceMemoryBlock::DestroyBuffer() {
         vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation);
         buffer = VK_NULL_HANDLE;
         allocation = VK_NULL_HANDLE;
-    }
-}
-
-void AddressMemoryBlock::CreateBuffer(const Location &loc, const VkBufferCreateInfo *buffer_create_info,
-                                      const VmaAllocationCreateInfo *allocation_create_info) {
-    VkResult result =
-        vmaCreateBuffer(gpuav.vma_allocator_, buffer_create_info, allocation_create_info, &buffer, &allocation, nullptr);
-    if (result != VK_SUCCESS) {
-        gpuav.InternalVmaError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.");
-    }
-
-    assert(buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT);
-    // After creating the buffer, get the address right away
-    device_address = gpuav.GetBufferDeviceAddressHelper(buffer);
-    if (device_address == 0) {
-        gpuav.InternalError(gpuav.device, loc, "Failed to get address with DispatchGetBufferDeviceAddress.");
     }
 }
 

--- a/layers/gpu/resources/gpuav_resources.cpp
+++ b/layers/gpu/resources/gpuav_resources.cpp
@@ -155,7 +155,7 @@ void DeviceMemoryBlock::DestroyBuffer(VmaAllocator allocator) {
 void AddressMemoryBlock::MapMemory(const Location &loc, void **data) const {
     VkResult result = vmaMapMemory(gpuav.vma_allocator_, allocation, data);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to map device memory.", true);
+        gpuav.InternalVmaError(gpuav.device, loc, "Unable to map device memory.");
     }
 }
 
@@ -164,14 +164,14 @@ void AddressMemoryBlock::UnmapMemory() const { vmaUnmapMemory(gpuav.vma_allocato
 void AddressMemoryBlock::FlushAllocation(const Location &loc, VkDeviceSize offset, VkDeviceSize size) const {
     VkResult result = vmaFlushAllocation(gpuav.vma_allocator_, allocation, offset, size);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to flush device memory.", true);
+        gpuav.InternalVmaError(gpuav.device, loc, "Unable to flush device memory.");
     }
 }
 
 void AddressMemoryBlock::InvalidateAllocation(const Location &loc, VkDeviceSize offset, VkDeviceSize size) const {
     VkResult result = vmaInvalidateAllocation(gpuav.vma_allocator_, allocation, offset, size);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to invalidate device memory.", true);
+        gpuav.InternalVmaError(gpuav.device, loc, "Unable to invalidate device memory.");
     }
 }
 
@@ -180,7 +180,7 @@ void AddressMemoryBlock::CreateBuffer(const Location &loc, const VkBufferCreateI
     VkResult result =
         vmaCreateBuffer(gpuav.vma_allocator_, buffer_create_info, allocation_create_info, &buffer, &allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.", true);
+        gpuav.InternalVmaError(gpuav.device, loc, "Unable to allocate device memory for internal buffer.");
     }
 
     assert(buffer_create_info->usage & VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT);

--- a/layers/gpu/resources/gpuav_resources.cpp
+++ b/layers/gpu/resources/gpuav_resources.cpp
@@ -144,7 +144,7 @@ void SharedResourcesManager::Clear() {
     shared_validation_resources_map_.clear();
 }
 
-void DeviceMemoryBlock::Destroy(VmaAllocator allocator) {
+void DeviceMemoryBlock::DestroyBuffer(VmaAllocator allocator) {
     if (buffer != VK_NULL_HANDLE) {
         vmaDestroyBuffer(allocator, buffer, allocation);
         buffer = VK_NULL_HANDLE;
@@ -191,7 +191,13 @@ void AddressMemoryBlock::CreateBuffer(const Location &loc, const VkBufferCreateI
     }
 }
 
-void AddressMemoryBlock::DestroyBuffer() { vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation); }
+void AddressMemoryBlock::DestroyBuffer() {
+    if (buffer != VK_NULL_HANDLE) {
+        vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation);
+        buffer = VK_NULL_HANDLE;
+        allocation = VK_NULL_HANDLE;
+    }
+}
 
 VkDescriptorSet GpuResourcesManager::GetManagedDescriptorSet(VkDescriptorSetLayout desc_set_layout) {
     std::pair<VkDescriptorPool, VkDescriptorSet> descriptor;
@@ -209,7 +215,7 @@ void GpuResourcesManager::DestroyResources() {
     descriptors_.clear();
 
     for (auto &mem_block : mem_blocks_) {
-        mem_block.Destroy(vma_allocator_);
+        mem_block.DestroyBuffer(vma_allocator_);
     }
     mem_blocks_.clear();
 }

--- a/layers/gpu/resources/gpuav_resources.h
+++ b/layers/gpu/resources/gpuav_resources.h
@@ -55,9 +55,10 @@ struct DeviceMemoryBlock {
     const Validator &gpuav;
     VkBuffer buffer = VK_NULL_HANDLE;
     VmaAllocation allocation = VK_NULL_HANDLE;
+    // If buffer was not created with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT then this will not be zero
+    VkDeviceAddress device_address = 0;
 
     explicit DeviceMemoryBlock(Validator &gpuav) : gpuav(gpuav) {}
-    virtual ~DeviceMemoryBlock(){};
 
     // Warps VMA calls so we can report (unlikely) errors if found while making the usages of these cleaner
     // (while these don't return errors up the chain, if we are hitting a VMA error, likely not going to recover anyway)
@@ -66,19 +67,9 @@ struct DeviceMemoryBlock {
     void FlushAllocation(const Location &loc, VkDeviceSize offset = 0, VkDeviceSize size = VK_WHOLE_SIZE) const;
     void InvalidateAllocation(const Location &loc, VkDeviceSize offset = 0, VkDeviceSize size = VK_WHOLE_SIZE) const;
 
-    virtual void CreateBuffer(const Location &loc, const VkBufferCreateInfo *buffer_create_info,
-                              const VmaAllocationCreateInfo *allocation_create_info);
-    void DestroyBuffer();
-};
-
-// Similar to DeviceMemoryBlock, but used for things that will require Buffer Device Address
-struct AddressMemoryBlock : public DeviceMemoryBlock {
-    VkDeviceAddress device_address{0};
-
-    explicit AddressMemoryBlock(Validator &gpuav) : DeviceMemoryBlock(gpuav) {}
-
     void CreateBuffer(const Location &loc, const VkBufferCreateInfo *buffer_create_info,
-                      const VmaAllocationCreateInfo *allocation_create_info) override;
+                      const VmaAllocationCreateInfo *allocation_create_info);
+    void DestroyBuffer();
 };
 
 class GpuResourcesManager {

--- a/layers/gpu/resources/gpuav_resources.h
+++ b/layers/gpu/resources/gpuav_resources.h
@@ -54,8 +54,9 @@ class DescriptorSetManager {
 struct DeviceMemoryBlock {
     VkBuffer buffer = VK_NULL_HANDLE;
     VmaAllocation allocation = VK_NULL_HANDLE;
-    void Destroy(VmaAllocator allocator);
     bool IsNull() { return buffer == VK_NULL_HANDLE; }
+
+    void DestroyBuffer(VmaAllocator allocator);
 };
 
 // Similar to DeviceMemoryBlock, but used for things that will require Buffer Device Address

--- a/layers/gpu/resources/gpuav_resources.h
+++ b/layers/gpu/resources/gpuav_resources.h
@@ -51,12 +51,10 @@ class DescriptorSetManager {
 };
 
 // Simplest wrapper around device memory and the allocation
-struct DeviceMemoryBlock {
-    const Validator &gpuav;
+class DeviceMemoryBlock {
+  public:
     VkBuffer buffer = VK_NULL_HANDLE;
     VmaAllocation allocation = VK_NULL_HANDLE;
-    // If buffer was not created with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT then this will not be zero
-    VkDeviceAddress device_address = 0;
 
     explicit DeviceMemoryBlock(Validator &gpuav) : gpuav(gpuav) {}
 
@@ -70,6 +68,13 @@ struct DeviceMemoryBlock {
     void CreateBuffer(const Location &loc, const VkBufferCreateInfo *buffer_create_info,
                       const VmaAllocationCreateInfo *allocation_create_info);
     void DestroyBuffer();
+
+    VkDeviceAddress Address() const { return device_address; };
+
+  private:
+    const Validator &gpuav;
+    // If buffer was not created with VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT then this will not be zero
+    VkDeviceAddress device_address = 0;
 };
 
 class GpuResourcesManager {

--- a/layers/gpu/resources/gpuav_shader_resources.h
+++ b/layers/gpu/resources/gpuav_shader_resources.h
@@ -43,6 +43,8 @@ struct DescBindingInfo {
     // Hold a buffer for each descriptor set
     // Note: The index here is from vkCmdBindDescriptorSets::firstSet
     std::vector<DescSetState> descriptor_set_buffers;
+
+    DescBindingInfo(Validator &gpuav) : bindless_state(gpuav) {}
 };
 
 // These match the Structures found in the instrumentation GLSL logic

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -140,7 +140,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
     VkResult result = vmaCreateBuffer(gpuav.vma_allocator_, &buffer_info, &alloc_info, &error_output_buffer.buffer,
                                       &error_output_buffer.allocation, nullptr);
     if (result != VK_SUCCESS) {
-        gpuav.InternalError(command_buffer, loc, "Unable to allocate device memory for error output buffer.", true);
+        gpuav.InternalVmaError(command_buffer, loc, "Unable to allocate device memory for error output buffer.");
         return false;
     }
 
@@ -153,7 +153,7 @@ static bool AllocateErrorLogsBuffer(Validator &gpuav, VkCommandBuffer command_bu
         }
         vmaUnmapMemory(gpuav.vma_allocator_, error_output_buffer.allocation);
     } else {
-        gpuav.InternalError(command_buffer, loc, "Unable to map device memory allocated for error output buffer.", true);
+        gpuav.InternalVmaError(command_buffer, loc, "Unable to map device memory allocated for error output buffer.");
         return false;
     }
 
@@ -195,7 +195,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = vmaCreateBuffer(gpuav->vma_allocator_, &buffer_info, &alloc_info, &cmd_errors_counts_buffer_.buffer,
                                  &cmd_errors_counts_buffer_.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc, "Unable to allocate device memory for commands errors counts buffer.", true);
+            gpuav->InternalVmaError(gpuav->device, loc, "Unable to allocate device memory for commands errors counts buffer.");
             return;
         }
 
@@ -215,7 +215,7 @@ void CommandBuffer::AllocateResources(const Location &loc) {
         result = vmaCreateBuffer(gpuav->vma_allocator_, &buffer_info, &alloc_info, &bda_ranges_snapshot_.buffer,
                                  &bda_ranges_snapshot_.allocation, nullptr);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(gpuav->device, loc, "Unable to allocate device memory for buffer device address data.", true);
+            gpuav->InternalVmaError(gpuav->device, loc, "Unable to allocate device memory for buffer device address data.");
             return;
         }
     }
@@ -321,7 +321,7 @@ bool CommandBuffer::UpdateBdaRangesBuffer(const Location &loc) {
     VkResult result =
         vmaMapMemory(gpuav->vma_allocator_, bda_ranges_snapshot_.allocation, reinterpret_cast<void **>(&bda_table_ptr));
     if (result != VK_SUCCESS) {
-        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory in UpdateBdaRangesBuffer.", true);
+        gpuav->InternalVmaError(gpuav->device, loc, "Unable to map device memory in UpdateBdaRangesBuffer.");
         return false;
     }
 
@@ -440,7 +440,7 @@ void CommandBuffer::ClearCmdErrorsCountsBuffer(const Location &loc) const {
     VkResult result = vmaMapMemory(gpuav->vma_allocator_, cmd_errors_counts_buffer_.allocation,
                                    reinterpret_cast<void **>(&cmd_errors_counts_buffer_ptr));
     if (result != VK_SUCCESS) {
-        gpuav->InternalError(gpuav->device, loc, "Unable to map device memory for commands errors counts buffer.", true);
+        gpuav->InternalVmaError(gpuav->device, loc, "Unable to map device memory for commands errors counts buffer.");
         return;
     }
     std::memset(cmd_errors_counts_buffer_ptr, 0, static_cast<size_t>(GetCmdErrorsCountsBufferByteSize()));
@@ -486,7 +486,7 @@ void CommandBuffer::PostProcess(VkQueue queue, const Location &loc) {
 
         VkResult result = vmaMapMemory(gpuav->vma_allocator_, buffer_info.output_mem_block.allocation, (void **)&data);
         if (result != VK_SUCCESS) {
-            gpuav->InternalError(queue, loc, "Unable to map device memory allocated for DebugPrintf buffer.", true);
+            gpuav->InternalVmaError(queue, loc, "Unable to map device memory allocated for DebugPrintf buffer.");
             return;
         }
 

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -393,7 +393,7 @@ void CommandBuffer::ResetCBState() {
 
     // Free the device memory and descriptor set(s) associated with a command buffer.
     for (auto &buffer_info : debug_printf_buffer_infos) {
-        buffer_info.output_mem_block.Destroy(gpuav->vma_allocator_);
+        buffer_info.output_mem_block.DestroyBuffer(gpuav->vma_allocator_);
     }
     debug_printf_buffer_infos.clear();
 
@@ -407,9 +407,9 @@ void CommandBuffer::ResetCBState() {
     di_input_buffer_list.clear();
     current_bindless_buffer = VK_NULL_HANDLE;
 
-    error_output_buffer_.Destroy(gpuav->vma_allocator_);
-    cmd_errors_counts_buffer_.Destroy(gpuav->vma_allocator_);
-    bda_ranges_snapshot_.Destroy(gpuav->vma_allocator_);
+    error_output_buffer_.DestroyBuffer(gpuav->vma_allocator_);
+    cmd_errors_counts_buffer_.DestroyBuffer(gpuav->vma_allocator_);
+    bda_ranges_snapshot_.DestroyBuffer(gpuav->vma_allocator_);
     bda_ranges_snapshot_version_ = 0;
 
     if (validation_cmd_desc_pool_ != VK_NULL_HANDLE && validation_cmd_desc_set_ != VK_NULL_HANDLE) {

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -35,7 +35,6 @@
 namespace gpuav {
 
 class Validator;
-class GpuShaderInstrumentor;
 struct DescBindingInfo;
 
 struct DebugPrintfBufferInfo {
@@ -141,8 +140,8 @@ class CommandBuffer : public vvl::CommandBuffer {
 
 class Queue : public vvl::Queue {
   public:
-    Queue(GpuShaderInstrumentor &shader_instrumentor_, VkQueue q, uint32_t family_index, uint32_t queue_index,
-          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties &queueFamilyProperties, bool timeline_khr);
+    Queue(Validator &gpuav, VkQueue q, uint32_t family_index, uint32_t queue_index, VkDeviceQueueCreateFlags flags,
+          const VkQueueFamilyProperties &queueFamilyProperties, bool timeline_khr);
     virtual ~Queue();
 
   protected:
@@ -151,7 +150,7 @@ class Queue : public vvl::Queue {
     void SubmitBarrier(const Location &loc, uint64_t seq);
     void Retire(vvl::QueueSubmission &) override;
 
-    GpuShaderInstrumentor &shader_instrumentor_;
+    Validator &state_;
     VkCommandPool barrier_command_pool_{VK_NULL_HANDLE};
     VkCommandBuffer barrier_command_buffer_{VK_NULL_HANDLE};
     VkSemaphore barrier_sem_{VK_NULL_HANDLE};

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -129,12 +129,12 @@ class CommandBuffer : public vvl::CommandBuffer {
     VkDescriptorPool validation_cmd_desc_pool_ = VK_NULL_HANDLE;
 
     // Buffer storing GPU-AV errors
-    DeviceMemoryBlock error_output_buffer_ = {};
+    DeviceMemoryBlock error_output_buffer_;
     // Buffer storing an error count per validated commands.
     // Used to limit the number of errors a single command can emit.
-    DeviceMemoryBlock cmd_errors_counts_buffer_ = {};
+    DeviceMemoryBlock cmd_errors_counts_buffer_;
     // Buffer storing a snapshot of buffer device address ranges
-    DeviceMemoryBlock bda_ranges_snapshot_ = {};
+    DeviceMemoryBlock bda_ranges_snapshot_;
     uint32_t bda_ranges_snapshot_version_ = 0;
 };
 


### PR DESCRIPTION
(Broken up into nice commits)

The goal of this was to have `DeviceMemoryBlock` wrap VMA so we can now just go

```c++
    debug_printf_output_buffer.CreateBuffer(loc, &buffer_info, &alloc_info);

    uint32_t *data;
    debug_printf_output_buffer.MapMemory(loc, reinterpret_cast<void **>(&data));
    memset(data, 0, gpuav.gpuav_settings.debug_printf_buffer_size);
    debug_printf_output_buffer.UnmapMemory();
```

without the many (error-prone copy-and-pasted) "is VMA returning VK_SUCCESS" checks

While at it, I had to move a lot of stuff out of `GpuShaderInstrumentor` to the main GPU-AV class object (because now there is no trying to duplicate work for DebugPrintf) ... we can on the future of `GpuShaderInstrumentor` later, but this now leaves it where it is only dealing with "shader instrumentation" and not allocating memory and other things not really related to that scope