### PR TITLE
test: Cleanup shader helper

### DIFF
--- a/tests/framework/render.cpp
+++ b/tests/framework/render.cpp
@@ -27,6 +27,7 @@
 #include "generated/vk_extension_helper.h"
 #include "layer_validation_tests.h"
 #include "vk_layer_config.h"
+#include "shader_helper.h"
 
 #if defined(VK_USE_PLATFORM_METAL_EXT)
 #include "apple_wsi.h"
@@ -1199,4 +1200,10 @@ void VkRenderFramework::SetDefaultDynamicStatesAll(VkCommandBuffer cmdBuffer) {
     VkColorComponentFlags colorWriteMask =
         VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT;
     vk::CmdSetColorWriteMaskEXT(cmdBuffer, 0u, 1u, &colorWriteMask);
+}
+
+std::vector<uint32_t> VkRenderFramework::GLSLToSPV(VkShaderStageFlagBits stage, const char *code, const spv_target_env env) {
+    std::vector<uint32_t> spv;
+    GLSLtoSPV(m_device->Physical().limits_, stage, code, spv, env);
+    return spv;
 }

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -158,7 +158,7 @@ class VkRenderFramework : public VkTestFramework {
     std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const GLSLContainer &code,
                                     const spv_target_env env = SPV_ENV_VULKAN_1_0) {
         std::vector<uint32_t> spv;
-        GLSLtoSPV(&m_device->Physical().limits_, stage, code, spv, env);
+        GLSLtoSPV(m_device->Physical().limits_, stage, code, spv, env);
         return spv;
     }
 

--- a/tests/framework/render.h
+++ b/tests/framework/render.h
@@ -154,13 +154,7 @@ class VkRenderFramework : public VkTestFramework {
     // struct, so be sure to call SetTargetApiVersion before
     void AddDisabledFeature(vkt::Feature feature);
 
-    template <typename GLSLContainer>
-    std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const GLSLContainer &code,
-                                    const spv_target_env env = SPV_ENV_VULKAN_1_0) {
-        std::vector<uint32_t> spv;
-        GLSLtoSPV(m_device->Physical().limits_, stage, code, spv, env);
-        return spv;
-    }
+    std::vector<uint32_t> GLSLToSPV(VkShaderStageFlagBits stage, const char *code, const spv_target_env env = SPV_ENV_VULKAN_1_0);
 
     void SetDesiredFailureMsg(const VkFlags msg_flags, const std::string &msg) {
         m_errorMonitor->SetDesiredFailureMsg(msg_flags, msg);

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -723,10 +723,6 @@ bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limit
         spv::spirvbin_t(0).remap(spirv, spv::spirvbin_t::STRIP);
     }
 
-    if (this->m_do_everything_spv) {
-        spv::spirvbin_t(0).remap(spirv, spv::spirvbin_t::DO_EVERYTHING);
-    }
-
     delete shader;
 
     return true;

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -246,8 +246,8 @@ struct GlslangTargetEnv {
 // Compile a given string containing GLSL into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type,
-                                const char *p_shader, std::vector<uint32_t> &spirv, const spv_target_env spv_env) {
+bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
+               std::vector<uint32_t> &spirv, const spv_target_env spv_env) {
     TBuiltInResource resources;
     ProcessConfigFile(device_limits, resources);
 
@@ -287,8 +287,7 @@ bool VkTestFramework::GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, con
 // Compile a given string containing SPIR-V assembly into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm,
-                               std::vector<uint32_t> &spv) {
+bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv) {
     spv_binary binary;
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(target_env);
@@ -310,7 +309,7 @@ VkPipelineShaderStageCreateInfo const &VkShaderObj::GetStageCreateInfo() const {
 VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkShaderStageFlagBits stage, const spv_target_env env,
                          SpvSourceType source_type, const VkSpecializationInfo *spec_info, char const *entry_point,
                          const void *pNext)
-    : m_framework(*framework), m_device(*(framework->DeviceObj())), m_source(source), m_spv_env(env) {
+    : m_device(*(framework->DeviceObj())), m_source(source), m_spv_env(env) {
     m_stage_info = vku::InitStructHelper();
     m_stage_info.flags = 0;
     m_stage_info.stage = stage;
@@ -326,7 +325,7 @@ VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkSha
 
 bool VkShaderObj::InitFromGLSL(const void *pNext) {
     std::vector<uint32_t> spv;
-    m_framework.GLSLtoSPV(m_device.Physical().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
+    GLSLtoSPV(m_device.Physical().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.pNext = pNext;
@@ -346,7 +345,7 @@ VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device *custom_device) {
     // 99% of tests just use the framework's VkDevice, but this allows for tests to use custom device object
     // Can't set at contructor time since all reference members need to be initialized then.
     VkPhysicalDeviceLimits limits = (custom_device) ? custom_device->Physical().limits_ : m_device.Physical().limits_;
-    m_framework.GLSLtoSPV(limits, m_stage_info.stage, m_source, spv, m_spv_env);
+    GLSLtoSPV(limits, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
@@ -359,7 +358,7 @@ VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device *custom_device) {
 
 bool VkShaderObj::InitFromASM() {
     std::vector<uint32_t> spv;
-    m_framework.ASMtoSPV(m_spv_env, 0, m_source, spv);
+    ASMtoSPV(m_spv_env, 0, m_source, spv);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);
@@ -372,7 +371,7 @@ bool VkShaderObj::InitFromASM() {
 
 VkResult VkShaderObj::InitFromASMTry() {
     std::vector<uint32_t> spv;
-    m_framework.ASMtoSPV(m_spv_env, 0, m_source, spv);
+    ASMtoSPV(m_spv_env, 0, m_source, spv);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);

--- a/tests/framework/shader_helper.cpp
+++ b/tests/framework/shader_helper.cpp
@@ -18,538 +18,127 @@
 
 #include "shader_helper.h"
 #include "glslang/SPIRV/GlslangToSpv.h"
-#include "glslang/SPIRV/SPVRemapper.h"
+#include <glslang/Public/ShaderLang.h>
 
-//
-// These are the default resources for TBuiltInResources, used for both
-//  - parsing this string for the case where the user didn't supply one
-//  - dumping out a template for user construction of a config file
-//
-static const char *DefaultConfig =
-    "MaxLights 32\n"
-    "MaxClipPlanes 6\n"
-    "MaxTextureUnits 32\n"
-    "MaxTextureCoords 32\n"
-    "MaxVertexAttribs 64\n"
-    "MaxVertexUniformComponents 4096\n"
-    "MaxVaryingFloats 64\n"
-    "MaxVertexTextureImageUnits 32\n"
-    "MaxCombinedTextureImageUnits 80\n"
-    "MaxTextureImageUnits 32\n"
-    "MaxFragmentUniformComponents 4096\n"
-    "MaxDrawBuffers 32\n"
-    "MaxVertexUniformVectors 128\n"
-    "MaxVaryingVectors 8\n"
-    "MaxFragmentUniformVectors 16\n"
-    "MaxVertexOutputVectors 16\n"
-    "MaxFragmentInputVectors 15\n"
-    "MinProgramTexelOffset -8\n"
-    "MaxProgramTexelOffset 7\n"
-    "MaxClipDistances 8\n"
-    "MaxComputeWorkGroupCountX 65535\n"
-    "MaxComputeWorkGroupCountY 65535\n"
-    "MaxComputeWorkGroupCountZ 65535\n"
-    "MaxComputeWorkGroupSizeX 1024\n"
-    "MaxComputeWorkGroupSizeY 1024\n"
-    "MaxComputeWorkGroupSizeZ 64\n"
-    "MaxComputeUniformComponents 1024\n"
-    "MaxComputeTextureImageUnits 16\n"
-    "MaxComputeImageUniforms 8\n"
-    "MaxComputeAtomicCounters 8\n"
-    "MaxComputeAtomicCounterBuffers 1\n"
-    "MaxVaryingComponents 60\n"
-    "MaxVertexOutputComponents 64\n"
-    "MaxGeometryInputComponents 64\n"
-    "MaxGeometryOutputComponents 128\n"
-    "MaxFragmentInputComponents 128\n"
-    "MaxImageUnits 8\n"
-    "MaxCombinedImageUnitsAndFragmentOutputs 8\n"
-    "MaxCombinedShaderOutputResources 8\n"
-    "MaxImageSamples 0\n"
-    "MaxVertexImageUniforms 0\n"
-    "MaxTessControlImageUniforms 0\n"
-    "MaxTessEvaluationImageUniforms 0\n"
-    "MaxGeometryImageUniforms 0\n"
-    "MaxFragmentImageUniforms 8\n"
-    "MaxCombinedImageUniforms 8\n"
-    "MaxGeometryTextureImageUnits 16\n"
-    "MaxGeometryOutputVertices 256\n"
-    "MaxGeometryTotalOutputComponents 1024\n"
-    "MaxGeometryUniformComponents 1024\n"
-    "MaxGeometryVaryingComponents 64\n"
-    "MaxTessControlInputComponents 128\n"
-    "MaxTessControlOutputComponents 128\n"
-    "MaxTessControlTextureImageUnits 16\n"
-    "MaxTessControlUniformComponents 1024\n"
-    "MaxTessControlTotalOutputComponents 4096\n"
-    "MaxTessEvaluationInputComponents 128\n"
-    "MaxTessEvaluationOutputComponents 128\n"
-    "MaxTessEvaluationTextureImageUnits 16\n"
-    "MaxTessEvaluationUniformComponents 1024\n"
-    "MaxTessPatchComponents 120\n"
-    "MaxPatchVertices 32\n"
-    "MaxTessGenLevel 64\n"
-    "MaxViewports 16\n"
-    "MaxVertexAtomicCounters 0\n"
-    "MaxTessControlAtomicCounters 0\n"
-    "MaxTessEvaluationAtomicCounters 0\n"
-    "MaxGeometryAtomicCounters 0\n"
-    "MaxFragmentAtomicCounters 8\n"
-    "MaxCombinedAtomicCounters 8\n"
-    "MaxAtomicCounterBindings 1\n"
-    "MaxVertexAtomicCounterBuffers 0\n"
-    "MaxTessControlAtomicCounterBuffers 0\n"
-    "MaxTessEvaluationAtomicCounterBuffers 0\n"
-    "MaxGeometryAtomicCounterBuffers 0\n"
-    "MaxFragmentAtomicCounterBuffers 1\n"
-    "MaxCombinedAtomicCounterBuffers 1\n"
-    "MaxAtomicCounterBufferSize 16384\n"
-    "MaxTransformFeedbackBuffers 4\n"
-    "MaxTransformFeedbackInterleavedComponents 64\n"
-    "MaxCullDistances 8\n"
-    "MaxCombinedClipAndCullDistances 8\n"
-    "MaxSamples 4\n"
-    "MaxMeshOutputVerticesNV 256\n"
-    "MaxMeshOutputPrimitivesNV 512\n"
-    "MaxMeshWorkGroupSizeX_NV 32\n"
-    "MaxMeshWorkGroupSizeY_NV 1\n"
-    "MaxMeshWorkGroupSizeZ_NV 1\n"
-    "MaxTaskWorkGroupSizeX_NV 32\n"
-    "MaxTaskWorkGroupSizeY_NV 1\n"
-    "MaxTaskWorkGroupSizeZ_NV 1\n"
-    "MaxMeshViewCountNV 4\n"
-    "MaxMeshOutputVerticesEXT 256\n"
-    "MaxMeshOutputPrimitivesEXT 512\n"
-    "MaxMeshWorkGroupSizeX_EXT 32\n"
-    "MaxMeshWorkGroupSizeY_EXT 1\n"
-    "MaxMeshWorkGroupSizeZ_EXT 1\n"
-    "MaxTaskWorkGroupSizeX_EXT 32\n"
-    "MaxTaskWorkGroupSizeY_EXT 1\n"
-    "MaxTaskWorkGroupSizeZ_EXT 1\n"
-    "MaxMeshViewCountEXT 4\n"
+static void ProcessConfigFile(const VkPhysicalDeviceLimits &device_limits, TBuiltInResource &out_resources) {
+    // These are the default resources for TBuiltInResources.
+    out_resources.maxLights = 32;
+    out_resources.maxClipPlanes = 6;
+    out_resources.maxTextureUnits = 32;
+    out_resources.maxTextureCoords = 32;
+    out_resources.maxVertexAttribs = 64;
+    out_resources.maxVertexUniformComponents = 4096;
+    out_resources.maxVaryingFloats = 64;
+    out_resources.maxVertexTextureImageUnits = 32;
+    out_resources.maxCombinedTextureImageUnits = 80;
+    out_resources.maxTextureImageUnits = 32;
+    out_resources.maxFragmentUniformComponents = 4096;
+    out_resources.maxDrawBuffers = 32;
+    out_resources.maxVertexUniformVectors = 128;
+    out_resources.maxVaryingVectors = 8;
+    out_resources.maxFragmentUniformVectors = 16;
+    out_resources.maxVertexOutputVectors = 16;
+    out_resources.maxFragmentInputVectors = 15;
+    out_resources.minProgramTexelOffset = -8;
+    out_resources.maxProgramTexelOffset = 7;
+    out_resources.maxClipDistances = device_limits.maxClipDistances;
+    out_resources.maxComputeWorkGroupCountX = device_limits.maxComputeWorkGroupCount[0];
+    out_resources.maxComputeWorkGroupCountY = device_limits.maxComputeWorkGroupCount[1];
+    out_resources.maxComputeWorkGroupCountZ = device_limits.maxComputeWorkGroupCount[2];
+    out_resources.maxComputeWorkGroupSizeX = device_limits.maxComputeWorkGroupSize[0];
+    out_resources.maxComputeWorkGroupSizeY = device_limits.maxComputeWorkGroupSize[1];
+    out_resources.maxComputeWorkGroupSizeZ = device_limits.maxComputeWorkGroupSize[2];
+    out_resources.maxComputeUniformComponents = 1024;
+    out_resources.maxComputeTextureImageUnits = 16;
+    out_resources.maxComputeImageUniforms = 8;
+    out_resources.maxComputeAtomicCounters = 8;
+    out_resources.maxComputeAtomicCounterBuffers = 1;
+    out_resources.maxVaryingComponents = 60;
+    out_resources.maxVertexOutputComponents = device_limits.maxVertexOutputComponents;
+    out_resources.maxGeometryInputComponents = device_limits.maxGeometryInputComponents;
+    out_resources.maxGeometryOutputComponents = device_limits.maxGeometryOutputComponents;
+    out_resources.maxFragmentInputComponents = device_limits.maxFragmentInputComponents;
+    out_resources.maxImageUnits = 8;
+    out_resources.maxCombinedImageUnitsAndFragmentOutputs = 8;
+    out_resources.maxCombinedShaderOutputResources = 8;
+    out_resources.maxImageSamples = 0;
+    out_resources.maxVertexImageUniforms = 0;
+    out_resources.maxTessControlImageUniforms = 0;
+    out_resources.maxTessEvaluationImageUniforms = 0;
+    out_resources.maxGeometryImageUniforms = 0;
+    out_resources.maxFragmentImageUniforms = 8;
+    out_resources.maxCombinedImageUniforms = 8;
+    out_resources.maxGeometryTextureImageUnits = 16;
+    out_resources.maxGeometryOutputVertices = device_limits.maxGeometryOutputVertices;
+    out_resources.maxGeometryTotalOutputComponents = device_limits.maxGeometryTotalOutputComponents;
+    out_resources.maxGeometryUniformComponents = 1024;
+    out_resources.maxGeometryVaryingComponents = 64;
+    out_resources.maxTessControlInputComponents = 128;
+    out_resources.maxTessControlOutputComponents = 128;
+    out_resources.maxTessControlTextureImageUnits = 16;
+    out_resources.maxTessControlUniformComponents = 1024;
+    out_resources.maxTessControlTotalOutputComponents = 4096;
+    out_resources.maxTessEvaluationInputComponents = 128;
+    out_resources.maxTessEvaluationOutputComponents = 128;
+    out_resources.maxTessEvaluationTextureImageUnits = 16;
+    out_resources.maxTessEvaluationUniformComponents = 1024;
+    out_resources.maxTessPatchComponents = 120;
+    out_resources.maxPatchVertices = 32;
+    out_resources.maxTessGenLevel = 64;
+    out_resources.maxViewports = device_limits.maxViewports;
+    out_resources.maxVertexAtomicCounters = 0;
+    out_resources.maxTessControlAtomicCounters = 0;
+    out_resources.maxTessEvaluationAtomicCounters = 0;
+    out_resources.maxGeometryAtomicCounters = 0;
+    out_resources.maxFragmentAtomicCounters = 8;
+    out_resources.maxCombinedAtomicCounters = 8;
+    out_resources.maxAtomicCounterBindings = 1;
+    out_resources.maxVertexAtomicCounterBuffers = 0;
+    out_resources.maxTessControlAtomicCounterBuffers = 0;
+    out_resources.maxTessEvaluationAtomicCounterBuffers = 0;
+    out_resources.maxGeometryAtomicCounterBuffers = 0;
+    out_resources.maxFragmentAtomicCounterBuffers = 1;
+    out_resources.maxCombinedAtomicCounterBuffers = 1;
+    out_resources.maxAtomicCounterBufferSize = 16384;
+    out_resources.maxTransformFeedbackBuffers = 4;
+    out_resources.maxTransformFeedbackInterleavedComponents = 64;
+    out_resources.maxCullDistances = device_limits.maxCullDistances;
+    out_resources.maxCombinedClipAndCullDistances = 8;
+    out_resources.maxSamples = 4;
+    out_resources.maxMeshOutputVerticesNV = 256;
+    out_resources.maxMeshOutputPrimitivesNV = 512;
+    out_resources.maxMeshWorkGroupSizeX_NV = 32;
+    out_resources.maxMeshWorkGroupSizeY_NV = 1;
+    out_resources.maxMeshWorkGroupSizeZ_NV = 1;
+    out_resources.maxTaskWorkGroupSizeX_NV = 32;
+    out_resources.maxTaskWorkGroupSizeY_NV = 1;
+    out_resources.maxTaskWorkGroupSizeZ_NV = 1;
+    out_resources.maxMeshViewCountNV = 4;
+    out_resources.maxMeshOutputVerticesEXT = 256;
+    out_resources.maxMeshOutputPrimitivesEXT = 512;
+    out_resources.maxMeshWorkGroupSizeX_EXT = 32;
+    out_resources.maxMeshWorkGroupSizeY_EXT = 1;
+    out_resources.maxMeshWorkGroupSizeZ_EXT = 1;
+    out_resources.maxTaskWorkGroupSizeX_EXT = 32;
+    out_resources.maxTaskWorkGroupSizeY_EXT = 1;
+    out_resources.maxTaskWorkGroupSizeZ_EXT = 1;
+    out_resources.maxMeshViewCountEXT = 4;
 
-    "nonInductiveForLoops 1\n"
-    "whileLoops 1\n"
-    "doWhileLoops 1\n"
-    "generalUniformIndexing 1\n"
-    "generalAttributeMatrixVectorIndexing 1\n"
-    "generalVaryingIndexing 1\n"
-    "generalSamplerIndexing 1\n"
-    "generalVariableIndexing 1\n"
-    "generalConstantMatrixVectorIndexing 1\n";
-
-//
-// *.conf => this is a config file that can set limits/resources
-//
-bool VkTestFramework::SetConfigFile(const std::string &name) {
-    if (name.size() < 5) return false;
-
-    if (name.compare(name.size() - 5, 5, ".conf") == 0) {
-        ConfigFile = name;
-        return true;
-    }
-
-    return false;
-}
-
-//
-// Parse either a .conf file provided by the user or the default string above.
-//
-void VkTestFramework::ProcessConfigFile(VkPhysicalDeviceLimits const *const device_limits) {
-    char **configStrings = 0;
-    char *config = 0;
-    bool config_file_specified = false;
-    if (ConfigFile.size() > 0) {
-        configStrings = ReadFileData(ConfigFile.c_str());
-        if (configStrings) {
-            config = *configStrings;
-            config_file_specified = true;
-        } else {
-            printf("Error opening configuration file; will instead use the default configuration\n");
-        }
-    }
-
-    if (config == 0) {
-        config = (char *)alloca(strlen(DefaultConfig) + 1);
-        strcpy(config, DefaultConfig);
-    }
-
-    const char *delims = " \t\n\r";
-    const char *token = strtok(config, delims);
-    while (token) {
-        const char *valueStr = strtok(0, delims);
-        if (valueStr == 0 || !(valueStr[0] == '-' || (valueStr[0] >= '0' && valueStr[0] <= '9'))) {
-            printf("Error: '%s' bad .conf file.  Each name must be followed by one number.\n", valueStr ? valueStr : "");
-            return;
-        }
-        int value = atoi(valueStr);
-
-        if (strcmp(token, "MaxLights") == 0)
-            Resources.maxLights = value;
-        else if (strcmp(token, "MaxClipPlanes") == 0)
-            Resources.maxClipPlanes = value;
-        else if (strcmp(token, "MaxTextureUnits") == 0)
-            Resources.maxTextureUnits = value;
-        else if (strcmp(token, "MaxTextureCoords") == 0)
-            Resources.maxTextureCoords = value;
-        else if (strcmp(token, "MaxVertexAttribs") == 0)
-            Resources.maxVertexAttribs = value;
-        else if (strcmp(token, "MaxVertexUniformComponents") == 0)
-            Resources.maxVertexUniformComponents = value;
-        else if (strcmp(token, "MaxVaryingFloats") == 0)
-            Resources.maxVaryingFloats = value;
-        else if (strcmp(token, "MaxVertexTextureImageUnits") == 0)
-            Resources.maxVertexTextureImageUnits = value;
-        else if (strcmp(token, "MaxCombinedTextureImageUnits") == 0)
-            Resources.maxCombinedTextureImageUnits = value;
-        else if (strcmp(token, "MaxTextureImageUnits") == 0)
-            Resources.maxTextureImageUnits = value;
-        else if (strcmp(token, "MaxFragmentUniformComponents") == 0)
-            Resources.maxFragmentUniformComponents = value;
-        else if (strcmp(token, "MaxDrawBuffers") == 0)
-            Resources.maxDrawBuffers = value;
-        else if (strcmp(token, "MaxVertexUniformVectors") == 0)
-            Resources.maxVertexUniformVectors = value;
-        else if (strcmp(token, "MaxVaryingVectors") == 0)
-            Resources.maxVaryingVectors = value;
-        else if (strcmp(token, "MaxFragmentUniformVectors") == 0)
-            Resources.maxFragmentUniformVectors = value;
-        else if (strcmp(token, "MaxVertexOutputVectors") == 0)
-            Resources.maxVertexOutputVectors = value;
-        else if (strcmp(token, "MaxFragmentInputVectors") == 0)
-            Resources.maxFragmentInputVectors = value;
-        else if (strcmp(token, "MinProgramTexelOffset") == 0)
-            Resources.minProgramTexelOffset = value;
-        else if (strcmp(token, "MaxProgramTexelOffset") == 0)
-            Resources.maxProgramTexelOffset = value;
-        else if (strcmp(token, "MaxClipDistances") == 0)
-            Resources.maxClipDistances = (config_file_specified ? value : device_limits->maxClipDistances);
-        else if (strcmp(token, "MaxComputeWorkGroupCountX") == 0)
-            Resources.maxComputeWorkGroupCountX = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[0]);
-        else if (strcmp(token, "MaxComputeWorkGroupCountY") == 0)
-            Resources.maxComputeWorkGroupCountY = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[1]);
-        else if (strcmp(token, "MaxComputeWorkGroupCountZ") == 0)
-            Resources.maxComputeWorkGroupCountZ = (config_file_specified ? value : device_limits->maxComputeWorkGroupCount[2]);
-        else if (strcmp(token, "MaxComputeWorkGroupSizeX") == 0)
-            Resources.maxComputeWorkGroupSizeX = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[0]);
-        else if (strcmp(token, "MaxComputeWorkGroupSizeY") == 0)
-            Resources.maxComputeWorkGroupSizeY = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[1]);
-        else if (strcmp(token, "MaxComputeWorkGroupSizeZ") == 0)
-            Resources.maxComputeWorkGroupSizeZ = (config_file_specified ? value : device_limits->maxComputeWorkGroupSize[2]);
-        else if (strcmp(token, "MaxComputeUniformComponents") == 0)
-            Resources.maxComputeUniformComponents = value;
-        else if (strcmp(token, "MaxComputeTextureImageUnits") == 0)
-            Resources.maxComputeTextureImageUnits = value;
-        else if (strcmp(token, "MaxComputeImageUniforms") == 0)
-            Resources.maxComputeImageUniforms = value;
-        else if (strcmp(token, "MaxComputeAtomicCounters") == 0)
-            Resources.maxComputeAtomicCounters = value;
-        else if (strcmp(token, "MaxComputeAtomicCounterBuffers") == 0)
-            Resources.maxComputeAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxVaryingComponents") == 0)
-            Resources.maxVaryingComponents = value;
-        else if (strcmp(token, "MaxVertexOutputComponents") == 0)
-            Resources.maxVertexOutputComponents = (config_file_specified ? value : device_limits->maxVertexOutputComponents);
-        else if (strcmp(token, "MaxGeometryInputComponents") == 0)
-            Resources.maxGeometryInputComponents = (config_file_specified ? value : device_limits->maxGeometryInputComponents);
-        else if (strcmp(token, "MaxGeometryOutputComponents") == 0)
-            Resources.maxGeometryOutputComponents = (config_file_specified ? value : device_limits->maxGeometryOutputComponents);
-        else if (strcmp(token, "MaxFragmentInputComponents") == 0)
-            Resources.maxFragmentInputComponents = (config_file_specified ? value : device_limits->maxFragmentInputComponents);
-        else if (strcmp(token, "MaxImageUnits") == 0)
-            Resources.maxImageUnits = value;
-        else if (strcmp(token, "MaxCombinedImageUnitsAndFragmentOutputs") == 0)
-            Resources.maxCombinedImageUnitsAndFragmentOutputs = value;
-        else if (strcmp(token, "MaxCombinedShaderOutputResources") == 0)
-            Resources.maxCombinedShaderOutputResources = value;
-        else if (strcmp(token, "MaxImageSamples") == 0)
-            Resources.maxImageSamples = value;
-        else if (strcmp(token, "MaxVertexImageUniforms") == 0)
-            Resources.maxVertexImageUniforms = value;
-        else if (strcmp(token, "MaxTessControlImageUniforms") == 0)
-            Resources.maxTessControlImageUniforms = value;
-        else if (strcmp(token, "MaxTessEvaluationImageUniforms") == 0)
-            Resources.maxTessEvaluationImageUniforms = value;
-        else if (strcmp(token, "MaxGeometryImageUniforms") == 0)
-            Resources.maxGeometryImageUniforms = value;
-        else if (strcmp(token, "MaxFragmentImageUniforms") == 0)
-            Resources.maxFragmentImageUniforms = value;
-        else if (strcmp(token, "MaxCombinedImageUniforms") == 0)
-            Resources.maxCombinedImageUniforms = value;
-        else if (strcmp(token, "MaxGeometryTextureImageUnits") == 0)
-            Resources.maxGeometryTextureImageUnits = value;
-        else if (strcmp(token, "MaxGeometryOutputVertices") == 0)
-            Resources.maxGeometryOutputVertices = (config_file_specified ? value : device_limits->maxGeometryOutputVertices);
-        else if (strcmp(token, "MaxGeometryTotalOutputComponents") == 0)
-            Resources.maxGeometryTotalOutputComponents =
-                (config_file_specified ? value : device_limits->maxGeometryTotalOutputComponents);
-        else if (strcmp(token, "MaxGeometryUniformComponents") == 0)
-            Resources.maxGeometryUniformComponents = value;
-        else if (strcmp(token, "MaxGeometryVaryingComponents") == 0)
-            Resources.maxGeometryVaryingComponents = value;
-        else if (strcmp(token, "MaxTessControlInputComponents") == 0)
-            Resources.maxTessControlInputComponents = value;
-        else if (strcmp(token, "MaxTessControlOutputComponents") == 0)
-            Resources.maxTessControlOutputComponents = value;
-        else if (strcmp(token, "MaxTessControlTextureImageUnits") == 0)
-            Resources.maxTessControlTextureImageUnits = value;
-        else if (strcmp(token, "MaxTessControlUniformComponents") == 0)
-            Resources.maxTessControlUniformComponents = value;
-        else if (strcmp(token, "MaxTessControlTotalOutputComponents") == 0)
-            Resources.maxTessControlTotalOutputComponents = value;
-        else if (strcmp(token, "MaxTessEvaluationInputComponents") == 0)
-            Resources.maxTessEvaluationInputComponents = value;
-        else if (strcmp(token, "MaxTessEvaluationOutputComponents") == 0)
-            Resources.maxTessEvaluationOutputComponents = value;
-        else if (strcmp(token, "MaxTessEvaluationTextureImageUnits") == 0)
-            Resources.maxTessEvaluationTextureImageUnits = value;
-        else if (strcmp(token, "MaxTessEvaluationUniformComponents") == 0)
-            Resources.maxTessEvaluationUniformComponents = value;
-        else if (strcmp(token, "MaxTessPatchComponents") == 0)
-            Resources.maxTessPatchComponents = value;
-        else if (strcmp(token, "MaxPatchVertices") == 0)
-            Resources.maxPatchVertices = value;
-        else if (strcmp(token, "MaxTessGenLevel") == 0)
-            Resources.maxTessGenLevel = value;
-        else if (strcmp(token, "MaxViewports") == 0)
-            Resources.maxViewports = (config_file_specified ? value : device_limits->maxViewports);
-        else if (strcmp(token, "MaxVertexAtomicCounters") == 0)
-            Resources.maxVertexAtomicCounters = value;
-        else if (strcmp(token, "MaxTessControlAtomicCounters") == 0)
-            Resources.maxTessControlAtomicCounters = value;
-        else if (strcmp(token, "MaxTessEvaluationAtomicCounters") == 0)
-            Resources.maxTessEvaluationAtomicCounters = value;
-        else if (strcmp(token, "MaxGeometryAtomicCounters") == 0)
-            Resources.maxGeometryAtomicCounters = value;
-        else if (strcmp(token, "MaxFragmentAtomicCounters") == 0)
-            Resources.maxFragmentAtomicCounters = value;
-        else if (strcmp(token, "MaxCombinedAtomicCounters") == 0)
-            Resources.maxCombinedAtomicCounters = value;
-        else if (strcmp(token, "MaxAtomicCounterBindings") == 0)
-            Resources.maxAtomicCounterBindings = value;
-        else if (strcmp(token, "MaxVertexAtomicCounterBuffers") == 0)
-            Resources.maxVertexAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxTessControlAtomicCounterBuffers") == 0)
-            Resources.maxTessControlAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxTessEvaluationAtomicCounterBuffers") == 0)
-            Resources.maxTessEvaluationAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxGeometryAtomicCounterBuffers") == 0)
-            Resources.maxGeometryAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxFragmentAtomicCounterBuffers") == 0)
-            Resources.maxFragmentAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxCombinedAtomicCounterBuffers") == 0)
-            Resources.maxCombinedAtomicCounterBuffers = value;
-        else if (strcmp(token, "MaxAtomicCounterBufferSize") == 0)
-            Resources.maxAtomicCounterBufferSize = value;
-        else if (strcmp(token, "MaxTransformFeedbackBuffers") == 0)
-            Resources.maxTransformFeedbackBuffers = value;
-        else if (strcmp(token, "MaxTransformFeedbackInterleavedComponents") == 0)
-            Resources.maxTransformFeedbackInterleavedComponents = value;
-        else if (strcmp(token, "MaxCullDistances") == 0)
-            Resources.maxCullDistances = (config_file_specified ? value : device_limits->maxCullDistances);
-        else if (strcmp(token, "MaxCombinedClipAndCullDistances") == 0)
-            Resources.maxCombinedClipAndCullDistances = value;
-        else if (strcmp(token, "MaxSamples") == 0)
-            Resources.maxSamples = value;
-        else if (strcmp(token, "MaxMeshOutputVerticesNV") == 0)
-            Resources.maxMeshOutputVerticesNV = value;
-        else if (strcmp(token, "MaxMeshOutputPrimitivesNV") == 0)
-            Resources.maxMeshOutputPrimitivesNV = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeX_NV") == 0)
-            Resources.maxMeshWorkGroupSizeX_NV = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeY_NV") == 0)
-            Resources.maxMeshWorkGroupSizeY_NV = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeZ_NV") == 0)
-            Resources.maxMeshWorkGroupSizeZ_NV = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeX_NV") == 0)
-            Resources.maxTaskWorkGroupSizeX_NV = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeY_NV") == 0)
-            Resources.maxTaskWorkGroupSizeY_NV = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeZ_NV") == 0)
-            Resources.maxTaskWorkGroupSizeZ_NV = value;
-        else if (strcmp(token, "MaxMeshViewCountNV") == 0)
-            Resources.maxMeshViewCountNV = value;
-        else if (strcmp(token, "MaxMeshOutputVerticesEXT") == 0)
-            Resources.maxMeshOutputVerticesEXT = value;
-        else if (strcmp(token, "MaxMeshOutputPrimitivesEXT") == 0)
-            Resources.maxMeshOutputPrimitivesEXT = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeX_EXT") == 0)
-            Resources.maxMeshWorkGroupSizeX_EXT = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeY_EXT") == 0)
-            Resources.maxMeshWorkGroupSizeY_EXT = value;
-        else if (strcmp(token, "MaxMeshWorkGroupSizeZ_EXT") == 0)
-            Resources.maxMeshWorkGroupSizeZ_EXT = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeX_EXT") == 0)
-            Resources.maxTaskWorkGroupSizeX_EXT = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeY_EXT") == 0)
-            Resources.maxTaskWorkGroupSizeY_EXT = value;
-        else if (strcmp(token, "MaxTaskWorkGroupSizeZ_EXT") == 0)
-            Resources.maxTaskWorkGroupSizeZ_EXT = value;
-        else if (strcmp(token, "MaxMeshViewCountEXT") == 0)
-            Resources.maxMeshViewCountEXT = value;
-
-        else if (strcmp(token, "nonInductiveForLoops") == 0)
-            Resources.limits.nonInductiveForLoops = (value != 0);
-        else if (strcmp(token, "whileLoops") == 0)
-            Resources.limits.whileLoops = (value != 0);
-        else if (strcmp(token, "doWhileLoops") == 0)
-            Resources.limits.doWhileLoops = (value != 0);
-        else if (strcmp(token, "generalUniformIndexing") == 0)
-            Resources.limits.generalUniformIndexing = (value != 0);
-        else if (strcmp(token, "generalAttributeMatrixVectorIndexing") == 0)
-            Resources.limits.generalAttributeMatrixVectorIndexing = (value != 0);
-        else if (strcmp(token, "generalVaryingIndexing") == 0)
-            Resources.limits.generalVaryingIndexing = (value != 0);
-        else if (strcmp(token, "generalSamplerIndexing") == 0)
-            Resources.limits.generalSamplerIndexing = (value != 0);
-        else if (strcmp(token, "generalVariableIndexing") == 0)
-            Resources.limits.generalVariableIndexing = (value != 0);
-        else if (strcmp(token, "generalConstantMatrixVectorIndexing") == 0)
-            Resources.limits.generalConstantMatrixVectorIndexing = (value != 0);
-        else
-            printf("Warning: unrecognized limit (%s) in configuration file.\n", token);
-
-        token = strtok(0, delims);
-    }
-    if (configStrings) FreeFileData(configStrings);
-}
-
-void VkTestFramework::SetMessageOptions(EShMessages &messages) {
-    if (m_compile_options & EOptionRelaxedErrors) messages = (EShMessages)(messages | EShMsgRelaxedErrors);
-    if (m_compile_options & EOptionIntermediate) messages = (EShMessages)(messages | EShMsgAST);
-    if (m_compile_options & EOptionSuppressWarnings) messages = (EShMessages)(messages | EShMsgSuppressWarnings);
-}
-
-#ifndef _WIN32
-#include <errno.h>
-int fopen_s(FILE **pFile, const char *filename, const char *mode) {
-    if (!pFile || !filename || !mode) {
-        return EINVAL;
-    }
-
-    FILE *f = fopen(filename, mode);
-    if (!f) {
-        if (errno != 0) {
-            return errno;
-        } else {
-            return ENOENT;
-        }
-    }
-    *pFile = f;
-
-    return 0;
-}
-#endif
-
-//
-//   Malloc a string of sufficient size and read a string into it.
-//
-char **VkTestFramework::ReadFileData(const char *fileName) {
-    FILE *in;
-#if defined(_WIN32) && defined(__GNUC__)
-    in = fopen(fileName, "r");
-    int errorCode = in ? 0 : 1;
-#else
-    int errorCode = fopen_s(&in, fileName, "r");
-#endif
-
-    size_t count = 0;
-    const int maxSourceStrings = 5;
-    char **return_data = (char **)malloc(sizeof(char *) * (maxSourceStrings + 1));
-
-    if (errorCode) {
-        printf("Error: unable to open input file: %s\n", fileName);
-        return nullptr;
-    }
-
-    while (fgetc(in) != EOF) count++;
-
-    if (fseek(in, 0, SEEK_SET) != 0) {
-        printf("Error fseek to start of file\n");
-        return nullptr;
-    }
-
-    char *fdata = (char *)malloc(count + 2);
-    if (fdata == nullptr) {
-        printf("Error allocating memory\n");
-        return nullptr;
-    }
-    if (fread(fdata, 1, count, in) != count) {
-        printf("Error reading input file: %s\n", fileName);
-        return nullptr;
-    }
-    fdata[count] = '\0';
-    fclose(in);
-    if (count == 0) {
-        return_data[0] = (char *)malloc(count + 2);
-        return_data[0][0] = '\0';
-        m_num_shader_strings = 0;
-        return return_data;
-    } else
-        m_num_shader_strings = 1;
-
-    size_t len = (int)(ceil)((float)count / (float)m_num_shader_strings);
-    size_t ptr_len = 0, i = 0;
-    while (count > 0) {
-        return_data[i] = (char *)malloc(len + 2);
-        memcpy(return_data[i], fdata + ptr_len, len);
-        return_data[i][len] = '\0';
-        count -= (len);
-        ptr_len += (len);
-        if (count < len) {
-            if (count == 0) {
-                m_num_shader_strings = (static_cast<int>(i) + 1);
-                break;
-            }
-            len = count;
-        }
-        ++i;
-    }
-    return return_data;
-}
-
-void VkTestFramework::FreeFileData(char **data) {
-    for (int i = 0; i < m_num_shader_strings; i++) free(data[i]);
-}
-
-//
-//   Deduce the language from the filename.  Files must end in one of the
-//   following extensions:
-//
-//   .vert = vertex
-//   .tesc = tessellation control
-//   .tese = tessellation evaluation
-//   .geom = geometry
-//   .frag = fragment
-//   .comp = compute
-//
-EShLanguage VkTestFramework::FindLanguage(const std::string &name) {
-    size_t ext = name.rfind('.');
-    if (ext == std::string::npos) {
-        return EShLangVertex;
-    }
-
-    std::string suffix = name.substr(ext + 1, std::string::npos);
-    if (suffix == "vert")
-        return EShLangVertex;
-    else if (suffix == "tesc")
-        return EShLangTessControl;
-    else if (suffix == "tese")
-        return EShLangTessEvaluation;
-    else if (suffix == "geom")
-        return EShLangGeometry;
-    else if (suffix == "frag")
-        return EShLangFragment;
-    else if (suffix == "comp")
-        return EShLangCompute;
-
-    return EShLangVertex;
+    out_resources.limits.nonInductiveForLoops = 1;
+    out_resources.limits.whileLoops = 1;
+    out_resources.limits.doWhileLoops = 1;
+    out_resources.limits.generalUniformIndexing = 1;
+    out_resources.limits.generalAttributeMatrixVectorIndexing = 1;
+    out_resources.limits.generalVaryingIndexing = 1;
+    out_resources.limits.generalSamplerIndexing = 1;
+    out_resources.limits.generalVariableIndexing = 1;
+    out_resources.limits.generalConstantMatrixVectorIndexing = 1;
 }
 
 //
 // Convert VK shader type to compiler's
 //
-EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_type) {
+static EShLanguage FindLanguage(const VkShaderStageFlagBits shader_type) {
     switch (shader_type) {
         case VK_SHADER_STAGE_VERTEX_BIT:
             return EShLangVertex;
@@ -594,6 +183,7 @@ EShLanguage VkTestFramework::FindLanguage(const VkShaderStageFlagBits shader_typ
             return EShLangMesh;
 
         default:
+            assert(false);
             return EShLangVertex;
     }
 }
@@ -656,74 +246,39 @@ struct GlslangTargetEnv {
 // Compile a given string containing GLSL into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
-                                const char *pshader, std::vector<uint32_t> &spirv, const spv_target_env spv_env) {
-    glslang::TProgram program;
-    const char *shaderStrings[1];
+bool VkTestFramework::GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type,
+                                const char *p_shader, std::vector<uint32_t> &spirv, const spv_target_env spv_env) {
+    TBuiltInResource resources;
+    ProcessConfigFile(device_limits, resources);
 
-    // TODO: Do we want to load a special config file depending on the
-    // shader source? Optional name maybe?
-    //    SetConfigFile(fileName);
-
-    ProcessConfigFile(device_limits);
-
-    EShMessages messages = EShMsgDefault;
-    SetMessageOptions(messages);
-    messages = static_cast<EShMessages>(messages | EShMsgSpvRules | EShMsgVulkanRules);
-
+    EShMessages messages = static_cast<EShMessages>(EShMsgDefault | EShMsgSpvRules | EShMsgVulkanRules);
     EShLanguage stage = FindLanguage(shader_type);
-    glslang::TShader *shader = new glslang::TShader(stage);
+    glslang::TShader shader(stage);
     GlslangTargetEnv glslang_env(spv_env);
-    shader->setEnvTarget(glslang::EshTargetSpv, glslang_env);
-    shader->setEnvClient(glslang::EShClientVulkan, glslang_env);
+    shader.setEnvTarget(glslang::EshTargetSpv, glslang_env);
+    shader.setEnvClient(glslang::EShClientVulkan, glslang_env);
 
-    shaderStrings[0] = pshader;
-    shader->setStrings(shaderStrings, 1);
+    const char *shader_strings[1];
+    shader_strings[0] = p_shader;
+    shader.setStrings(shader_strings, 1);
 
-    if (!shader->parse(&Resources, (m_compile_options & EOptionDefaultDesktop) ? 110 : 100, false, messages)) {
-        if (!(m_compile_options & EOptionSuppressInfolog)) {
-            puts(shader->getInfoLog());
-            puts(shader->getInfoDebugLog());
-        }
-
+    if (!shader.parse(&resources, 100, false, messages)) {
+        puts(shader.getInfoLog());
+        puts(shader.getInfoDebugLog());
         return false;  // something didn't work
     }
 
-    program.addShader(shader);
-
-    //
-    // Program-level processing...
-    //
+    glslang::TProgram program;
+    program.addShader(&shader);
 
     if (!program.link(messages)) {
-        if (!(m_compile_options & EOptionSuppressInfolog)) {
-            puts(shader->getInfoLog());
-            puts(shader->getInfoDebugLog());
-        }
-
+        puts(shader.getInfoLog());
+        puts(shader.getInfoDebugLog());
         return false;
-    }
-
-    if (m_compile_options & EOptionDumpReflection) {
-        program.buildReflection();
-        program.dumpReflection();
     }
 
     glslang::SpvOptions spv_options;
     glslang::GlslangToSpv(*program.getIntermediate(stage), spirv, &spv_options);
-
-    //
-    // Test the different modes of SPIR-V modification
-    //
-    if (this->m_canonicalize_spv) {
-        spv::spirvbin_t(0).remap(spirv, spv::spirvbin_t::ALL_BUT_STRIP);
-    }
-
-    if (this->m_strip_spv) {
-        spv::spirvbin_t(0).remap(spirv, spv::spirvbin_t::STRIP);
-    }
-
-    delete shader;
 
     return true;
 }
@@ -732,12 +287,12 @@ bool VkTestFramework::GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limit
 // Compile a given string containing SPIR-V assembly into SPV for use by VK
 // Return value of false means an error was encountered.
 //
-bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm,
+bool VkTestFramework::ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm,
                                std::vector<uint32_t> &spv) {
     spv_binary binary;
     spv_diagnostic diagnostic = nullptr;
     spv_context context = spvContextCreate(target_env);
-    spv_result_t error = spvTextToBinaryWithOptions(context, pasm, strlen(pasm), options, &binary, &diagnostic);
+    spv_result_t error = spvTextToBinaryWithOptions(context, p_asm, strlen(p_asm), options, &binary, &diagnostic);
     spvContextDestroy(context);
     if (error) {
         spvDiagnosticPrint(diagnostic);
@@ -771,7 +326,7 @@ VkShaderObj::VkShaderObj(VkRenderFramework *framework, const char *source, VkSha
 
 bool VkShaderObj::InitFromGLSL(const void *pNext) {
     std::vector<uint32_t> spv;
-    m_framework.GLSLtoSPV(&m_device.Physical().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
+    m_framework.GLSLtoSPV(m_device.Physical().limits_, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.pNext = pNext;
@@ -791,7 +346,7 @@ VkResult VkShaderObj::InitFromGLSLTry(const vkt::Device *custom_device) {
     // 99% of tests just use the framework's VkDevice, but this allows for tests to use custom device object
     // Can't set at contructor time since all reference members need to be initialized then.
     VkPhysicalDeviceLimits limits = (custom_device) ? custom_device->Physical().limits_ : m_device.Physical().limits_;
-    m_framework.GLSLtoSPV(&limits, m_stage_info.stage, m_source, spv, m_spv_env);
+    m_framework.GLSLtoSPV(limits, m_stage_info.stage, m_source, spv, m_spv_env);
 
     VkShaderModuleCreateInfo moduleCreateInfo = vku::InitStructHelper();
     moduleCreateInfo.codeSize = spv.size() * sizeof(uint32_t);

--- a/tests/framework/shader_helper.h
+++ b/tests/framework/shader_helper.h
@@ -22,29 +22,9 @@
 #include <glslang/Public/ShaderLang.h>
 
 #include "render.h"
-#include "test_framework.h"
 #include "shader_templates.h"
 
 class VkRenderFramework;
-class VkTestFramework;
-
-// Command-line options
-enum TOptions {
-    EOptionNone = 0x000,
-    EOptionIntermediate = 0x001,
-    EOptionSuppressInfolog = 0x002,
-    EOptionMemoryLeakMode = 0x004,
-    EOptionRelaxedErrors = 0x008,
-    EOptionGiveWarnings = 0x010,
-    EOptionLinkProgram = 0x020,
-    EOptionMultiThreaded = 0x040,
-    EOptionDumpConfig = 0x080,
-    EOptionDumpReflection = 0x100,
-    EOptionSuppressWarnings = 0x200,
-    EOptionDumpVersions = 0x400,
-    EOptionSpv = 0x800,
-    EOptionDefaultDesktop = 0x1000,
-};
 
 // What is the incoming source to be turned into VkShaderModuleCreateInfo::pCode
 typedef enum {
@@ -54,6 +34,10 @@ typedef enum {
     SPV_SOURCE_GLSL_TRY,
     SPV_SOURCE_ASM_TRY,
 } SpvSourceType;
+
+bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
+               std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
+bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv);
 
 // VkShaderObj is really just the Shader Module, but we named before VK_EXT_shader_object
 // TODO - move all of VkShaderObj to vkt::ShaderModule
@@ -83,7 +67,6 @@ class VkShaderObj : public vkt::ShaderModule {
 
   protected:
     VkPipelineShaderStageCreateInfo m_stage_info;
-    VkRenderFramework &m_framework;
     vkt::Device &m_device;
     const char *m_source;
     spv_target_env m_spv_env;

--- a/tests/framework/test_framework.cpp
+++ b/tests/framework/test_framework.cpp
@@ -19,6 +19,7 @@
 #include "test_framework.h"
 #include "vk_layer_config.h"
 #include "generated/vk_function_pointers.h"
+#include <glslang/Public/ShaderLang.h>
 #include CONFIG_HEADER_FILE
 #include <filesystem>
 #include <cmath>
@@ -193,11 +194,7 @@ void TestEnvironment::TearDown() { glslang::FinalizeProcess(); }
 void VkTestFramework::InitArgs(int *argc, char *argv[]) {
     for (int i = 1; i < *argc; ++i) {
         const std::string_view current_argument = argv[i];
-        if (current_argument == "--strip-SPV") {
-            m_strip_spv = true;
-        } else if (current_argument == "--canonicalize-SPV") {
-            m_canonicalize_spv = true;
-        } else if (current_argument == "--print-vu") {
+        if (current_argument == "--print-vu") {
             m_print_vu = true;
         } else if (current_argument == "--syncval-disable-core") {
             m_syncval_disable_core = true;
@@ -218,12 +215,6 @@ void VkTestFramework::InitArgs(int *argc, char *argv[]) {
                 "\t--gpuav-disable-core\n"
                 "\t\tDisable core validation when running gpu-av tests.\n"
                 "\t\tBy default both CoreChecks and gpu-av is enabled.\n");
-            printf(
-                "\t--strip-SPV\n"
-                "\t\tStrip SPIR-V debug information (line numbers, names, etc).\n");
-            printf(
-                "\t--canonicalize-SPV\n"
-                "\t\tRemap SPIR-V ids before submission to aid compression.\n");
             printf(
                 "\t--device-index <physical device index>\n"
                 "\t\tIndex into VkPhysicalDevice array returned from vkEnumeratePhysicalDevices.\n"

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -35,10 +35,6 @@ class VkTestFramework : public ::testing::Test {
     static void InitArgs(int *argc, char *argv[]);
     static void Finish();
 
-    bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
-                   std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
-    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv);
-
     static inline bool m_print_vu = false;
     static inline bool m_syncval_disable_core = false;
     static inline bool m_gpuav_disable_core = false;

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -45,7 +45,6 @@ class VkTestFramework : public ::testing::Test {
 
     static inline bool m_canonicalize_spv = false;
     static inline bool m_strip_spv = false;
-    static inline bool m_do_everything_spv = false;
     static inline bool m_print_vu = false;
     static inline bool m_syncval_disable_core = false;
     static inline bool m_gpuav_disable_core = false;

--- a/tests/framework/test_framework.h
+++ b/tests/framework/test_framework.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <spirv-tools/libspirv.hpp>
-#include <glslang/Public/ShaderLang.h>
 #include "test_common.h"
 
 #include <stdbool.h>
@@ -36,15 +35,10 @@ class VkTestFramework : public ::testing::Test {
     static void InitArgs(int *argc, char *argv[]);
     static void Finish();
 
-    virtual bool GLSLtoSPV(VkPhysicalDeviceLimits const *const device_limits, const VkShaderStageFlagBits shader_type,
-                           const char *pshader, std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
-    virtual bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *pasm, std::vector<uint32_t> &spv);
+    bool GLSLtoSPV(const VkPhysicalDeviceLimits &device_limits, const VkShaderStageFlagBits shader_type, const char *p_shader,
+                   std::vector<uint32_t> &spv, const spv_target_env spv_env = SPV_ENV_VULKAN_1_0);
+    bool ASMtoSPV(const spv_target_env target_env, const uint32_t options, const char *p_asm, std::vector<uint32_t> &spv);
 
-    char **ReadFileData(const char *fileName);
-    void FreeFileData(char **data);
-
-    static inline bool m_canonicalize_spv = false;
-    static inline bool m_strip_spv = false;
     static inline bool m_print_vu = false;
     static inline bool m_syncval_disable_core = false;
     static inline bool m_gpuav_disable_core = false;
@@ -55,17 +49,6 @@ class VkTestFramework : public ::testing::Test {
 #endif
 
   private:
-    int m_compile_options = 0;
-    int m_num_shader_strings = 0;
-    TBuiltInResource Resources;
-    void SetMessageOptions(EShMessages &messages);
-    void ProcessConfigFile(VkPhysicalDeviceLimits const *const device_limits);
-    EShLanguage FindLanguage(const std::string &name);
-    EShLanguage FindLanguage(const VkShaderStageFlagBits shader_type);
-    std::string ConfigFile;
-    bool SetConfigFile(const std::string &name);
-    std::string m_testName;
-
     static inline int m_width = 0;
     static inline int m_height = 0;
 };

--- a/tests/unit/debug_printf.cpp
+++ b/tests/unit/debug_printf.cpp
@@ -2258,7 +2258,7 @@ TEST_F(NegativeDebugPrintf, Maintenance5) {
     )glsl";
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, shader_source, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, shader_source, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();

--- a/tests/unit/gpu_av_buffer_device_address.cpp
+++ b/tests/unit/gpu_av_buffer_device_address.cpp
@@ -379,8 +379,8 @@ TEST_F(NegativeGpuAVBufferDeviceAddress, Maintenance5) {
 
     std::vector<uint32_t> vert_shader;
     std::vector<uint32_t> frag_shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexDrawPassthroughGlsl, vert_shader);
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_FRAGMENT_BIT, fs_source, frag_shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexDrawPassthroughGlsl, vert_shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_FRAGMENT_BIT, fs_source, frag_shader);
 
     VkShaderModuleCreateInfo module_create_info_vert = vku::InitStructHelper();
     module_create_info_vert.pCode = vert_shader.data();

--- a/tests/unit/pipeline.cpp
+++ b/tests/unit/pipeline.cpp
@@ -1058,7 +1058,7 @@ TEST_F(NegativePipeline, NullStagepNameMaintenance5) {
     InitRenderTarget();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();
@@ -1086,7 +1086,7 @@ TEST_F(NegativePipeline, NullStagepNameMaintenance5Compute) {
     RETURN_IF_SKIP(Init());
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_COMPUTE_BIT, kMinimalShaderGlsl, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();

--- a/tests/unit/shader_object.cpp
+++ b/tests/unit/shader_object.cpp
@@ -13,7 +13,7 @@
 #include "../framework/shader_object_helper.h"
 #include "../framework/descriptor_helper.h"
 #include "../framework/render_pass_helper.h"
-#include "../framework/shader_templates.h"
+#include "../framework/shader_helper.h"
 
 class NegativeShaderObject : public ShaderObjectTest {};
 

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -58,7 +58,7 @@ TEST_F(NegativeShaderSpirv, CodeSize) {
         std::vector<uint32_t> shader;
         VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
         VkShaderModule module;
-        this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
+        GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
         module_create_info.pCode = shader.data();
         // Introduce failure by making codeSize a non-multiple of 4
         module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -95,7 +95,7 @@ TEST_F(NegativeShaderSpirv, CodeSizeMaintenance5) {
     m_errorMonitor->VerifyFound();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kVertexMinimalGlsl, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -131,7 +131,7 @@ TEST_F(NegativeShaderSpirv, CodeSizeMaintenance5Compute) {
     m_errorMonitor->VerifyFound();
 
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, kMinimalShaderGlsl, shader);
     module_create_info.pCode = shader.data();
     // Introduce failure by making codeSize a non-multiple of 4
     module_create_info.codeSize = shader.size() * sizeof(uint32_t) - 1;
@@ -634,7 +634,7 @@ TEST_F(NegativeShaderSpirv, SpirvStatelessMaintenance5) {
         }
     )glsl";
     std::vector<uint32_t> shader;
-    this->GLSLtoSPV(&m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, vsSource, shader);
+    GLSLtoSPV(m_device->Physical().limits_, VK_SHADER_STAGE_VERTEX_BIT, vsSource, shader);
 
     VkShaderModuleCreateInfo module_create_info = vku::InitStructHelper();
     module_create_info.pCode = shader.data();


### PR DESCRIPTION
We use to have 2 different workflows to parse the GLSL into SPIR-V for tests (Android used shaderc)

We (over a year ago) unified all of that, in the process we left behind a lot of old shader code

We have had all these ways to configure glsl with `.conf` files and other flows that I have never once used (and I have added most of the shader validation tests)

The PR removes unused workflows so we can add new ones we care about (like adding `-g` or `-gVS` to have glslang print out debug info and test if it is providing that information in GPU-AV tests)