### PR TITLE
printf: Ray tracing tests

### DIFF
--- a/tests/framework/ray_tracing_objects.cpp
+++ b/tests/framework/ray_tracing_objects.cpp
@@ -13,6 +13,7 @@
 
 #include "utils/vk_layer_utils.h"
 
+// #define VVL_DEBUG_LOG_SBT
 #ifdef VVL_DEBUG_LOG_SBT
 #include <iostream>
 #endif
@@ -134,7 +135,7 @@ GeometryKHR &GeometryKHR::SetTrianglesMaxVertex(uint32_t max_vertex) {
 
 GeometryKHR &GeometryKHR::SetTrianglesTransformBuffer(vkt::Buffer &&transform_buffer) {
     triangles_.device_transform_buffer = std::move(transform_buffer);
-    vk_obj_.geometry.triangles.transformData.deviceAddress = triangles_.device_transform_buffer.Address();
+    vk_obj_.geometry.triangles.transformData.deviceAddress = triangles_.device_transform_buffer.address();
     return *this;
 }
 
@@ -178,15 +179,14 @@ GeometryKHR &GeometryKHR::SetAABBsDeviceAddress(VkDeviceAddress address) {
     return *this;
 }
 
-GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &device, VkAccelerationStructureKHR blas) {
+GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &device, VkAccelerationStructureKHR blas,
+                                                          const VkAccelerationStructureInstanceKHR &instance) {
     auto vkGetAccelerationStructureDeviceAddressKHR = reinterpret_cast<PFN_vkGetAccelerationStructureDeviceAddressKHR>(
         vk::GetDeviceProcAddr(device.handle(), "vkGetAccelerationStructureDeviceAddressKHR"));
     assert(vkGetAccelerationStructureDeviceAddressKHR);
-    VkAccelerationStructureDeviceAddressInfoKHR as_address_info = vku::InitStructHelper();
-    as_address_info.accelerationStructure = blas;
-    const VkDeviceAddress as_address = vkGetAccelerationStructureDeviceAddressKHR(device.handle(), &as_address_info);
-    VkAccelerationStructureInstanceKHR vk_instance{};
-
+    VkAccelerationStructureDeviceAddressInfoKHR blas_address_info = vku::InitStructHelper();
+    blas_address_info.accelerationStructure = blas;
+    const VkDeviceAddress as_address = vkGetAccelerationStructureDeviceAddressKHR(device.handle(), &blas_address_info);
     // Ray Tracing gems 2, page 235, is a good reference on how to fill this affine transform
     // Noting M that transform, (x, y, z) a vertex, transformation is:
     // M * (x, y, z, 1) =
@@ -194,47 +194,39 @@ GeometryKHR &GeometryKHR::AddInstanceDeviceAccelStructRef(const vkt::Device &dev
     //     M[1][0] * x + M[1][1] * y + M[1][2] * z + M[1][3],
     //     M[2][0] * x + M[2][1] * y + M[2][2] * z + M[2][3] )
 
-    // Identity transform:
-    vk_instance.transform.matrix[0][0] = 1.0f;
-    vk_instance.transform.matrix[1][1] = 1.0f;
-    vk_instance.transform.matrix[2][2] = 1.0f;
-    vk_instance.instanceCustomIndex = 0;
-    // "mask is an 8-bit visibility mask for the geometry. The instance may only be hit if Cull Mask & instance.mask != 0"
-    vk_instance.mask = 0xff;
-    vk_instance.instanceShaderBindingTableRecordOffset = 0;
-    vk_instance.flags = 0;  // Could use VK_GEOMETRY_INSTANCE_FORCE_OPAQUE_BIT_KHR
-    vk_instance.accelerationStructureReference = static_cast<uint64_t>(as_address);
-    instance_.vk_instances.push_back(vk_instance);
+    instances_.vk_instances.emplace_back(instance).accelerationStructureReference = static_cast<uint64_t>(as_address);
     ++primitiveCount_;
 
     // Create instance buffer
-    assert(!instance_.buffer.initialized());  // for now, do not handle already initialized buffer
+
     VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
     alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
-    instance_.buffer.init(
-        device, instance_.vk_instances.size() * sizeof(VkAccelerationStructureInstanceKHR),
+    vkt::Buffer instances_buffer(
+        device, instances_.vk_instances.size() * sizeof(VkAccelerationStructureInstanceKHR),
         VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR,
         VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
 
-    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instance_.buffer.Memory().Map());
-    for (size_t vk_instance_i = 0; vk_instance_i < instance_.vk_instances.size(); ++vk_instance_i) {
-        instance_buffer_ptr[vk_instance_i] = instance_.vk_instances[vk_instance_i];
+    auto instance_buffer_ptr = static_cast<VkAccelerationStructureInstanceKHR *>(instances_buffer.memory().map());
+    for (size_t vk_instance_i = 0; vk_instance_i < instances_.vk_instances.size(); ++vk_instance_i) {
+        instance_buffer_ptr[vk_instance_i] = instances_.vk_instances[vk_instance_i];
     }
-    instance_.buffer.Memory().Unmap();
+    instances_buffer.memory().unmap();
+
+    instances_.buffer = std::move(instances_buffer);
 
     vk_obj_.geometry.instances.arrayOfPointers = VK_FALSE;
-    vk_obj_.geometry.instances.data.deviceAddress = instance_.buffer.Address();
+    vk_obj_.geometry.instances.data.deviceAddress = instances_.buffer.address();
     return *this;
 }
 
 GeometryKHR &GeometryKHR::AddInstanceHostAccelStructRef(VkAccelerationStructureKHR blas) {
-    instance_.vk_instances.emplace_back(VkAccelerationStructureInstanceKHR{});
+    instances_.vk_instances.emplace_back(VkAccelerationStructureInstanceKHR{});
     ++primitiveCount_;
-    instance_.vk_instances.back().accelerationStructureReference = (uint64_t)(blas);
+    instances_.vk_instances.back().accelerationStructureReference = (uint64_t)(blas);
     // leave other instance_ attributes to 0
 
     vk_obj_.geometry.instances.arrayOfPointers = VK_FALSE;
-    vk_obj_.geometry.instances.data.hostAddress = instance_.vk_instances.data();
+    vk_obj_.geometry.instances.data.hostAddress = instances_.vk_instances.data();
     return *this;
 }
 
@@ -244,12 +236,17 @@ GeometryKHR &GeometryKHR::SetInstancesDeviceAddress(VkDeviceAddress address) {
 }
 
 GeometryKHR &GeometryKHR::SetInstanceHostAccelStructRef(VkAccelerationStructureKHR blas, uint32_t instance_i) {
-    instance_.vk_instances[instance_i].accelerationStructureReference = (uint64_t)(blas);
+    instances_.vk_instances[instance_i].accelerationStructureReference = (uint64_t)(blas);
     return *this;
 }
 
 GeometryKHR &GeometryKHR::SetInstanceHostAddress(void *address) {
     vk_obj_.geometry.instances.data.hostAddress = address;
+    return *this;
+}
+
+GeometryKHR &GeometryKHR::SetInstanceShaderBindingTableRecordOffset(uint32_t instance_i, uint32_t instance_sbt_record_offset) {
+    instances_.vk_instances[instance_i].instanceShaderBindingTableRecordOffset = instance_sbt_record_offset;
     return *this;
 }
 
@@ -448,11 +445,6 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetEnableScratchBuild(bool build_scr
     return *this;
 }
 
-BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetBottomLevelAS(std::shared_ptr<BuildGeometryInfoKHR> bottom_level_as) {
-    blas_ = std::move(bottom_level_as);
-    return *this;
-}
-
 BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetInfoCount(uint32_t info_count) {
     assert(info_count <= 1);
     vk_info_count_ = info_count;
@@ -495,26 +487,16 @@ BuildGeometryInfoKHR &BuildGeometryInfoKHR::SetIndirectDeviceAddress(std::option
 }
 
 void BuildGeometryInfoKHR::BuildCmdBuffer(VkCommandBuffer cmd_buffer, bool use_ppGeometries /*= true*/) {
-    if (blas_) {
-        // blas_->BuildCmdBuffer(cmd_buffer, use_ppGeometries);
-        assert(blas_->GetDstAS()->IsBuilt());
-    }
     SetupBuild(true);
     VkCmdBuildAccelerationStructuresKHR(cmd_buffer, true);
 }
 
 void BuildGeometryInfoKHR::BuildCmdBufferIndirect(VkCommandBuffer cmd_buffer) {
-    if (blas_) {
-        blas_->BuildCmdBufferIndirect(cmd_buffer);
-    }
     SetupBuild(true);
     VkCmdBuildAccelerationStructuresIndirectKHR(cmd_buffer);
 }
 
 void BuildGeometryInfoKHR::BuildHost() {
-    if (blas_) {
-        blas_->BuildHost();
-    }
     SetupBuild(false);
     VkBuildAccelerationStructuresKHR();
 }
@@ -785,9 +767,6 @@ void BuildAccelerationStructuresKHR(VkCommandBuffer cmd_buffer, std::vector<Buil
     size_t pRange_infos_offset = 0;
 
     for (auto &build_info : infos) {
-        if (build_info.blas_) {
-            build_info.blas_->BuildCmdBuffer(cmd_buffer, true);
-        }
         build_info.SetupBuild(true);
 
         // Fill current vk_info_ with geometry data in ppGeometries, and get build ranges
@@ -840,9 +819,6 @@ void BuildHostAccelerationStructuresKHR(VkDevice device, std::vector<BuildGeomet
     size_t pRange_infos_offset = 0;
 
     for (auto &build_info : infos) {
-        if (build_info.blas_) {
-            build_info.blas_->BuildHost();
-        }
         build_info.SetupBuild(false);
 
         // Fill current vk_info_ with geometry data in ppGeometries, and get build ranges
@@ -911,13 +887,13 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, size_t
         indices[3 * triangle_i + 2] = 2;
     }
 
-    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.Memory().Map());
+    auto vertex_buffer_ptr = static_cast<float *>(vertex_buffer.memory().map());
     std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
-    vertex_buffer.Memory().Unmap();
+    vertex_buffer.memory().unmap();
 
-    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.Memory().Map());
+    auto index_buffer_ptr = static_cast<uint32_t *>(index_buffer.memory().map());
     std::copy(indices.begin(), indices.end(), index_buffer_ptr);
-    index_buffer.Memory().Unmap();
+    index_buffer.memory().unmap();
 
     // clang-format off
     VkTransformMatrixKHR transform_matrix = {{
@@ -927,12 +903,12 @@ GeometryKHR GeometrySimpleOnDeviceTriangleInfo(const vkt::Device &device, size_t
     }};
     // clang-format on
 
-    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.Memory().Map());
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.memory().map());
     std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
-    transform_buffer.Memory().Unmap();
+    transform_buffer.memory().unmap();
 
     // Assign vertex and index buffers to out geometry
-    triangle_geometry.SetTrianglesDeviceVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3));
+    triangle_geometry.SetTrianglesDeviceVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3) - 1);
     triangle_geometry.SetTrianglesIndexType(VK_INDEX_TYPE_UINT32);
     triangle_geometry.SetTrianglesDeviceIndexBuffer(std::move(index_buffer));
     triangle_geometry.SetTrianglesTransformBuffer(std::move(transform_buffer));
@@ -945,7 +921,6 @@ GeometryKHR GeometrySimpleOnHostTriangleInfo() {
     GeometryKHR triangle_geometry;
 
     triangle_geometry.SetType(GeometryKHR::Type::Triangle);
-
     // Fill vertex and index buffers with one triangle
     triangle_geometry.SetPrimitiveCount(1);
     constexpr std::array vertices = {1.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
@@ -958,10 +933,115 @@ GeometryKHR GeometrySimpleOnHostTriangleInfo() {
     std::copy(indices.data(), indices.data() + indices.size(), index_buffer.get());
 
     // Assign vertex and index buffers to out geometry
-    triangle_geometry.SetTrianglesHostVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3 - 1));
+    triangle_geometry.SetTrianglesHostVertexBuffer(std::move(vertex_buffer), uint32_t(vertices.size() / 3) - 1);
     triangle_geometry.SetTrianglesHostIndexBuffer(std::move(index_buffer));
 
     return triangle_geometry;
+}
+
+GeometryKHR GeometryCubeOnDeviceInfo(const vkt::Device &device) {
+    GeometryKHR cube_geometry;
+
+    cube_geometry.SetType(GeometryKHR::Type::Triangle);
+
+    // I assumed a right handed coordinate system, because why not
+    // clang-format off
+    /*
+                Z
+                |
+         6--------------5
+        /|             /|
+       / |            / |
+      /  |           /  |
+     7--------------4   |
+     |   |          |   |
+     |   2----------|---1
+     |  /           |  /
+     | /            | /-------> Y
+     |/             |/
+     3--------------0
+            \
+             \
+              X
+    */
+    // clang-format on
+
+    // Triangles count
+    cube_geometry.SetPrimitiveCount(2 * 6);
+    struct Vertex {
+        float x, y, z;
+    };
+    constexpr std::array<Vertex, 8> vertices = {{
+        {1.0f, 1.0f, -1.0f},
+        {-1.0f, 1.0f, -1.0f},
+        {-1.0f, -1.0f, -1.0f},
+        {1.0f, -1.0f, -1.0f},
+
+        {1.0f, 1.0f, 1.0f},
+        {-1.0f, 1.0f, 1.0f},
+        {-1.0f, -1.0f, 1.0f},
+        {1.0f, -1.0f, 1.0f},
+    }};
+
+    struct TriangleIndices {
+        uint32_t i0, i1, i2;
+    };
+    constexpr std::array<TriangleIndices, 2 * 6> indices = {{// face oriented by +X
+                                                             TriangleIndices{3, 0, 4}, TriangleIndices{4, 7, 3},
+                                                             // face oriented by +Y
+                                                             TriangleIndices{0, 4, 5}, TriangleIndices{0, 5, 1},
+                                                             // face oriented by +Z
+                                                             TriangleIndices{4, 5, 6}, TriangleIndices{4, 6, 7},
+
+                                                             // face oriented by -X
+                                                             TriangleIndices{1, 6, 5}, TriangleIndices{1, 2, 6},
+                                                             // face oriented bye -Y
+                                                             TriangleIndices{2, 6, 7}, TriangleIndices{2, 7, 3},
+                                                             // face oriented by -z
+                                                             TriangleIndices{0, 1, 3}, TriangleIndices{1, 3, 2}}};
+
+    // clang-format off
+    VkTransformMatrixKHR transform_matrix = {{
+        { 1.0f, 0.0f, 0.0f, 0.0f },
+        { 0.0f, 1.0f, 0.0f, 0.0f },
+        { 0.0f, 0.0f, 1.0f, 0.0f },
+    }};
+    // clang-format on
+
+    // Allocate vertex and index buffers
+    VkMemoryAllocateFlagsInfo alloc_flags = vku::InitStructHelper();
+    alloc_flags.flags = VK_MEMORY_ALLOCATE_DEVICE_ADDRESS_BIT_KHR;
+    const VkBufferUsageFlags buffer_usage = VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_BUILD_INPUT_READ_ONLY_BIT_KHR |
+                                            VK_BUFFER_USAGE_ACCELERATION_STRUCTURE_STORAGE_BIT_KHR |
+                                            VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT;
+
+    vkt::Buffer vertex_buffer(device, sizeof(vertices[0]) * vertices.size(), buffer_usage,
+                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
+    vkt::Buffer index_buffer(device, sizeof(indices[0]) * indices.size(), buffer_usage,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
+    vkt::Buffer transform_buffer(device, sizeof(VkTransformMatrixKHR), buffer_usage,
+                                 VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT, &alloc_flags);
+
+    auto vertex_buffer_ptr = static_cast<Vertex *>(vertex_buffer.memory().map());
+    std::copy(vertices.begin(), vertices.end(), vertex_buffer_ptr);
+    vertex_buffer.memory().unmap();
+
+    auto index_buffer_ptr = static_cast<TriangleIndices *>(index_buffer.memory().map());
+    std::copy(indices.begin(), indices.end(), index_buffer_ptr);
+    index_buffer.memory().unmap();
+
+    auto transform_buffer_ptr = static_cast<VkTransformMatrixKHR *>(transform_buffer.memory().map());
+    std::memcpy(transform_buffer_ptr, &transform_matrix, sizeof(transform_matrix));
+    transform_buffer.memory().unmap();
+
+    // Assign vertex and index buffers to out geometry
+    cube_geometry.SetTrianglesDeviceVertexBuffer(std::move(vertex_buffer), 8 - 1);
+    cube_geometry.SetTrianglesIndexType(VK_INDEX_TYPE_UINT32);
+    cube_geometry.SetTrianglesDeviceIndexBuffer(std::move(index_buffer));
+    cube_geometry.SetTrianglesTransformBuffer(std::move(transform_buffer));
+    cube_geometry.SetFlags(VK_GEOMETRY_OPAQUE_BIT_KHR);
+
+    return cube_geometry;
 }
 
 GeometryKHR GeometrySimpleOnDeviceAABBInfo(const vkt::Device &device) {
@@ -1016,7 +1096,12 @@ GeometryKHR GeometrySimpleDeviceInstance(const vkt::Device &device, VkAccelerati
     GeometryKHR instance_geometry;
 
     instance_geometry.SetType(GeometryKHR::Type::Instance);
-    instance_geometry.AddInstanceDeviceAccelStructRef(device, device_blas);
+    VkAccelerationStructureInstanceKHR instance{};
+    instance.transform.matrix[0][0] = 1.0f;
+    instance.transform.matrix[1][1] = 1.0f;
+    instance.transform.matrix[2][2] = 1.0f;
+    instance.mask = 0xff;
+    instance_geometry.AddInstanceDeviceAccelStructRef(device, device_blas, instance);
 
     return instance_geometry;
 }
@@ -1074,6 +1159,26 @@ std::shared_ptr<AccelerationStructureKHR> AccelStructSimpleOnDeviceTopLevel(cons
 
 BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Device &device,
                                                                 GeometryKHR::Type geometry_type /*= GeometryKHR::Type::Triangle*/) {
+    // Set geometry
+    GeometryKHR geometry;
+    switch (geometry_type) {
+        case GeometryKHR::Type::Triangle:
+            geometry = GeometrySimpleOnDeviceTriangleInfo(device);
+            break;
+        case GeometryKHR::Type::AABB:
+            geometry = GeometrySimpleOnDeviceAABBInfo(device);
+            break;
+        case GeometryKHR::Type::Instance:
+            [[fallthrough]];
+        case GeometryKHR::Type::_INTERNAL_UNSPECIFIED:
+            assert(false);
+            break;
+    }
+
+    return BuildGeometryInfoOnDeviceBottomLevel(device, std::move(geometry));
+}
+
+BuildGeometryInfoKHR BuildGeometryInfoOnDeviceBottomLevel(const vkt::Device &device, GeometryKHR &&geometry) {
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_BOTTOM_LEVEL_KHR);
@@ -1082,19 +1187,7 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceBottomLevel(const vkt::Devic
 
     // Set geometry
     std::vector<GeometryKHR> geometries;
-    switch (geometry_type) {
-        case GeometryKHR::Type::Triangle:
-            geometries.emplace_back(GeometrySimpleOnDeviceTriangleInfo(device));
-            break;
-        case GeometryKHR::Type::AABB:
-            geometries.emplace_back(GeometrySimpleOnDeviceAABBInfo(device));
-            break;
-        case GeometryKHR::Type::Instance:
-            [[fallthrough]];
-        case GeometryKHR::Type::_INTERNAL_UNSPECIFIED:
-            assert(false);
-            break;
-    }
+    geometries.emplace_back(std::move(geometry));
     out_build_info.SetGeometries(std::move(geometries));
     out_build_info.SetBuildRanges(out_build_info.GetBuildRangeInfosFromGeometries());
 
@@ -1150,21 +1243,19 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostBottomLevel(const vkt::Device 
     return out_build_info;
 }
 
-BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(
-    const vkt::Device &device, std::shared_ptr<BuildGeometryInfoKHR> on_device_bottom_level_geometry) {
+vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(const vkt::Device &device,
+                                                                      std::shared_ptr<BuildGeometryInfoKHR> on_device_blas) {
+    assert(on_device_blas->GetDstAS()->IsBuilt());
+
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
     out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
-    // Set bottom level acceleration structure
-    assert(on_device_bottom_level_geometry->GetDstAS()->IsBuilt());
-    out_build_info.SetBottomLevelAS(std::move(on_device_bottom_level_geometry));
-
     // Set geometry to one instance pointing to bottom level acceleration structure
     std::vector<GeometryKHR> geometries;
-    geometries.emplace_back(GeometrySimpleDeviceInstance(device, out_build_info.GetBottomLevelAS()->GetDstAS()->handle()));
+    geometries.emplace_back(GeometrySimpleDeviceInstance(device, on_device_blas->GetDstAS()->handle()));
     out_build_info.SetGeometries(std::move(geometries));
     out_build_info.SetBuildRanges(out_build_info.GetBuildRangeInfosFromGeometries());
 
@@ -1183,21 +1274,19 @@ BuildGeometryInfoKHR BuildGeometryInfoSimpleOnDeviceTopLevel(
     return out_build_info;
 }
 
-BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &device,
-                                                           std::shared_ptr<BuildGeometryInfoKHR> on_host_bottom_level_geometry) {
+vkt::as::BuildGeometryInfoKHR BuildGeometryInfoSimpleOnHostTopLevel(const vkt::Device &device,
+                                                                    std::shared_ptr<BuildGeometryInfoKHR> on_host_blas) {
+    assert(on_host_blas->GetDstAS()->IsBuilt());
+
     BuildGeometryInfoKHR out_build_info(&device);
 
     out_build_info.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
     out_build_info.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_HOST_KHR);
     out_build_info.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
 
-    // Set bottom level acceleration structure
-    assert(on_host_bottom_level_geometry->GetDstAS()->IsBuilt());
-    out_build_info.SetBottomLevelAS(std::move(on_host_bottom_level_geometry));
-
     // Set geometry to one instance pointing to bottom level acceleration structure
     std::vector<GeometryKHR> geometries;
-    geometries.emplace_back(GeometrySimpleHostInstance(out_build_info.GetBottomLevelAS()->GetDstAS()->handle()));
+    geometries.emplace_back(GeometrySimpleHostInstance(on_host_blas->GetDstAS()->handle()));
     out_build_info.SetGeometries(std::move(geometries));
     out_build_info.SetBuildRanges(out_build_info.GetBuildRangeInfosFromGeometries());
 
@@ -1281,12 +1370,12 @@ void Pipeline::CreateDescriptorSet() { desc_set_ = std::make_unique<OneOffDescri
 void Pipeline::SetPushConstantRangeSize(uint32_t byte_size) { push_constant_range_size_ = byte_size; }
 
 void Pipeline::SetGlslRayGenShader(const char *glsl) {
-    ray_gen_ = std::make_unique<VkShaderObj>(&test_, glsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2);
+    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, glsl, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2));
 }
 
-void Pipeline::SetSpirvRayGenShader(const char *spirv, const char *entry_point) {
-    ray_gen_ = std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2, SPV_SOURCE_ASM,
-                                             nullptr, entry_point);
+void Pipeline::AddSpirvRayGenShader(const char *spirv, const char *entry_point) {
+    ray_gen_shaders_.emplace_back(std::make_unique<VkShaderObj>(&test_, spirv, VK_SHADER_STAGE_RAYGEN_BIT_KHR, SPV_ENV_VULKAN_1_2,
+                                                                SPV_SOURCE_ASM, nullptr, entry_point));
 }
 
 void Pipeline::AddGlslMissShader(const char *glsl) {
@@ -1345,13 +1434,19 @@ void Pipeline::BuildPipeline() {
     }
 
     // Assemble shaders information (stages and groups)
+    // ----
+    // ---------
+    // DO NOT DARE CHANGE THE ORDER IN WHICH SHADERS ARE ADDED,
+    // OR BE READY TO REDO SBT CREATION LOGIC
+    // ---------
+    // ----
     std::vector<VkPipelineShaderStageCreateInfo> pipeline_stage_cis;
     assert(shader_group_cis_.empty());  // For now this list is expected to be empty at this point
-    if (ray_gen_) {
+    for (const auto &ray_gen_shader : ray_gen_shaders_) {
         VkPipelineShaderStageCreateInfo raygen_stage_ci = vku::InitStructHelper();
         raygen_stage_ci.stage = VK_SHADER_STAGE_RAYGEN_BIT_KHR;
-        raygen_stage_ci.module = *ray_gen_;
-        raygen_stage_ci.pName = ray_gen_->GetStageCreateInfo().pName;
+        raygen_stage_ci.module = ray_gen_shader->handle();
+        raygen_stage_ci.pName = ray_gen_shader->GetStageCreateInfo().pName;
         pipeline_stage_cis.emplace_back(raygen_stage_ci);
 
         VkRayTracingShaderGroupCreateInfoKHR raygen_group_ci = vku::InitStructHelper();
@@ -1362,11 +1457,11 @@ void Pipeline::BuildPipeline() {
         raygen_group_ci.intersectionShader = VK_SHADER_UNUSED_KHR;
         shader_group_cis_.emplace_back(raygen_group_ci);
     }
-    for (const auto [miss_shader_i, miss_shader] : vvl::enumerate(miss_shaders_)) {
+    for (const auto &miss_shader : miss_shaders_) {
         VkPipelineShaderStageCreateInfo miss_stage_ci = vku::InitStructHelper();
         miss_stage_ci.stage = VK_SHADER_STAGE_MISS_BIT_KHR;
-        miss_stage_ci.module = *miss_shader->get();
-        miss_stage_ci.pName = (*miss_shader)->GetStageCreateInfo().pName;
+        miss_stage_ci.module = miss_shader->handle();
+        miss_stage_ci.pName = miss_shader->GetStageCreateInfo().pName;
         pipeline_stage_cis.emplace_back(miss_stage_ci);
 
         VkRayTracingShaderGroupCreateInfoKHR miss_group_ci = vku::InitStructHelper();
@@ -1377,11 +1472,11 @@ void Pipeline::BuildPipeline() {
         miss_group_ci.intersectionShader = VK_SHADER_UNUSED_KHR;
         shader_group_cis_.emplace_back(miss_group_ci);
     }
-    for (const auto [closest_hit_i, closest_hit] : vvl::enumerate(closest_hit_shaders_)) {
+    for (const auto &closest_hit : closest_hit_shaders_) {
         VkPipelineShaderStageCreateInfo closest_hit_stage_ci = vku::InitStructHelper();
         closest_hit_stage_ci.stage = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR;
-        closest_hit_stage_ci.module = *closest_hit->get();
-        closest_hit_stage_ci.pName = (*closest_hit)->GetStageCreateInfo().pName;
+        closest_hit_stage_ci.module = closest_hit->handle();
+        closest_hit_stage_ci.pName = closest_hit->GetStageCreateInfo().pName;
         pipeline_stage_cis.emplace_back(closest_hit_stage_ci);
 
         VkRayTracingShaderGroupCreateInfoKHR closest_hit_group_ci = vku::InitStructHelper();
@@ -1427,14 +1522,34 @@ void Pipeline::BuildPipeline() {
 }
 
 void Pipeline::BuildSbt() {
+    // As of now, no function support if not using any ray generation shader
+    assert(!ray_gen_shaders_.empty());
+
     std::vector<uint8_t> sbt_host_storage = GetRayTracingShaderGroupHandles();
 
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     test_.GetPhysicalDeviceProperties2(rt_pipeline_props);
+    const uint32_t handle_size_aligned =
+        Align(rt_pipeline_props.shaderGroupHandleSize, rt_pipeline_props.shaderGroupHandleAlignment);
+
+    // Since every ray generation entry in the ray tracing shader headers buffer can be the start of the ray gen SBT,
+    // they all have to be aligned to shaderGroupBaseAlignment
+    const VkDeviceSize ray_gen_shaders_sbt_entry_byte_size = ray_gen_shaders_.size() * rt_pipeline_props.shaderGroupBaseAlignment;
+    // For miss and closest hit shaders, we consider that the corresponding SBTs always start at the first miss/closest hit entry
+    // => only it needs to be aligned to shaderGroupBaseAlignment,
+    // and within miss/closes hit entries alignment is shaderGroupHandleAlignment
+    const VkDeviceSize miss_shaders_sbt_entry_byte_size = miss_shaders_.size() * handle_size_aligned;
+    const VkDeviceSize closest_hit_shaders_sbt_entry_byte_size = miss_shaders_.size() * handle_size_aligned;
+    VkDeviceSize sbt_buffer_size = ray_gen_shaders_sbt_entry_byte_size;
+    sbt_buffer_size = Align<VkDeviceSize>(sbt_buffer_size, rt_pipeline_props.shaderGroupBaseAlignment);
+    sbt_buffer_size += miss_shaders_sbt_entry_byte_size;
+    sbt_buffer_size = Align<VkDeviceSize>(sbt_buffer_size, rt_pipeline_props.shaderGroupBaseAlignment);
+    sbt_buffer_size += closest_hit_shaders_sbt_entry_byte_size;
 
     // Allocate buffer to store SBT, and fill it with sbt_host_storage
     VkBufferCreateInfo sbt_buffer_info = vku::InitStructHelper();
-    sbt_buffer_info.size = Align<VkDeviceSize>(sbt_host_storage.size() + 2 * rt_pipeline_props.shaderGroupBaseAlignment, 4096);
+
+    sbt_buffer_info.size = sbt_buffer_size;
     sbt_buffer_info.usage =
         VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT | VK_BUFFER_USAGE_SHADER_BINDING_TABLE_BIT_KHR | VK_BUFFER_USAGE_TRANSFER_SRC_BIT;
     VkMemoryPropertyFlags sbt_buffer_mem_props = VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT;
@@ -1446,55 +1561,189 @@ void Pipeline::BuildSbt() {
     std::cout << "SBT buffer fill:\n";
 #endif
 
-    void *const sbt_buffer_base_ptr = sbt_buffer_.Memory().Map();
+    void *const sbt_buffer_base_ptr = sbt_buffer_.memory().map();
     void *sbt_buffer_ptr = sbt_buffer_base_ptr;
     (void)sbt_buffer_base_ptr;
     size_t sbt_buffer_space_left = static_cast<size_t>(sbt_buffer_info.size);
     uint8_t *sbt_host_storage_ptr = sbt_host_storage.data();
 
-    const uint32_t handle_size_aligned =
-        Align(rt_pipeline_props.shaderGroupHandleSize, rt_pipeline_props.shaderGroupHandleAlignment);
+    // Fill Ray Generation shaders headers
+    // ---
+    {
+        void *ray_gen_sbt = nullptr;
+        for (size_t ray_gen_i = 0; ray_gen_i < ray_gen_shaders_.size(); ++ray_gen_i) {
+            if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
+                            sbt_buffer_space_left)) {
+                assert(false);
+                return;
+            }
+            if (!ray_gen_sbt) ray_gen_sbt = sbt_buffer_ptr;
+            std::memcpy(sbt_buffer_ptr, sbt_host_storage_ptr, rt_pipeline_props.shaderGroupHandleSize);
+            sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+            sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
 
-    // Fill SBT with ray gen shader
-    void *ray_gen_sbt = sbt_buffer_ptr;
-    std::memcpy(ray_gen_sbt, sbt_host_storage_ptr, handle_size_aligned);
+            sbt_host_storage_ptr += rt_pipeline_props.shaderGroupHandleSize;
+        }
+        (void)ray_gen_sbt;
+
 #ifdef VVL_DEBUG_LOG_SBT
-    std::cout << "Ray Gen SBT entry: offset = 0 | size = " << handle_size_aligned << '\n';
-#endif
-    sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + handle_size_aligned;
-    sbt_buffer_space_left -= handle_size_aligned;
-    sbt_host_storage_ptr += rt_pipeline_props.shaderGroupHandleSize;
+        {
+            std::cout << "Ray Gen SBT entry: offset = 0 | size = " << ray_gen_shaders_sbt_entry_byte_size << '\n';
+            const uint32_t break_every = rt_pipeline_props.shaderGroupHandleSize;
+            const auto original_fmt_flags = std::cout.flags();
+            std::cout << "Ray Gen shader handles:\n";
+            size_t line_i = 0;
+            for (size_t byte_i = 0;
+                 byte_i < ray_gen_shaders_.size() * Align<VkDeviceSize>(rt_pipeline_props.shaderGroupHandleSize,
+                                                                        rt_pipeline_props.shaderGroupBaseAlignment);
+                 ++byte_i) {
+                if (byte_i > 0 && (byte_i % break_every == 0)) {
+                    std::cout << std::endl;
+                }
+                if (byte_i % break_every == 0) {
+                    std::cout << std::setw(4) << (break_every * line_i + ((uint64_t)ray_gen_sbt - (uint64_t)sbt_buffer_base_ptr))
+                              << ": ";
+                    ++line_i;
+                }
 
-    // Fill SBT with miss shaders
-    if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, miss_shaders_.size() * handle_size_aligned, sbt_buffer_ptr,
+                uint32_t byte = ((uint8_t *)ray_gen_sbt)[byte_i];
+                std::cout << std::hex;
+                if (byte == 0)
+                    std::cout << "-- ";
+                else {
+                    std::cout << std::setw(2);
+                    std::cout << byte;
+                    std::cout << " ";
+                }
+                std::cout << std::dec;
+            }
+            std::cout.flags(original_fmt_flags);
+            std::cout << std::endl;
+        }
+#endif
+    }
+
+    // Fill Miss shaders headers
+    // ---
+
+    {
+        if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
+                        sbt_buffer_space_left)) {
+            assert(false);
+            return;
+        }
+
+        void *miss_sbt = nullptr;
+        for (size_t miss_i = 0; miss_i < miss_shaders_.size(); ++miss_i) {
+            if (!std::align(rt_pipeline_props.shaderGroupHandleAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
+                            sbt_buffer_space_left)) {
+                assert(false);
+                return;
+            }
+            if (!miss_sbt) miss_sbt = sbt_buffer_ptr;
+
+            std::memcpy(sbt_buffer_ptr, sbt_host_storage_ptr, rt_pipeline_props.shaderGroupHandleSize);
+            sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+            sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
+
+            sbt_host_storage_ptr += rt_pipeline_props.shaderGroupHandleSize;
+        }
+        (void)miss_sbt;
+
+#ifdef VVL_DEBUG_LOG_SBT
+        {
+            std::cout << "Miss shaders SBT entry: offset = " << ((uint64_t)miss_sbt - (uint64_t)sbt_buffer_base_ptr)
+                      << " | size = " << miss_shaders_sbt_entry_byte_size << '\n';
+            const uint32_t break_every = rt_pipeline_props.shaderGroupHandleSize;
+            const auto original_fmt_flags = std::cout.flags();
+            std::cout << "Miss shader handles:\n";
+            size_t line_i = 0;
+            for (size_t byte_i = 0; byte_i < miss_shaders_.size() * handle_size_aligned; ++byte_i) {
+                if (byte_i > 0 && (byte_i % break_every == 0)) {
+                    std::cout << std::endl;
+                }
+                if (byte_i % break_every == 0) {
+                    std::cout << std::setw(4) << (break_every * line_i + ((uint64_t)miss_sbt - (uint64_t)sbt_buffer_base_ptr))
+                              << ": ";
+                    ++line_i;
+                }
+
+                uint32_t byte = ((uint8_t *)miss_sbt)[byte_i];
+                std::cout << std::hex;
+                if (byte == 0)
+                    std::cout << "-- ";
+                else {
+                    std::cout << std::setw(2);
+                    std::cout << byte;
+                    std::cout << " ";
+                }
+                std::cout << std::dec;
+            }
+            std::cout.flags(original_fmt_flags);
+            std::cout << std::endl;
+        }
+#endif
+    }
+
+    // Fill Closest Hit shaders headers
+    // ---
+
+    if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
                     sbt_buffer_space_left)) {
         assert(false);
-    }
-    void *miss_shaders_sbt = sbt_buffer_ptr;
-    std::memcpy(miss_shaders_sbt, sbt_host_storage.data() + handle_size_aligned, miss_shaders_.size() * handle_size_aligned);
-#ifdef VVL_DEBUG_LOG_SBT
-    std::cout << "Miss shaders SBT entry: offset = " << ((uint64_t)miss_shaders_sbt - (uint64_t)sbt_buffer_base_ptr)
-              << " | size = " << (miss_shaders_.size() * handle_size_aligned) << '\n';
-#endif
-    sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + miss_shaders_.size() * handle_size_aligned;
-    sbt_buffer_space_left -= miss_shaders_.size() * handle_size_aligned;
-    sbt_host_storage_ptr += miss_shaders_.size() * rt_pipeline_props.shaderGroupHandleSize;
-
-    // Fill SBT with closest hit shaders
-    if (!std::align(rt_pipeline_props.shaderGroupBaseAlignment, closest_hit_shaders_.size() * handle_size_aligned, sbt_buffer_ptr,
-                    sbt_buffer_space_left)) {
-        assert(false);
+        return;
     }
 
-    void *closest_hit_shaders_sbt = sbt_buffer_ptr;
-    std::memcpy(closest_hit_shaders_sbt, sbt_host_storage_ptr, closest_hit_shaders_.size() * handle_size_aligned);
+    void *closest_hit_sbt = nullptr;
+    for (size_t closest_hit_i = 0; closest_hit_i < closest_hit_shaders_.size(); ++closest_hit_i) {
+        if (!std::align(rt_pipeline_props.shaderGroupHandleAlignment, rt_pipeline_props.shaderGroupHandleSize, sbt_buffer_ptr,
+                        sbt_buffer_space_left)) {
+            assert(false);
+            return;
+        }
+        if (!closest_hit_sbt) closest_hit_sbt = sbt_buffer_ptr;
+
+        std::memcpy(sbt_buffer_ptr, sbt_host_storage_ptr, rt_pipeline_props.shaderGroupHandleSize);
+        sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + rt_pipeline_props.shaderGroupHandleSize;
+        sbt_buffer_space_left -= rt_pipeline_props.shaderGroupHandleSize;
+
+        sbt_host_storage_ptr += rt_pipeline_props.shaderGroupHandleSize;
+    }
+    (void)closest_hit_sbt;
+
 #ifdef VVL_DEBUG_LOG_SBT
-    std::cout << "Closest hit shaders SBT entry: offset = " << ((uint64_t)closest_hit_shaders_sbt - (uint64_t)sbt_buffer_base_ptr)
-              << " | size = " << (closest_hit_shaders_.size() * handle_size_aligned) << '\n';
+    {
+        std::cout << "Closest hit shaders SBT entry: offset = " << ((uint64_t)closest_hit_sbt - (uint64_t)sbt_buffer_base_ptr)
+                  << " | size = " << closest_hit_shaders_sbt_entry_byte_size << '\n';
+        const uint32_t break_every = rt_pipeline_props.shaderGroupHandleSize;
+        const auto original_fmt_flags = std::cout.flags();
+        std::cout << "Closest hit shader handles:\n";
+        size_t line_i = 0;
+        for (size_t byte_i = 0; byte_i < closest_hit_shaders_.size() * handle_size_aligned; ++byte_i) {
+            if (byte_i > 0 && (byte_i % break_every == 0)) {
+                std::cout << std::endl;
+            }
+            if (byte_i % break_every == 0) {
+                std::cout << std::setw(4) << (break_every * line_i + ((uint64_t)closest_hit_sbt - (uint64_t)sbt_buffer_base_ptr))
+                          << ": ";
+                ++line_i;
+            }
+
+            uint32_t byte = ((uint8_t *)closest_hit_sbt)[byte_i];
+            std::cout << std::hex;
+            if (byte == 0)
+                std::cout << "-- ";
+            else {
+                std::cout << std::setw(2);
+                std::cout << byte;
+                std::cout << " ";
+            }
+            std::cout << std::dec;
+        }
+        std::cout.flags(original_fmt_flags);
+        std::cout << std::endl;
+    }
 #endif
-    sbt_buffer_ptr = (uint8_t *)sbt_buffer_ptr + closest_hit_shaders_.size() * handle_size_aligned;
-    sbt_buffer_space_left -= closest_hit_shaders_.size() * handle_size_aligned;
-    sbt_host_storage_ptr += closest_hit_shaders_.size() * rt_pipeline_props.shaderGroupHandleSize;
 
     sbt_buffer_.Memory().Unmap();
 }
@@ -1508,15 +1757,20 @@ void Pipeline::DeferBuild() {
     }
 }
 
-vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt() {
+vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt(uint32_t ray_gen_shader_i /*= 0*/) {
+    // As of now, no function support if not using any ray generation shader
+    assert(!ray_gen_shaders_.empty());
+
     VkPhysicalDeviceRayTracingPipelinePropertiesKHR rt_pipeline_props = vku::InitStructHelper();
     VkPhysicalDeviceProperties2 props2 = vku::InitStructHelper(&rt_pipeline_props);
     vk::GetPhysicalDeviceProperties2(device_->Physical(), &props2);
 
+    const uint32_t handle_size_base_aligned =
+        Align(rt_pipeline_props.shaderGroupHandleSize, rt_pipeline_props.shaderGroupBaseAlignment);
     const uint32_t handle_size_aligned =
         Align(rt_pipeline_props.shaderGroupHandleSize, rt_pipeline_props.shaderGroupHandleAlignment);
 
-    const VkDeviceAddress sbt_base_address = sbt_buffer_.Address();
+    const VkDeviceAddress sbt_base_address = sbt_buffer_.address();
     VkDeviceAddress sbt_address = sbt_base_address;
 
     assert(sbt_address == Align<VkDeviceAddress>(sbt_address, rt_pipeline_props.shaderGroupBaseAlignment));
@@ -1525,11 +1779,12 @@ vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt() {
     std::cout << "SBT Buffer get:\n";
 #endif
 
+    // Can only have one ray generation shader
     VkStridedDeviceAddressRegionKHR ray_gen_sbt{};
-    ray_gen_sbt.deviceAddress = sbt_address;
-    ray_gen_sbt.stride = handle_size_aligned;
-    ray_gen_sbt.size = handle_size_aligned;
-    sbt_address += ray_gen_sbt.size;
+    ray_gen_sbt.deviceAddress = sbt_address + ray_gen_shader_i * handle_size_base_aligned;
+    ray_gen_sbt.stride = handle_size_base_aligned;
+    ray_gen_sbt.size = handle_size_base_aligned;
+    sbt_address += ray_gen_shaders_.size() * handle_size_base_aligned;
 #ifdef VVL_DEBUG_LOG_SBT
     std::cout << "Ray Gen SBT entry: @ = " << ray_gen_sbt.deviceAddress
               << " (offset from base = " << ray_gen_sbt.deviceAddress - sbt_base_address << ") | stride = " << ray_gen_sbt.stride
@@ -1576,7 +1831,7 @@ vkt::rt::TraceRaysSbt Pipeline::GetTraceRaysSbt() {
 
 uint32_t Pipeline::GetShaderGroupsCount() {
     uint32_t shader_groups_count = 0;
-    if (ray_gen_) ++shader_groups_count;
+    shader_groups_count += size32(ray_gen_shaders_);
     shader_groups_count += size32(miss_shaders_);
     shader_groups_count += size32(closest_hit_shaders_);
     return shader_groups_count;
@@ -1598,6 +1853,50 @@ std::vector<uint8_t> Pipeline::GetRayTracingShaderGroupHandles() {
     if (IsValueIn(result, {VK_ERROR_OUT_OF_HOST_MEMORY, VK_ERROR_OUT_OF_DEVICE_MEMORY})) {
         assert(false);
     }
+
+#ifdef VVL_DEBUG_LOG_SBT
+    const uint32_t break_every = rt_pipeline_props.shaderGroupHandleSize;
+    const size_t ray_gen_entries_offset = 0;
+    const size_t miss_shaders_offset = ray_gen_shaders_.size();
+    const size_t closest_hit_shaders_offset = ray_gen_shaders_.size() + miss_shaders_.size();
+
+    std::cout << "SBT entries obtained from driver:\n";
+    const auto original_fmt_flags = std::cout.flags();
+    {
+        size_t line_i = 0;
+        for (size_t i = 0; i < sbt_host_storage.size(); ++i) {
+            if (i > 0 && (i % break_every == 0)) {
+                std::cout << std::endl;
+            }
+            if (i % break_every == 0) {
+                if (line_i == ray_gen_entries_offset) {
+                    std::cout << "Ray Gen shader handles:\n";
+                } else if (line_i == miss_shaders_offset) {
+                    std::cout << "Miss shader handles:\n";
+                } else if (line_i == closest_hit_shaders_offset) {
+                    std::cout << "Closes hit shader handles:\n";
+                }
+                std::cout << std::setw(4) << line_i * break_every << ": ";
+                ++line_i;
+            }
+
+            uint32_t byte = sbt_host_storage[i];
+            std::cout << std::hex;
+            if (byte == 0)
+                std::cout << "-- ";
+            else {
+                std::cout << std::setw(2);
+                std::cout << byte;
+                std::cout << " ";
+            }
+            std::cout << std::dec;
+        }
+    }
+    std::cout.flags(original_fmt_flags);
+    std::cout << "\n\n";
+
+#endif  // VVL_DEBUG_LOG_SBT
+
     return sbt_host_storage;
 }
 

--- a/tests/framework/ray_tracing_objects.h
+++ b/tests/framework/ray_tracing_objects.h
@@ -109,7 +109,7 @@ class GeometryKHR {
       private:
         VkAccelerationStructureGeometryKHR vk_obj_;
         Type type_ = Type::_INTERNAL_UNSPECIFIED;
-        uint32_t primitiveCount_ = 0;
+        uint32_t primitive_count_ = 0;
         Triangles triangles_;
         AABBs aabbs_;
         Instances instances_;
@@ -342,6 +342,7 @@ class Pipeline {
         return *desc_set_;
     }
     TraceRaysSbt GetTraceRaysSbt(uint32_t ray_gen_shader_i = 0);
+    vkt::Buffer GetTraceRaysSbtIndirectBuffer(uint32_t ray_gen_shader_i, uint32_t width, uint32_t height, uint32_t depth);
     uint32_t GetShaderGroupsCount();
     std::vector<uint8_t> GetRayTracingShaderGroupHandles();
     std::vector<uint8_t> GetRayTracingCaptureReplayShaderGroupHandles();

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -41,7 +41,7 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
         #extension GL_EXT_debug_printf : enable
         layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
         layout(location = 0) rayPayloadEXT vec3 hit;
-
+       
         void main() {
             debugPrintfEXT("In Raygen\n");
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
@@ -60,14 +60,14 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
 
     pipeline.Build();
 
-    m_command_buffer.Begin();
+    m_command_buffer.begin();
     vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
                               &pipeline.GetDescriptorSet().set_, 0, nullptr);
     vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
     vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
     vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
                         &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.End();
+    m_command_buffer.end();
     m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "In Raygen");
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
@@ -75,7 +75,7 @@ TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
 }
 
 TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
-    TEST_DESCRIPTION("Test debug printf in raygen shader.");
+    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders.");
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::rayTracingPipeline);
@@ -92,18 +92,18 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
 
     // Build Bottom Level Acceleration Structure
-    m_command_buffer.Begin();
+    m_command_buffer.begin();
     blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.End();
+    m_command_buffer.end();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
     // Build Top Level Acceleration Structure
     vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.Begin();
+    m_command_buffer.begin();
     tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.End();
+    m_command_buffer.end();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
@@ -111,9 +111,9 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     // Buffer used to count invocations for the 3 shader types
     vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
                              VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    m_command_buffer.Begin();
+    m_command_buffer.begin();
     vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.End();
+    m_command_buffer.end();
     m_default_queue->Submit(m_command_buffer);
     m_default_queue->Wait();
 
@@ -130,7 +130,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         };
 
         layout(location = 0) rayPayloadEXT vec3 hit;
-
+       
         void main() {
             debugPrintfEXT("In Raygen\n");
             atomicAdd(debug_buffer[0], 1);
@@ -138,21 +138,21 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
             vec3 ray_origin = vec3(0,0,-50);
             vec3 ray_direction = vec3(0,0,1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-
+            
             // Will miss
             ray_origin = vec3(0,0,-50);
             ray_direction = vec3(0,0,-1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-
+            
             // Will miss
             ray_origin = vec3(0,0,50);
             ray_direction = vec3(0,0,1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-
+            
             ray_origin = vec3(0,0,50);
             ray_direction = vec3(0,0,-1);
             traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-
+            
             // Will miss
             ray_origin = vec3(0,0,0);
             ray_direction = vec3(0,0,1);
@@ -214,9 +214,9 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
 
     pipeline.Build();
 
-    uint32_t frames_count = 250;
+    uint32_t frames_count = 100;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.Begin();
+        m_command_buffer.begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
                                   0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
         vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
@@ -225,7 +225,7 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
         vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
                             &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
 
-        m_command_buffer.End();
+        m_command_buffer.end();
         m_errorMonitor->SetDesiredInfo("In Raygen");
         m_errorMonitor->SetDesiredInfo("In Miss", 3);
         m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
@@ -234,9 +234,985 @@ TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
     }
     m_errorMonitor->VerifyFound();
 
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.Memory().Map());
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
     ASSERT_EQ(debug_buffer_ptr[0], frames_count);
     ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
     ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
-    debug_buffer.Memory().Unmap();
+    debug_buffer.memory().unmap();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
+    TEST_DESCRIPTION(
+        "Test debug printf in a multi entry points shader. 1 ray generation shader, 1 miss shader, 1 closest hit shader");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+
+    RETURN_IF_SKIP(InitState());
+
+    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
+    // implicitly depends on the default triangle position.
+    auto blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.begin();
+    blas->BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
+    m_command_buffer.begin();
+    tlas.BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Buffer used to count invocations for the 3 shader types
+    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    m_command_buffer.begin();
+    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
+    m_command_buffer.end();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    // slang shader. Compiled with:
+    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
+    /*
+[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+
+struct RayPayload {
+    float3 hit;
+};
+
+[shader("raygeneration")]
+void rayGenShader()
+{
+    printf("In Raygen");
+    InterlockedAdd(debug_buffer[0], 1);
+    RayPayload ray_payload = { float3(0) };
+    RayDesc ray;
+    ray.TMin = 0.01;
+    ray.TMax = 1000.0;
+
+    // Will hit
+    ray.Origin = float3(0,0,-50);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,-50);
+    ray.Direction = float3(0,0,-1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,50);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,50);
+    ray.Direction = float3(0,0,-1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+}
+
+[shader("miss")]
+void missShader(inout RayPayload payload)
+{
+    printf("In Miss");
+    InterlockedAdd(debug_buffer[1], 1);
+    payload.hit = float3(0.1, 0.2, 0.3);
+}
+
+[shader("closesthit")]
+void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+{
+    printf("In Closest Hit");
+    InterlockedAdd(debug_buffer[2], 1);
+    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+attr.barycentrics.y); payload.hit = barycentric_coords;
+}
+    */
+    const char* ray_tracing_pipeline_spv = R"asm(
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos; 40
+; Bound: 151
+; Schema: 0
+OpCapability RayTracingKHR
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpExtension "SPV_KHR_ray_tracing"
+%11 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %rayGenShader "main" %p %debug_buffer %tlas
+OpEntryPoint MissKHR %missShader "main" %debug_buffer %119
+OpEntryPoint ClosestHitKHR %closestHitShader "main" %debug_buffer %147 %137
+
+; Debug Information
+OpSource Slang 1
+%12 = OpString "In Raygen"
+%115 = OpString "In Miss"
+%131 = OpString "In Closest Hit"
+OpName %RayDesc "RayDesc"                           ; id %5
+OpMemberName %RayDesc 0 "Origin"
+OpMemberName %RayDesc 1 "TMin"
+OpMemberName %RayDesc 2 "Direction"
+OpMemberName %RayDesc 3 "TMax"
+OpName %ray "ray"                                   ; id %9
+OpName %ray "ray"                                   ; id %9
+OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
+OpName %debug_buffer "debug_buffer"                 ; id %21
+OpName %RayPayload "RayPayload"                     ; id %27
+OpMemberName %RayPayload 0 "hit"
+OpName %ray_payload "ray_payload"                   ; id %28
+OpName %p "p"                                       ; id %50
+OpName %tlas "tlas"                                 ; id %59
+OpName %ray_payload_0 "ray_payload"                 ; id %62
+OpName %ray_payload_1 "ray_payload"                 ; id %75
+OpName %ray_payload_2 "ray_payload"                 ; id %88
+OpName %ray_payload_3 "ray_payload"                 ; id %99
+OpName %rayGenShader "rayGenShader"                 ; id %2
+OpName %missShader "missShader"                     ; id %112
+OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %134
+OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
+OpName %barycentric_coords "barycentric_coords"     ; id %146
+OpName %closestHitShader "closestHitShader"         ; id %128
+
+; Annotations
+OpMemberDecorate %RayDesc 0 Offset 0
+OpMemberDecorate %RayDesc 1 Offset 12
+OpMemberDecorate %RayDesc 2 Offset 16
+OpMemberDecorate %RayDesc 3 Offset 28
+OpDecorate %_runtimearr_uint ArrayStride 4
+OpDecorate %RWStructuredBuffer Block
+OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+OpDecorate %debug_buffer Binding 1
+OpDecorate %debug_buffer DescriptorSet 0
+OpMemberDecorate %RayPayload 0 Offset 0
+OpDecorate %p Location 0
+OpDecorate %tlas Binding 0
+OpDecorate %tlas DescriptorSet 0
+OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
+
+; Types, variables and constants
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v3float = OpTypeVector %float 3
+%RayDesc = OpTypeStruct %v3float %float %v3float %float
+%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint = OpTypeInt 32 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%uint_1 = OpConstant %uint 1
+%uint_0 = OpConstant %uint 0
+%float_0 = OpConstant %float 0
+%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%RayPayload = OpTypeStruct %v3float
+%int_1 = OpConstant %int 1
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0_00999999978 = OpConstant %float 0.00999999978
+%int_3 = OpConstant %int 3
+%float_1000 = OpConstant %float 1000
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%float_n50 = OpConstant %float -50
+%40 = OpConstantComposite %v3float %float_0 %float_0 %float_n50
+%int_2 = OpConstant %int 2
+%float_1 = OpConstant %float 1
+%45 = OpConstantComposite %v3float %float_0 %float_0 %float_1
+%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
+%56 = OpTypeAccelerationStructureKHR
+%_ptr_UniformConstant_56 = OpTypePointer UniformConstant %56
+%uint_255 = OpConstant %uint 255
+%float_n1 = OpConstant %float -1
+%64 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
+%float_50 = OpConstant %float 50
+%76 = OpConstantComposite %v3float %float_0 %float_0 %float_50
+%100 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
+%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
+%float_0_100000001 = OpConstant %float 0.100000001
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+%122 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
+%v2float = OpTypeVector %float 2
+%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
+%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
+%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
+%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
+%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
+%tlas = OpVariable %_ptr_UniformConstant_56 UniformConstant                         ; Binding 0, DescriptorSet 0
+%119 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+%137 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
+%147 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+
+; Function rayGenShader
+%rayGenShader = OpFunction %void None %3
+%4 = OpLabel
+%ray = OpVariable %_ptr_Function_RayDesc Function
+%10 = OpExtInst %void %11 1 %12
+%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
+%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
+%ray_payload = OpCompositeConstruct %RayPayload %25
+%31 = OpAccessChain %_ptr_Function_float %ray %int_1
+OpStore %31 %float_0_00999999978
+%35 = OpAccessChain %_ptr_Function_float %ray %int_3
+OpStore %35 %float_1000
+%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
+OpStore %39 %40
+%44 = OpAccessChain %_ptr_Function_v3float %ray %int_2
+OpStore %44 %45
+%48 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload
+%52 = OpCompositeExtract %v3float %48 0
+%53 = OpCompositeExtract %v3float %48 2
+%54 = OpCompositeExtract %float %48 1
+%55 = OpCompositeExtract %float %48 3
+%57 = OpLoad %56 %tlas
+OpTraceRayKHR %57 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %52 %54 %53 %55 %p
+%ray_payload_0 = OpLoad %RayPayload %p
+OpStore %39 %40
+OpStore %44 %64
+%67 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_0
+%69 = OpCompositeExtract %v3float %67 0
+%70 = OpCompositeExtract %v3float %67 2
+%71 = OpCompositeExtract %float %67 1
+%72 = OpCompositeExtract %float %67 3
+%73 = OpLoad %56 %tlas
+OpTraceRayKHR %73 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %69 %71 %70 %72 %p
+%ray_payload_1 = OpLoad %RayPayload %p
+OpStore %39 %76
+OpStore %44 %45
+%80 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_1
+%82 = OpCompositeExtract %v3float %80 0
+%83 = OpCompositeExtract %v3float %80 2
+%84 = OpCompositeExtract %float %80 1
+%85 = OpCompositeExtract %float %80 3
+%86 = OpLoad %56 %tlas
+OpTraceRayKHR %86 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %82 %84 %83 %85 %p
+%ray_payload_2 = OpLoad %RayPayload %p
+OpStore %39 %76
+OpStore %44 %64
+%91 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_2
+%93 = OpCompositeExtract %v3float %91 0
+%94 = OpCompositeExtract %v3float %91 2
+%95 = OpCompositeExtract %float %91 1
+%96 = OpCompositeExtract %float %91 3
+%97 = OpLoad %56 %tlas
+OpTraceRayKHR %97 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %93 %95 %94 %96 %p
+%ray_payload_3 = OpLoad %RayPayload %p
+OpStore %39 %100
+OpStore %44 %45
+%103 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_3
+%105 = OpCompositeExtract %v3float %103 0
+%106 = OpCompositeExtract %v3float %103 2
+%107 = OpCompositeExtract %float %103 1
+%108 = OpCompositeExtract %float %103 3
+%109 = OpLoad %56 %tlas
+OpTraceRayKHR %109 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %105 %107 %106 %108 %p
+OpReturn
+OpFunctionEnd
+
+; Function missShader
+%missShader = OpFunction %void None %3
+%113 = OpLabel
+%114 = OpExtInst %void %11 1 %115
+%116 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
+%117 = OpAtomicIAdd %uint %116 %uint_1 %uint_0 %uint_1
+%121 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %119 %int_0
+OpStore %121 %122
+OpReturn
+OpFunctionEnd
+
+; Function closestHitShader
+%closestHitShader = OpFunction %void None %3
+%129 = OpLabel
+%130 = OpExtInst %void %11 1 %131
+%132 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
+%133 = OpAtomicIAdd %uint %132 %uint_1 %uint_0 %uint_1
+%139 = OpAccessChain %_ptr_HitAttributeKHR_v2float %137 %int_0
+%140 = OpLoad %v2float %139
+%141 = OpCompositeExtract %float %140 0
+%142 = OpFSub %float %float_1 %141
+%143 = OpLoad %v2float %139
+%144 = OpCompositeExtract %float %143 1
+%145 = OpFSub %float %142 %144
+%barycentric_coords = OpCompositeConstruct %v3float %145 %141 %144
+%148 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %147 %int_0
+OpStore %148 %barycentric_coords
+OpReturn
+OpFunctionEnd
+    )asm";
+
+    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "main");
+    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "main");
+    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "main");
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
+                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    uint32_t frames_count = 100;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.begin();
+        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
+                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
+        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
+                            &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
+
+        m_command_buffer.end();
+        m_errorMonitor->SetDesiredInfo("In Raygen");
+        m_errorMonitor->SetDesiredInfo("In Miss", 3);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
+        m_default_queue->Submit(m_command_buffer);
+        m_default_queue->Wait();
+    }
+    m_errorMonitor->VerifyFound();
+
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    ASSERT_EQ(debug_buffer_ptr[0], frames_count);
+    ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
+    debug_buffer.memory().unmap();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2) {
+    TEST_DESCRIPTION(
+        "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders. ");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    // slang shader. Compiled with:
+    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
+    // /!\ /!\ /!\ you need to manually edit the OpEntryPoint in the resulting spir-v to match the slang shader
+    /*
+[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+
+struct RayPayload {
+    float3 hit;
+};
+
+[shader("raygeneration")]
+void rayGenShader()
+{
+    printf("In Raygen 1");
+    InterlockedAdd(debug_buffer[0], 1);
+    RayPayload ray_payload = { float3(0) };
+    RayDesc ray;
+    ray.TMin = 0.01;
+    ray.TMax = 1000.0;
+
+    // Will miss
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,0,-1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will hit cube 1
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(1,0,0);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(-1,0,0);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+}
+
+[shader("raygeneration")]
+void rayGenShader2()
+{
+    printf("In Raygen 2");
+    InterlockedAdd(debug_buffer[1], 1);
+    RayPayload ray_payload = { float3(0) };
+    RayDesc ray;
+    ray.TMin = 0.01;
+    ray.TMax = 1000.0;
+
+    // Will hit cube 1
+    ray.Origin = float3(-50,0,0);
+    ray.Direction = float3(1,0,0);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will hit cube 2
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+}
+
+[shader("miss")]
+void missShader(inout RayPayload payload)
+{
+    printf("In Miss 1");
+    InterlockedAdd(debug_buffer[2], 1);
+    payload.hit = float3(0.1, 0.2, 0.3);
+}
+
+[shader("miss")]
+void missShader2(inout RayPayload payload)
+{
+    printf("In Miss 2");
+    InterlockedAdd(debug_buffer[3], 1);
+    payload.hit = float3(42, 42, 42);
+}
+
+[shader("closesthit")]
+void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+{
+    printf("In Closest Hit 1");
+    InterlockedAdd(debug_buffer[4], 1);
+    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+attr.barycentrics.y); payload.hit = barycentric_coords;
+
+    RayPayload ray_payload = { float3(0) };
+    RayDesc ray;
+
+    ray.TMin = 0.01;
+    ray.TMax = 1000.0;
+    const uint32_t miss_shader_i = 1;
+
+    // Supposed to hit cube 2, and invoke closestHitShader2
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+
+    // Supposed to miss, and call missShader2
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,1,0);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, miss_shader_i, ray, ray_payload);
+}
+
+[shader("closesthit")]
+void closestHitShader2(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+{
+    printf("In Closest Hit 2");
+    InterlockedAdd(debug_buffer[5], 1);
+    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+attr.barycentrics.y); payload.hit = 999 * barycentric_coords;
+}
+    */
+    const char* ray_tracing_pipeline_spv = R"asm(
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos; 40
+; Bound: 236
+; Schema: 0
+OpCapability RayTracingKHR
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpExtension "SPV_KHR_ray_tracing"
+%11 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %rayGenShader "rayGenShader" %p %debug_buffer %tlas
+OpEntryPoint RayGenerationKHR %rayGenShader2 "rayGenShader2" %p %debug_buffer %tlas
+OpEntryPoint MissKHR %missShader "missShader" %debug_buffer %136
+OpEntryPoint MissKHR %missShader2 "missShader2" %debug_buffer %151
+OpEntryPoint ClosestHitKHR %closestHitShader "closestHitShader" %p %debug_buffer %tlas %178 %168
+OpEntryPoint ClosestHitKHR %closestHitShader2 "closestHitShader2" %debug_buffer %230 %221
+
+; Debug Information
+OpSource Slang 1
+%12 = OpString "In Raygen 1"
+%91 = OpString "In Raygen 2"
+%132 = OpString "In Miss 1"
+%148 = OpString "In Miss 2"
+%161 = OpString "In Closest Hit 1"
+%217 = OpString "In Closest Hit 2"
+OpName %RayDesc "RayDesc"                           ; id %5
+OpMemberName %RayDesc 0 "Origin"
+OpMemberName %RayDesc 1 "TMin"
+OpMemberName %RayDesc 2 "Direction"
+OpMemberName %RayDesc 3 "TMax"
+OpName %ray "ray"                                   ; id %9
+OpName %ray "ray"                                   ; id %9
+OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
+OpName %debug_buffer "debug_buffer"                 ; id %21
+OpName %RayPayload "RayPayload"                     ; id %27
+OpMemberName %RayPayload 0 "hit"
+OpName %ray_payload "ray_payload"                   ; id %28
+OpName %p "p"                                       ; id %49
+OpName %tlas "tlas"                                 ; id %58
+OpName %ray_payload_0 "ray_payload"                 ; id %61
+OpName %ray_payload_1 "ray_payload"                 ; id %74
+OpName %rayGenShader "rayGenShader"                 ; id %2
+OpName %ray_0 "ray"                                 ; id %89
+OpName %ray_0 "ray"                                 ; id %89
+OpName %ray_payload_2 "ray_payload"                 ; id %95
+OpName %ray_payload_3 "ray_payload"                 ; id %115
+OpName %rayGenShader2 "rayGenShader2"               ; id %87
+OpName %missShader "missShader"                     ; id %129
+OpName %missShader2 "missShader2"                   ; id %145
+OpName %ray_1 "ray"                                 ; id %159
+OpName %ray_1 "ray"                                 ; id %159
+OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %165
+OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
+OpName %barycentric_coords "barycentric_coords"     ; id %177
+OpName %ray_payload_4 "ray_payload"                 ; id %182
+OpName %ray_payload_5 "ray_payload"                 ; id %201
+OpName %closestHitShader "closestHitShader"         ; id %157
+OpName %barycentric_coords_0 "barycentric_coords"   ; id %229
+OpName %closestHitShader2 "closestHitShader2"       ; id %214
+
+; Annotations
+OpMemberDecorate %RayDesc 0 Offset 0
+OpMemberDecorate %RayDesc 1 Offset 12
+OpMemberDecorate %RayDesc 2 Offset 16
+OpMemberDecorate %RayDesc 3 Offset 28
+OpDecorate %_runtimearr_uint ArrayStride 4
+OpDecorate %RWStructuredBuffer Block
+OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+OpDecorate %debug_buffer Binding 1
+OpDecorate %debug_buffer DescriptorSet 0
+OpMemberDecorate %RayPayload 0 Offset 0
+OpDecorate %p Location 0
+OpDecorate %tlas Binding 0
+OpDecorate %tlas DescriptorSet 0
+OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
+
+; Types, variables and constants
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v3float = OpTypeVector %float 3
+%RayDesc = OpTypeStruct %v3float %float %v3float %float
+%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint = OpTypeInt 32 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%uint_1 = OpConstant %uint 1
+%uint_0 = OpConstant %uint 0
+%float_0 = OpConstant %float 0
+%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%RayPayload = OpTypeStruct %v3float
+%int_1 = OpConstant %int 1
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0_00999999978 = OpConstant %float 0.00999999978
+%int_3 = OpConstant %int 3
+%float_1000 = OpConstant %float 1000
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%40 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%int_2 = OpConstant %int 2
+%float_n1 = OpConstant %float -1
+%44 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
+%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
+%55 = OpTypeAccelerationStructureKHR
+%_ptr_UniformConstant_55 = OpTypePointer UniformConstant %55
+%uint_255 = OpConstant %uint 255
+%float_1 = OpConstant %float 1
+%63 = OpConstantComposite %v3float %float_1 %float_0 %float_0
+%76 = OpConstantComposite %v3float %float_n1 %float_0 %float_0
+%94 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%float_n50 = OpConstant %float -50
+%101 = OpConstantComposite %v3float %float_n50 %float_0 %float_0
+%105 = OpConstantComposite %v3float %float_1 %float_0 %float_0
+%116 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%118 = OpConstantComposite %v3float %float_0 %float_0 %float_1
+%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
+%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
+%float_0_100000001 = OpConstant %float 0.100000001
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+%139 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
+%float_42 = OpConstant %float 42
+%153 = OpConstantComposite %v3float %float_42 %float_42 %float_42
+%int_4 = OpConstant %int 4
+%v2float = OpTypeVector %float 2
+%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
+%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
+%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
+%181 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%188 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%191 = OpConstantComposite %v3float %float_0 %float_0 %float_1
+%203 = OpConstantComposite %v3float %float_0 %float_1 %float_0
+%int_5 = OpConstant %int 5
+%float_999 = OpConstant %float 999
+%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
+%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
+%tlas = OpVariable %_ptr_UniformConstant_55 UniformConstant                         ; Binding 0, DescriptorSet 0
+%136 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+%151 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+%168 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
+%178 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+%221 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
+%230 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+
+; Function rayGenShader
+%rayGenShader = OpFunction %void None %3
+%4 = OpLabel
+%ray = OpVariable %_ptr_Function_RayDesc Function
+%10 = OpExtInst %void %11 1 %12
+%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
+%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
+%ray_payload = OpCompositeConstruct %RayPayload %25
+%31 = OpAccessChain %_ptr_Function_float %ray %int_1
+OpStore %31 %float_0_00999999978
+%35 = OpAccessChain %_ptr_Function_float %ray %int_3
+OpStore %35 %float_1000
+%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
+OpStore %39 %40
+%43 = OpAccessChain %_ptr_Function_v3float %ray %int_2
+OpStore %43 %44
+%47 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload
+%51 = OpCompositeExtract %v3float %47 0
+%52 = OpCompositeExtract %v3float %47 2
+%53 = OpCompositeExtract %float %47 1
+%54 = OpCompositeExtract %float %47 3
+%56 = OpLoad %55 %tlas
+OpTraceRayKHR %56 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %51 %53 %52 %54 %p
+%ray_payload_0 = OpLoad %RayPayload %p
+OpStore %39 %40
+OpStore %43 %63
+%66 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_0
+%68 = OpCompositeExtract %v3float %66 0
+%69 = OpCompositeExtract %v3float %66 2
+%70 = OpCompositeExtract %float %66 1
+%71 = OpCompositeExtract %float %66 3
+%72 = OpLoad %55 %tlas
+OpTraceRayKHR %72 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %68 %70 %69 %71 %p
+%ray_payload_1 = OpLoad %RayPayload %p
+OpStore %39 %40
+OpStore %43 %76
+%78 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_1
+%80 = OpCompositeExtract %v3float %78 0
+%81 = OpCompositeExtract %v3float %78 2
+%82 = OpCompositeExtract %float %78 1
+%83 = OpCompositeExtract %float %78 3
+%84 = OpLoad %55 %tlas
+OpTraceRayKHR %84 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %80 %82 %81 %83 %p
+OpReturn
+OpFunctionEnd
+
+; Function rayGenShader2
+%rayGenShader2 = OpFunction %void None %3
+%88 = OpLabel
+%ray_0 = OpVariable %_ptr_Function_RayDesc Function
+%90 = OpExtInst %void %11 1 %91
+%92 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
+%93 = OpAtomicIAdd %uint %92 %uint_1 %uint_0 %uint_1
+%ray_payload_2 = OpCompositeConstruct %RayPayload %94
+%96 = OpAccessChain %_ptr_Function_float %ray_0 %int_1
+OpStore %96 %float_0_00999999978
+%98 = OpAccessChain %_ptr_Function_float %ray_0 %int_3
+OpStore %98 %float_1000
+%100 = OpAccessChain %_ptr_Function_v3float %ray_0 %int_0
+OpStore %100 %101
+%104 = OpAccessChain %_ptr_Function_v3float %ray_0 %int_2
+OpStore %104 %105
+%107 = OpLoad %RayDesc %ray_0
+OpStore %p %ray_payload_2
+%109 = OpCompositeExtract %v3float %107 0
+%110 = OpCompositeExtract %v3float %107 2
+%111 = OpCompositeExtract %float %107 1
+%112 = OpCompositeExtract %float %107 3
+%113 = OpLoad %55 %tlas
+OpTraceRayKHR %113 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %109 %111 %110 %112 %p
+%ray_payload_3 = OpLoad %RayPayload %p
+OpStore %100 %116
+OpStore %104 %118
+%120 = OpLoad %RayDesc %ray_0
+OpStore %p %ray_payload_3
+%122 = OpCompositeExtract %v3float %120 0
+%123 = OpCompositeExtract %v3float %120 2
+%124 = OpCompositeExtract %float %120 1
+%125 = OpCompositeExtract %float %120 3
+%126 = OpLoad %55 %tlas
+OpTraceRayKHR %126 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %122 %124 %123 %125 %p
+OpReturn
+OpFunctionEnd
+
+; Function missShader
+%missShader = OpFunction %void None %3
+%130 = OpLabel
+%131 = OpExtInst %void %11 1 %132
+%133 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
+%134 = OpAtomicIAdd %uint %133 %uint_1 %uint_0 %uint_1
+%138 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %136 %int_0
+OpStore %138 %139
+OpReturn
+OpFunctionEnd
+
+; Function missShader2
+%missShader2 = OpFunction %void None %3
+%146 = OpLabel
+%147 = OpExtInst %void %11 1 %148
+%149 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_3
+%150 = OpAtomicIAdd %uint %149 %uint_1 %uint_0 %uint_1
+%152 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %151 %int_0
+OpStore %152 %153
+OpReturn
+OpFunctionEnd
+
+; Function closestHitShader
+%closestHitShader = OpFunction %void None %3
+%158 = OpLabel
+%ray_1 = OpVariable %_ptr_Function_RayDesc Function
+%160 = OpExtInst %void %11 1 %161
+%163 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_4
+%164 = OpAtomicIAdd %uint %163 %uint_1 %uint_0 %uint_1
+%170 = OpAccessChain %_ptr_HitAttributeKHR_v2float %168 %int_0
+%171 = OpLoad %v2float %170
+%172 = OpCompositeExtract %float %171 0
+%173 = OpFSub %float %float_1 %172
+%174 = OpLoad %v2float %170
+%175 = OpCompositeExtract %float %174 1
+%176 = OpFSub %float %173 %175
+%barycentric_coords = OpCompositeConstruct %v3float %176 %172 %175
+%179 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %178 %int_0
+OpStore %179 %barycentric_coords
+%ray_payload_4 = OpCompositeConstruct %RayPayload %181
+%183 = OpAccessChain %_ptr_Function_float %ray_1 %int_1
+OpStore %183 %float_0_00999999978
+%185 = OpAccessChain %_ptr_Function_float %ray_1 %int_3
+OpStore %185 %float_1000
+%187 = OpAccessChain %_ptr_Function_v3float %ray_1 %int_0
+OpStore %187 %188
+%190 = OpAccessChain %_ptr_Function_v3float %ray_1 %int_2
+OpStore %190 %191
+%193 = OpLoad %RayDesc %ray_1
+OpStore %p %ray_payload_4
+%195 = OpCompositeExtract %v3float %193 0
+%196 = OpCompositeExtract %v3float %193 2
+%197 = OpCompositeExtract %float %193 1
+%198 = OpCompositeExtract %float %193 3
+%199 = OpLoad %55 %tlas
+OpTraceRayKHR %199 %uint_0 %uint_255 %uint_0 %uint_0 %uint_1 %195 %197 %196 %198 %p
+%ray_payload_5 = OpLoad %RayPayload %p
+OpStore %187 %188
+OpStore %190 %203
+%205 = OpLoad %RayDesc %ray_1
+OpStore %p %ray_payload_5
+%207 = OpCompositeExtract %v3float %205 0
+%208 = OpCompositeExtract %v3float %205 2
+%209 = OpCompositeExtract %float %205 1
+%210 = OpCompositeExtract %float %205 3
+%211 = OpLoad %55 %tlas
+OpTraceRayKHR %211 %uint_0 %uint_255 %uint_0 %uint_0 %uint_1 %207 %209 %208 %210 %p
+OpReturn
+OpFunctionEnd
+
+; Function closestHitShader2
+%closestHitShader2 = OpFunction %void None %3
+%215 = OpLabel
+%216 = OpExtInst %void %11 1 %217
+%219 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_5
+%220 = OpAtomicIAdd %uint %219 %uint_1 %uint_0 %uint_1
+%222 = OpAccessChain %_ptr_HitAttributeKHR_v2float %221 %int_0
+%223 = OpLoad %v2float %222
+%224 = OpCompositeExtract %float %223 0
+%225 = OpFSub %float %float_1 %224
+%226 = OpLoad %v2float %222
+%227 = OpCompositeExtract %float %226 1
+%228 = OpFSub %float %225 %227
+%barycentric_coords_0 = OpCompositeConstruct %v3float %228 %224 %227
+%231 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %230 %int_0
+%232 = OpVectorTimesScalar %v3float %barycentric_coords_0 %float_999
+OpStore %231 %232
+OpReturn
+OpFunctionEnd
+    )asm";
+
+    vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
+    auto cube_blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube)));
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.begin();
+    cube_blas->BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure:
+    // 2 instances of the cube, at different positions
+    // clang-format off
+    /*
+                cube instance 2, translation (x = 0, y = 0, z = 50)
+                +----+
+                |  2 |
+                +----+
+
+                  Z
+                  ^
+                  |              +----+
+                  +---> X        |  1 | cube instance 1, translation (x = 50, y = 0, z = 0)
+                                 +----+
+    */
+    // clang-format on
+    vkt::as::BuildGeometryInfoKHR tlas(m_device);
+
+    tlas.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+    tlas.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
+    tlas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
+
+    std::vector<vkt::as::GeometryKHR> cube_instances(1);
+    cube_instances[0].SetType(vkt::as::GeometryKHR::Type::Instance);
+
+    VkAccelerationStructureInstanceKHR cube_instance_1{};
+    cube_instance_1.transform.matrix[0][0] = 1.0f;
+    cube_instance_1.transform.matrix[1][1] = 1.0f;
+    cube_instance_1.transform.matrix[2][2] = 1.0f;
+    cube_instance_1.transform.matrix[0][3] = 50.0f;
+    cube_instance_1.transform.matrix[1][3] = 0.0f;
+    cube_instance_1.transform.matrix[2][3] = 0.0f;
+    cube_instance_1.mask = 0xff;
+    cube_instance_1.instanceCustomIndex = 0;
+    // Cube instance 1 will be associated to closest hit shader 1
+    cube_instance_1.instanceShaderBindingTableRecordOffset = 0;
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas->GetDstAS()->handle(), cube_instance_1);
+
+    VkAccelerationStructureInstanceKHR cube_instance_2{};
+    cube_instance_2.transform.matrix[0][0] = 1.0f;
+    cube_instance_2.transform.matrix[1][1] = 1.0f;
+    cube_instance_2.transform.matrix[2][2] = 1.0f;
+    cube_instance_2.transform.matrix[0][3] = 0.0f;
+    cube_instance_2.transform.matrix[1][3] = 0.0f;
+    cube_instance_2.transform.matrix[2][3] = 50.0f;
+    cube_instance_2.mask = 0xff;
+    cube_instance_2.instanceCustomIndex = 0;
+    // Cube instance 2 will be associated to closest hit shader 2
+    cube_instance_2.instanceShaderBindingTableRecordOffset = 1;
+    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas->GetDstAS()->handle(), cube_instance_2);
+
+    tlas.SetGeometries(std::move(cube_instances));
+    tlas.SetBuildRanges(tlas.GetBuildRangeInfosFromGeometries());
+
+    // Set source and destination acceleration structures info. Does not create handles, it is done in Build()
+    tlas.SetSrcAS(vkt::as::blueprint::AccelStructNull(*m_device));
+    auto dstAsSize = tlas.GetSizeInfo().accelerationStructureSize;
+    auto dst_as = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, dstAsSize);
+    dst_as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+    tlas.SetDstAS(std::move(dst_as));
+    tlas.SetUpdateDstAccelStructSizeBeforeBuild(true);
+
+    tlas.SetInfoCount(1);
+    tlas.SetNullInfos(false);
+    tlas.SetNullBuildRangeInfos(false);
+
+    m_command_buffer.begin();
+    tlas.BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Buffer used to count invocations for the 2 * 3 shaders
+    vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
+                             VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    m_command_buffer.begin();
+    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
+    m_command_buffer.end();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "rayGenShader");
+    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "rayGenShader2");
+    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "missShader");
+    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "missShader2");
+    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "closestHitShader");
+    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "closestHitShader2");
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
+                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    uint32_t frames_count = 1;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.begin();
+        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
+                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
+        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+
+        // Invoke ray gen shader 1
+        vkt::rt::TraceRaysSbt sbt_ray_gen_1 = pipeline.GetTraceRaysSbt(0);
+        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &sbt_ray_gen_1.ray_gen_sbt, &sbt_ray_gen_1.miss_sbt, &sbt_ray_gen_1.hit_sbt,
+                            &sbt_ray_gen_1.callable_sbt, 1, 1, 1);
+
+        // Invoke ray gen shader 2
+        vkt::rt::TraceRaysSbt sbt_ray_gen_2 = pipeline.GetTraceRaysSbt(1);
+        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &sbt_ray_gen_2.ray_gen_sbt, &sbt_ray_gen_2.miss_sbt, &sbt_ray_gen_2.hit_sbt,
+                            &sbt_ray_gen_2.callable_sbt, 1, 1, 1);
+
+        m_command_buffer.end();
+        m_errorMonitor->SetDesiredInfo("In Raygen 1");
+        m_errorMonitor->SetDesiredInfo("In Raygen 2");
+        m_errorMonitor->SetDesiredInfo("In Miss 1", 2);
+        m_errorMonitor->SetDesiredInfo("In Miss 2", 2);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit 1", 2);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit 2", 3);
+        m_default_queue->Submit(m_command_buffer);
+        m_default_queue->Wait();
+    }
+    m_errorMonitor->VerifyFound();
+
+    // Check debug buffer to cross check that every expected shader invocation happened
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    (void)debug_buffer_ptr;
+    ASSERT_EQ(debug_buffer_ptr[0], 1 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[1], 1 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[2], (2 + 0) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[3], (1 + 1) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[4], (1 + 1) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[5], (1 + 2) * frames_count);
+    debug_buffer.memory().unmap();
 }

--- a/tests/unit/debug_printf_ray_tracing.cpp
+++ b/tests/unit/debug_printf_ray_tracing.cpp
@@ -21,610 +21,99 @@
 #include "../framework/gpu_av_helper.h"
 #include "../framework/ray_tracing_objects.h"
 
-class NegativeDebugPrintfRayTracing : public DebugPrintfTests {};
-
-TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
-    TEST_DESCRIPTION("Test debug printf in raygen shader.");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
-    AddRequiredFeature(vkt::Feature::accelerationStructure);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
-    RETURN_IF_SKIP(InitState());
-
-    vkt::rt::Pipeline pipeline(*this, m_device);
-
-    const char* ray_gen = R"glsl(
-        #version 460
-        #extension GL_EXT_ray_tracing : require
-        #extension GL_EXT_debug_printf : enable
-        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-        layout(location = 0) rayPayloadEXT vec3 hit;
-       
-        void main() {
-            debugPrintfEXT("In Raygen\n");
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
-        }
-    )glsl";
-    pipeline.SetGlslRayGenShader(ray_gen);
-
-    pipeline.AddGlslMissShader(kRayTracingPayloadMinimalGlsl);
-    pipeline.AddGlslClosestHitShader(kRayTracingPayloadMinimalGlsl);
-
-    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
-    pipeline.CreateDescriptorSet();
-    vkt::as::BuildGeometryInfoKHR tlas(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, m_command_buffer));
-    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
-    pipeline.GetDescriptorSet().UpdateDescriptorSets();
-
-    pipeline.Build();
-
-    m_command_buffer.begin();
-    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
-                              &pipeline.GetDescriptorSet().set_, 0, nullptr);
-    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
-    vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
-    vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
-                        &trace_rays_sbt.callable_sbt, 1, 1, 1);
-    m_command_buffer.end();
-    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "In Raygen");
-    m_default_queue->Submit(m_command_buffer);
-    m_default_queue->Wait();
-    m_errorMonitor->VerifyFound();
-}
-
-TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
-    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders.");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
-    AddRequiredFeature(vkt::Feature::accelerationStructure);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
-
-    RETURN_IF_SKIP(InitState());
-
-    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
-    // implicitly depends on the default triangle position.
-    auto blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
-        vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
-
-    // Build Bottom Level Acceleration Structure
-    m_command_buffer.begin();
-    blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
-
-    m_default_queue->Submit(m_command_buffer);
-    m_device->Wait();
-
-    // Build Top Level Acceleration Structure
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.begin();
-    tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
-
-    m_default_queue->Submit(m_command_buffer);
-    m_device->Wait();
-
-    // Buffer used to count invocations for the 3 shader types
-    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    m_command_buffer.begin();
-    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
-    m_default_queue->Submit(m_command_buffer);
-    m_default_queue->Wait();
-
-    vkt::rt::Pipeline pipeline(*this, m_device);
-
-    const char* ray_gen = R"glsl(
-        #version 460
-        #extension GL_EXT_ray_tracing : require
-        #extension GL_EXT_debug_printf : enable
-
-        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-        layout(binding = 1, set = 0) buffer DbgBuffer {
-          uint debug_buffer[];
-        };
-
-        layout(location = 0) rayPayloadEXT vec3 hit;
-       
-        void main() {
-            debugPrintfEXT("In Raygen\n");
-            atomicAdd(debug_buffer[0], 1);
-
-            vec3 ray_origin = vec3(0,0,-50);
-            vec3 ray_direction = vec3(0,0,1);
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
-            // Will miss
-            ray_origin = vec3(0,0,-50);
-            ray_direction = vec3(0,0,-1);
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
-            // Will miss
-            ray_origin = vec3(0,0,50);
-            ray_direction = vec3(0,0,1);
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
-            ray_origin = vec3(0,0,50);
-            ray_direction = vec3(0,0,-1);
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-            
-            // Will miss
-            ray_origin = vec3(0,0,0);
-            ray_direction = vec3(0,0,1);
-            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
-        }
-    )glsl";
-    pipeline.SetGlslRayGenShader(ray_gen);
-
-    const char* miss = R"glsl(
-        #version 460
-        #extension GL_EXT_ray_tracing : require
-        #extension GL_EXT_debug_printf : enable
-
-        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-        layout(binding = 1, set = 0) buffer DbgBuffer {
-          uint debug_buffer[];
-        };
-
-        layout(location = 0) rayPayloadInEXT vec3 hit;
-
-        void main() {
-            debugPrintfEXT("In Miss\n");
-            atomicAdd(debug_buffer[1], 1);
-            hit = vec3(0.1, 0.2, 0.3);
-        }
-    )glsl";
-    pipeline.AddGlslMissShader(miss);
-
-    const char* closest_hit = R"glsl(
-        #version 460
-        #extension GL_EXT_ray_tracing : require
-        #extension GL_EXT_debug_printf : enable
-
-        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
-        layout(binding = 1, set = 0) buffer DbgBuffer {
-          uint debug_buffer[];
-        };
-
-
-        layout(location = 0) rayPayloadInEXT vec3 hit;
-        hitAttributeEXT vec2 baryCoord;
-
-        void main() {
-            debugPrintfEXT("In Closest Hit\n");
-            atomicAdd(debug_buffer[2], 1);
-            const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
-            hit = barycentricCoords;
-        }
-    )glsl";
-    pipeline.AddGlslClosestHitShader(closest_hit);
-
-    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
-    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    pipeline.CreateDescriptorSet();
-    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
-    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
-                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    pipeline.GetDescriptorSet().UpdateDescriptorSets();
-
-    pipeline.Build();
-
-    uint32_t frames_count = 100;
-    for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
-        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
-                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
-        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
-        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
-
-        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
-                            &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
-
-        m_command_buffer.end();
-        m_errorMonitor->SetDesiredInfo("In Raygen");
-        m_errorMonitor->SetDesiredInfo("In Miss", 3);
-        m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
-        m_default_queue->Submit(m_command_buffer);
-        m_default_queue->Wait();
-    }
-    m_errorMonitor->VerifyFound();
-
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
-    ASSERT_EQ(debug_buffer_ptr[0], frames_count);
-    ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
-    ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
-    debug_buffer.memory().unmap();
-}
-
-TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
-    TEST_DESCRIPTION(
-        "Test debug printf in a multi entry points shader. 1 ray generation shader, 1 miss shader, 1 closest hit shader");
-
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
-    AddRequiredFeature(vkt::Feature::accelerationStructure);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
-
-    RETURN_IF_SKIP(InitState());
-
-    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
-    // implicitly depends on the default triangle position.
-    auto blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
-        vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
-
-    // Build Bottom Level Acceleration Structure
-    m_command_buffer.begin();
-    blas->BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
-
-    m_default_queue->Submit(m_command_buffer);
-    m_device->Wait();
-
-    // Build Top Level Acceleration Structure
-    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
-    m_command_buffer.begin();
-    tlas.BuildCmdBuffer(m_command_buffer.handle());
-    m_command_buffer.end();
-
-    m_default_queue->Submit(m_command_buffer);
-    m_device->Wait();
-
-    // Buffer used to count invocations for the 3 shader types
-    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
-    m_command_buffer.begin();
-    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
-    m_command_buffer.end();
-    m_default_queue->Submit(m_command_buffer);
-    m_default_queue->Wait();
-
-    vkt::rt::Pipeline pipeline(*this, m_device);
-
-    // slang shader. Compiled with:
-    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
+class NegativeDebugPrintfRayTracing : public DebugPrintfTests {
+  public:
+    // Build Top Level Acceleration Structure:
+    // 2 instances of the cube, at different positions
+    // clang-format off
     /*
-[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
-[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+        cube instance 2, translation (x = 0, y = 0, z = 50)
+        +----+
+        |  2 |
+        +----+
 
-struct RayPayload {
-    float3 hit;
+           Z
+           ^
+           |            +----+
+           +---> X      |  1 | cube instance 1, translation (x = 50, y = 0, z = 0)
+                        +----+
+     */
+    // clang-format on
+    vkt::as::BuildGeometryInfoKHR GetCubesTLAS(std::shared_ptr<vkt::as::BuildGeometryInfoKHR>& out_cube_blas) {
+        vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
+        out_cube_blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+            vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube)));
+
+        // Build Bottom Level Acceleration Structure
+        m_command_buffer.begin();
+        out_cube_blas->BuildCmdBuffer(m_command_buffer.handle());
+        m_command_buffer.end();
+
+        m_default_queue->Submit(m_command_buffer);
+        m_device->Wait();
+
+        vkt::as::BuildGeometryInfoKHR tlas(m_device);
+
+        tlas.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+        tlas.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
+        tlas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
+
+        std::vector<vkt::as::GeometryKHR> cube_instances(1);
+        cube_instances[0].SetType(vkt::as::GeometryKHR::Type::Instance);
+
+        VkAccelerationStructureInstanceKHR cube_instance_1{};
+        cube_instance_1.transform.matrix[0][0] = 1.0f;
+        cube_instance_1.transform.matrix[1][1] = 1.0f;
+        cube_instance_1.transform.matrix[2][2] = 1.0f;
+        cube_instance_1.transform.matrix[0][3] = 50.0f;
+        cube_instance_1.transform.matrix[1][3] = 0.0f;
+        cube_instance_1.transform.matrix[2][3] = 0.0f;
+        cube_instance_1.mask = 0xff;
+        cube_instance_1.instanceCustomIndex = 0;
+        // Cube instance 1 will be associated to closest hit shader 1
+        cube_instance_1.instanceShaderBindingTableRecordOffset = 0;
+        cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, out_cube_blas->GetDstAS()->handle(), cube_instance_1);
+
+        VkAccelerationStructureInstanceKHR cube_instance_2{};
+        cube_instance_2.transform.matrix[0][0] = 1.0f;
+        cube_instance_2.transform.matrix[1][1] = 1.0f;
+        cube_instance_2.transform.matrix[2][2] = 1.0f;
+        cube_instance_2.transform.matrix[0][3] = 0.0f;
+        cube_instance_2.transform.matrix[1][3] = 0.0f;
+        cube_instance_2.transform.matrix[2][3] = 50.0f;
+        cube_instance_2.mask = 0xff;
+        cube_instance_2.instanceCustomIndex = 0;
+        // Cube instance 2 will be associated to closest hit shader 2
+        cube_instance_2.instanceShaderBindingTableRecordOffset = 1;
+        cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, out_cube_blas->GetDstAS()->handle(), cube_instance_2);
+
+        tlas.SetGeometries(std::move(cube_instances));
+        tlas.SetBuildRanges(tlas.GetBuildRangeInfosFromGeometries());
+
+        // Set source and destination acceleration structures info. Does not create handles, it is done in Build()
+        tlas.SetSrcAS(vkt::as::blueprint::AccelStructNull(*m_device));
+        auto dstAsSize = tlas.GetSizeInfo().accelerationStructureSize;
+        auto dst_as = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, dstAsSize);
+        dst_as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
+        tlas.SetDstAS(std::move(dst_as));
+        tlas.SetUpdateDstAccelStructSizeBeforeBuild(true);
+
+        tlas.SetInfoCount(1);
+        tlas.SetNullInfos(false);
+        tlas.SetNullBuildRangeInfos(false);
+
+        m_command_buffer.begin();
+        tlas.BuildCmdBuffer(m_command_buffer.handle());
+        m_command_buffer.end();
+
+        m_default_queue->Submit(m_command_buffer);
+        m_device->Wait();
+
+        return tlas;
+    }
 };
 
-[shader("raygeneration")]
-void rayGenShader()
-{
-    printf("In Raygen");
-    InterlockedAdd(debug_buffer[0], 1);
-    RayPayload ray_payload = { float3(0) };
-    RayDesc ray;
-    ray.TMin = 0.01;
-    ray.TMax = 1000.0;
-
-    // Will hit
-    ray.Origin = float3(0,0,-50);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,-50);
-    ray.Direction = float3(0,0,-1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,50);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,50);
-    ray.Direction = float3(0,0,-1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-    // Will miss
-    ray.Origin = float3(0,0,0);
-    ray.Direction = float3(0,0,1);
-    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
-
-}
-
-[shader("miss")]
-void missShader(inout RayPayload payload)
-{
-    printf("In Miss");
-    InterlockedAdd(debug_buffer[1], 1);
-    payload.hit = float3(0.1, 0.2, 0.3);
-}
-
-[shader("closesthit")]
-void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
-{
-    printf("In Closest Hit");
-    InterlockedAdd(debug_buffer[2], 1);
-    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
-attr.barycentrics.y); payload.hit = barycentric_coords;
-}
-    */
-    const char* ray_tracing_pipeline_spv = R"asm(
-; SPIR-V
-; Version: 1.5
-; Generator: Khronos; 40
-; Bound: 151
-; Schema: 0
-OpCapability RayTracingKHR
-OpCapability Shader
-OpExtension "SPV_KHR_non_semantic_info"
-OpExtension "SPV_KHR_storage_buffer_storage_class"
-OpExtension "SPV_KHR_ray_tracing"
-%11 = OpExtInstImport "NonSemantic.DebugPrintf"
-OpMemoryModel Logical GLSL450
-OpEntryPoint RayGenerationKHR %rayGenShader "main" %p %debug_buffer %tlas
-OpEntryPoint MissKHR %missShader "main" %debug_buffer %119
-OpEntryPoint ClosestHitKHR %closestHitShader "main" %debug_buffer %147 %137
-
-; Debug Information
-OpSource Slang 1
-%12 = OpString "In Raygen"
-%115 = OpString "In Miss"
-%131 = OpString "In Closest Hit"
-OpName %RayDesc "RayDesc"                           ; id %5
-OpMemberName %RayDesc 0 "Origin"
-OpMemberName %RayDesc 1 "TMin"
-OpMemberName %RayDesc 2 "Direction"
-OpMemberName %RayDesc 3 "TMax"
-OpName %ray "ray"                                   ; id %9
-OpName %ray "ray"                                   ; id %9
-OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
-OpName %debug_buffer "debug_buffer"                 ; id %21
-OpName %RayPayload "RayPayload"                     ; id %27
-OpMemberName %RayPayload 0 "hit"
-OpName %ray_payload "ray_payload"                   ; id %28
-OpName %p "p"                                       ; id %50
-OpName %tlas "tlas"                                 ; id %59
-OpName %ray_payload_0 "ray_payload"                 ; id %62
-OpName %ray_payload_1 "ray_payload"                 ; id %75
-OpName %ray_payload_2 "ray_payload"                 ; id %88
-OpName %ray_payload_3 "ray_payload"                 ; id %99
-OpName %rayGenShader "rayGenShader"                 ; id %2
-OpName %missShader "missShader"                     ; id %112
-OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %134
-OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
-OpName %barycentric_coords "barycentric_coords"     ; id %146
-OpName %closestHitShader "closestHitShader"         ; id %128
-
-; Annotations
-OpMemberDecorate %RayDesc 0 Offset 0
-OpMemberDecorate %RayDesc 1 Offset 12
-OpMemberDecorate %RayDesc 2 Offset 16
-OpMemberDecorate %RayDesc 3 Offset 28
-OpDecorate %_runtimearr_uint ArrayStride 4
-OpDecorate %RWStructuredBuffer Block
-OpMemberDecorate %RWStructuredBuffer 0 Offset 0
-OpDecorate %debug_buffer Binding 1
-OpDecorate %debug_buffer DescriptorSet 0
-OpMemberDecorate %RayPayload 0 Offset 0
-OpDecorate %p Location 0
-OpDecorate %tlas Binding 0
-OpDecorate %tlas DescriptorSet 0
-OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
-
-; Types, variables and constants
-%void = OpTypeVoid
-%3 = OpTypeFunction %void
-%float = OpTypeFloat 32
-%v3float = OpTypeVector %float 3
-%RayDesc = OpTypeStruct %v3float %float %v3float %float
-%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
-%int = OpTypeInt 32 1
-%int_0 = OpConstant %int 0
-%uint = OpTypeInt 32 0
-%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
-%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
-%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
-%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
-%uint_1 = OpConstant %uint 1
-%uint_0 = OpConstant %uint 0
-%float_0 = OpConstant %float 0
-%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%RayPayload = OpTypeStruct %v3float
-%int_1 = OpConstant %int 1
-%_ptr_Function_float = OpTypePointer Function %float
-%float_0_00999999978 = OpConstant %float 0.00999999978
-%int_3 = OpConstant %int 3
-%float_1000 = OpConstant %float 1000
-%_ptr_Function_v3float = OpTypePointer Function %v3float
-%float_n50 = OpConstant %float -50
-%40 = OpConstantComposite %v3float %float_0 %float_0 %float_n50
-%int_2 = OpConstant %int 2
-%float_1 = OpConstant %float 1
-%45 = OpConstantComposite %v3float %float_0 %float_0 %float_1
-%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
-%56 = OpTypeAccelerationStructureKHR
-%_ptr_UniformConstant_56 = OpTypePointer UniformConstant %56
-%uint_255 = OpConstant %uint 255
-%float_n1 = OpConstant %float -1
-%64 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
-%float_50 = OpConstant %float 50
-%76 = OpConstantComposite %v3float %float_0 %float_0 %float_50
-%100 = OpConstantComposite %v3float %float_0 %float_0 %float_0
-%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
-%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
-%float_0_100000001 = OpConstant %float 0.100000001
-%float_0_200000003 = OpConstant %float 0.200000003
-%float_0_300000012 = OpConstant %float 0.300000012
-%122 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
-%v2float = OpTypeVector %float 2
-%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
-%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
-%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
-%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
-%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
-%tlas = OpVariable %_ptr_UniformConstant_56 UniformConstant                         ; Binding 0, DescriptorSet 0
-%119 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-%137 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
-%147 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
-
-; Function rayGenShader
-%rayGenShader = OpFunction %void None %3
-%4 = OpLabel
-%ray = OpVariable %_ptr_Function_RayDesc Function
-%10 = OpExtInst %void %11 1 %12
-%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
-%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
-%ray_payload = OpCompositeConstruct %RayPayload %25
-%31 = OpAccessChain %_ptr_Function_float %ray %int_1
-OpStore %31 %float_0_00999999978
-%35 = OpAccessChain %_ptr_Function_float %ray %int_3
-OpStore %35 %float_1000
-%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
-OpStore %39 %40
-%44 = OpAccessChain %_ptr_Function_v3float %ray %int_2
-OpStore %44 %45
-%48 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload
-%52 = OpCompositeExtract %v3float %48 0
-%53 = OpCompositeExtract %v3float %48 2
-%54 = OpCompositeExtract %float %48 1
-%55 = OpCompositeExtract %float %48 3
-%57 = OpLoad %56 %tlas
-OpTraceRayKHR %57 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %52 %54 %53 %55 %p
-%ray_payload_0 = OpLoad %RayPayload %p
-OpStore %39 %40
-OpStore %44 %64
-%67 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_0
-%69 = OpCompositeExtract %v3float %67 0
-%70 = OpCompositeExtract %v3float %67 2
-%71 = OpCompositeExtract %float %67 1
-%72 = OpCompositeExtract %float %67 3
-%73 = OpLoad %56 %tlas
-OpTraceRayKHR %73 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %69 %71 %70 %72 %p
-%ray_payload_1 = OpLoad %RayPayload %p
-OpStore %39 %76
-OpStore %44 %45
-%80 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_1
-%82 = OpCompositeExtract %v3float %80 0
-%83 = OpCompositeExtract %v3float %80 2
-%84 = OpCompositeExtract %float %80 1
-%85 = OpCompositeExtract %float %80 3
-%86 = OpLoad %56 %tlas
-OpTraceRayKHR %86 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %82 %84 %83 %85 %p
-%ray_payload_2 = OpLoad %RayPayload %p
-OpStore %39 %76
-OpStore %44 %64
-%91 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_2
-%93 = OpCompositeExtract %v3float %91 0
-%94 = OpCompositeExtract %v3float %91 2
-%95 = OpCompositeExtract %float %91 1
-%96 = OpCompositeExtract %float %91 3
-%97 = OpLoad %56 %tlas
-OpTraceRayKHR %97 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %93 %95 %94 %96 %p
-%ray_payload_3 = OpLoad %RayPayload %p
-OpStore %39 %100
-OpStore %44 %45
-%103 = OpLoad %RayDesc %ray
-OpStore %p %ray_payload_3
-%105 = OpCompositeExtract %v3float %103 0
-%106 = OpCompositeExtract %v3float %103 2
-%107 = OpCompositeExtract %float %103 1
-%108 = OpCompositeExtract %float %103 3
-%109 = OpLoad %56 %tlas
-OpTraceRayKHR %109 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %105 %107 %106 %108 %p
-OpReturn
-OpFunctionEnd
-
-; Function missShader
-%missShader = OpFunction %void None %3
-%113 = OpLabel
-%114 = OpExtInst %void %11 1 %115
-%116 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
-%117 = OpAtomicIAdd %uint %116 %uint_1 %uint_0 %uint_1
-%121 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %119 %int_0
-OpStore %121 %122
-OpReturn
-OpFunctionEnd
-
-; Function closestHitShader
-%closestHitShader = OpFunction %void None %3
-%129 = OpLabel
-%130 = OpExtInst %void %11 1 %131
-%132 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
-%133 = OpAtomicIAdd %uint %132 %uint_1 %uint_0 %uint_1
-%139 = OpAccessChain %_ptr_HitAttributeKHR_v2float %137 %int_0
-%140 = OpLoad %v2float %139
-%141 = OpCompositeExtract %float %140 0
-%142 = OpFSub %float %float_1 %141
-%143 = OpLoad %v2float %139
-%144 = OpCompositeExtract %float %143 1
-%145 = OpFSub %float %142 %144
-%barycentric_coords = OpCompositeConstruct %v3float %145 %141 %144
-%148 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %147 %int_0
-OpStore %148 %barycentric_coords
-OpReturn
-OpFunctionEnd
-    )asm";
-
-    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "main");
-    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "main");
-    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "main");
-
-    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
-    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
-    pipeline.CreateDescriptorSet();
-    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
-    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
-                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
-    pipeline.GetDescriptorSet().UpdateDescriptorSets();
-
-    pipeline.Build();
-
-    uint32_t frames_count = 100;
-    for (uint32_t frame = 0; frame < frames_count; ++frame) {
-        m_command_buffer.begin();
-        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
-                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
-        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
-        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
-
-        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
-                            &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
-
-        m_command_buffer.end();
-        m_errorMonitor->SetDesiredInfo("In Raygen");
-        m_errorMonitor->SetDesiredInfo("In Miss", 3);
-        m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
-        m_default_queue->Submit(m_command_buffer);
-        m_default_queue->Wait();
-    }
-    m_errorMonitor->VerifyFound();
-
-    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
-    ASSERT_EQ(debug_buffer_ptr[0], frames_count);
-    ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
-    ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
-    debug_buffer.memory().unmap();
-}
-
-TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2) {
-    TEST_DESCRIPTION(
-        "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders. ");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
-    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
-    AddRequiredFeature(vkt::Feature::accelerationStructure);
-    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
-    RETURN_IF_SKIP(InitDebugPrintfFramework());
-    RETURN_IF_SKIP(InitState());
-
+const char* GetSlangShader1() {
     // slang shader. Compiled with:
     // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
     // /!\ /!\ /!\ you need to manually edit the OpEntryPoint in the resulting spir-v to match the slang shader
@@ -1062,90 +551,618 @@ OpReturn
 OpFunctionEnd
     )asm";
 
-    vkt::as::GeometryKHR cube(vkt::as::blueprint::GeometryCubeOnDeviceInfo(*m_device));
-    auto cube_blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
-        vkt::as::blueprint::BuildGeometryInfoOnDeviceBottomLevel(*m_device, std::move(cube)));
+    return ray_tracing_pipeline_spv;
+}
+
+const char* GetSlangShader2() {
+    // slang shader. Compiled with:
+    // slangc.exe -capability GL_EXT_debug_printf .\ray_tracing.slang -target spirv-asm -profile glsl_460 -O0 -o ray_tracing.spv
+    /*
+[[vk::binding(0, 0)]] uniform RaytracingAccelerationStructure tlas;
+[[vk::binding(1, 0)]] RWStructuredBuffer<uint32_t> debug_buffer;
+
+struct RayPayload {
+    float3 hit;
+};
+
+[shader("raygeneration")]
+void rayGenShader()
+{
+    printf("In Raygen");
+    InterlockedAdd(debug_buffer[0], 1);
+    RayPayload ray_payload = { float3(0) };
+    RayDesc ray;
+    ray.TMin = 0.01;
+    ray.TMax = 1000.0;
+
+    // Will hit
+    ray.Origin = float3(0,0,-50);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,-50);
+    ray.Direction = float3(0,0,-1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,50);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,50);
+    ray.Direction = float3(0,0,-1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+    // Will miss
+    ray.Origin = float3(0,0,0);
+    ray.Direction = float3(0,0,1);
+    TraceRay(tlas, RAY_FLAG_NONE, 0xff, 0, 0, 0, ray, ray_payload);
+
+}
+
+[shader("miss")]
+void missShader(inout RayPayload payload)
+{
+    printf("In Miss");
+    InterlockedAdd(debug_buffer[1], 1);
+    payload.hit = float3(0.1, 0.2, 0.3);
+}
+
+[shader("closesthit")]
+void closestHitShader(inout RayPayload payload, in BuiltInTriangleIntersectionAttributes attr)
+{
+    printf("In Closest Hit");
+    InterlockedAdd(debug_buffer[2], 1);
+    const float3 barycentric_coords = float3(1.0f - attr.barycentrics.x - attr.barycentrics.y, attr.barycentrics.x,
+attr.barycentrics.y); payload.hit = barycentric_coords;
+}
+    */
+    const char* ray_tracing_pipeline_spv = R"asm(
+; SPIR-V
+; Version: 1.5
+; Generator: Khronos; 40
+; Bound: 151
+; Schema: 0
+OpCapability RayTracingKHR
+OpCapability Shader
+OpExtension "SPV_KHR_non_semantic_info"
+OpExtension "SPV_KHR_storage_buffer_storage_class"
+OpExtension "SPV_KHR_ray_tracing"
+%11 = OpExtInstImport "NonSemantic.DebugPrintf"
+OpMemoryModel Logical GLSL450
+OpEntryPoint RayGenerationKHR %rayGenShader "main" %p %debug_buffer %tlas
+OpEntryPoint MissKHR %missShader "main" %debug_buffer %119
+OpEntryPoint ClosestHitKHR %closestHitShader "main" %debug_buffer %147 %137
+
+; Debug Information
+OpSource Slang 1
+%12 = OpString "In Raygen"
+%115 = OpString "In Miss"
+%131 = OpString "In Closest Hit"
+OpName %RayDesc "RayDesc"                           ; id %5
+OpMemberName %RayDesc 0 "Origin"
+OpMemberName %RayDesc 1 "TMin"
+OpMemberName %RayDesc 2 "Direction"
+OpMemberName %RayDesc 3 "TMax"
+OpName %ray "ray"                                   ; id %9
+OpName %ray "ray"                                   ; id %9
+OpName %RWStructuredBuffer "RWStructuredBuffer"     ; id %18
+OpName %debug_buffer "debug_buffer"                 ; id %21
+OpName %RayPayload "RayPayload"                     ; id %27
+OpMemberName %RayPayload 0 "hit"
+OpName %ray_payload "ray_payload"                   ; id %28
+OpName %p "p"                                       ; id %50
+OpName %tlas "tlas"                                 ; id %59
+OpName %ray_payload_0 "ray_payload"                 ; id %62
+OpName %ray_payload_1 "ray_payload"                 ; id %75
+OpName %ray_payload_2 "ray_payload"                 ; id %88
+OpName %ray_payload_3 "ray_payload"                 ; id %99
+OpName %rayGenShader "rayGenShader"                 ; id %2
+OpName %missShader "missShader"                     ; id %112
+OpName %BuiltInTriangleIntersectionAttributes "BuiltInTriangleIntersectionAttributes"   ; id %134
+OpMemberName %BuiltInTriangleIntersectionAttributes 0 "barycentrics"
+OpName %barycentric_coords "barycentric_coords"     ; id %146
+OpName %closestHitShader "closestHitShader"         ; id %128
+
+; Annotations
+OpMemberDecorate %RayDesc 0 Offset 0
+OpMemberDecorate %RayDesc 1 Offset 12
+OpMemberDecorate %RayDesc 2 Offset 16
+OpMemberDecorate %RayDesc 3 Offset 28
+OpDecorate %_runtimearr_uint ArrayStride 4
+OpDecorate %RWStructuredBuffer Block
+OpMemberDecorate %RWStructuredBuffer 0 Offset 0
+OpDecorate %debug_buffer Binding 1
+OpDecorate %debug_buffer DescriptorSet 0
+OpMemberDecorate %RayPayload 0 Offset 0
+OpDecorate %p Location 0
+OpDecorate %tlas Binding 0
+OpDecorate %tlas DescriptorSet 0
+OpMemberDecorate %BuiltInTriangleIntersectionAttributes 0 Offset 0
+
+; Types, variables and constants
+%void = OpTypeVoid
+%3 = OpTypeFunction %void
+%float = OpTypeFloat 32
+%v3float = OpTypeVector %float 3
+%RayDesc = OpTypeStruct %v3float %float %v3float %float
+%_ptr_Function_RayDesc = OpTypePointer Function %RayDesc
+%int = OpTypeInt 32 1
+%int_0 = OpConstant %int 0
+%uint = OpTypeInt 32 0
+%_ptr_StorageBuffer_uint = OpTypePointer StorageBuffer %uint
+%_runtimearr_uint = OpTypeRuntimeArray %uint        ; ArrayStride 4
+%RWStructuredBuffer = OpTypeStruct %_runtimearr_uint    ; Block
+%_ptr_StorageBuffer_RWStructuredBuffer = OpTypePointer StorageBuffer %RWStructuredBuffer
+%uint_1 = OpConstant %uint 1
+%uint_0 = OpConstant %uint 0
+%float_0 = OpConstant %float 0
+%25 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%RayPayload = OpTypeStruct %v3float
+%int_1 = OpConstant %int 1
+%_ptr_Function_float = OpTypePointer Function %float
+%float_0_00999999978 = OpConstant %float 0.00999999978
+%int_3 = OpConstant %int 3
+%float_1000 = OpConstant %float 1000
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%float_n50 = OpConstant %float -50
+%40 = OpConstantComposite %v3float %float_0 %float_0 %float_n50
+%int_2 = OpConstant %int 2
+%float_1 = OpConstant %float 1
+%45 = OpConstantComposite %v3float %float_0 %float_0 %float_1
+%_ptr_RayPayloadKHR_RayPayload = OpTypePointer RayPayloadKHR %RayPayload
+%56 = OpTypeAccelerationStructureKHR
+%_ptr_UniformConstant_56 = OpTypePointer UniformConstant %56
+%uint_255 = OpConstant %uint 255
+%float_n1 = OpConstant %float -1
+%64 = OpConstantComposite %v3float %float_0 %float_0 %float_n1
+%float_50 = OpConstant %float 50
+%76 = OpConstantComposite %v3float %float_0 %float_0 %float_50
+%100 = OpConstantComposite %v3float %float_0 %float_0 %float_0
+%_ptr_IncomingRayPayloadKHR_RayPayload = OpTypePointer IncomingRayPayloadKHR %RayPayload
+%_ptr_IncomingRayPayloadKHR_v3float = OpTypePointer IncomingRayPayloadKHR %v3float
+%float_0_100000001 = OpConstant %float 0.100000001
+%float_0_200000003 = OpConstant %float 0.200000003
+%float_0_300000012 = OpConstant %float 0.300000012
+%122 = OpConstantComposite %v3float %float_0_100000001 %float_0_200000003 %float_0_300000012
+%v2float = OpTypeVector %float 2
+%BuiltInTriangleIntersectionAttributes = OpTypeStruct %v2float
+%_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes = OpTypePointer HitAttributeKHR %BuiltInTriangleIntersectionAttributes
+%_ptr_HitAttributeKHR_v2float = OpTypePointer HitAttributeKHR %v2float
+%debug_buffer = OpVariable %_ptr_StorageBuffer_RWStructuredBuffer StorageBuffer     ; Binding 1, DescriptorSet 0
+%p = OpVariable %_ptr_RayPayloadKHR_RayPayload RayPayloadKHR                        ; Location 0
+%tlas = OpVariable %_ptr_UniformConstant_56 UniformConstant                         ; Binding 0, DescriptorSet 0
+%119 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+%137 = OpVariable %_ptr_HitAttributeKHR_BuiltInTriangleIntersectionAttributes HitAttributeKHR
+%147 = OpVariable %_ptr_IncomingRayPayloadKHR_RayPayload IncomingRayPayloadKHR
+
+; Function rayGenShader
+%rayGenShader = OpFunction %void None %3
+%4 = OpLabel
+%ray = OpVariable %_ptr_Function_RayDesc Function
+%10 = OpExtInst %void %11 1 %12
+%17 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_0
+%22 = OpAtomicIAdd %uint %17 %uint_1 %uint_0 %uint_1
+%ray_payload = OpCompositeConstruct %RayPayload %25
+%31 = OpAccessChain %_ptr_Function_float %ray %int_1
+OpStore %31 %float_0_00999999978
+%35 = OpAccessChain %_ptr_Function_float %ray %int_3
+OpStore %35 %float_1000
+%39 = OpAccessChain %_ptr_Function_v3float %ray %int_0
+OpStore %39 %40
+%44 = OpAccessChain %_ptr_Function_v3float %ray %int_2
+OpStore %44 %45
+%48 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload
+%52 = OpCompositeExtract %v3float %48 0
+%53 = OpCompositeExtract %v3float %48 2
+%54 = OpCompositeExtract %float %48 1
+%55 = OpCompositeExtract %float %48 3
+%57 = OpLoad %56 %tlas
+OpTraceRayKHR %57 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %52 %54 %53 %55 %p
+%ray_payload_0 = OpLoad %RayPayload %p
+OpStore %39 %40
+OpStore %44 %64
+%67 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_0
+%69 = OpCompositeExtract %v3float %67 0
+%70 = OpCompositeExtract %v3float %67 2
+%71 = OpCompositeExtract %float %67 1
+%72 = OpCompositeExtract %float %67 3
+%73 = OpLoad %56 %tlas
+OpTraceRayKHR %73 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %69 %71 %70 %72 %p
+%ray_payload_1 = OpLoad %RayPayload %p
+OpStore %39 %76
+OpStore %44 %45
+%80 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_1
+%82 = OpCompositeExtract %v3float %80 0
+%83 = OpCompositeExtract %v3float %80 2
+%84 = OpCompositeExtract %float %80 1
+%85 = OpCompositeExtract %float %80 3
+%86 = OpLoad %56 %tlas
+OpTraceRayKHR %86 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %82 %84 %83 %85 %p
+%ray_payload_2 = OpLoad %RayPayload %p
+OpStore %39 %76
+OpStore %44 %64
+%91 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_2
+%93 = OpCompositeExtract %v3float %91 0
+%94 = OpCompositeExtract %v3float %91 2
+%95 = OpCompositeExtract %float %91 1
+%96 = OpCompositeExtract %float %91 3
+%97 = OpLoad %56 %tlas
+OpTraceRayKHR %97 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %93 %95 %94 %96 %p
+%ray_payload_3 = OpLoad %RayPayload %p
+OpStore %39 %100
+OpStore %44 %45
+%103 = OpLoad %RayDesc %ray
+OpStore %p %ray_payload_3
+%105 = OpCompositeExtract %v3float %103 0
+%106 = OpCompositeExtract %v3float %103 2
+%107 = OpCompositeExtract %float %103 1
+%108 = OpCompositeExtract %float %103 3
+%109 = OpLoad %56 %tlas
+OpTraceRayKHR %109 %uint_0 %uint_255 %uint_0 %uint_0 %uint_0 %105 %107 %106 %108 %p
+OpReturn
+OpFunctionEnd
+
+; Function missShader
+%missShader = OpFunction %void None %3
+%113 = OpLabel
+%114 = OpExtInst %void %11 1 %115
+%116 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_1
+%117 = OpAtomicIAdd %uint %116 %uint_1 %uint_0 %uint_1
+%121 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %119 %int_0
+OpStore %121 %122
+OpReturn
+OpFunctionEnd
+
+; Function closestHitShader
+%closestHitShader = OpFunction %void None %3
+%129 = OpLabel
+%130 = OpExtInst %void %11 1 %131
+%132 = OpAccessChain %_ptr_StorageBuffer_uint %debug_buffer %int_0 %int_2
+%133 = OpAtomicIAdd %uint %132 %uint_1 %uint_0 %uint_1
+%139 = OpAccessChain %_ptr_HitAttributeKHR_v2float %137 %int_0
+%140 = OpLoad %v2float %139
+%141 = OpCompositeExtract %float %140 0
+%142 = OpFSub %float %float_1 %141
+%143 = OpLoad %v2float %139
+%144 = OpCompositeExtract %float %143 1
+%145 = OpFSub %float %142 %144
+%barycentric_coords = OpCompositeConstruct %v3float %145 %141 %144
+%148 = OpAccessChain %_ptr_IncomingRayPayloadKHR_v3float %147 %int_0
+OpStore %148 %barycentric_coords
+OpReturn
+OpFunctionEnd
+    )asm";
+
+    return ray_tracing_pipeline_spv;
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, Raygen) {
+    TEST_DESCRIPTION("Test debug printf in raygen shader.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+        layout(location = 0) rayPayloadEXT vec3 hit;
+       
+        void main() {
+            debugPrintfEXT("In Raygen\n");
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, vec3(0,0,1), 0.1, vec3(0,0,1), 1000.0, 0);
+        }
+    )glsl";
+    pipeline.SetGlslRayGenShader(ray_gen);
+
+    pipeline.AddGlslMissShader(kRayTracingPayloadMinimalGlsl);
+    pipeline.AddGlslClosestHitShader(kRayTracingPayloadMinimalGlsl);
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.CreateDescriptorSet();
+    vkt::as::BuildGeometryInfoKHR tlas(vkt::as::blueprint::BuildOnDeviceTopLevel(*m_device, *m_default_queue, m_command_buffer));
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    m_command_buffer.begin();
+    vk::CmdBindDescriptorSets(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(), 0, 1,
+                              &pipeline.GetDescriptorSet().set_, 0, nullptr);
+    vk::CmdBindPipeline(m_command_buffer, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+    vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+    vk::CmdTraceRaysKHR(m_command_buffer, &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt, &trace_rays_sbt.hit_sbt,
+                        &trace_rays_sbt.callable_sbt, 1, 1, 1);
+    m_command_buffer.end();
+    m_errorMonitor->SetDesiredFailureMsg(kInformationBit, "In Raygen");
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, RaygenOneMissShaderOneClosestHitShader) {
+    TEST_DESCRIPTION("Test debug printf in raygen, miss and closest hit shaders.");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+
+    RETURN_IF_SKIP(InitState());
+
+    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
+    // implicitly depends on the default triangle position.
+    auto blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
 
     // Build Bottom Level Acceleration Structure
     m_command_buffer.begin();
-    cube_blas->BuildCmdBuffer(m_command_buffer.handle());
+    blas->BuildCmdBuffer(m_command_buffer.handle());
     m_command_buffer.end();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
 
-    // Build Top Level Acceleration Structure:
-    // 2 instances of the cube, at different positions
-    // clang-format off
-    /*
-                cube instance 2, translation (x = 0, y = 0, z = 50)
-                +----+
-                |  2 |
-                +----+
-
-                  Z
-                  ^
-                  |              +----+
-                  +---> X        |  1 | cube instance 1, translation (x = 50, y = 0, z = 0)
-                                 +----+
-    */
-    // clang-format on
-    vkt::as::BuildGeometryInfoKHR tlas(m_device);
-
-    tlas.SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
-    tlas.SetBuildType(VK_ACCELERATION_STRUCTURE_BUILD_TYPE_DEVICE_KHR);
-    tlas.SetMode(VK_BUILD_ACCELERATION_STRUCTURE_MODE_BUILD_KHR);
-
-    std::vector<vkt::as::GeometryKHR> cube_instances(1);
-    cube_instances[0].SetType(vkt::as::GeometryKHR::Type::Instance);
-
-    VkAccelerationStructureInstanceKHR cube_instance_1{};
-    cube_instance_1.transform.matrix[0][0] = 1.0f;
-    cube_instance_1.transform.matrix[1][1] = 1.0f;
-    cube_instance_1.transform.matrix[2][2] = 1.0f;
-    cube_instance_1.transform.matrix[0][3] = 50.0f;
-    cube_instance_1.transform.matrix[1][3] = 0.0f;
-    cube_instance_1.transform.matrix[2][3] = 0.0f;
-    cube_instance_1.mask = 0xff;
-    cube_instance_1.instanceCustomIndex = 0;
-    // Cube instance 1 will be associated to closest hit shader 1
-    cube_instance_1.instanceShaderBindingTableRecordOffset = 0;
-    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas->GetDstAS()->handle(), cube_instance_1);
-
-    VkAccelerationStructureInstanceKHR cube_instance_2{};
-    cube_instance_2.transform.matrix[0][0] = 1.0f;
-    cube_instance_2.transform.matrix[1][1] = 1.0f;
-    cube_instance_2.transform.matrix[2][2] = 1.0f;
-    cube_instance_2.transform.matrix[0][3] = 0.0f;
-    cube_instance_2.transform.matrix[1][3] = 0.0f;
-    cube_instance_2.transform.matrix[2][3] = 50.0f;
-    cube_instance_2.mask = 0xff;
-    cube_instance_2.instanceCustomIndex = 0;
-    // Cube instance 2 will be associated to closest hit shader 2
-    cube_instance_2.instanceShaderBindingTableRecordOffset = 1;
-    cube_instances[0].AddInstanceDeviceAccelStructRef(*m_device, cube_blas->GetDstAS()->handle(), cube_instance_2);
-
-    tlas.SetGeometries(std::move(cube_instances));
-    tlas.SetBuildRanges(tlas.GetBuildRangeInfosFromGeometries());
-
-    // Set source and destination acceleration structures info. Does not create handles, it is done in Build()
-    tlas.SetSrcAS(vkt::as::blueprint::AccelStructNull(*m_device));
-    auto dstAsSize = tlas.GetSizeInfo().accelerationStructureSize;
-    auto dst_as = vkt::as::blueprint::AccelStructSimpleOnDeviceBottomLevel(*m_device, dstAsSize);
-    dst_as->SetType(VK_ACCELERATION_STRUCTURE_TYPE_TOP_LEVEL_KHR);
-    tlas.SetDstAS(std::move(dst_as));
-    tlas.SetUpdateDstAccelStructSizeBeforeBuild(true);
-
-    tlas.SetInfoCount(1);
-    tlas.SetNullInfos(false);
-    tlas.SetNullBuildRangeInfos(false);
-
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
     m_command_buffer.begin();
     tlas.BuildCmdBuffer(m_command_buffer.handle());
     m_command_buffer.end();
 
     m_default_queue->Submit(m_command_buffer);
     m_device->Wait();
+
+    // Buffer used to count invocations for the 3 shader types
+    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    m_command_buffer.begin();
+    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
+    m_command_buffer.end();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    const char* ray_gen = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+        layout(binding = 1, set = 0) buffer DbgBuffer {
+          uint debug_buffer[];
+        };
+
+        layout(location = 0) rayPayloadEXT vec3 hit;
+       
+        void main() {
+            debugPrintfEXT("In Raygen\n");
+            atomicAdd(debug_buffer[0], 1);
+
+            vec3 ray_origin = vec3(0,0,-50);
+            vec3 ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+            
+            // Will miss
+            ray_origin = vec3(0,0,-50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+            
+            // Will miss
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+            
+            ray_origin = vec3(0,0,50);
+            ray_direction = vec3(0,0,-1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+            
+            // Will miss
+            ray_origin = vec3(0,0,0);
+            ray_direction = vec3(0,0,1);
+            traceRayEXT(tlas, gl_RayFlagsOpaqueEXT, 0xff, 0, 0, 0, ray_origin, 0.01, ray_direction, 1000.0, 0);
+        }
+    )glsl";
+    pipeline.SetGlslRayGenShader(ray_gen);
+
+    const char* miss = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+        layout(binding = 1, set = 0) buffer DbgBuffer {
+          uint debug_buffer[];
+        };
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+
+        void main() {
+            debugPrintfEXT("In Miss\n");
+            atomicAdd(debug_buffer[1], 1);
+            hit = vec3(0.1, 0.2, 0.3);
+        }
+    )glsl";
+    pipeline.AddGlslMissShader(miss);
+
+    const char* closest_hit = R"glsl(
+        #version 460
+        #extension GL_EXT_ray_tracing : require
+        #extension GL_EXT_debug_printf : enable
+
+        layout(binding = 0, set = 0) uniform accelerationStructureEXT tlas;
+        layout(binding = 1, set = 0) buffer DbgBuffer {
+          uint debug_buffer[];
+        };
+
+
+        layout(location = 0) rayPayloadInEXT vec3 hit;
+        hitAttributeEXT vec2 baryCoord;
+
+        void main() {
+            debugPrintfEXT("In Closest Hit\n");
+            atomicAdd(debug_buffer[2], 1);
+            const vec3 barycentricCoords = vec3(1.0f - baryCoord.x - baryCoord.y, baryCoord.x, baryCoord.y);
+            hit = barycentricCoords;
+        }
+    )glsl";
+    pipeline.AddGlslClosestHitShader(closest_hit);
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
+                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    uint32_t frames_count = 100;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.begin();
+        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
+                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
+        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
+                            &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
+
+        m_command_buffer.end();
+        m_errorMonitor->SetDesiredInfo("In Raygen");
+        m_errorMonitor->SetDesiredInfo("In Miss", 3);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
+        m_default_queue->Submit(m_command_buffer);
+        m_default_queue->Wait();
+    }
+    m_errorMonitor->VerifyFound();
+
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    ASSERT_EQ(debug_buffer_ptr[0], frames_count);
+    ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
+    debug_buffer.memory().unmap();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader) {
+    TEST_DESCRIPTION(
+        "Test debug printf in a multi entry points shader. 1 ray generation shader, 1 miss shader, 1 closest hit shader");
+
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+
+    RETURN_IF_SKIP(InitState());
+
+    // #ARNO_TODO: For clarity, here geometry should be set explicitly, as of now the ray hitting or not
+    // implicitly depends on the default triangle position.
+    auto blas = std::make_shared<vkt::as::BuildGeometryInfoKHR>(
+        vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceBottomLevel(*m_device, vkt::as::GeometryKHR::Type::Triangle));
+
+    // Build Bottom Level Acceleration Structure
+    m_command_buffer.begin();
+    blas->BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Build Top Level Acceleration Structure
+    vkt::as::BuildGeometryInfoKHR tlas = vkt::as::blueprint::BuildGeometryInfoSimpleOnDeviceTopLevel(*m_device, blas);
+    m_command_buffer.begin();
+    tlas.BuildCmdBuffer(m_command_buffer.handle());
+    m_command_buffer.end();
+
+    m_default_queue->Submit(m_command_buffer);
+    m_device->Wait();
+
+    // Buffer used to count invocations for the 3 shader types
+    vkt::Buffer debug_buffer(*m_device, 3 * sizeof(uint32_t), VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    m_command_buffer.begin();
+    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
+    m_command_buffer.end();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    pipeline.AddSpirvRayGenShader(GetSlangShader2(), "main");
+    pipeline.AddSpirvMissShader(GetSlangShader2(), "main");
+    pipeline.AddSpirvClosestHitShader(GetSlangShader2(), "main");
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
+                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    uint32_t frames_count = 42;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.begin();
+        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
+                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
+        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+        vkt::rt::TraceRaysSbt trace_rays_sbt = pipeline.GetTraceRaysSbt();
+
+        vk::CmdTraceRaysKHR(m_command_buffer.handle(), &trace_rays_sbt.ray_gen_sbt, &trace_rays_sbt.miss_sbt,
+                            &trace_rays_sbt.hit_sbt, &trace_rays_sbt.callable_sbt, 1, 1, 1);
+
+        m_command_buffer.end();
+        m_errorMonitor->SetDesiredInfo("In Raygen");
+        m_errorMonitor->SetDesiredInfo("In Miss", 3);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit", 2);
+        m_default_queue->Submit(m_command_buffer);
+        m_default_queue->Wait();
+    }
+    m_errorMonitor->VerifyFound();
+
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    ASSERT_EQ(debug_buffer_ptr[0], frames_count);
+    ASSERT_EQ(debug_buffer_ptr[1], 3 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[2], 2 * frames_count);
+    debug_buffer.memory().unmap();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRays) {
+    TEST_DESCRIPTION(
+        "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders."
+        "Trace rays using vkCmdTraceRaysKHR");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    std::shared_ptr<vkt::as::BuildGeometryInfoKHR> cube_blas;
+    vkt::as::BuildGeometryInfoKHR tlas = GetCubesTLAS(cube_blas);
 
     // Buffer used to count invocations for the 2 * 3 shaders
     vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
@@ -1159,12 +1176,12 @@ OpFunctionEnd
 
     vkt::rt::Pipeline pipeline(*this, m_device);
 
-    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "rayGenShader");
-    pipeline.AddSpirvRayGenShader(ray_tracing_pipeline_spv, "rayGenShader2");
-    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "missShader");
-    pipeline.AddSpirvMissShader(ray_tracing_pipeline_spv, "missShader2");
-    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "closestHitShader");
-    pipeline.AddSpirvClosestHitShader(ray_tracing_pipeline_spv, "closestHitShader2");
+    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader");
+    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader2");
+    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader");
+    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader2");
+    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader");
+    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader2");
 
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
     pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
@@ -1176,7 +1193,7 @@ OpFunctionEnd
 
     pipeline.Build();
 
-    uint32_t frames_count = 1;
+    uint32_t frames_count = 42;
     for (uint32_t frame = 0; frame < frames_count; ++frame) {
         m_command_buffer.begin();
         vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
@@ -1204,6 +1221,92 @@ OpFunctionEnd
         m_default_queue->Wait();
     }
     m_errorMonitor->VerifyFound();
+
+    // Check debug buffer to cross check that every expected shader invocation happened
+    auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());
+    (void)debug_buffer_ptr;
+    ASSERT_EQ(debug_buffer_ptr[0], 1 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[1], 1 * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[2], (2 + 0) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[3], (1 + 1) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[4], (1 + 1) * frames_count);
+    ASSERT_EQ(debug_buffer_ptr[5], (1 + 2) * frames_count);
+    debug_buffer.memory().unmap();
+}
+
+TEST_F(NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2CmdTraceRaysIndirect) {
+    TEST_DESCRIPTION(
+        "Test debug printf in a multi entry points shader. 2 ray generation shaders, 2 miss shaders, 2 closest hit shaders."
+        "Trace rays using vkCmdTraceRaysIndirect2KHR");
+    SetTargetApiVersion(VK_API_VERSION_1_2);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_PIPELINE_EXTENSION_NAME);
+    AddRequiredExtensions(VK_KHR_RAY_TRACING_MAINTENANCE_1_EXTENSION_NAME);
+    AddRequiredFeature(vkt::Feature::rayTracingPipeline);
+    AddRequiredFeature(vkt::Feature::accelerationStructure);
+    AddRequiredFeature(vkt::Feature::bufferDeviceAddress);
+    AddRequiredFeature(vkt::Feature::rayTracingPipelineTraceRaysIndirect2);
+    RETURN_IF_SKIP(InitDebugPrintfFramework());
+    RETURN_IF_SKIP(InitState());
+
+    std::shared_ptr<vkt::as::BuildGeometryInfoKHR> cube_blas;
+    vkt::as::BuildGeometryInfoKHR tlas = GetCubesTLAS(cube_blas);
+
+    // Buffer used to count invocations for the 2 * 3 shaders
+    vkt::Buffer debug_buffer(*m_device, 2 * 3 * sizeof(uint32_t),
+                             VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    m_command_buffer.begin();
+    vk::CmdFillBuffer(m_command_buffer.handle(), debug_buffer.handle(), 0, debug_buffer.CreateInfo().size, 0);
+    m_command_buffer.end();
+    m_default_queue->Submit(m_command_buffer);
+    m_default_queue->Wait();
+
+    vkt::rt::Pipeline pipeline(*this, m_device);
+
+    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader");
+    pipeline.AddSpirvRayGenShader(GetSlangShader1(), "rayGenShader2");
+    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader");
+    pipeline.AddSpirvMissShader(GetSlangShader1(), "missShader2");
+    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader");
+    pipeline.AddSpirvClosestHitShader(GetSlangShader1(), "closestHitShader2");
+
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR, 0);
+    pipeline.AddBinding(VK_DESCRIPTOR_TYPE_STORAGE_BUFFER, 1);
+    pipeline.CreateDescriptorSet();
+    pipeline.GetDescriptorSet().WriteDescriptorAccelStruct(0, 1, &tlas.GetDstAS()->handle());
+    pipeline.GetDescriptorSet().WriteDescriptorBufferInfo(1, debug_buffer.handle(), 0, VK_WHOLE_SIZE,
+                                                          VK_DESCRIPTOR_TYPE_STORAGE_BUFFER);
+    pipeline.GetDescriptorSet().UpdateDescriptorSets();
+
+    pipeline.Build();
+
+    vkt::Buffer sbt_ray_gen_1 = pipeline.GetTraceRaysSbtIndirectBuffer(0, 1, 1, 1);
+    vkt::Buffer sbt_ray_gen_2 = pipeline.GetTraceRaysSbtIndirectBuffer(1, 1, 1, 1);
+
+    uint32_t frames_count = 42;
+    for (uint32_t frame = 0; frame < frames_count; ++frame) {
+        m_command_buffer.begin();
+        vk::CmdBindDescriptorSets(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.GetPipelineLayout(),
+                                  0, 1, &pipeline.GetDescriptorSet().set_, 0, nullptr);
+        vk::CmdBindPipeline(m_command_buffer.handle(), VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline.Handle());
+
+        // Invoke ray gen shader 1
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_1.address());
+
+        // Invoke ray gen shader 2
+        vk::CmdTraceRaysIndirect2KHR(m_command_buffer.handle(), sbt_ray_gen_2.address());
+
+        m_command_buffer.end();
+        m_errorMonitor->SetDesiredInfo("In Raygen 1");
+        m_errorMonitor->SetDesiredInfo("In Raygen 2");
+        m_errorMonitor->SetDesiredInfo("In Miss 1", 2);
+        m_errorMonitor->SetDesiredInfo("In Miss 2", 2);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit 1", 2);
+        m_errorMonitor->SetDesiredInfo("In Closest Hit 2", 3);
+        m_default_queue->Submit(m_command_buffer);
+        m_default_queue->Wait();
+        m_errorMonitor->VerifyFound();
+    }
 
     // Check debug buffer to cross check that every expected shader invocation happened
     auto debug_buffer_ptr = static_cast<uint32_t*>(debug_buffer.memory().map());

--- a/tests/unit/gpu_av_ray_query_positive.cpp
+++ b/tests/unit/gpu_av_ray_query_positive.cpp
@@ -86,8 +86,8 @@ TEST_F(PositiveGpuAVRayQuery, ComputeDynamicTminTmax) {
 
         void main() {
             rayQueryEXT query;
-            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(0),
-              trace_rays_params.t_min, vec3(0,0,1), trace_rays_params.t_max);
+            rayQueryInitializeEXT(query, tlas, gl_RayFlagsTerminateOnFirstHitEXT, 0xff, vec3(100000),
+              trace_rays_params.t_min, vec3(0,1,0), trace_rays_params.t_max);
             rayQueryProceedEXT(query);
         }
     )glsl";

--- a/tests/unit/gpu_av_ray_tracing_positive.cpp
+++ b/tests/unit/gpu_av_ray_tracing_positive.cpp
@@ -688,7 +688,7 @@ TEST_F(PositiveGpuAVRayTracing, BasicTraceRaysMultiEntryPoint) {
                OpFunctionEnd
       )";
 
-    pipeline.SetSpirvRayGenShader(shader_source, "mainRaygen");
+    pipeline.AddSpirvRayGenShader(shader_source, "mainRaygen");
     pipeline.AddSpirvMissShader(shader_source, "mainMiss");
     pipeline.AddSpirvClosestHitShader(shader_source, "mainClosestHit");
 


### PR DESCRIPTION
part of https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8562

Main new test: `NegativeDebugPrintfRayTracing, OneMultiEntryPointsShader2`
"Complex" ray tracing tests, involving 2 cubes, 2 ray generation shaders, 2 miss shaders, and 2 closest hit shaders. Rays are traced in various ways to invoke precise shaders.
I wrote the shader code in slang, to have one shader with multiple entry points.

![95vm7m](https://github.com/user-attachments/assets/9031aa4a-2fac-4b48-9a51-357552899fdf)



