### PR TITLE
sync: Disable validation of ranges defined by indirect buffer

### DIFF
--- a/layers/sync/sync_commandbuffer.h
+++ b/layers/sync/sync_commandbuffer.h
@@ -290,10 +290,10 @@ class CommandBufferAccessContext : public CommandExecutionContext, DebugNameProv
     void RecordEndRendering(const RecordObject &record_obj);
     bool ValidateDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, const Location &loc) const;
     void RecordDispatchDrawDescriptorSet(VkPipelineBindPoint pipelineBindPoint, ResourceUsageTag tag);
-    bool ValidateDrawVertex(const std::optional<uint32_t> &vertexCount, uint32_t firstVertex, const Location &loc) const;
-    void RecordDrawVertex(const std::optional<uint32_t> &vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
-    bool ValidateDrawVertexIndex(const std::optional<uint32_t> &indexCount, uint32_t firstIndex, const Location &loc) const;
-    void RecordDrawVertexIndex(const std::optional<uint32_t> &indexCount, uint32_t firstIndex, ResourceUsageTag tag);
+    bool ValidateDrawVertex(std::optional<uint32_t> vertexCount, uint32_t firstVertex, const Location &loc) const;
+    void RecordDrawVertex(std::optional<uint32_t> vertexCount, uint32_t firstVertex, ResourceUsageTag tag);
+    bool ValidateDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, const Location &loc) const;
+    void RecordDrawVertexIndex(uint32_t indexCount, uint32_t firstIndex, ResourceUsageTag tag);
     bool ValidateDrawAttachment(const Location &loc) const;
     bool ValidateDrawDynamicRenderingAttachment(const Location &loc) const;
     void RecordDrawAttachment(ResourceUsageTag tag);

--- a/layers/sync/sync_common.cpp
+++ b/layers/sync/sync_common.cpp
@@ -65,19 +65,3 @@ ResourceAccessRange MakeRange(VkDeviceSize offset, uint32_t first_index, uint32_
     const VkDeviceSize range_size = count * stride;
     return MakeRange(range_start, range_size);
 }
-
-ResourceAccessRange MakeRange(const vvl::VertexBufferBinding& binding, uint32_t first_index, const std::optional<uint32_t>& count,
-                              uint32_t stride) {
-    if (count) {
-        return MakeRange(binding.offset, first_index, count.value(), stride);
-    }
-    return MakeRange(binding);
-}
-
-ResourceAccessRange MakeRange(const vvl::IndexBufferBinding& binding, uint32_t first_index, const std::optional<uint32_t>& count,
-                              uint32_t index_size) {
-    if (count) {
-        return MakeRange(binding.offset, first_index, count.value(), index_size);
-    }
-    return MakeRange(binding);
-}

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -66,10 +66,6 @@ ResourceAccessRange MakeRange(VkDeviceSize start, VkDeviceSize size);
 ResourceAccessRange MakeRange(const vvl::Buffer &buffer, VkDeviceSize offset, VkDeviceSize size);
 ResourceAccessRange MakeRange(const vvl::BufferView &buf_view_state);
 ResourceAccessRange MakeRange(VkDeviceSize offset, uint32_t first_index, uint32_t count, uint32_t stride);
-ResourceAccessRange MakeRange(const vvl::VertexBufferBinding &binding, uint32_t first_index, const std::optional<uint32_t> &count,
-                              uint32_t stride);
-ResourceAccessRange MakeRange(const vvl::IndexBufferBinding &binding, uint32_t first_index, const std::optional<uint32_t> &count,
-                              uint32_t index_size);
 
 extern const ResourceAccessRange kFullRange;
 

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -1652,11 +1652,8 @@ bool SyncValidator::PreCallValidateCmdDrawIndirect(VkCommandBuffer commandBuffer
     skip |= cb_access_context->ValidateDrawAttachment(error_obj.location);
     skip |= ValidateIndirectBuffer(*cb_access_context, *context, commandBuffer, sizeof(VkDrawIndirectCommand), buffer, offset,
                                    drawCount, stride, error_obj.location);
-
-    // TODO: For now, we validate the whole vertex buffer. It might cause some false positive.
-    //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will validate the vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertex(std::optional<uint32_t>(), 0, error_obj.location);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // skip |= cb_access_context->ValidateDrawVertex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1673,10 +1670,8 @@ void SyncValidator::PreCallRecordCmdDrawIndirect(VkCommandBuffer commandBuffer, 
     cb_access_context->RecordDrawAttachment(tag);
     RecordIndirectBuffer(*cb_access_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, drawCount, stride);
 
-    // TODO: For now, we record the whole vertex buffer. It might cause some false positive.
-    //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will record the vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertex(std::optional<uint32_t>(), 0, tag);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // cb_access_context->RecordDrawVertex(?, ?, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1697,10 +1692,8 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirect(VkCommandBuffer comman
     skip |= ValidateIndirectBuffer(*cb_access_context, *context, commandBuffer, sizeof(VkDrawIndexedIndirectCommand), buffer,
                                    offset, drawCount, stride, error_obj.location);
 
-    // TODO: For now, we validate the whole index and vertex buffer. It might cause some false positive.
-    //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will validate the index and vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertexIndex(std::optional<uint32_t>(), 0, error_obj.location);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // skip |= cb_access_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1717,10 +1710,8 @@ void SyncValidator::PreCallRecordCmdDrawIndexedIndirect(VkCommandBuffer commandB
     cb_access_context->RecordDrawAttachment(tag);
     RecordIndirectBuffer(*cb_access_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, drawCount, stride);
 
-    // TODO: For now, we record the whole index and vertex buffer. It might cause some false positive.
-    //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will record the index and vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertexIndex(std::optional<uint32_t>(), 0, tag);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // cb_access_context->RecordDrawVertexIndex(?, ?, tag);
 }
 
 bool SyncValidator::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1742,10 +1733,8 @@ bool SyncValidator::PreCallValidateCmdDrawIndirectCount(VkCommandBuffer commandB
                                    maxDrawCount, stride, error_obj.location);
     skip |= ValidateCountBuffer(*cb_access_context, *context, commandBuffer, countBuffer, countBufferOffset, error_obj.location);
 
-    // TODO: For now, we validate the whole vertex buffer. It might cause some false positive.
-    //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will validate the vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertex(std::optional<uint32_t>(), 0, error_obj.location);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // skip |= cb_access_context->ValidateDrawVertex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1763,10 +1752,8 @@ void SyncValidator::RecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, Vk
     RecordIndirectBuffer(*cb_access_context, tag, sizeof(VkDrawIndirectCommand), buffer, offset, 1, stride);
     RecordCountBuffer(*cb_access_context, tag, countBuffer, countBufferOffset);
 
-    // TODO: For now, we record the whole vertex buffer. It might cause some false positive.
-    //       VkDrawIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will record the vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertex(std::optional<uint32_t>(), 0, tag);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // cb_access_context->RecordDrawVertex(?, ?, tag);
 }
 
 void SyncValidator::PreCallRecordCmdDrawIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,
@@ -1827,10 +1814,8 @@ bool SyncValidator::PreCallValidateCmdDrawIndexedIndirectCount(VkCommandBuffer c
                                    offset, maxDrawCount, stride, error_obj.location);
     skip |= ValidateCountBuffer(*cb_access_context, *context, commandBuffer, countBuffer, countBufferOffset, error_obj.location);
 
-    // TODO: For now, we validate the whole index and vertex buffer. It might cause some false positive.
-    //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will validate the index and vertex buffer in SubmitQueue in the future.
-    skip |= cb_access_context->ValidateDrawVertexIndex(std::optional<uint32_t>(), 0, error_obj.location);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // skip |= cb_access_context->ValidateDrawVertexIndex(?, ?, error_obj.location);
     return skip;
 }
 
@@ -1848,10 +1833,8 @@ void SyncValidator::RecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuf
     RecordIndirectBuffer(*cb_access_context, tag, sizeof(VkDrawIndexedIndirectCommand), buffer, offset, 1, stride);
     RecordCountBuffer(*cb_access_context, tag, countBuffer, countBufferOffset);
 
-    // TODO: For now, we record the whole index and vertex buffer. It might cause some false positive.
-    //       VkDrawIndexedIndirectCommand buffer could be changed until SubmitQueue.
-    //       We will update the index and vertex buffer in SubmitQueue in the future.
-    cb_access_context->RecordDrawVertexIndex(std::optional<uint32_t>(), 0, tag);
+    // TODO: Shader instrumentation support is needed to read indirect buffer content (new syncval mode)
+    // cb_access_context->RecordDrawVertexIndex(?, ?, tag);
 }
 
 void SyncValidator::PreCallRecordCmdDrawIndexedIndirectCount(VkCommandBuffer commandBuffer, VkBuffer buffer, VkDeviceSize offset,


### PR DESCRIPTION
Validation of ranges that depend on the values of indirect buffer requires shader instrumentation support or injection of additional commands that read the content of indirect buffers just before the draw (similar to descriptors). Disable corresponding functionality that tried to do its best (validated entire range) since it causes false-positives.

Closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8664, https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8502.
~~Also potentially addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3605.~~
Pretty sure if closes https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/3605 too because that test uses indirect action command, will additionally notify authors.
