### PR TITLE
gpu: Add ShaderDebugInfo in error message

### DIFF
--- a/layers/gpu/spirv/debug_printf_pass.cpp
+++ b/layers/gpu/spirv/debug_printf_pass.cpp
@@ -511,7 +511,7 @@ bool DebugPrintfPass::Run() {
         if (strcmp(import_string, "NonSemantic.DebugPrintf") == 0) {
             module_.ext_inst_imports_.erase(inst_it);
             break;
-        } else if (strcmp(import_string, "NonSemantic.") == 0) {
+        } else if (strncmp(import_string, "NonSemantic.", 12) == 0) {
             other_non_semantic = true;
         }
     }


### PR DESCRIPTION
Adds support for [Non-Semantic Shader Debug Info](https://htmlpreview.github.io/?https://github.com/KhronosGroup/SPIRV-Registry/blob/main/nonsemantic/NonSemantic.Shader.DebugInfo.100.html) so that GPU-AV (and verbose DebugPrintf) can provide the exact source line that caused the error

`NonSemantic.Shader.DebugInfo` is a successor of the original `OpLine`/`OpSource`

This adds a lot of tests to help confirm coverage as well