### PR TITLE
gpu: Cleanup DescriptorSet class

### DIFF
--- a/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
+++ b/layers/gpu/descriptor_validation/gpuav_descriptor_set.h
@@ -38,8 +38,11 @@ class DescriptorSet : public vvl::DescriptorSet {
     VkDeviceAddress GetLayoutAddress(Validator &gpuav, const Location &loc);
     VkDeviceAddress GetInputAddress(Validator &gpuav, const Location &loc);
     std::shared_ptr<DeviceMemoryBlock> GetPostProcessBuffer(Validator &gpuav, const Location &loc);
+    bool HasPostProcessBuffer() const { return post_process_block_ != nullptr; }
 
     const DeviceMemoryBlock &LayoutBlock() const { return layout_block_; }
+
+    BindingVariableMap binding_req_map = {};
 
   protected:
     bool SkipBinding(const vvl::DescriptorBinding &binding, bool is_dynamic_accessed) const override { return true; }

--- a/layers/gpu/instrumentation/gpuav_instrumentation.h
+++ b/layers/gpu/instrumentation/gpuav_instrumentation.h
@@ -20,13 +20,14 @@
 #include <vulkan/vulkan.h>
 #include <string>
 #include <vector>
+#include <memory>
 
 struct Location;
 struct LogObjectList;
 namespace gpuav {
-struct DescSetState;
 class Validator;
 class CommandBuffer;
+class DescriptorSet;
 
 void UpdateInstrumentationDescSet(Validator& gpuav, CommandBuffer& cb_state, VkDescriptorSet instrumentation_desc_set,
                                   const Location& loc);
@@ -39,17 +40,17 @@ void PostCallSetupShaderInstrumentationResources(Validator& gpuav, CommandBuffer
 
 // Return true iff a error has been found
 bool LogInstrumentationError(Validator& gpuav, VkCommandBuffer cmd_buffer, const LogObjectList& objlist, uint32_t operation_index,
-                             const uint32_t* error_record, const std::vector<DescSetState>& descriptor_sets,
+                             const uint32_t* error_record, const std::vector<std::shared_ptr<DescriptorSet>>& descriptor_sets,
                              VkPipelineBindPoint pipeline_bind_point, bool uses_shader_object, bool uses_robustness,
                              const Location& loc);
 
 // Return true iff an error has been found in error_record, among the list of errors this function manages
 bool LogMessageInstBindlessDescriptor(Validator& gpuav, const uint32_t* error_record, std::string& out_error_msg,
-                                      std::string& out_vuid_msg, const std::vector<DescSetState>& descriptor_sets,
+                                      std::string& out_vuid_msg, const std::vector<std::shared_ptr<DescriptorSet>>& descriptor_sets,
                                       const Location& loc, bool uses_shader_object, bool& out_oob_access);
 bool LogMessageInstNonBindlessOOB(Validator& gpuav, const uint32_t* error_record, std::string& out_error_msg,
-                                  std::string& out_vuid_msg, const std::vector<DescSetState>& descriptor_sets, const Location& loc,
-                                  bool uses_shader_object, bool& out_oob_access);
+                                  std::string& out_vuid_msg, const std::vector<std::shared_ptr<DescriptorSet>>& descriptor_sets,
+                                  const Location& loc, bool uses_shader_object, bool& out_oob_access);
 bool LogMessageInstBufferDeviceAddress(const uint32_t* error_record, std::string& out_error_msg, std::string& out_vuid_msg,
                                        bool& out_oob_access);
 bool LogMessageInstRayQuery(const uint32_t* error_record, std::string& out_error_msg, std::string& out_vuid_msg);

--- a/layers/gpu/resources/gpuav_shader_resources.h
+++ b/layers/gpu/resources/gpuav_shader_resources.h
@@ -27,20 +27,11 @@
 
 namespace gpuav {
 
-struct DescSetState {
-    std::shared_ptr<DescriptorSet> state = {};
-    BindingVariableMap binding_req_map = {};
-    // State that will be used by the GPU-AV shader instrumentation
-    // For update-after-bind, this will be set during queue submission
-    // Otherwise it will be set when the DescriptorSet is bound.
-    std::shared_ptr<DeviceMemoryBlock> post_process_buffer = {};
-};
-
 struct DescBindingInfo {
     DeviceMemoryBlock bindless_state;
     // Hold a buffer for each descriptor set
     // Note: The index here is from vkCmdBindDescriptorSets::firstSet
-    std::vector<DescSetState> descriptor_set_buffers;
+    std::vector<std::shared_ptr<DescriptorSet>> descriptor_set_buffers;
 
     DescBindingInfo(Validator &gpuav) : bindless_state(gpuav) {}
 };


### PR DESCRIPTION
This just removes `struct DescSetState` which was just a wrapper around the `gpu::DescriptorSet` class, so this just moves that logic into `gpu::DescriptorSet` so that we have a single interface