### PR TITLE
gpu: RFC - Reduce LUT in descriptor indexing

### DIFF
--- a/layers/gpu/shaders/instrumentation/bindless_descriptor.comp
+++ b/layers/gpu/shaders/instrumentation/bindless_descriptor.comp
@@ -30,19 +30,6 @@
 #include "gpuav_shaders_constants.h"
 #include "common_descriptor_sets.h"
 
-layout(buffer_reference, buffer_reference_align = 8, std430) buffer DescriptorLayoutData {
-    // BindingLayout[0]
-    uint num_bindings;
-    uint pad; // always zero, used to keep things aligned
-
-    // BindingLayout[1] - BindingLayout[N]
-    // struct glsl::BindingLayout {
-    //   x: count
-    //   y: state_start
-    // }
-    uvec2 data[];
-};
-
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer DescriptorSetInData {
     // struct glsl::DescriptorState {
     //   x: id
@@ -51,47 +38,33 @@ layout(buffer_reference, buffer_reference_align = 8, std430) buffer DescriptorSe
     uvec2 data[];
 };
 
-layout(buffer_reference, buffer_reference_align = 8, std430) buffer DescriptorSetOutData {
-    // size of descriptor count (including all array elements)
-    // Used to mark which indexes were accessed
-    uint data[];
-};
-
 layout(buffer_reference, buffer_reference_align = 8, std430) buffer GlobalState {
     // Maps to DescriptorHeap and used to detect if descriptor is still valid on CPU
     uint data[];
 };
 
-struct DescriptorSetRecord {
-    DescriptorLayoutData layout_data;
-    DescriptorSetInData in_data;
-    DescriptorSetOutData out_data;
-};
-
 layout(set = kInstDefaultDescriptorSet, binding = kBindingInstBindlessDescriptor, std430) buffer BindlessStateBuffer {
     GlobalState global_state;
-    DescriptorSetRecord desc_sets[kDebugInputBindlessMaxDescSets];
+    DescriptorSetInData desc_sets[kDebugInputBindlessMaxDescSets];
 } bindless_state_buffer;
 
 bool inst_bindless_descriptor(const uint inst_num, const uvec4 stage_info, const uint desc_set,
-                              const uint binding, const uint desc_index, const uint byte_offset) {
+                              const uint binding, const uint desc_index, const uint byte_offset,
+                              const uint layout_size, const uint layout_offset) {
     uint error = 0u;
     uint param_0 = 0u;
     uint param_1 = 0u;
     do {
-        DescriptorLayoutData layout_data = bindless_state_buffer.desc_sets[desc_set].layout_data;
-
-        uvec2 binding_state = layout_data.data[binding];
-        if (desc_index >= binding_state.x) {
+        if (desc_index >= layout_size) {
             error = kErrorSubCodeBindlessDescriptorBounds;
-            param_0 = binding_state.x;
+            param_0 = layout_size;
             break;
         }
 
-        DescriptorSetInData in_data = bindless_state_buffer.desc_sets[desc_set].in_data;
+        DescriptorSetInData in_data = bindless_state_buffer.desc_sets[desc_set];
 
         // check if the descriptor was ever initialized
-        uint state_index = binding_state.y + desc_index;
+        uint state_index = layout_offset + desc_index;
         uint desc_id = in_data.data[state_index].x & kDebugInputBindlessSkipId;
         uint desc_type = (in_data.data[state_index].x & ~kDebugInputBindlessSkipId) >> kDescBitShift;
         if (desc_id == 0u) {
@@ -135,13 +108,6 @@ bool inst_bindless_descriptor(const uint inst_num, const uvec4 stage_info, const
                 break;
             }
         }
-
-        DescriptorSetOutData out_data = bindless_state_buffer.desc_sets[desc_set].out_data;
-        // The index has been accessed, write out for post processing
-        //
-        // Two pointers *could* be the same pointer if shared VkDescriptorSet handles
-        // ex - desc_sets[0].out_data == desc_sets[1].out_data
-        out_data.data[state_index] = kDescriptorSetWrittenMask | desc_set;
     } while (false);
 
     if (0u != error) {

--- a/layers/gpu/spirv/bindless_descriptor_pass.cpp
+++ b/layers/gpu/spirv/bindless_descriptor_pass.cpp
@@ -109,10 +109,13 @@ uint32_t BindlessDescriptorPass::CreateFunctionCall(BasicBlock& block, Instructi
     const uint32_t function_def = GetLinkFunctionId();
     const uint32_t bool_type = module_.type_manager_.GetTypeBool().Id();
 
+    const Constant& layout_size = module_.type_manager_.GetConstantUInt32(layout_table_[descriptor_binding_].count);
+    const Constant& layout_offset = module_.type_manager_.GetConstantUInt32(layout_table_[descriptor_binding_].state_start);
+
     block.CreateInstruction(
         spv::OpFunctionCall,
         {bool_type, function_result, function_def, injection_data.inst_position_id, injection_data.stage_info_id, set_constant.Id(),
-         binding_constant.Id(), descriptor_index_id, descriptor_offset_id_},
+         binding_constant.Id(), descriptor_index_id, descriptor_offset_id_, layout_size.Id(), layout_offset.Id()},
         inst_it);
 
     return function_result;

--- a/layers/gpu/spirv/bindless_descriptor_pass.h
+++ b/layers/gpu/spirv/bindless_descriptor_pass.h
@@ -20,13 +20,22 @@
 namespace gpuav {
 namespace spirv {
 
+struct BindingLayout {
+    uint32_t count;
+    uint32_t state_start;
+};
+
 // Create a pass to instrument bindless descriptor checking
 // This pass instruments all bindless references to check that descriptor
 // array indices are inbounds, and if the descriptor indexing extension is
 // enabled, that the descriptor has been initialized.
 class BindlessDescriptorPass : public InjectConditionalFunctionPass {
   public:
-    BindlessDescriptorPass(Module& module) : InjectConditionalFunctionPass(module) {}
+    BindlessDescriptorPass(Module& module) : InjectConditionalFunctionPass(module) {
+        // To simulate the "Stress" test pipeline
+        layout_table_.push_back({1, 0});
+        layout_table_.push_back({64, 1});
+    }
     const char* Name() const final { return "BindlessDescriptorPass"; }
     void PrintDebugInfo();
 
@@ -49,6 +58,8 @@ class BindlessDescriptorPass : public InjectConditionalFunctionPass {
 
     // < original ID, new CopyObject ID >
     vvl::unordered_map<uint32_t, uint32_t> copy_object_map_;
+
+    std::vector<BindingLayout> layout_table_;
 };
 
 }  // namespace spirv

--- a/layers/vulkan/generated/gpuav_shader_hash.h
+++ b/layers/vulkan/generated/gpuav_shader_hash.h
@@ -24,4 +24,4 @@
 
 #pragma once
 
-#define GPU_AV_SHADER_GIT_HASH "e96d8c8e03a71a894b0ac19f33f0a647a94f96d8"
+#define GPU_AV_SHADER_GIT_HASH "91349acfff6141dacc107610fc44b746c7472e08"


### PR DESCRIPTION
(Numbers from Intel Mesa Compiler)

**Before**
- Average compile time 1.75 seconds
- 14,365 instructions
- 88 loops
- 1,809,340 cycles
- 327,952 bytes

**After**
- Average compile time 2.4 seconds (because spend more time cleaning things up)
- 11,969 instructions
- 0 loops
- 282,842 cycles
- 260,384 bytes
