### PR TITLE
gpu: Descriptor Indexing cleanup

### DIFF
--- a/layers/drawdispatch/descriptor_validator.cpp
+++ b/layers/drawdispatch/descriptor_validator.cpp
@@ -65,9 +65,16 @@ std::string vvl::DescriptorValidator::DescribeDescriptor(const DescriptorBinding
     return ss.str();
 }
 
-vvl::DescriptorValidator::DescriptorValidator(ValidationStateTracker &dev, vvl::CommandBuffer &cb, vvl::DescriptorSet &set,
-                                              uint32_t set_index_, VkFramebuffer fb, const Location &l)
-    : dev_state(dev), cb_state(cb), descriptor_set(set), set_index(set_index_), framebuffer(fb), loc(l), vuids(GetDrawDispatchVuid(loc.function)) {}
+vvl::DescriptorValidator::DescriptorValidator(ValidationStateTracker &dev, vvl::CommandBuffer &cb_state,
+                                              vvl::DescriptorSet &descriptor_set, uint32_t set_index, VkFramebuffer framebuffer,
+                                              const Location &loc)
+    : dev_state(dev),
+      cb_state(cb_state),
+      descriptor_set(descriptor_set),
+      set_index(set_index),
+      framebuffer(framebuffer),
+      loc(loc),
+      vuids(GetDrawDispatchVuid(loc.function)) {}
 
 template <typename T>
 bool vvl::DescriptorValidator::ValidateDescriptors(const DescriptorBindingInfo &binding_info, const T &binding) const {

--- a/layers/drawdispatch/descriptor_validator.h
+++ b/layers/drawdispatch/descriptor_validator.h
@@ -43,13 +43,13 @@ using DescriptorBindingInfo = std::pair<uint32_t, std::vector<DescriptorRequirem
 
 class DescriptorValidator {
  public:
-   DescriptorValidator(ValidationStateTracker& dev, vvl::CommandBuffer& cb, vvl::DescriptorSet& set, uint32_t set_index,
-                       VkFramebuffer fb, const Location& l);
+   DescriptorValidator(ValidationStateTracker& dev, vvl::CommandBuffer& cb_state, vvl::DescriptorSet& descriptor_set,
+                       uint32_t set_index, VkFramebuffer framebuffer, const Location& loc);
 
    template <typename T>
-   std::string FormatHandle(T&& h) const {
-       return dev_state.FormatHandle(std::forward<T>(h));
-    }
+   std::string FormatHandle(T&& handle) const {
+       return dev_state.FormatHandle(std::forward<T>(handle));
+   }
 
     bool ValidateBinding(const DescriptorBindingInfo& binding_info, const vvl::DescriptorBinding& binding) const;
     bool ValidateBinding(const DescriptorBindingInfo& binding_info, const std::vector<uint32_t> &indices);
@@ -91,4 +91,4 @@ class DescriptorValidator {
     const DrawDispatchVuid& vuids;
 
 };
-}
+}  // namespace vvl

--- a/layers/gpu/core/gpuav.h
+++ b/layers/gpu/core/gpuav.h
@@ -35,7 +35,6 @@ class ImageView;
 class Queue;
 class Sampler;
 class DescriptorSet;
-struct DescSetState;
 }  // namespace gpuav
 
 VALSTATETRACK_DERIVED_STATE_OBJECT(VkBuffer, gpuav::Buffer, vvl::Buffer)

--- a/layers/gpu/core/gpuav_record.cpp
+++ b/layers/gpu/core/gpuav_record.cpp
@@ -213,7 +213,7 @@ void Validator::PostCallRecordCmdBindPipeline(VkCommandBuffer commandBuffer, VkP
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
         return;
     }
-    UpdateBoundPipeline(*this, *cb_state, pipelineBindPoint, pipeline, record_obj.location);
+    descriptor::UpdateBoundPipeline(*this, *cb_state, pipelineBindPoint, pipeline, record_obj.location);
 }
 
 void Validator::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffer, VkPipelineBindPoint pipelineBindPoint,
@@ -228,7 +228,7 @@ void Validator::PostCallRecordCmdBindDescriptorSets(VkCommandBuffer commandBuffe
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
         return;
     }
-    UpdateBoundDescriptors(*this, *cb_state, pipelineBindPoint, record_obj.location);
+    descriptor::UpdateBoundDescriptors(*this, *cb_state, pipelineBindPoint, record_obj.location);
 }
 void Validator::PostCallRecordCmdBindDescriptorSets2KHR(VkCommandBuffer commandBuffer,
                                                         const VkBindDescriptorSetsInfoKHR *pBindDescriptorSetsInfo,
@@ -242,13 +242,13 @@ void Validator::PostCallRecordCmdBindDescriptorSets2KHR(VkCommandBuffer commandB
     }
 
     if (IsStageInPipelineBindPoint(pBindDescriptorSetsInfo->stageFlags, VK_PIPELINE_BIND_POINT_GRAPHICS)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     }
     if (IsStageInPipelineBindPoint(pBindDescriptorSetsInfo->stageFlags, VK_PIPELINE_BIND_POINT_COMPUTE)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, record_obj.location);
     }
     if (IsStageInPipelineBindPoint(pBindDescriptorSetsInfo->stageFlags, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, record_obj.location);
     }
 }
 
@@ -264,7 +264,7 @@ void Validator::PreCallRecordCmdPushDescriptorSetKHR(VkCommandBuffer commandBuff
         InternalError(commandBuffer, record_obj.location, "Unrecognized command buffer.");
         return;
     }
-    UpdateBoundDescriptors(*this, *cb_state, pipelineBindPoint, record_obj.location);
+    descriptor::UpdateBoundDescriptors(*this, *cb_state, pipelineBindPoint, record_obj.location);
 }
 
 void Validator::PreCallRecordCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuffer,
@@ -278,13 +278,13 @@ void Validator::PreCallRecordCmdPushDescriptorSet2KHR(VkCommandBuffer commandBuf
     }
 
     if (IsStageInPipelineBindPoint(pPushDescriptorSetInfo->stageFlags, VK_PIPELINE_BIND_POINT_GRAPHICS)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_GRAPHICS, record_obj.location);
     }
     if (IsStageInPipelineBindPoint(pPushDescriptorSetInfo->stageFlags, VK_PIPELINE_BIND_POINT_COMPUTE)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_COMPUTE, record_obj.location);
     }
     if (IsStageInPipelineBindPoint(pPushDescriptorSetInfo->stageFlags, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR)) {
-        UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, record_obj.location);
+        descriptor::UpdateBoundDescriptors(*this, *cb_state, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, record_obj.location);
     }
 }
 

--- a/layers/gpu/descriptor_validation/gpuav_descriptor_validation.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_validation.h
@@ -18,7 +18,6 @@
 #pragma once
 
 #include <vulkan/vulkan.h>
-#include "vma/vma.h"
 
 struct Location;
 
@@ -26,9 +25,11 @@ namespace gpuav {
 class CommandBuffer;
 class Validator;
 
+namespace descriptor {
 void UpdateBoundPipeline(Validator& gpuav, CommandBuffer& cb_state, VkPipelineBindPoint pipeline_bind_point, VkPipeline pipeline,
                          const Location& loc);
 void UpdateBoundDescriptors(Validator& gpuav, CommandBuffer& cb_state, VkPipelineBindPoint pipeline_bind_point,
                             const Location& loc);
 [[nodiscard]] bool UpdateBindlessStateBuffer(Validator& gpuav, CommandBuffer& cb_state, const Location& loc);
+}  // namespace descriptor
 }  // namespace gpuav

--- a/layers/gpu/resources/gpuav_resources.cpp
+++ b/layers/gpu/resources/gpuav_resources.cpp
@@ -192,6 +192,7 @@ void DeviceMemoryBlock::DestroyBuffer() {
         vmaDestroyBuffer(gpuav.vma_allocator_, buffer, allocation);
         buffer = VK_NULL_HANDLE;
         allocation = VK_NULL_HANDLE;
+        device_address = 0;
     }
 }
 

--- a/layers/gpu/resources/gpuav_shader_resources.h
+++ b/layers/gpu/resources/gpuav_shader_resources.h
@@ -28,9 +28,8 @@
 namespace gpuav {
 
 struct DescSetState {
-    uint32_t num = 0;
     std::shared_ptr<DescriptorSet> state = {};
-    BindingVariableMap binding_req = {};
+    BindingVariableMap binding_req_map = {};
     // State that will be used by the GPU-AV shader instrumentation
     // For update-after-bind, this will be set during queue submission
     // Otherwise it will be set when the DescriptorSet is bound.

--- a/layers/gpu/resources/gpuav_shader_resources.h
+++ b/layers/gpu/resources/gpuav_shader_resources.h
@@ -33,8 +33,7 @@ struct DescSetState {
     // State that will be used by the GPU-AV shader instrumentation
     // For update-after-bind, this will be set during queue submission
     // Otherwise it will be set when the DescriptorSet is bound.
-    std::shared_ptr<DescriptorSet::State> gpu_state = {};
-    std::shared_ptr<DescriptorSet::State> output_state = {};
+    std::shared_ptr<DeviceMemoryBlock> post_process_buffer = {};
 };
 
 struct DescBindingInfo {

--- a/layers/gpu/resources/gpuav_subclasses.cpp
+++ b/layers/gpu/resources/gpuav_subclasses.cpp
@@ -430,7 +430,7 @@ void CommandBuffer::UpdateCommandCount(VkPipelineBindPoint bind_point) {
 bool CommandBuffer::PreProcess(const Location &loc) {
     auto gpuav = static_cast<Validator *>(&dev_data);
 
-    bool succeeded = UpdateBindlessStateBuffer(*gpuav, *this, loc);
+    bool succeeded = descriptor::UpdateBindlessStateBuffer(*gpuav, *this, loc);
     if (!succeeded) {
         return false;
     }

--- a/tests/spirv/instrumentation.cpp
+++ b/tests/spirv/instrumentation.cpp
@@ -110,7 +110,7 @@ int main(int argc, char** argv) {
         PrintUsage(argv[0]);
         return EXIT_FAILURE;
     } else if (!std::filesystem::exists(argv[1])) {
-        std::cout << "ERROR: " << argv[1] << " Does not exists\n";
+        std::cout << "ERROR: " << argv[1] << " Does not exists\n(First arugment must be input spirv)\n";
         return EXIT_FAILURE;
     }
 
@@ -169,12 +169,14 @@ int main(int argc, char** argv) {
     if (all_passes || ray_query_pass) {
         module.RunPassRayQuery();
     }
-    if (all_passes || debug_printf_pass) {
-        module.RunPassDebugPrintf(kInstDefaultDebugPrintfBinding);
-    }
 
     for (const auto& info : module.link_info_) {
         module.LinkFunction(info);
+    }
+
+    // DebugPrintf goes at end to match how we do it in GpuShaderInstrumentor::InstrumentShader()
+    if (all_passes || debug_printf_pass) {
+        module.RunPassDebugPrintf(kInstDefaultDebugPrintfBinding);
     }
 
     module.PostProcess();


### PR DESCRIPTION
In efforts to create a post processing output that is independent, went in and had to clean up some of the descriptor indexing. Was able to replace things like `DescriptorSet::State` with our new `DeviceMemoryBlock` class
