### PR TITLE
Add a common spirv_logging.cpp helper

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -144,6 +144,8 @@ vvl_sources = [
   "layers/error_message/logging.h",
   "layers/error_message/record_object.h",
   "layers/error_message/log_message_type.h",
+  "layers/error_message/spirv_logging.cpp",
+  "layers/error_message/spirv_logging.h",
   "layers/external/inplace_function.h",
   "layers/external/vma/vk_mem_alloc.h",
   "layers/external/vma/vma.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -183,6 +183,8 @@ target_sources(vvl PRIVATE
     core_checks/cc_ycbcr.cpp
     drawdispatch/descriptor_validator.cpp
     drawdispatch/drawdispatch_vuids.cpp
+    error_message/spirv_logging.h
+    error_message/spirv_logging.cpp
     external/vma/vma.h
     external/vma/vma.cpp
     ${API_TYPE}/generated/best_practices.cpp

--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -1,0 +1,163 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "spirv_logging.h"
+#include <regex>
+#include <sstream>
+
+#include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
+#include <spirv/unified1/spirv.hpp>
+
+const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &instructions, uint32_t string_id) {
+    const spirv::Instruction *string_insn = nullptr;
+    for (const auto &insn : instructions) {
+        if (insn.Opcode() == spv::OpString && insn.Length() >= 3 && insn.Word(1) == string_id) {
+            string_insn = &insn;
+            break;
+        }
+        // OpString can only be in the debug section, so can break early if not found
+        if (insn.Opcode() == spv::OpFunction) {
+            assert(false);
+            break;
+        }
+    }
+    return string_insn;
+};
+
+// Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
+// Split the single string into a vector of strings, one for each line, for easier processing.
+void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uint32_t reported_file_id,
+                  std::vector<std::string> &out_opsource_lines) {
+    for (size_t i = 0; i < instructions.size(); i++) {
+        const auto &insn = instructions[i];
+        if ((insn.Opcode() != spv::OpSource) || (insn.Length() < 5) || (insn.Word(3) != reported_file_id)) {
+            continue;
+        }
+
+        std::istringstream in_stream;
+        std::string current_line;
+        in_stream.str(insn.GetAsString(4));
+        while (std::getline(in_stream, current_line)) {
+            out_opsource_lines.emplace_back(current_line);
+        }
+
+        for (size_t k = i + 1; k < instructions.size(); k++) {
+            const auto &continue_insn = instructions[k];
+            if (continue_insn.Opcode() != spv::OpSourceContinued) {
+                return;
+            }
+            in_stream.clear();  // without, will fail getline
+            in_stream.str(continue_insn.GetAsString(1));
+            while (std::getline(in_stream, current_line)) {
+                out_opsource_lines.emplace_back(current_line);
+            }
+        }
+        return;
+    }
+}
+
+void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const uint32_t debug_source_id,
+                     uint32_t &out_file_string_id, std::vector<std::string> &out_opsource_lines) {
+    for (size_t i = 0; i < instructions.size(); i++) {
+        const auto &insn = instructions[i];
+        if (insn.ResultId() != debug_source_id) {
+            continue;
+        }
+        out_file_string_id = insn.Word(5);
+
+        if (insn.Length() < 7) {
+            return;  // Optional source Text not provided
+        }
+
+        uint32_t string_id = insn.Word(6);
+        auto string_inst = FindOpString(instructions, string_id);
+        if (!string_inst) {
+            return;  // error should be caught in spirv-val, but don't crash here
+        }
+
+        std::istringstream in_stream;
+        std::string current_line;
+        in_stream.str(string_inst->GetAsString(2));
+        while (std::getline(in_stream, current_line)) {
+            out_opsource_lines.emplace_back(current_line);
+        }
+
+        for (size_t k = i + 1; k < instructions.size(); k++) {
+            const auto &continue_insn = instructions[k];
+            if (continue_insn.Opcode() != spv::OpExtInst ||
+                continue_insn.Word(4) != NonSemanticShaderDebugInfo100DebugSourceContinued) {
+                return;
+            }
+            string_id = continue_insn.Word(5);
+            string_inst = FindOpString(instructions, string_id);
+            if (!string_inst) {
+                return;  // error should be caught in spirv-val, but don't crash here
+            }
+
+            in_stream.clear();  // without, will fail getline
+            in_stream.str(string_inst->GetAsString(2));
+            while (std::getline(in_stream, current_line)) {
+                out_opsource_lines.emplace_back(current_line);
+            }
+        }
+        return;
+    }
+}
+
+// The task here is to search the OpSource content to find the #line directive with the
+// line number that is closest to, but still prior to the reported error line number and
+// still within the reported filename.
+// From this known position in the OpSource content we can add the difference between
+// the #line line number and the reported error line number to determine the location
+// in the OpSource content of the reported error line.
+//
+// Considerations:
+// - Look only at #line directives that specify the reported_filename since
+//   the reported error line number refers to its location in the reported filename.
+// - If a #line directive does not have a filename, the file is the reported filename, or
+//   the filename found in a prior #line directive.  (This is C-preprocessor behavior)
+// - It is possible (e.g., inlining) for blocks of code to get shuffled out of their
+//   original order and the #line directives are used to keep the numbering correct.  This
+//   is why we need to examine the entire contents of the source, instead of leaving early
+//   when finding a #line line number larger than the reported error line number.
+//
+bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
+    static const std::regex line_regex(  // matches #line directives
+        "^"                              // beginning of line
+        "\\s*"                           // optional whitespace
+        "#"                              // required text
+        "\\s*"                           // optional whitespace
+        "line"                           // required text
+        "\\s+"                           // required whitespace
+        "([0-9]+)"                       // required first capture - line number
+        "(\\s+)?"                        // optional second capture - whitespace
+        "(\".+\")?"                      // optional third capture - quoted filename with at least one char inside
+        ".*");                           // rest of line (needed when using std::regex_match since the entire line is tested)
+
+    std::smatch captures;
+
+    const bool found_line = std::regex_match(string, captures, line_regex);
+    if (!found_line) return false;
+
+    // filename is optional and considered found only if the whitespace and the filename are captured
+    if (captures[2].matched && captures[3].matched) {
+        // Remove enclosing double quotes.  The regex guarantees the quotes and at least one char.
+        filename = captures[3].str().substr(1, captures[3].str().size() - 2);
+    }
+    *linenumber = (uint32_t)std::stoul(captures[1]);
+    return true;
+}

--- a/layers/error_message/spirv_logging.h
+++ b/layers/error_message/spirv_logging.h
@@ -1,0 +1,34 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+#include <vector>
+#include <string>
+#include "state_tracker/shader_instruction.h"
+
+// When producing error messages for SPIR-V related items and the user generated the shader with debug information, we can use these
+// helpers to print out information from their High Level source instead of some cryptic SPIR-V jargon
+
+const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &instructions, uint32_t string_id);
+
+void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uint32_t reported_file_id,
+                  std::vector<std::string> &out_opsource_lines);
+
+void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const uint32_t debug_source_id,
+                     uint32_t &out_file_string_id, std::vector<std::string> &out_opsource_lines);
+
+bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename);

--- a/layers/gpu/debug_printf/debug_printf.cpp
+++ b/layers/gpu/debug_printf/debug_printf.cpp
@@ -22,7 +22,7 @@
 #include "gpu/shaders/gpuav_shaders_constants.h"
 #include "gpu/resources/gpuav_subclasses.h"
 #include "gpu/core/gpuav.h"
-#include "gpu/spirv/instruction.h"
+#include "state_tracker/shader_instruction.h"
 
 #include <iostream>
 
@@ -154,7 +154,7 @@ static std::vector<Substring> ParseFormatString(const std::string &format_string
     return parsed_strings;
 }
 
-static std::string FindFormatString(const std::vector<gpuav::spirv::Instruction> &instructions, uint32_t string_id) {
+static std::string FindFormatString(const std::vector<Instruction> &instructions, uint32_t string_id) {
     std::string format_string;
     for (const auto &insn : instructions) {
         if (insn.Opcode() == spv::OpString && insn.Word(1) == string_id) {
@@ -215,8 +215,8 @@ void AnalyzeAndGenerateMessage(Validator &gpuav, VkCommandBuffer command_buffer,
             return;
         }
 
-        std::vector<gpuav::spirv::Instruction> instructions;
-        gpuav::spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
+        std::vector<Instruction> instructions;
+        spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
 
         // Search through the shader source for the printf format string for this invocation
         const std::string format_string = FindFormatString(instructions, debug_record->format_string_id);

--- a/layers/gpu/instrumentation/gpuav_instrumentation.cpp
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.cpp
@@ -769,7 +769,7 @@ bool LogInstrumentationError(Validator &gpuav, VkCommandBuffer cmd_buffer, const
         }
 
         // If we somehow can't find our state, we can still report our error message
-        std::vector<spirv::Instruction> instructions;
+        std::vector<Instruction> instructions;
         if (instrumented_shader && !instrumented_shader->instrumented_spirv.empty()) {
             spirv::GenerateInstructions(instrumented_shader->instrumented_spirv, instructions);
         }

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.cpp
@@ -28,13 +28,13 @@
 #include "utils/vk_layer_utils.h"
 #include "sync/sync_utils.h"
 #include "state_tracker/pipeline_state.h"
+#include "error_message/spirv_logging.h"
 
 #include "state_tracker/descriptor_sets.h"
 #include "state_tracker/shader_object_state.h"
 #include "state_tracker/shader_instruction.h"
 
 #include <cassert>
-#include <regex>
 #include <fstream>
 #include <string>
 
@@ -1293,146 +1293,6 @@ static std::string LookupDebugUtilsNameNoLock(const DebugReport *debug_report, c
         object_label = "(" + object_label + ")";
     }
     return object_label;
-}
-
-static const Instruction *FindOpString(const std::vector<Instruction> &instructions, uint32_t string_id) {
-    const Instruction *string_insn = nullptr;
-    for (const auto &insn : instructions) {
-        if (insn.Opcode() == spv::OpString && insn.Length() >= 3 && insn.Word(1) == string_id) {
-            string_insn = &insn;
-            break;
-        }
-        // OpString can only be in the debug section, so can break early if not found
-        if (insn.Opcode() == spv::OpFunction) {
-            assert(false);
-            break;
-        }
-    }
-    return string_insn;
-};
-
-// Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
-// Split the single string into a vector of strings, one for each line, for easier processing.
-static void ReadOpSource(const std::vector<Instruction> &instructions, const uint32_t reported_file_id,
-                         std::vector<std::string> &out_opsource_lines) {
-    for (size_t i = 0; i < instructions.size(); i++) {
-        const auto &insn = instructions[i];
-        if ((insn.Opcode() != spv::OpSource) || (insn.Length() < 5) || (insn.Word(3) != reported_file_id)) {
-            continue;
-        }
-
-        std::istringstream in_stream;
-        std::string cur_line;
-        in_stream.str(insn.GetAsString(4));
-        while (std::getline(in_stream, cur_line)) {
-            out_opsource_lines.emplace_back(cur_line);
-        }
-
-        for (size_t k = i + 1; k < instructions.size(); k++) {
-            const auto &continue_insn = instructions[k];
-            if (continue_insn.Opcode() != spv::OpSourceContinued) {
-                return;
-            }
-            in_stream.clear();  // without, will fail getline
-            in_stream.str(continue_insn.GetAsString(1));
-            while (std::getline(in_stream, cur_line)) {
-                out_opsource_lines.emplace_back(cur_line);
-            }
-        }
-        return;
-    }
-}
-
-static void ReadDebugSource(const std::vector<Instruction> &instructions, const uint32_t debug_source_id,
-                            uint32_t &out_file_string_id, std::vector<std::string> &out_opsource_lines) {
-    for (size_t i = 0; i < instructions.size(); i++) {
-        const auto &insn = instructions[i];
-        if (insn.ResultId() != debug_source_id) {
-            continue;
-        }
-        out_file_string_id = insn.Word(5);
-
-        if (insn.Length() < 7) {
-            return;  // Optional source Text not provided
-        }
-
-        uint32_t string_id = insn.Word(6);
-        auto string_inst = FindOpString(instructions, string_id);
-        if (!string_inst) {
-            return;  // error should be caught in spirv-val, but don't crash here
-        }
-
-        std::istringstream in_stream;
-        std::string cur_line;
-        in_stream.str(string_inst->GetAsString(2));
-        while (std::getline(in_stream, cur_line)) {
-            out_opsource_lines.emplace_back(cur_line);
-        }
-
-        for (size_t k = i + 1; k < instructions.size(); k++) {
-            const auto &continue_insn = instructions[k];
-            if (continue_insn.Opcode() != spv::OpExtInst ||
-                continue_insn.Word(4) != NonSemanticShaderDebugInfo100DebugSourceContinued) {
-                return;
-            }
-            string_id = continue_insn.Word(5);
-            string_inst = FindOpString(instructions, string_id);
-            if (!string_inst) {
-                return;  // error should be caught in spirv-val, but don't crash here
-            }
-
-            in_stream.clear();  // without, will fail getline
-            in_stream.str(string_inst->GetAsString(2));
-            while (std::getline(in_stream, cur_line)) {
-                out_opsource_lines.emplace_back(cur_line);
-            }
-        }
-        return;
-    }
-}
-
-// The task here is to search the OpSource content to find the #line directive with the
-// line number that is closest to, but still prior to the reported error line number and
-// still within the reported filename.
-// From this known position in the OpSource content we can add the difference between
-// the #line line number and the reported error line number to determine the location
-// in the OpSource content of the reported error line.
-//
-// Considerations:
-// - Look only at #line directives that specify the reported_filename since
-//   the reported error line number refers to its location in the reported filename.
-// - If a #line directive does not have a filename, the file is the reported filename, or
-//   the filename found in a prior #line directive.  (This is C-preprocessor behavior)
-// - It is possible (e.g., inlining) for blocks of code to get shuffled out of their
-//   original order and the #line directives are used to keep the numbering correct.  This
-//   is why we need to examine the entire contents of the source, instead of leaving early
-//   when finding a #line line number larger than the reported error line number.
-//
-static bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
-    static const std::regex line_regex(  // matches #line directives
-        "^"                              // beginning of line
-        "\\s*"                           // optional whitespace
-        "#"                              // required text
-        "\\s*"                           // optional whitespace
-        "line"                           // required text
-        "\\s+"                           // required whitespace
-        "([0-9]+)"                       // required first capture - line number
-        "(\\s+)?"                        // optional second capture - whitespace
-        "(\".+\")?"                      // optional third capture - quoted filename with at least one char inside
-        ".*");                           // rest of line (needed when using std::regex_match since the entire line is tested)
-
-    std::smatch captures;
-
-    const bool found_line = std::regex_match(string, captures, line_regex);
-    if (!found_line) return false;
-
-    // filename is optional and considered found only if the whitespace and the filename are captured
-    if (captures[2].matched && captures[3].matched) {
-        // Remove enclosing double quotes.  The regex guarantees the quotes and at least one char.
-        filename = captures[3].str().substr(1, captures[3].str().size() - 2);
-    }
-    *linenumber = (uint32_t)std::stoul(captures[1]);
-    return true;
 }
 
 // Generate the stage-specific part of the message.

--- a/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
+++ b/layers/gpu/instrumentation/gpuav_shader_instrumentor.h
@@ -18,10 +18,16 @@
 
 #include "containers/custom_containers.h"
 #include "generated/chassis.h"
+#include "state_tracker/shader_instruction.h"
 #include "state_tracker/state_tracker.h"
-#include "gpu/spirv/instruction.h"
 
 #include <vector>
+
+// There is a spirv::Instruction used for normal validation.
+// There is a gpuav::spirv::Instruction that is ONLY intended for shader instrumentation (designed so we can build the shader
+// instrumentation as a seperate library). For logging GPU-AV will want to make use of the normal validaiton instruction class, just
+// alias it with "Instruction" as that name shouldn't collide with anything.
+using Instruction = ::spirv::Instruction;
 
 namespace chassis {
 struct ShaderInstrumentationMetadata;
@@ -165,7 +171,7 @@ class GpuShaderInstrumentor : public ValidationStateTracker {
 
     bool IsSelectiveInstrumentationEnabled(const void *pNext);
 
-    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::vector<spirv::Instruction> &instructions,
+    std::string GenerateDebugInfoMessage(VkCommandBuffer commandBuffer, const std::vector<Instruction> &instructions,
                                          uint32_t stage_id, uint32_t stage_info_0, uint32_t stage_info_1, uint32_t stage_info_2,
                                          uint32_t instruction_position, const InstrumentedShader *instrumented_shader,
                                          uint32_t shader_id, VkPipelineBindPoint pipeline_bind_point,

--- a/layers/gpu/spirv/instruction.cpp
+++ b/layers/gpu/spirv/instruction.cpp
@@ -278,20 +278,5 @@ void Instruction::ReplaceLinkedId(vvl::unordered_map<uint32_t, uint32_t>& id_swa
     UpdateDebugInfo();
 }
 
-// All post SPIR-V processing we do is just needing to inspect single instructions without knowledge of the rest of the module.
-// We turn the saved vector of uint32_t into the Instruction class to make it easier to use
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions) {
-    assert(instructions.empty());
-    spirv_iterator it = spirv.begin();
-    it += 5;  // skip first 5 word of header
-    instructions.reserve(spirv.size() * 4);
-
-    uint32_t instruction_count = 0;
-    while (it != spirv.end()) {
-        auto new_insn = instructions.emplace_back(it, instruction_count++);
-        it += new_insn.Length();
-    }
-}
-
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/gpu/spirv/instruction.h
+++ b/layers/gpu/spirv/instruction.h
@@ -107,7 +107,5 @@ struct Instruction {
 #endif
 };
 
-void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions);
-
 }  // namespace spirv
 }  // namespace gpuav

--- a/layers/state_tracker/shader_instruction.cpp
+++ b/layers/state_tracker/shader_instruction.cpp
@@ -186,4 +186,22 @@ spv::StorageClass Instruction::StorageClass() const {
     return storage_class;
 }
 
+// When logging from things such as GPU-AV, we need to do some SPIR-V processing, but is just to inspect single instructions without
+// knowledge of the rest of the module. This function just turns the saved vector of uint32_t into the Instruction class to make it
+// easier to use.
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions) {
+    // Need to use until we have native std::span in c++20
+    using spirv_iterator = vvl::enumeration<const uint32_t, const uint32_t*>::iterator;
+
+    assert(instructions.empty());
+    spirv_iterator it = spirv.begin();
+    it += 5;  // skip first 5 word of header
+    instructions.reserve(spirv.size() * 4);
+
+    while (it != spirv.end()) {
+        auto new_insn = instructions.emplace_back(it);
+        it += new_insn.Length();
+    }
+}
+
 }  // namespace spirv

--- a/layers/state_tracker/shader_instruction.h
+++ b/layers/state_tracker/shader_instruction.h
@@ -104,4 +104,6 @@ class Instruction {
 #endif
 };
 
+void GenerateInstructions(const vvl::span<const uint32_t>& spirv, std::vector<Instruction>& instructions);
+
 }  // namespace spirv


### PR DESCRIPTION
I recently added ShaderDebugInfo in error message for GPU-AV https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8691

There are **many** normal core validation error messages that also should have source code printed in the error message

I have a follow-up PR to do it for some VUs, but want to get this in first which is just splitting the GPU-AV logging code for SPIR-V into a dedicated `spirv_logging` helper file