### PR TITLE
layers: Break dependency of in-use tracking on GPU state

### DIFF
--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1589,15 +1589,12 @@ void ValidationStateTracker::PostCallRecordGetDeviceQueue2(VkDevice device, cons
 }
 
 void ValidationStateTracker::PostCallRecordQueueWaitIdle(VkQueue queue, const RecordObject &record_obj) {
-    if (VK_SUCCESS != record_obj.result) return;
     if (auto queue_state = Get<vvl::Queue>(queue)) {
         queue_state->NotifyAndWait(record_obj.location);
     }
 }
 
 void ValidationStateTracker::PostCallRecordDeviceWaitIdle(VkDevice device, const RecordObject &record_obj) {
-    if (VK_SUCCESS != record_obj.result) return;
-
     // Sort the queues by id to notify in deterministic order (queue creation order).
     // This is not needed for correctness, but gives deterministic behavior to certain
     // types of bugs in the queue thread.


### PR DESCRIPTION
Inspired by https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8689 which was confusing and time consuming.

The idea is that in-use tracking is not a GPU side system. Evaluate resource in-use status based on CPU side API usage pattern. Make GPU/driver errors a separate axis of error handling.

The problem with mixing these two types of errors handling is that it leads to confusion in practice. For example, if the application is correctly structured to handle resource lifetimes or image layouts transition, but it did poor job with handling VkResult, and the error message reports that resource is still in use (but we just called vkDeviceWaitIdle!) or layout is incorrect when all transitions are properly specified. This misleading messages can focus attention on the wrong area (like spending few days debugging multithreaded system trying to understand why the resource is not tracked properly).

If necessary we might provide an option to detect non successful VkResult checks (have this already?) for critical places like submit/wait calls.

For now this change is experimental to observe how it works in practice.