### PR TITLE
gpuav: Devirtualize Run and PrintDebugInfo

### DIFF
--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -28,7 +28,7 @@ class BindlessDescriptorPass : public InjectConditionalFunctionPass {
   public:
     BindlessDescriptorPass(Module& module) : InjectConditionalFunctionPass(module) {}
     const char* Name() const final { return "BindlessDescriptorPass"; }
-    void PrintDebugInfo() final;
+    void PrintDebugInfo();
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/buffer_device_address_pass.h
+++ b/layers/gpu/spirv/buffer_device_address_pass.h
@@ -27,7 +27,7 @@ class BufferDeviceAddressPass : public InjectConditionalFunctionPass {
   public:
     BufferDeviceAddressPass(Module& module) : InjectConditionalFunctionPass(module) {}
     const char* Name() const final { return "BufferDeviceAddressPass"; }
-    void PrintDebugInfo() final;
+    void PrintDebugInfo();
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;

--- a/layers/gpu/spirv/debug_printf_pass.h
+++ b/layers/gpu/spirv/debug_printf_pass.h
@@ -28,8 +28,8 @@ class DebugPrintfPass : public Pass {
     DebugPrintfPass(Module& module, uint32_t binding_slot = 0) : Pass(module), binding_slot_(binding_slot) {}
     const char* Name() const final { return "DebugPrintfPass"; }
 
-    bool Run() final;
-    void PrintDebugInfo() final;
+    bool Run();
+    void PrintDebugInfo();
 
   private:
     bool AnalyzeInstruction(const Instruction& inst);

--- a/layers/gpu/spirv/inject_conditional_function_pass.h
+++ b/layers/gpu/spirv/inject_conditional_function_pass.h
@@ -46,7 +46,7 @@ namespace spirv {
 //    }
 class InjectConditionalFunctionPass : public Pass {
   public:
-    bool Run() final;
+    bool Run();
 
   protected:
     InjectConditionalFunctionPass(Module& module);

--- a/layers/gpu/spirv/inject_function_pass.h
+++ b/layers/gpu/spirv/inject_function_pass.h
@@ -25,7 +25,7 @@ namespace spirv {
 //     value = original_value;
 class InjectFunctionPass : public Pass {
   public:
-    bool Run() final;
+    bool Run();
 
   protected:
     InjectFunctionPass(Module& module);

--- a/layers/gpu/spirv/non_bindless_oob_buffer_pass.h
+++ b/layers/gpu/spirv/non_bindless_oob_buffer_pass.h
@@ -25,9 +25,9 @@ namespace spirv {
 class NonBindlessOOBBufferPass : public Pass {
   public:
     NonBindlessOOBBufferPass(Module& module);
-    void PrintDebugInfo() final;
+    void PrintDebugInfo();
     const char* Name() const final { return "NonBindlessOOBBufferPass"; }
-    bool Run() final;
+    bool Run();
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst);

--- a/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.h
+++ b/layers/gpu/spirv/non_bindless_oob_texel_buffer_pass.h
@@ -25,9 +25,9 @@ namespace spirv {
 class NonBindlessOOBTexelBufferPass : public Pass {
   public:
     NonBindlessOOBTexelBufferPass(Module& module);
-    void PrintDebugInfo() final;
+    void PrintDebugInfo();
     const char* Name() const final { return "NonBindlessOOBTexelBufferPass"; }
-    bool Run() final;
+    bool Run();
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst);

--- a/layers/gpu/spirv/pass.h
+++ b/layers/gpu/spirv/pass.h
@@ -35,10 +35,6 @@ struct InjectionData {
 class Pass {
   public:
     virtual const char* Name() const = 0;
-    // Return false if nothing was changed
-    virtual bool Run() { return false; }
-
-    virtual void PrintDebugInfo() {}
 
     // Finds (and creates if needed) decoration and returns the OpVariable it points to
     const Variable& GetBuiltinVariable(uint32_t built_in);

--- a/layers/gpu/spirv/ray_query_pass.h
+++ b/layers/gpu/spirv/ray_query_pass.h
@@ -25,7 +25,7 @@ class RayQueryPass : public InjectConditionalFunctionPass {
   public:
     RayQueryPass(Module& module) : InjectConditionalFunctionPass(module) {}
     const char* Name() const final { return "RayQueryPass"; }
-    void PrintDebugInfo() final;
+    void PrintDebugInfo();
 
   private:
     bool AnalyzeInstruction(const Function& function, const Instruction& inst) final;


### PR DESCRIPTION
They are never used through their base class,
so might as well remove the added complexity