### PR TITLE
tests: Update submit helpers

### DIFF
--- a/tests/unit/sync_val.cpp
+++ b/tests/unit/sync_val.cpp
@@ -5948,7 +5948,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite2) {
     vkt::Semaphore semaphore(*m_device);
 
     // Submit on Graphics queue: empty batch just so Transfer queue can synchronize with.
-    m_default_queue->Submit2(vkt::no_cmd, vkt::signal, semaphore);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
 
     // Submit on Graphics queue: image layout transition (WRITE access).
     vkt::CommandBuffer cb1(*m_device, m_command_pool);
@@ -5978,7 +5978,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingWrite2) {
     cb2.End();
 
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-RACING-WRITE");
-    transfer_queue->Submit2(cb2, vkt::wait, semaphore);
+    transfer_queue->Submit2(cb2, vkt::Wait(semaphore));
     m_errorMonitor->VerifyFound();
 
     m_default_queue->Wait();
@@ -6038,7 +6038,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingRead) {
     gfx_cb.Begin();
     vk::CmdCopyBuffer(gfx_cb, buffer, gfx_dst_buffer, 1, &region);
     gfx_cb.End();
-    gfx_queue->Submit2(gfx_cb, vkt::signal, semaphore);
+    gfx_queue->Submit2(gfx_cb, vkt::Signal(semaphore));
 
     // Submit 1 (gfx queue): another read from the same buffer
     gfx_cb2.Begin();
@@ -6050,7 +6050,7 @@ TEST_F(NegativeSyncVal, QSWriteRacingRead) {
     compute_cb.Begin();
     vk::CmdCopyBuffer(compute_cb, compute_src_buffer, compute_dst_buffer, 1, &region);
     compute_cb.End();
-    compute_queue->Submit2(compute_cb, vkt::signal, semaphore2);
+    compute_queue->Submit2(compute_cb, vkt::Signal(semaphore2));
 
     // Submit 3 (transfer queue): wait for gfx/compute semaphores
     {

--- a/tests/unit/sync_val_positive.cpp
+++ b/tests/unit/sync_val_positive.cpp
@@ -779,7 +779,7 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     vk::CmdDispatch(cb, 1, 1, 1);
     cb.End();
 
-    m_default_queue->Submit2(cb, vkt::signal, semaphore);
+    m_default_queue->Submit2(cb, vkt::Signal(semaphore));
 
     // Submit 1: transition image layout (write access)
     VkImageMemoryBarrier2 layout_transition = vku::InitStructHelper();
@@ -803,7 +803,7 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage) {
     vk::CmdPipelineBarrier2(cb2, &dep_info);
     cb2.End();
 
-    m_default_queue->Submit2(cb2, vkt::wait, semaphore);
+    m_default_queue->Submit2(cb2, vkt::Wait(semaphore));
     m_default_queue->Wait();
 }
 
@@ -841,14 +841,14 @@ TEST_F(PositiveSyncVal, QSTransitionWithSrcNoneStage2) {
     cb.Begin();
     vk::CmdClearColorImage(cb, image, VK_IMAGE_LAYOUT_GENERAL, &m_clear_color, 1, &layout_transition.subresourceRange);
     cb.End();
-    m_default_queue->Submit2(cb, vkt::signal, semaphore);
+    m_default_queue->Submit2(cb, vkt::Signal(semaphore));
 
     // Submit 2: Transition layout (WRITE access)
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
     cb2.Begin();
     vk::CmdPipelineBarrier2(cb2, &dep_info);
     cb2.End();
-    m_default_queue->Submit2(cb2, vkt::wait, semaphore);
+    m_default_queue->Submit2(cb2, vkt::Wait(semaphore));
     m_default_queue->Wait();
 }
 
@@ -884,7 +884,7 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
     cb.Begin();
     vk::CmdPipelineBarrier2(cb, &dep_info);
     cb.End();
-    m_default_queue->Submit2(cb, vkt::signal, semaphore);
+    m_default_queue->Submit2(cb, vkt::Signal(semaphore));
 
     // Submit1: wait for the semaphore and read image in the shader
     const OneOffDescriptorSet::Bindings bindings = {{0, VK_DESCRIPTOR_TYPE_STORAGE_IMAGE, 1, VK_SHADER_STAGE_ALL, nullptr}};
@@ -912,7 +912,7 @@ TEST_F(PositiveSyncVal, QSTransitionAndRead) {
                               nullptr);
     vk::CmdDispatch(cb2, 1, 1, 1);
     cb2.End();
-    m_default_queue->Submit2(cb2, vkt::wait, semaphore);
+    m_default_queue->Submit2(cb2, vkt::Wait(semaphore));
     m_default_queue->Wait();
 }
 
@@ -1130,10 +1130,10 @@ TEST_F(PositiveSyncVal, QSSynchronizedWritesAndAsyncWait) {
     dep_info.pImageMemoryBarriers = &image_barrier;
     vk::CmdPipelineBarrier2(cb0, &dep_info);
     cb0.End();
-    m_default_queue->Submit2(cb0, vkt::signal, semaphore);
+    m_default_queue->Submit2(cb0, vkt::Signal(semaphore));
 
     // Submit 1: empty submit on Transfer queue that waits for Submit 0.
-    transfer_queue->Submit2(vkt::no_cmd, vkt::wait, semaphore);
+    transfer_queue->Submit2(vkt::no_cmd, vkt::Wait(semaphore));
 
     // Submit 2: copy to image on Graphics queue. No synchronization is needed because of COPY+WRITE barrier from Submit 0.
     vkt::CommandBuffer cb2(*m_device, m_command_pool);
@@ -1471,10 +1471,9 @@ TEST_F(PositiveSyncVal, SignalUnsignalSignalMultipleSubmits) {
     command_buffer2.Copy(buffer_a, buffer_b);
     command_buffer2.End();
 
-    m_default_queue->Submit2(vkt::no_cmd, vkt::signal, semaphore);
-    m_default_queue->Submit2(m_command_buffer, semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, semaphore,
-                             VK_PIPELINE_STAGE_ALL_COMMANDS_BIT);
-    m_default_queue->Submit2(command_buffer2, vkt::wait, semaphore);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::Signal(semaphore));
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(semaphore), vkt::Signal(semaphore));
+    m_default_queue->Submit2(command_buffer2, vkt::Wait(semaphore));
     m_default_queue->Wait();
 }
 

--- a/tests/unit/sync_val_semaphore_positive.cpp
+++ b/tests/unit/sync_val_semaphore_positive.cpp
@@ -25,7 +25,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitInitialValue) {
     TEST_DESCRIPTION("Wait on the initial value");
     RETURN_IF_SKIP(InitTimelineSemaphore());
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE, 1);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
     m_default_queue->Wait();
 }
 
@@ -40,8 +40,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignal) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 1));
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_default_queue->Wait();
 }
 
@@ -56,8 +56,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSync1) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->SubmitWithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
-    m_default_queue->SubmitWithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit(m_command_buffer, vkt::TimelineSignal(semaphore, 1));
+    m_default_queue->Submit(m_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_default_queue->Wait();
 }
 
@@ -78,8 +78,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalTwoQueues) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 1));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_device->Wait();
 }
 
@@ -94,8 +94,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSmallerValue) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 2);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 2));
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_default_queue->Wait();
 }
 
@@ -116,8 +116,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalSmallerValueTwoQueues) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 2);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 2));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(semaphore, 1));
     m_device->Wait();
 }
 
@@ -132,8 +132,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStage) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT));
     m_default_queue->Wait();
 }
 
@@ -148,8 +148,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStage2) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1, VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT));
     m_default_queue->Wait();
 }
 
@@ -170,8 +170,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitAfterSignalNonDefaultStageTwoQueues
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT));
     m_device->Wait();
 }
 
@@ -192,8 +192,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignal) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::signal, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 1));
     m_device->Wait();
 }
 
@@ -214,8 +214,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalSync1) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->SubmitWithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
-    m_second_queue->SubmitWithTimelineSemaphore(m_second_command_buffer, vkt::signal, semaphore, 1);
+    m_default_queue->Submit(m_command_buffer, vkt::TimelineWait(semaphore, 1));
+    m_second_queue->Submit(m_second_command_buffer, vkt::TimelineSignal(semaphore, 1));
     m_device->Wait();
 }
 
@@ -236,8 +236,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitSmallerValueBeforeSignal) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::signal, semaphore, 2);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 2));
     m_device->Wait();
 }
 
@@ -258,8 +258,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalNonDefaultStage) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::signal, semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 3, VK_PIPELINE_STAGE_2_COPY_BIT));
     m_device->Wait();
 }
 
@@ -280,9 +280,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitBeforeSignalNonDefaultStage2) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT);
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::signal, semaphore, 3,
-                                                 VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1, VK_PIPELINE_STAGE_2_COPY_BIT));
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineSignal(semaphore, 3, VK_PIPELINE_STAGE_2_ALL_TRANSFER_BIT));
     m_device->Wait();
 }
 
@@ -297,11 +296,11 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitLatestSignal) {
     m_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, 2);  // includes all stages
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT));
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, 2));  // includes all stages
 
     // If due to regression signal=1 resolves this wait then it should generate a WAW hazard due to stage mask mismatch
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 2);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 2));
     m_device->Wait();
 }
 
@@ -322,11 +321,11 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitLatestSignalTwoQueues) {
     m_second_command_buffer.End();
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, 2);  // includes all stages
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 1, VK_PIPELINE_STAGE_VERTEX_SHADER_BIT));
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, 2));  // includes all stages
 
     // If due to regression signal=1 resolves this wait then it should generate a WAW hazard due to stage mask mismatch
-    m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, vkt::wait, semaphore, 2);
+    m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(semaphore, 2));
     m_device->Wait();
 }
 
@@ -341,10 +340,10 @@ TEST_F(PositiveSyncValTimelineSemaphore, QueuesCollaborateToResolveEachOthersWai
     vkt::Semaphore first_queue_wait(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     vkt::Semaphore second_queue_wait(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
 
-    m_second_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, second_queue_wait, 1);
-    m_second_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, first_queue_wait, 1);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, second_queue_wait, 1);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, first_queue_wait, 1);
+    m_second_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(second_queue_wait, 1));
+    m_second_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(first_queue_wait, 1));
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(second_queue_wait, 1));
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(first_queue_wait, 1));
     m_device->Wait();
 }
 
@@ -356,9 +355,9 @@ TEST_F(PositiveSyncValTimelineSemaphore, SignalResolvesTwoWaits) {
         GTEST_SKIP() << "Three queues are needed";
     }
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_second_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
-    m_third_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, 1);
+    m_second_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
+    m_third_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, 1));
     m_device->Wait();
 }
 
@@ -371,8 +370,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, SignalResolvesTwoWaits2) {
     }
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     semaphore.Signal(1);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
-    m_second_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
+    m_second_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
     m_device->Wait();
 }
 
@@ -396,7 +395,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, SyncSubmitsWithSingleSemaphore) {
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, semaphore, i - 1, semaphore, i);
+        m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, i - 1), vkt::TimelineSignal(semaphore, i));
     }
     m_device->Wait();
 }
@@ -415,7 +414,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, FrameSynchronization) {
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, i);
+        m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, i));
         semaphore.Wait(i, vvl::kU64Max);
     }
     m_device->Wait();
@@ -438,7 +437,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, FrameSynchronization2) {
 
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     for (int i = 1; i <= N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, i);
+        m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, i));
         while (semaphore.GetCounterValue() != i)
             ;
     }
@@ -457,7 +456,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, HostSignal) {
     TEST_DESCRIPTION("Host signal finishes device wait");
     RETURN_IF_SKIP(InitTimelineSemaphore());
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
     semaphore.Signal(1);
     m_device->Wait();
 }
@@ -466,7 +465,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, HostWaitWait) {
     TEST_DESCRIPTION("Wait for semaphore one more time on the host");
     RETURN_IF_SKIP(InitTimelineSemaphore());
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, 1);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, 1));
     semaphore.Wait(1, kWaitTimeout);
     // Test that the second wait does not cause any issues.
     semaphore.Wait(1, kWaitTimeout);
@@ -482,7 +481,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, HostSignalSignal) {
     // Test that the second signal does not cause any issues.
     semaphore.Signal(2);
 
-    m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
     m_device->Wait();
 }
 
@@ -562,7 +561,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, KhronosTimelineSemaphoreExample) {
     auto thread1 = [this, &timeline]() {
         const uint64_t wait_value_1 = 0;    // No-op wait. Value is always >= 0.
         const uint64_t signal_value_1 = 5;  // Unblock thread2's CPU work.
-        m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, timeline, wait_value_1, timeline, signal_value_1);
+        m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(timeline, wait_value_1),
+                                 vkt::TimelineSignal(timeline, signal_value_1));
     };
     auto thread2 = [&timeline, &bytes]() {
         // Wait for thread1's device work to complete.
@@ -578,7 +578,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, KhronosTimelineSemaphoreExample) {
     auto thread3 = [this, &timeline]() {
         const uint64_t wait_value_3 = 7;    // Wait for thread2's CPU work to complete.
         const uint64_t signal_value_3 = 8;  // Signal completion of all work.
-        m_second_queue->Submit2WithTimelineSemaphore(m_second_command_buffer, timeline, wait_value_3, timeline, signal_value_3);
+        m_second_queue->Submit2(m_second_command_buffer, vkt::TimelineWait(timeline, wait_value_3),
+                                vkt::TimelineSignal(timeline, signal_value_3));
     };
 
     std::thread t1(thread1);
@@ -605,8 +606,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, ResolveManyWaitBeforeSignals) {
     // Increase constant value to get longer running time.
     uint32_t N = 1000;
     for (uint32_t i = 0; i < N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::wait, semaphore, i + 1);
-        m_second_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, i + 1);
+        m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineWait(semaphore, i + 1));
+        m_second_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, i + 1));
         m_device->Wait();
     }
 }
@@ -648,8 +649,8 @@ TEST_F(PositiveSyncValTimelineSemaphore, ExternalSemaphoreWaitBeforeSignal) {
     // to track external signal). Check that the list of unresolved batches and signals does not grow.
     const int N = 100;
     for (int i = 1; i <= N; i++) {
-        m_default_queue->SubmitWithTimelineSemaphore(vkt::no_cmd, vkt::wait, export_semaphore, i);
-        m_second_queue->SubmitWithTimelineSemaphore(vkt::no_cmd, vkt::signal, import_semaphore, i);
+        m_default_queue->Submit(vkt::no_cmd, vkt::TimelineWait(export_semaphore, i));
+        m_second_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(import_semaphore, i));
         m_device->Wait();
     }
 }
@@ -662,7 +663,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, QueueWaitIdleRemovesSignals) {
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     const uint32_t N = 100;
     for (uint32_t i = 1; i <= N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, i);
+        m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, i));
         // The maximum number of registered signals will be around 25
         if (i % 25 == 0) {
             m_default_queue->Wait();
@@ -678,7 +679,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, DeviceWaitIdleRemovesignals) {
     vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
     const uint32_t N = 100;
     for (uint32_t i = 1; i <= N; i++) {
-        m_default_queue->Submit2WithTimelineSemaphore(vkt::no_cmd, vkt::signal, semaphore, i);
+        m_default_queue->Submit2(vkt::no_cmd, vkt::TimelineSignal(semaphore, i));
         // The maximum number of registered signals will be around 50
         if (i % 50 == 0) {
             m_device->Wait();
@@ -754,8 +755,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitForFencesWithTimelineSignalBatches)
 
     // The first batch context.
     // Specify VERTEX_SHADER signal scope, so waiting for timeline signal does not protect buffer copy
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::signal, semaphore, 1,
-                                                  VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT, fence);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineSignal(semaphore, 1, VK_PIPELINE_STAGE_2_VERTEX_SHADER_BIT), fence);
 
     // The second batch context which imports the first one.
     // The timeline signal in the first submit still references the first batch.
@@ -769,7 +769,7 @@ TEST_F(PositiveSyncValTimelineSemaphore, WaitForFencesWithTimelineSignalBatches)
     // Waiting for timeline signal imports the first batch stored in that signal.
     // In case of regression the first batch will contain unprotected copy writes and
     // this will cause WRITE-AFTER-WRITE hazard.
-    m_default_queue->Submit2WithTimelineSemaphore(m_command_buffer, vkt::wait, semaphore, 1);
+    m_default_queue->Submit2(m_command_buffer, vkt::TimelineWait(semaphore, 1));
 
     m_default_queue->Wait();
 }

--- a/tests/unit/sync_val_wsi.cpp
+++ b/tests/unit/sync_val_wsi.cpp
@@ -152,11 +152,11 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
 
     // The wait mask doesn't match the operations in the command buffer
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-WRITE-AFTER-READ");
-    m_default_queue->Submit(m_command_buffer, vkt::wait, sem, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(sem, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT));
     m_errorMonitor->VerifyFound();
 
     // Now then wait mask matches the operations in the command buffer
-    m_default_queue->Submit(m_command_buffer, vkt::wait, sem, VK_PIPELINE_STAGE_TRANSFER_BIT);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(sem, VK_PIPELINE_STAGE_TRANSFER_BIT));
 
     // Try presenting without waiting for the ILT to finish
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-PRESENT-AFTER-WRITE");
@@ -174,7 +174,7 @@ TEST_F(NegativeSyncValWsi, PresentAcquire) {
     write_barrier_cb(images[acquired_index], VK_IMAGE_LAYOUT_UNDEFINED, VK_IMAGE_LAYOUT_PRESENT_SRC_KHR);
 
     fence.Reset();
-    m_default_queue->Submit(m_command_buffer, vkt::signal, sem);
+    m_default_queue->Submit(m_command_buffer, vkt::Signal(sem));
 
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-PRESENT-AFTER-WRITE");
     present_image(acquired_index, nullptr, nullptr);  // present without fence can't timeout
@@ -219,8 +219,8 @@ TEST_F(NegativeSyncValWsi, PresentDoesNotWaitForSubmit2) {
     vk::CmdPipelineBarrier2(m_command_buffer, &dep_info);
     m_command_buffer.End();
 
-    m_default_queue->Submit2(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore,
-                             VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT);
+    m_default_queue->Submit2(m_command_buffer, vkt::Wait(acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT),
+                             vkt::Signal(submit_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT));
 
     // DO NOT wait for submit. This should generate present after write (ILT) harard.
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-PRESENT-AFTER-WRITE");
@@ -258,7 +258,8 @@ TEST_F(NegativeSyncValWsi, PresentDoesNotWaitForSubmit) {
                            VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, 0, 0, nullptr, 0, nullptr, 1, &layout_transition);
     m_command_buffer.End();
 
-    m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT, submit_semaphore);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore, VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT),
+                            vkt::Signal(submit_semaphore));
 
     // DO NOT wait for submit. This should generate present after write (ILT) harard.
     m_errorMonitor->SetDesiredError("SYNC-HAZARD-PRESENT-AFTER-WRITE");

--- a/tests/unit/wsi_positive.cpp
+++ b/tests/unit/wsi_positive.cpp
@@ -429,7 +429,8 @@ TEST_F(PositiveWsi, SwapchainAcquireImageAndPresent) {
                            nullptr, 0, nullptr, 1, &present_transition);
     m_command_buffer.End();
 
-    m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT, submit_semaphore);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore, VK_PIPELINE_STAGE_TOP_OF_PIPE_BIT),
+                            vkt::Signal(submit_semaphore));
     m_default_queue->Present(submit_semaphore, m_swapchain, image_index);
     m_default_queue->Wait();
 }
@@ -538,7 +539,7 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence) {
         command_buffers[image_index].Begin();
         command_buffers[image_index].End();
 
-        m_default_queue->Submit(command_buffers[image_index], vkt::signal, submit_semaphores[image_index]);
+        m_default_queue->Submit(command_buffers[image_index], vkt::Signal(submit_semaphores[image_index]));
         m_default_queue->Present(submit_semaphores[image_index], m_swapchain, image_index);
     }
     m_default_queue->Wait();
@@ -567,7 +568,7 @@ TEST_F(PositiveWsi, RetireSubmissionUsingAcquireFence2) {
     command_buffers[image_index].Begin();
     command_buffers[image_index].End();
 
-    m_default_queue->Submit(command_buffers[image_index], vkt::signal, submit_semaphores[image_index]);
+    m_default_queue->Submit(command_buffers[image_index], vkt::Signal(submit_semaphores[image_index]));
     m_default_queue->Present(submit_semaphores[image_index], m_swapchain, image_index);
 
     // Here the application decides to destroy swapchain (e.g. resize event)
@@ -1331,7 +1332,7 @@ TEST_F(PositiveWsi, PresentFenceWaitsForSubmission) {
         vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                                nullptr, 0, nullptr, 1, &present_transition);
         m_command_buffer.End();
-        m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, submit_semaphore);
+        m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(submit_semaphore));
 
         vkt::Fence present_fence(*m_device);
         VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();
@@ -1416,7 +1417,7 @@ TEST_F(PositiveWsi, PresentFenceRetiresPresentQueueOperation) {
 
         const uint32_t image_index = m_swapchain.AcquireNextImage(frame.image_acquired, kWaitTimeout);
 
-        m_default_queue->Submit(vkt::no_cmd, frame.image_acquired, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, frame.submit_finished);
+        m_default_queue->Submit(vkt::no_cmd, vkt::Wait(frame.image_acquired), vkt::Signal(frame.submit_finished));
 
         VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();
         present_fence_info.swapchainCount = 1;
@@ -1454,7 +1455,7 @@ TEST_F(PositiveWsi, QueueWaitsForPresentFence) {
     vk::CmdPipelineBarrier(m_command_buffer, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, VK_PIPELINE_STAGE_BOTTOM_OF_PIPE_BIT, 0, 0,
                            nullptr, 0, nullptr, 1, &present_transition);
     m_command_buffer.End();
-    m_default_queue->Submit(m_command_buffer, acquire_semaphore, VK_PIPELINE_STAGE_ALL_COMMANDS_BIT, submit_semaphore);
+    m_default_queue->Submit(m_command_buffer, vkt::Wait(acquire_semaphore), vkt::Signal(submit_semaphore));
 
     vkt::Fence present_fence(*m_device);
     VkSwapchainPresentFenceInfoEXT present_fence_info = vku::InitStructHelper();


### PR DESCRIPTION
This unifies submit helpers so functions that work with timeline semaphores do not need distinctive names.
Also makes it more visible if semaphore describes wait or signal.