### PR TITLE
layers: Add Shader Debug Info into core validation

### DIFF
--- a/layers/core_checks/cc_spirv.cpp
+++ b/layers/core_checks/cc_spirv.cpp
@@ -892,180 +892,180 @@ bool CoreChecks::ValidateAtomicsTypes(const spirv::Module &module_state, const s
     const bool valid_16_float_vector = (enabled_features.shaderFloat16VectorAtomics == VK_TRUE);
     // clang-format on
 
-    for (const spirv::Instruction *atomic_def : stateless_data.atomic_inst) {
-        const spirv::AtomicInstructionInfo &atomic = module_state.GetAtomicInfo(*atomic_def);
-        const uint32_t opcode = atomic_def->Opcode();
+    for (const spirv::Instruction *atomic_def_ptr : stateless_data.atomic_inst) {
+        const spirv::Instruction &atomic_def = *atomic_def_ptr;
+        const spirv::AtomicInstructionInfo &atomic = module_state.GetAtomicInfo(atomic_def);
+        const uint32_t opcode = atomic_def.Opcode();
 
         if (atomic.type == spv::OpTypeFloat && (atomic.vector_size == 2 || atomic.vector_size == 4)) {
             if (!valid_16_float_vector) {
-                skip |= LogError("VUID-RuntimeSpirv-shaderFloat16VectorAtomics-09581", module_state.handle(), loc,
-                                 "SPIR-V is using 16-bit float vector atomics operations\n%s\nwith %s storage class, but "
-                                 "shaderFloat16VectorAtomics was not enabled.",
-                                 atomic_def->Describe().c_str(), string_SpvStorageClass(atomic.storage_class));
+                skip |=
+                    LogError("VUID-RuntimeSpirv-shaderFloat16VectorAtomics-09581", module_state.handle(), loc,
+                             "SPIR-V is using 16-bit float vector atomics operationswith %s storage class, but "
+                             "shaderFloat16VectorAtomics was not enabled.\n%s\n",
+                             string_SpvStorageClass(atomic.storage_class), module_state.DescribeInstruction(atomic_def).c_str());
             }
         } else if ((atomic.bit_width == 64) && (atomic.type == spv::OpTypeInt)) {
             // Validate 64-bit image atomics
             if (((atomic.storage_class == spv::StorageClassStorageBuffer) || (atomic.storage_class == spv::StorageClassUniform)) &&
                 (enabled_features.shaderBufferInt64Atomics == VK_FALSE)) {
-                skip |= LogError("VUID-RuntimeSpirv-None-06278", module_state.handle(), loc,
-                                 "SPIR-V is using 64-bit int atomics operations\n%s\nwith %s storage class, but "
-                                 "shaderBufferInt64Atomics was not enabled.",
-                                 atomic_def->Describe().c_str(), string_SpvStorageClass(atomic.storage_class));
+                skip |=
+                    LogError("VUID-RuntimeSpirv-None-06278", module_state.handle(), loc,
+                             "SPIR-V is using 64-bit int atomics operations with %s storage class, but "
+                             "shaderBufferInt64Atomics was not enabled. \n%s\n",
+                             string_SpvStorageClass(atomic.storage_class), module_state.DescribeInstruction(atomic_def).c_str());
             } else if ((atomic.storage_class == spv::StorageClassWorkgroup) &&
                        (enabled_features.shaderSharedInt64Atomics == VK_FALSE)) {
                 skip |= LogError("VUID-RuntimeSpirv-None-06279", module_state.handle(), loc,
-                                 "SPIR-V is using 64-bit int atomics operations\n%s\nwith Workgroup storage class, but "
-                                 "shaderSharedInt64Atomics was not enabled.",
-                                 atomic_def->Describe().c_str());
+                                 "SPIR-V is using 64-bit int atomics operations with Workgroup storage class, but "
+                                 "shaderSharedInt64Atomics was not enabled.\n%s\n",
+                                 module_state.DescribeInstruction(atomic_def).c_str());
             } else if ((atomic.storage_class == spv::StorageClassImage) && (valid_image_64_int == false)) {
                 skip |= LogError("VUID-RuntimeSpirv-None-06288", module_state.handle(), loc,
-                                 "SPIR-V is using 64-bit int atomics operations\n%s\nwith Image storage class, but "
-                                 "shaderImageInt64Atomics was not enabled.",
-                                 atomic_def->Describe().c_str());
+                                 "SPIR-V is using 64-bit int atomics operations with Image storage class, but "
+                                 "shaderImageInt64Atomics was not enabled.\n%s\n",
+                                 module_state.DescribeInstruction(atomic_def).c_str());
             }
         } else if (atomic.type == spv::OpTypeFloat) {
             // Validate Floats
             if (atomic.storage_class == spv::StorageClassStorageBuffer) {
                 if (valid_storage_buffer_float == false) {
                     skip |= LogError("VUID-RuntimeSpirv-None-06284", module_state.handle(), loc,
-                                     "SPIR-V is using float atomics operations\n%s\nwith StorageBuffer storage class, but none of "
-                                     "the required features were enabled.",
-                                     atomic_def->Describe().c_str());
+                                     "SPIR-V is using float atomics operations with StorageBuffer storage class, but none of "
+                                     "the required features were enabled.\n%s\n",
+                                     module_state.DescribeInstruction(atomic_def).c_str());
                 } else if (opcode == spv::OpAtomicFAddEXT) {
                     if ((atomic.bit_width == 16) && (enabled_features.shaderBufferFloat16AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                                         "SPIR-V is using 16-bit float atomics for add operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat16AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 16-bit float atomics for add operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat16AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderBufferFloat32AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 32-bit float atomics for add operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat32AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 32-bit float atomics for add operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat32AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderBufferFloat64AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                         "SPIR-V is using 64-bit float atomics for add operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat64AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 64-bit float atomics for add operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat64AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 } else if (opcode == spv::OpAtomicFMinEXT || opcode == spv::OpAtomicFMaxEXT) {
                     if ((atomic.bit_width == 16) && (enabled_features.shaderBufferFloat16AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                                         "SPIR-V is using 16-bit float atomics for min/max operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat16AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 16-bit float atomics for min/max operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat16AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderBufferFloat32AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 32-bit float atomics for min/max operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat32AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 32-bit float atomics for min/max operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat32AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderBufferFloat64AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                         "SPIR-V is using 64-bit float atomics for min/max operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat64AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 64-bit float atomics for min/max operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat64AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 } else {
                     // Assume is valid load/store/exchange (rest of supported atomic operations) or else spirv-val will catch
                     if ((atomic.bit_width == 16) && (enabled_features.shaderBufferFloat16Atomics == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 16-bit float atomics for load/store/exhange operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat16Atomics was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 16-bit float atomics for load/store/exhange operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat16Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderBufferFloat32Atomics == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 32-bit float atomics for load/store/exhange operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat32Atomics was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 32-bit float atomics for load/store/exhange operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat32Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderBufferFloat64Atomics == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                         "SPIR-V is using 64-bit float atomics for load/store/exhange operations\n%s\nwith "
-                                         "StorageBuffer storage class, but shaderBufferFloat64Atomics was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 64-bit float atomics for load/store/exhange operations with "
+                                         "StorageBuffer storage class, but shaderBufferFloat64Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 }
             } else if (atomic.storage_class == spv::StorageClassWorkgroup) {
                 if (valid_workgroup_float == false) {
                     skip |= LogError("VUID-RuntimeSpirv-None-06285", module_state.handle(), loc,
-                                     "SPIR-V is using float atomics operations\n%s\nwith Workgroup storage class, but none of the "
-                                     "required features were enabled.",
-                                     atomic_def->Describe().c_str());
+                                     "SPIR-V is using float atomics operations with Workgroup storage class, but none of the "
+                                     "required features were enabled.\n%s\n",
+                                     module_state.DescribeInstruction(atomic_def).c_str());
                 } else if (opcode == spv::OpAtomicFAddEXT) {
                     if ((atomic.bit_width == 16) && (enabled_features.shaderSharedFloat16AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                                         "SPIR-V is using 16-bit float atomics for add operations\n%s\nwith Workgroup "
-                                         "storage class, but shaderSharedFloat16AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 16-bit float atomics for add operations with Workgroup "
+                                         "storage class, but shaderSharedFloat16AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderSharedFloat32AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 32-bit float atomics for add operations\n%s\nwith Workgroup "
-                                         "storage class, but shaderSharedFloat32AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 32-bit float atomics for add operations with Workgroup "
+                                         "storage class, but shaderSharedFloat32AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderSharedFloat64AtomicAdd == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                         "SPIR-V is using 64-bit float atomics for add operations\n%s\nwith Workgroup "
-                                         "storage class, but shaderSharedFloat64AtomicAdd was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 64-bit float atomics for add operations with Workgroup "
+                                         "storage class, but shaderSharedFloat64AtomicAdd was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 } else if (opcode == spv::OpAtomicFMinEXT || opcode == spv::OpAtomicFMaxEXT) {
                     if ((atomic.bit_width == 16) && (enabled_features.shaderSharedFloat16AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                                         "SPIR-V is using 16-bit float atomics for min/max operations\n%s\nwith "
-                                         "Workgroup storage class, but shaderSharedFloat16AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 16-bit float atomics for min/max operations with "
+                                         "Workgroup storage class, but shaderSharedFloat16AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderSharedFloat32AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                         "SPIR-V is using 32-bit float atomics for min/max operations\n%s\nwith "
-                                         "Workgroup storage class, but shaderSharedFloat32AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 32-bit float atomics for min/max operations with "
+                                         "Workgroup storage class, but shaderSharedFloat32AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderSharedFloat64AtomicMinMax == VK_FALSE)) {
                         skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                         "SPIR-V is using 64-bit float atomics for min/max operations\n%s\nwith "
-                                         "Workgroup storage class, but shaderSharedFloat64AtomicMinMax was not enabled.",
-                                         atomic_def->Describe().c_str());
+                                         "SPIR-V is using 64-bit float atomics for min/max operations with "
+                                         "Workgroup storage class, but shaderSharedFloat64AtomicMinMax was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 } else {
                     // Assume is valid load/store/exchange (rest of supported atomic operations) or else spirv-val will catch
                     if ((atomic.bit_width == 16) && (enabled_features.shaderSharedFloat16Atomics == VK_FALSE)) {
-                        skip |=
-                            LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                                     "SPIR-V is using 16-bit float atomics for load/store/exhange operations\n%s\nwith Workgroup "
-                                     "storage class, but shaderSharedFloat16Atomics was not enabled.",
-                                     atomic_def->Describe().c_str());
+                        skip |= LogError("VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
+                                         "SPIR-V is using 16-bit float atomics for load/store/exhange operations with Workgroup "
+                                         "storage class, but shaderSharedFloat16Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 32) && (enabled_features.shaderSharedFloat32Atomics == VK_FALSE)) {
-                        skip |=
-                            LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                                     "SPIR-V is using 32-bit float atomics for load/store/exhange operations\n%s\nwith Workgroup "
-                                     "storage class, but shaderSharedFloat32Atomics was not enabled.",
-                                     atomic_def->Describe().c_str());
+                        skip |= LogError("VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
+                                         "SPIR-V is using 32-bit float atomics for load/store/exhange operations with Workgroup "
+                                         "storage class, but shaderSharedFloat32Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     } else if ((atomic.bit_width == 64) && (enabled_features.shaderSharedFloat64Atomics == VK_FALSE)) {
-                        skip |=
-                            LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                                     "SPIR-V is using 64-bit float atomics for load/store/exhange operations\n%s\nwith Workgroup "
-                                     "storage class, but shaderSharedFloat64Atomics was not enabled.",
-                                     atomic_def->Describe().c_str());
+                        skip |= LogError("VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
+                                         "SPIR-V is using 64-bit float atomics for load/store/exhange operations with Workgroup "
+                                         "storage class, but shaderSharedFloat64Atomics was not enabled.\n%s\n",
+                                         module_state.DescribeInstruction(atomic_def).c_str());
                     }
                 }
             } else if ((atomic.storage_class == spv::StorageClassImage) && (valid_image_float == false)) {
                 skip |= LogError("VUID-RuntimeSpirv-None-06286", module_state.handle(), loc,
-                                 "SPIR-V is using float atomics operations\n%s\nwith Image storage class, but none of the required "
-                                 "features were enabled.",
-                                 atomic_def->Describe().c_str());
+                                 "SPIR-V is using float atomics operations with Image storage class, but none of the required "
+                                 "features were enabled.\n%s\n",
+                                 module_state.DescribeInstruction(atomic_def).c_str());
             } else if ((atomic.bit_width == 16) && (valid_16_float == false)) {
                 skip |= LogError(
                     "VUID-RuntimeSpirv-None-06337", module_state.handle(), loc,
-                    "SPIR-V is using 16-bit float atomics operations\n%s\n but none of the required features were enabled.",
-                    atomic_def->Describe().c_str());
+                    "SPIR-V is using 16-bit float atomics operations but none of the required features were enabled.\n%s\n",
+                    module_state.DescribeInstruction(atomic_def).c_str());
             } else if ((atomic.bit_width == 32) && (valid_32_float == false)) {
                 skip |= LogError(
                     "VUID-RuntimeSpirv-None-06338", module_state.handle(), loc,
-                    "SPIR-V is using 32-bit float atomics operations\n%s\n but none of the required features were enabled.",
-                    atomic_def->Describe().c_str());
+                    "SPIR-V is using 32-bit float atomics operations but none of the required features were enabled.\n%s\n",
+                    module_state.DescribeInstruction(atomic_def).c_str());
             } else if ((atomic.bit_width == 64) && (valid_64_float == false)) {
                 skip |= LogError(
                     "VUID-RuntimeSpirv-None-06339", module_state.handle(), loc,
-                    "SPIR-V is using 64-bit float atomics operations\n%s\n but snone of the required features were enabled.",
-                    atomic_def->Describe().c_str());
+                    "SPIR-V is using 64-bit float atomics operations but snone of the required features were enabled.\n%s\n",
+                    module_state.DescribeInstruction(atomic_def).c_str());
             }
         }
     }

--- a/layers/error_message/spirv_logging.cpp
+++ b/layers/error_message/spirv_logging.cpp
@@ -17,12 +17,21 @@
 
 #include "spirv_logging.h"
 #include <regex>
-#include <sstream>
+#include <string>
 
 #include <spirv/unified1/NonSemanticShaderDebugInfo100.h>
 #include <spirv/unified1/spirv.hpp>
 
-const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &instructions, uint32_t string_id) {
+struct SpirvLoggingInfo {
+    uint32_t file_string_id = 0;  // OpString with filename
+    uint32_t line_number_start = 0;
+    uint32_t line_number_end = 0;
+    uint32_t column_number = 0;            // most compiler will just give zero here, so just try and get a start column
+    bool using_shader_debug_info = false;  // NonSemantic.Shader.DebugInfo.100
+    std::string reported_filename;
+};
+
+static const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &instructions, uint32_t string_id) {
     const spirv::Instruction *string_insn = nullptr;
     for (const auto &insn : instructions) {
         if (insn.Opcode() == spv::OpString && insn.Length() >= 3 && insn.Word(1) == string_id) {
@@ -40,8 +49,8 @@ const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &in
 
 // Read the contents of the SPIR-V OpSource instruction and any following continuation instructions.
 // Split the single string into a vector of strings, one for each line, for easier processing.
-void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uint32_t reported_file_id,
-                  std::vector<std::string> &out_opsource_lines) {
+static void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uint32_t reported_file_id,
+                         std::vector<std::string> &out_source_lines) {
     for (size_t i = 0; i < instructions.size(); i++) {
         const auto &insn = instructions[i];
         if ((insn.Opcode() != spv::OpSource) || (insn.Length() < 5) || (insn.Word(3) != reported_file_id)) {
@@ -52,7 +61,7 @@ void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uin
         std::string current_line;
         in_stream.str(insn.GetAsString(4));
         while (std::getline(in_stream, current_line)) {
-            out_opsource_lines.emplace_back(current_line);
+            out_source_lines.emplace_back(current_line);
         }
 
         for (size_t k = i + 1; k < instructions.size(); k++) {
@@ -63,15 +72,15 @@ void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uin
             in_stream.clear();  // without, will fail getline
             in_stream.str(continue_insn.GetAsString(1));
             while (std::getline(in_stream, current_line)) {
-                out_opsource_lines.emplace_back(current_line);
+                out_source_lines.emplace_back(current_line);
             }
         }
         return;
     }
 }
 
-void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const uint32_t debug_source_id,
-                     uint32_t &out_file_string_id, std::vector<std::string> &out_opsource_lines) {
+static void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const uint32_t debug_source_id,
+                            uint32_t &out_file_string_id, std::vector<std::string> &out_source_lines) {
     for (size_t i = 0; i < instructions.size(); i++) {
         const auto &insn = instructions[i];
         if (insn.ResultId() != debug_source_id) {
@@ -93,7 +102,7 @@ void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const 
         std::string current_line;
         in_stream.str(string_inst->GetAsString(2));
         while (std::getline(in_stream, current_line)) {
-            out_opsource_lines.emplace_back(current_line);
+            out_source_lines.emplace_back(current_line);
         }
 
         for (size_t k = i + 1; k < instructions.size(); k++) {
@@ -111,7 +120,7 @@ void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const 
             in_stream.clear();  // without, will fail getline
             in_stream.str(string_inst->GetAsString(2));
             while (std::getline(in_stream, current_line)) {
-                out_opsource_lines.emplace_back(current_line);
+                out_source_lines.emplace_back(current_line);
             }
         }
         return;
@@ -135,7 +144,7 @@ void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const 
 //   is why we need to examine the entire contents of the source, instead of leaving early
 //   when finding a #line line number larger than the reported error line number.
 //
-bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename) {
+static bool GetLineFromDirective(const std::string &string, uint32_t *linenumber, std::string &filename) {
     static const std::regex line_regex(  // matches #line directives
         "^"                              // beginning of line
         "\\s*"                           // optional whitespace
@@ -160,4 +169,173 @@ bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::st
     }
     *linenumber = (uint32_t)std::stoul(captures[1]);
     return true;
+}
+
+// Return false if any error arise
+static bool GetLineAndFilename(std::ostringstream &ss, const std::vector<spirv::Instruction> &instructions,
+                               SpirvLoggingInfo &logging_info) {
+    const std::string debug_info_type = (logging_info.using_shader_debug_info) ? "DebugSource" : "OpLine";
+    if (logging_info.file_string_id == 0) {
+        // This error should be caught in spirv-val
+        ss << "(Unable to find file string from SPIR-V " << debug_info_type << ")\n";
+        return false;
+    }
+
+    auto file_string_insn = FindOpString(instructions, logging_info.file_string_id);
+    if (!file_string_insn) {
+        ss << "(Unable to find SPIR-V OpString from " << debug_info_type << " instruction.\n";
+        ss << "File ID = " << logging_info.file_string_id << ", Line Number = " << logging_info.line_number_start
+           << ", Column = " << logging_info.column_number << ")\n";
+        return false;
+    }
+
+    logging_info.reported_filename = file_string_insn->GetAsString(2);
+    if (!logging_info.reported_filename.empty()) {
+        ss << "in file " << logging_info.reported_filename << " ";
+    }
+
+    ss << "at line " << logging_info.line_number_start;
+    if (logging_info.line_number_end > logging_info.line_number_start) {
+        ss << " to " << logging_info.line_number_end;
+    }
+
+    if (logging_info.column_number != 0) {
+        ss << ", column " << logging_info.column_number;
+    }
+    ss << '\n';
+
+    return true;
+}
+
+static void GetSourceLines(std::ostringstream &ss, const std::vector<std::string> &source_lines,
+                           const SpirvLoggingInfo &logging_info) {
+    if (source_lines.empty()) {
+        if (logging_info.using_shader_debug_info) {
+            ss << "No Text operand found in DebugSource\n";
+        } else {
+            ss << "Unable to find SPIR-V OpSource\n";
+        }
+        return;
+    }
+
+    // Find the line in the OpSource content that corresponds to the reported error file and line.
+    uint32_t saved_line_number = 0;
+    std::string current_filename = logging_info.reported_filename;  // current "preprocessor" filename state.
+    std::vector<std::string>::size_type saved_opsource_offset = 0;
+
+    // This was designed to fine the best line if using #line in GLSL
+    bool found_best_line = false;
+    if (!logging_info.using_shader_debug_info) {
+        for (auto it = source_lines.begin(); it != source_lines.end(); ++it) {
+            uint32_t parsed_line_number;
+            std::string parsed_filename;
+            const bool found_line = GetLineFromDirective(*it, &parsed_line_number, parsed_filename);
+            if (!found_line) continue;
+
+            const bool found_filename = parsed_filename.size() > 0;
+            if (found_filename) {
+                current_filename = parsed_filename;
+            }
+            if ((!found_filename) || (current_filename == logging_info.reported_filename)) {
+                // Update the candidate best line directive, if the current one is prior and closer to the reported line
+                if (logging_info.line_number_start >= parsed_line_number) {
+                    if (!found_best_line || (logging_info.line_number_start - parsed_line_number <=
+                                             logging_info.line_number_start - saved_line_number)) {
+                        saved_line_number = parsed_line_number;
+                        saved_opsource_offset = std::distance(source_lines.begin(), it);
+                        found_best_line = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (logging_info.using_shader_debug_info) {
+        // For Shader Debug Info, we should have all the information we need
+        ss << '\n';
+        for (uint32_t line_index = logging_info.line_number_start; line_index <= logging_info.line_number_end; line_index++) {
+            if (line_index > source_lines.size()) {
+                ss << line_index << ": [No line found in source]";
+                break;
+            }
+            ss << line_index << ": " << source_lines[line_index - 1] << '\n';
+        }
+        // Only show column if since line is displayed
+        if (logging_info.column_number > 0 && logging_info.line_number_start == logging_info.line_number_end) {
+            std::string spaces(logging_info.column_number - 1, ' ');
+            ss << spaces << '^';
+        }
+
+    } else if (found_best_line) {
+        assert(logging_info.line_number_start >= saved_line_number);
+        const size_t opsource_index = (logging_info.line_number_start - saved_line_number) + 1 + saved_opsource_offset;
+        if (opsource_index < source_lines.size()) {
+            ss << '\n' << logging_info.line_number_start << ": " << source_lines[opsource_index] << '\n';
+        } else {
+            ss << "Internal error: calculated source line of " << opsource_index << " for source size of " << source_lines.size()
+               << " lines\n";
+        }
+    } else if (logging_info.line_number_start < source_lines.size() && logging_info.line_number_start != 0) {
+        // file lines normally start at 1 index
+        ss << '\n' << source_lines[logging_info.line_number_start - 1] << '\n';
+        if (logging_info.column_number > 0) {
+            std::string spaces(logging_info.column_number - 1, ' ');
+            ss << spaces << '^';
+        }
+    } else {
+        ss << "Unable to find a suitable line in SPIR-V OpSource\n";
+    }
+}
+
+void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<spirv::Instruction> &instructions,
+                         const spirv::Instruction &last_line_insn) {
+    // Instead of building up hash map that might not be used, reloop the constants to find the value.
+    // Non Semantic instructions are validated to have 32-bit integer constants (not spec constants).
+    auto get_constant_value = [&instructions](uint32_t id) {
+        for (const auto &insn : instructions) {
+            if (insn.Opcode() == spv::OpConstant && insn.ResultId() == id) {
+                return insn.Word(3);
+            } else if (insn.Opcode() == spv::OpFunction) {
+                break;
+            }
+        }
+        assert(false);
+        return 0u;
+    };
+
+    // Read the source code and split it up into separate lines.
+    //
+    // 1. OpLine will point to a OpSource/OpSourceContinued which have the string built-in
+    // 2. DebugLine will point to a DebugSource/DebugSourceContinued that each point to a OpString
+    //
+    // For the second one, we need to build the source lines up sooner
+    std::vector<std::string> source_lines;
+
+    SpirvLoggingInfo logging_info = {};
+    if (last_line_insn.Opcode() == spv::OpLine) {
+        logging_info.using_shader_debug_info = false;
+        logging_info.file_string_id = last_line_insn.Word(1);
+        logging_info.line_number_start = last_line_insn.Word(2);
+        logging_info.line_number_end = logging_info.line_number_start;  // OpLine only give a single line granularity
+        logging_info.column_number = last_line_insn.Word(3);
+    } else {
+        // NonSemanticShaderDebugInfo100DebugLine
+        logging_info.using_shader_debug_info = true;
+        logging_info.line_number_start = get_constant_value(last_line_insn.Word(6));
+        logging_info.line_number_end = get_constant_value(last_line_insn.Word(7));
+        logging_info.column_number = get_constant_value(last_line_insn.Word(8));
+        const uint32_t debug_source_id = last_line_insn.Word(5);
+        ReadDebugSource(instructions, debug_source_id, logging_info.file_string_id, source_lines);
+    }
+
+    if (!GetLineAndFilename(ss, instructions, logging_info)) {
+        return;
+    }
+
+    // Defer finding source from OpLine until we know we have a valid file string to tie it too
+    if (!logging_info.using_shader_debug_info) {
+        ReadOpSource(instructions, logging_info.file_string_id, source_lines);
+    }
+
+    GetSourceLines(ss, source_lines, logging_info);
 }

--- a/layers/error_message/spirv_logging.h
+++ b/layers/error_message/spirv_logging.h
@@ -17,18 +17,10 @@
 
 #pragma once
 #include <vector>
-#include <string>
+#include <sstream>
 #include "state_tracker/shader_instruction.h"
 
 // When producing error messages for SPIR-V related items and the user generated the shader with debug information, we can use these
 // helpers to print out information from their High Level source instead of some cryptic SPIR-V jargon
-
-const spirv::Instruction *FindOpString(const std::vector<spirv::Instruction> &instructions, uint32_t string_id);
-
-void ReadOpSource(const std::vector<spirv::Instruction> &instructions, const uint32_t reported_file_id,
-                  std::vector<std::string> &out_opsource_lines);
-
-void ReadDebugSource(const std::vector<spirv::Instruction> &instructions, const uint32_t debug_source_id,
-                     uint32_t &out_file_string_id, std::vector<std::string> &out_opsource_lines);
-
-bool GetLineAndFilename(const std::string &string, uint32_t *linenumber, std::string &filename);
+void GetShaderSourceInfo(std::ostringstream &ss, const std::vector<spirv::Instruction> &instructions,
+                         const spirv::Instruction &last_line_insn);

--- a/layers/state_tracker/shader_module.h
+++ b/layers/state_tracker/shader_module.h
@@ -630,6 +630,11 @@ struct Module {
         bool has_specialization_constants{false};
         bool uses_interpolate_at_sample{false};
 
+        // Will check if there is source debug information
+        // Won't save any other info and will retrieve the debug info if requested in a VU error message
+        bool using_legacy_debug_info{false};
+        uint32_t shader_debug_info_set_id = 0;  // non-zero means shader has NonSemantic.Shader.DebugInfo.100
+
         // EntryPoint has pointer references inside it that need to be preserved
         std::vector<std::shared_ptr<EntryPoint>> entry_points;
 
@@ -714,6 +719,7 @@ struct Module {
     void DescribeTypeInner(std::ostringstream &ss, uint32_t type, uint32_t indent) const;
     std::string DescribeType(uint32_t type) const;
     std::string DescribeVariable(uint32_t id) const;
+    std::string DescribeInstruction(const Instruction &error_insn) const;
 
     // Note that some shaders can have an input and output topology
     std::optional<VkPrimitiveTopology> GetTopology(const EntryPoint &entrypoint) const;

--- a/tests/unit/atomics.cpp
+++ b/tests/unit/atomics.cpp
@@ -1251,6 +1251,182 @@ TEST_F(NegativeAtomic, Float2WidthMismatch) {
     m_errorMonitor->VerifyFound();
 }
 
+TEST_F(NegativeAtomic, FloatOpSource) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    RETURN_IF_SKIP(Init());
+
+    std::string cs_source = R"(
+               OpCapability Shader
+          %2 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %1 = OpString "a.comp"
+               OpSource GLSL 450 %1 "#version 450
+#extension GL_EXT_shader_atomic_float : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float32 : enable
+
+layout(set = 0, binding = 0) buffer ssbo { float32_t y; };
+void main() {
+    y = 1 + atomicLoad(y, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);
+}"
+               OpSourceExtension "GL_EXT_shader_atomic_float"
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float32"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %ssbo "ssbo"
+               OpMemberName %ssbo 0 "y"
+               OpName %_ ""
+               OpModuleProcessed "client vulkan100"
+               OpModuleProcessed "target-env spirv1.3"
+               OpModuleProcessed "target-env vulkan1.1"
+               OpModuleProcessed "entry-point main"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %4 = OpTypeFunction %void
+      %float = OpTypeFloat 32
+       %ssbo = OpTypeStruct %float
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+          %_ = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+        %int = OpTypeInt 32 1
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+%_ptr_StorageBuffer_float = OpTypePointer StorageBuffer %float
+      %int_1 = OpConstant %int 1
+     %int_64 = OpConstant %int 64
+       %uint = OpTypeInt 32 0
+     %uint_1 = OpConstant %uint 1
+     %uint_0 = OpConstant %uint 0
+    %uint_64 = OpConstant %uint 64
+               OpLine %1 7 11
+       %main = OpFunction %void None %4
+          %6 = OpLabel
+               OpLine %1 8 0
+         %15 = OpAccessChain %_ptr_StorageBuffer_float %_ %int_0
+         %22 = OpAtomicLoad %float %15 %int_1 %uint_64
+         %23 = OpFAdd %float %float_1 %22
+         %24 = OpAccessChain %_ptr_StorageBuffer_float %_ %int_0
+               OpStore %24 %23
+               OpLine %1 9 0
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // VUID-RuntimeSpirv-None-06284
+    m_errorMonitor->SetDesiredError("atomicLoad(y, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);");
+    VkShaderObj const cs(this, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}
+
+TEST_F(NegativeAtomic, FloatShaderDebugInfo) {
+    SetTargetApiVersion(VK_API_VERSION_1_1);
+    AddRequiredExtensions(VK_KHR_SHADER_NON_SEMANTIC_INFO_EXTENSION_NAME);
+    RETURN_IF_SKIP(Init());
+
+    std::string cs_source = R"(
+               OpCapability Shader
+               OpExtension "SPV_KHR_non_semantic_info"
+          %1 = OpExtInstImport "NonSemantic.Shader.DebugInfo.100"
+          %3 = OpExtInstImport "GLSL.std.450"
+               OpMemoryModel Logical GLSL450
+               OpEntryPoint GLCompute %main "main"
+               OpExecutionMode %main LocalSize 1 1 1
+          %2 = OpString "a.comp"
+          %8 = OpString "uint"
+         %16 = OpString "main"
+         %19 = OpString "#version 450
+#extension GL_EXT_shader_atomic_float : enable
+#extension GL_KHR_memory_scope_semantics : enable
+#extension GL_EXT_shader_explicit_arithmetic_types_float32 : enable
+
+layout(set = 0, binding = 0) buffer ssbo { float32_t y; };
+void main() {
+    y = 1 + atomicLoad(y, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);
+}"
+         %29 = OpString "float"
+         %33 = OpString "y"
+         %36 = OpString "ssbo"
+         %43 = OpString ""
+         %45 = OpString "int"
+               OpSourceExtension "GL_EXT_shader_atomic_float"
+               OpSourceExtension "GL_EXT_shader_explicit_arithmetic_types_float32"
+               OpSourceExtension "GL_KHR_memory_scope_semantics"
+               OpName %main "main"
+               OpName %ssbo "ssbo"
+               OpMemberName %ssbo 0 "y"
+               OpName %_ ""
+               OpModuleProcessed "client vulkan100"
+               OpModuleProcessed "target-env spirv1.3"
+               OpModuleProcessed "target-env vulkan1.1"
+               OpModuleProcessed "entry-point main"
+               OpDecorate %ssbo Block
+               OpMemberDecorate %ssbo 0 Offset 0
+               OpDecorate %_ Binding 0
+               OpDecorate %_ DescriptorSet 0
+       %void = OpTypeVoid
+          %5 = OpTypeFunction %void
+       %uint = OpTypeInt 32 0
+    %uint_32 = OpConstant %uint 32
+     %uint_6 = OpConstant %uint 6
+     %uint_0 = OpConstant %uint 0
+          %9 = OpExtInst %void %1 DebugTypeBasic %8 %uint_32 %uint_6 %uint_0
+     %uint_3 = OpConstant %uint 3
+          %6 = OpExtInst %void %1 DebugTypeFunction %uint_3 %void
+         %18 = OpExtInst %void %1 DebugSource %2 %19
+     %uint_7 = OpConstant %uint 7
+     %uint_1 = OpConstant %uint 1
+     %uint_4 = OpConstant %uint 4
+     %uint_2 = OpConstant %uint 2
+         %21 = OpExtInst %void %1 DebugCompilationUnit %uint_1 %uint_4 %18 %uint_2
+         %17 = OpExtInst %void %1 DebugFunction %16 %6 %18 %uint_7 %uint_0 %21 %16 %uint_3 %uint_7
+      %float = OpTypeFloat 32
+         %30 = OpExtInst %void %1 DebugTypeBasic %29 %uint_32 %uint_3 %uint_0
+       %ssbo = OpTypeStruct %float
+    %uint_54 = OpConstant %uint 54
+         %32 = OpExtInst %void %1 DebugTypeMember %33 %30 %18 %uint_6 %uint_54 %uint_0 %uint_0 %uint_3
+     %uint_8 = OpConstant %uint 8
+         %35 = OpExtInst %void %1 DebugTypeComposite %36 %uint_1 %18 %uint_8 %uint_0 %21 %36 %uint_0 %uint_3 %32
+%_ptr_StorageBuffer_ssbo = OpTypePointer StorageBuffer %ssbo
+    %uint_12 = OpConstant %uint 12
+         %40 = OpExtInst %void %1 DebugTypePointer %35 %uint_12 %uint_0
+          %_ = OpVariable %_ptr_StorageBuffer_ssbo StorageBuffer
+         %42 = OpExtInst %void %1 DebugGlobalVariable %43 %35 %18 %uint_8 %uint_0 %21 %43 %_ %uint_8
+        %int = OpTypeInt 32 1
+         %46 = OpExtInst %void %1 DebugTypeBasic %45 %uint_32 %uint_4 %uint_0
+      %int_0 = OpConstant %int 0
+    %float_1 = OpConstant %float 1
+%_ptr_StorageBuffer_float = OpTypePointer StorageBuffer %float
+         %50 = OpExtInst %void %1 DebugTypePointer %30 %uint_12 %uint_0
+      %int_1 = OpConstant %int 1
+     %int_64 = OpConstant %int 64
+    %uint_64 = OpConstant %uint 64
+     %uint_9 = OpConstant %uint 9
+       %main = OpFunction %void None %5
+         %15 = OpLabel
+         %26 = OpExtInst %void %1 DebugScope %17
+         %27 = OpExtInst %void %1 DebugLine %18 %uint_7 %uint_7 %uint_0 %uint_0
+         %25 = OpExtInst %void %1 DebugFunctionDefinition %17 %main
+         %52 = OpExtInst %void %1 DebugLine %18 %uint_8 %uint_8 %uint_0 %uint_0
+         %51 = OpAccessChain %_ptr_StorageBuffer_float %_ %int_0
+         %56 = OpAtomicLoad %float %51 %int_1 %uint_64
+         %57 = OpFAdd %float %float_1 %56
+         %58 = OpAccessChain %_ptr_StorageBuffer_float %_ %int_0
+               OpStore %58 %57
+         %59 = OpExtInst %void %1 DebugLine %18 %uint_9 %uint_9 %uint_0 %uint_0
+               OpReturn
+               OpFunctionEnd
+    )";
+
+    // VUID-RuntimeSpirv-None-06284
+    m_errorMonitor->SetDesiredError("atomicLoad(y, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);");
+    VkShaderObj const cs(this, cs_source.c_str(), VK_SHADER_STAGE_COMPUTE_BIT, SPV_ENV_VULKAN_1_1, SPV_SOURCE_ASM);
+    m_errorMonitor->VerifyFound();
+}
+
 TEST_F(NegativeAtomic, InvalidStorageOperation) {
     TEST_DESCRIPTION(
         "If storage view use atomic operation, the view's format MUST support VK_FORMAT_FEATURE_STORAGE_IMAGE_ATOMIC_BIT or "


### PR DESCRIPTION
Follow up of https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8691

If users have debug information in their shader, will print source information (just added for Atomic VUs, will add rest after)

Before

```
Validation Error: [ VUID-RuntimeSpirv-None-06284 ] | MessageID = 0x6b26b332 | vkCreateShaderModule():  SPIR-V is using float atomics operations
%22 = OpAtomicLoad %8 %21 %14 %19
with StorageBuffer storage class, but none of the required features were enabled.
```

now :rocket: 

```
Validation Error: [ VUID-RuntimeSpirv-None-06284 ] | MessageID = 0x6b26b332 | vkCreateShaderModule():  SPIR-V is using float atomics operations with StorageBuffer storage class, but none of the required features were enabled.
%57 = OpAtomicLoad %31 %56 %47 %49
From shader debug information: in file a.comp at line 8

8:     y = 1 + atomicLoad(y, gl_ScopeDevice, gl_StorageSemanticsBuffer, gl_SemanticsRelaxed);

```