### PR TITLE
gpu: Cleanup in DeviceMemoryBlock

### DIFF
--- a/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
+++ b/layers/gpu/cmd_validation/gpuav_copy_buffer_to_image.cpp
@@ -204,8 +204,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
 
         cb_state.gpu_resources_manager.ManageDeviceMemoryBlock(copy_src_regions_mem_block);
 
-        uint32_t *gpu_regions_u32_ptr = nullptr;
-        copy_src_regions_mem_block.MapMemory(loc, reinterpret_cast<void **>(&gpu_regions_u32_ptr));
+        auto gpu_regions_u32_ptr = (uint32_t *)copy_src_regions_mem_block.MapMemory(loc);
 
         const uint32_t block_size = image_state->create_info.format == VK_FORMAT_D32_SFLOAT ? 4 : 5;
         uint32_t gpu_regions_count = 0;
@@ -281,7 +280,7 @@ void InsertCopyBufferToImageValidation(Validator &gpuav, const Location &loc, Co
         descriptor_buffer_infos[0].offset = 0;
         descriptor_buffer_infos[0].range = VK_WHOLE_SIZE;
         // Copy regions buffer
-        descriptor_buffer_infos[1].buffer = copy_src_regions_mem_block.buffer;
+        descriptor_buffer_infos[1].buffer = copy_src_regions_mem_block.Buffer();
         descriptor_buffer_infos[1].offset = 0;
         descriptor_buffer_infos[1].range = VK_WHOLE_SIZE;
 

--- a/layers/gpu/core/gpuav_setup.cpp
+++ b/layers/gpu/core/gpuav_setup.cpp
@@ -506,8 +506,7 @@ void Validator::PostCreateDevice(const VkDeviceCreateInfo *pCreateInfo, const Lo
         alloc_info.requiredFlags = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
         indices_buffer_.CreateBuffer(loc, &buffer_info, &alloc_info);
 
-        uint32_t *indices_ptr = nullptr;
-        indices_buffer_.MapMemory(loc, reinterpret_cast<void **>(&indices_ptr));
+        auto indices_ptr = (uint32_t *)indices_buffer_.MapMemory(loc);
 
         for (uint32_t i = 0; i < buffer_info.size / sizeof(uint32_t); ++i) {
             indices_ptr[i] = i / (indices_buffer_alignment_ / sizeof(uint32_t));

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -368,14 +368,13 @@ bool UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     debug_printf_output_buffer.CreateBuffer(loc, &buffer_info, &alloc_info);
 
     // Clear the output block to zeros so that only printf values from the gpu will be present
-    uint32_t *data;
-    debug_printf_output_buffer.MapMemory(loc, reinterpret_cast<void **>(&data));
-    memset(data, 0, gpuav.gpuav_settings.debug_printf_buffer_size);
+    auto printf_output_ptr = (uint32_t *)debug_printf_output_buffer.MapMemory(loc);
+    memset(printf_output_ptr, 0, gpuav.gpuav_settings.debug_printf_buffer_size);
     debug_printf_output_buffer.UnmapMemory();
 
     VkDescriptorBufferInfo debug_printf_desc_buffer_info = {};
     debug_printf_desc_buffer_info.range = gpuav.gpuav_settings.debug_printf_buffer_size;
-    debug_printf_desc_buffer_info.buffer = debug_printf_output_buffer.buffer;
+    debug_printf_desc_buffer_info.buffer = debug_printf_output_buffer.Buffer();
     debug_printf_desc_buffer_info.offset = 0;
 
     VkWriteDescriptorSet wds = vku::InitStructHelper();

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.cpp
@@ -88,11 +88,10 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
     // draw's descriptor set.
     di_buffers.bindless_state.CreateBuffer(loc, &buffer_info, &alloc_info);
 
-    glsl::BindlessStateBuffer *bindless_state{nullptr};
-    di_buffers.bindless_state.MapMemory(loc, reinterpret_cast<void **>(&bindless_state));
+    auto bindless_state = (glsl::BindlessStateBuffer *)di_buffers.bindless_state.MapMemory(loc);
 
     memset(bindless_state, 0, static_cast<size_t>(buffer_info.size));
-    cb_state.current_bindless_buffer = di_buffers.bindless_state.buffer;
+    cb_state.current_bindless_buffer = di_buffers.bindless_state.Buffer();
 
     bindless_state->global_state = gpuav.desc_heap_->GetDeviceAddress();
     di_buffers.descriptor_set_buffers.reserve(di_buffers.descriptor_set_buffers.size() + last_bound.per_set.size());
@@ -133,8 +132,7 @@ void UpdateBoundDescriptors(Validator &gpuav, CommandBuffer &cb_state, VkPipelin
 // For the given command buffer, map its debug data buffers and update the status of any update after bind descriptors
 [[nodiscard]] bool UpdateBindlessStateBuffer(Validator &gpuav, CommandBuffer &cb_state, const Location &loc) {
     for (auto &cmd_info : cb_state.di_input_buffer_list) {
-        glsl::BindlessStateBuffer *bindless_state{nullptr};
-        cmd_info.bindless_state.MapMemory(loc, reinterpret_cast<void **>(&bindless_state));
+        auto bindless_state = (glsl::BindlessStateBuffer *)cmd_info.bindless_state.MapMemory(loc);
 
         for (size_t i = 0; i < cmd_info.descriptor_set_buffers.size(); i++) {
             auto &set_buffer = cmd_info.descriptor_set_buffers[i];

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -171,7 +171,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     VkDescriptorBufferInfo indices_desc_buffer_info = {};
     {
         indices_desc_buffer_info.range = sizeof(uint32_t);
-        indices_desc_buffer_info.buffer = gpuav.indices_buffer_.buffer;
+        indices_desc_buffer_info.buffer = gpuav.indices_buffer_.Buffer();
         indices_desc_buffer_info.offset = 0;
 
         VkWriteDescriptorSet wds = vku::InitStructHelper();
@@ -230,7 +230,7 @@ void UpdateInstrumentationDescSet(Validator &gpuav, CommandBuffer &cb_state, VkD
     VkDescriptorBufferInfo bda_input_desc_buffer_info = {};
     if (gpuav.gpuav_settings.shader_instrumentation.buffer_device_address) {
         bda_input_desc_buffer_info.range = VK_WHOLE_SIZE;
-        bda_input_desc_buffer_info.buffer = cb_state.GetBdaRangesSnapshot().buffer;
+        bda_input_desc_buffer_info.buffer = cb_state.GetBdaRangesSnapshot().Buffer();
         bda_input_desc_buffer_info.offset = 0;
 
         VkWriteDescriptorSet wds = vku::InitStructHelper();

--- a/layers/gpu/resources/gpuav_resources.cpp
+++ b/layers/gpu/resources/gpuav_resources.cpp
@@ -144,11 +144,14 @@ void SharedResourcesManager::Clear() {
     shared_validation_resources_map_.clear();
 }
 
-void DeviceMemoryBlock::MapMemory(const Location &loc, void **data) const {
-    VkResult result = vmaMapMemory(gpuav.vma_allocator_, allocation, data);
+void *DeviceMemoryBlock::MapMemory(const Location &loc) const {
+    void *buffer_ptr = nullptr;
+    VkResult result = vmaMapMemory(gpuav.vma_allocator_, allocation, &buffer_ptr);
     if (result != VK_SUCCESS) {
         gpuav.InternalVmaError(gpuav.device, loc, "Unable to map device memory.");
+        return nullptr;
     }
+    return buffer_ptr;
 }
 
 void DeviceMemoryBlock::UnmapMemory() const { vmaUnmapMemory(gpuav.vma_allocator_, allocation); }

--- a/layers/gpu/resources/gpuav_subclasses.h
+++ b/layers/gpu/resources/gpuav_subclasses.h
@@ -85,15 +85,15 @@ class CommandBuffer : public vvl::CommandBuffer {
     uint32_t GetValidationErrorBufferDescSetIndex() const { return 0; }
 
     const VkBuffer &GetErrorOutputBuffer() const {
-        assert(error_output_buffer_.buffer != VK_NULL_HANDLE);
-        return error_output_buffer_.buffer;
+        assert(error_output_buffer_.Buffer() != VK_NULL_HANDLE);
+        return error_output_buffer_.Buffer();
     }
 
     VkDeviceSize GetCmdErrorsCountsBufferByteSize() const { return 8192 * sizeof(uint32_t); }
 
     const VkBuffer &GetCmdErrorsCountsBuffer() const {
-        assert(cmd_errors_counts_buffer_.buffer != VK_NULL_HANDLE);
-        return cmd_errors_counts_buffer_.buffer;
+        assert(cmd_errors_counts_buffer_.Buffer() != VK_NULL_HANDLE);
+        return cmd_errors_counts_buffer_.Buffer();
     }
 
     const DeviceMemoryBlock &GetBdaRangesSnapshot() const { return bda_ranges_snapshot_; }


### PR DESCRIPTION
- no public member in DeviceMemoryBlock
 => either everything public or nothing
- MapMemory simply returns a void* pointer
 => Just as the test framework. This pointer is immediately cast to appropriate type. Thought about using a template method to specify the type, but a simple manual cast is probably better here