### PR TITLE
sync: Cleanup of headers

### DIFF
--- a/layers/sync/sync_access_context.cpp
+++ b/layers/sync/sync_access_context.cpp
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 
-#include <cinttypes>
 #include "state_tracker/buffer_state.h"
 #include "state_tracker/video_session_state.h"
 #include "state_tracker/render_pass_state.h"

--- a/layers/sync/sync_access_state.cpp
+++ b/layers/sync/sync_access_state.cpp
@@ -16,6 +16,7 @@
  */
 #include "sync/sync_utils.h"
 #include "sync/sync_access_state.h"
+#include <vulkan/utility/vk_struct_helper.hpp>
 
 ResourceAccessState::OrderingBarriers ResourceAccessState::kOrderingRules = {
     {{VK_PIPELINE_STAGE_2_NONE_KHR, SyncStageAccessFlags()},

--- a/layers/sync/sync_common.cpp
+++ b/layers/sync/sync_common.cpp
@@ -16,7 +16,6 @@
  */
 
 #include "state_tracker/buffer_state.h"
-#include "state_tracker/image_state.h"
 #include "state_tracker/cmd_buffer_state.h"
 #include "sync/sync_common.h"
 

--- a/layers/sync/sync_common.h
+++ b/layers/sync/sync_common.h
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 #pragma once
-#include "error_message/error_location.h"
 #include "containers/subresource_adapter.h"
 #include "containers/range_vector.h"
 #include "generated/sync_validation_types.h"

--- a/layers/sync/sync_op.h
+++ b/layers/sync/sync_op.h
@@ -18,6 +18,7 @@
 
 #include "sync/sync_access_context.h"
 #include <vulkan/utility/vk_safe_struct.hpp>
+#include "error_message/error_location.h"
 
 class CommandBufferAccessContext;
 class CommandExecutionContext;

--- a/layers/sync/sync_validation.cpp
+++ b/layers/sync/sync_validation.cpp
@@ -16,14 +16,11 @@
  */
 
 #include <algorithm>
-#include <iostream>
-#include <limits>
 #include <memory>
 #include <vector>
 
 #include "sync/sync_validation.h"
 #include "sync/sync_image.h"
-#include "state_tracker/device_state.h"
 #include "state_tracker/buffer_state.h"
 #include "utils/convert_utils.h"
 #include "vk_layer_config.h"

--- a/layers/sync/sync_validation.h
+++ b/layers/sync/sync_validation.h
@@ -17,14 +17,11 @@
 
 #pragma once
 
-#include <limits>
 #include <memory>
-#include <set>
 #include <vulkan/vulkan.h>
 
 #include "sync/sync_common.h"
 #include "sync/sync_access_context.h"
-#include "sync/sync_renderpass.h"
 #include "sync/sync_commandbuffer.h"
 #include "sync/sync_stats.h"
 #include "sync/sync_submit.h"

--- a/layers/sync/sync_vuid_maps.cpp
+++ b/layers/sync/sync_vuid_maps.cpp
@@ -17,8 +17,6 @@
  */
 #include "sync/sync_vuid_maps.h"
 #include "error_message/error_location.h"
-#include "core_checks/core_validation.h"
-#include "generated/enum_flag_bits.h"
 
 #include <cassert>
 


### PR DESCRIPTION
Checking some `clangd` logs and noticed these sync files had some unused headers