### PR TITLE
Update deps enhancements

### DIFF
--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -422,8 +422,15 @@ class GoodRepo(object):
         if VERBOSE:
             print('Checking out {n} in {d}'.format(n=self.name, d=self.repo_dir))
 
-        if self._args.do_clean_repo:
+        if os.path.exists(os.path.join(self.repo_dir, '.git')):
+            url_changed = command_output(['git', 'config', '--get', 'remote.origin.url'], self.repo_dir).strip() != self.url
+        else:
+            url_changed = False
+
+        if self._args.do_clean_repo or url_changed:
             if os.path.isdir(self.repo_dir):
+                if VERBOSE:
+                    print('Clearing directory {d}'.format(d=self.repo_dir))
                 shutil.rmtree(self.repo_dir, onerror = on_rm_error)
         if not os.path.exists(os.path.join(self.repo_dir, '.git')):
             self.Clone()

--- a/scripts/update_deps.py
+++ b/scripts/update_deps.py
@@ -636,7 +636,7 @@ def CreateHelper(args, repos, filename):
             if repo.api is not None and repo.api != args.api:
                 continue
             if install_names and repo.name in install_names and repo.on_build_platform:
-                helper_file.write('set({var} "{dir}" CACHE STRING "" FORCE)\n'
+                helper_file.write('set({var} "{dir}" CACHE STRING "")\n'
                                   .format(
                                       var=install_names[repo.name],
                                       dir=escape(repo.install_dir)))


### PR DESCRIPTION
This PR contains fixes to two annoyances of ours, both arguably bug candidates:

- Dependency fetching breaks when the remote URL is changed in `update_deps.py`, which can easily be handled by wiping the clone dir.
- Both documentation and code suggests that the `XYZ_INSTALL_DIR` variables can be used to override where dependencies should be taken from, but the dep fetching machinery outright overwrites all user-provided paths.