### PR TITLE
layers: Add atexit to safely tear down layers

### DIFF
--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -26,3 +26,10 @@ There are VUID such as `VUID-VkBufferCreateInfo-pNext-pNext` that limit which `s
 There are VUs that will be worded something like `must be a valid pointer to ...`.
 
 The Validation Layers will check that the pointer is not null, but if the pointer is pointing to garbage, there is no way to safely dereference it.
+
+## stdlib exit()
+
+It is possible for an app to call `exit()` and do cleanup in their `atexit()` callback.
+Unfortunately, this will destroy our static allocation from under us and there is no way to detect it at runtime.
+We have our own `atexit()` call set at `vkCreateDevice()` time to cleanup the layers, so we require the application to call their `atexit()` **before** `vkCreateDevice()`.
+

--- a/layers/object_tracker/object_tracker_utils.cpp
+++ b/layers/object_tracker/object_tracker_utils.cpp
@@ -529,7 +529,11 @@ void ObjectLifetimes::PreCallRecordDestroyDevice(VkDevice device, const VkAlloca
                                                  const RecordObject &record_obj) {
     auto instance_data = GetLayerDataPtr(GetDispatchKey(physical_device), layer_data_map);
     auto object_lifetimes = instance_data->GetValidationObject<ObjectLifetimes>();
-    object_lifetimes->RecordDestroyObject(device, kVulkanObjectTypeDevice);
+    // If ObjectTracker was removed (in an early teardown) this might be null, could search in aborted_object_dispatch but if it is
+    // there, no need to record anything else
+    if (object_lifetimes) {
+        object_lifetimes->RecordDestroyObject(device, kVulkanObjectTypeDevice);
+    }
     DestroyLeakedDeviceObjects();
 
     // Clean up Queue's MemRef Linked Lists

--- a/layers/vulkan/generated/chassis.h
+++ b/layers/vulkan/generated/chassis.h
@@ -2296,6 +2296,7 @@ class ValidationObject {
     std::vector<ValidationObject*> aborted_object_dispatch;
     LayerObjectTypeId container_type;
     void ReleaseDeviceDispatchObject(LayerObjectTypeId type_id) const;
+    void ReleaseAllDispatchObjects() const;
 
     vvl::concurrent_unordered_map<VkDeferredOperationKHR, std::vector<std::function<void()>>, 0> deferred_operation_post_completion;
     vvl::concurrent_unordered_map<VkDeferredOperationKHR, std::vector<std::function<void(const std::vector<VkPipeline>&)>>, 0>

--- a/tests/unit/shader_spirv.cpp
+++ b/tests/unit/shader_spirv.cpp
@@ -2081,7 +2081,6 @@ TEST_F(NegativeShaderSpirv, QueueFamilyMemoryScope) {
 TEST_F(NegativeShaderSpirv, DeviceMemoryScopeDebugInfo) {
     SetTargetApiVersion(VK_API_VERSION_1_2);
     AddRequiredFeature(vkt::Feature::vulkanMemoryModel);
-    AddDisabledFeature(vkt::Feature::vulkanMemoryModelDeviceScope);
     RETURN_IF_SKIP(Init());
 
     char const *csSource = R"(


### PR DESCRIPTION
Helps addresses https://github.com/KhronosGroup/Vulkan-ValidationLayers/issues/8618

Note - still requires `VK_LAYER_DISABLES=VK_VALIDATION_FEATURE_DISABLE_UNIQUE_HANDLES_EXT` as need to still find a way to not have the handle wrapping blowup on us