### PR TITLE
layers: Validate monotonic increase of timeline values

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -126,6 +126,8 @@ vvl_sources = [
   "layers/core_checks/cc_spirv.cpp",
   "layers/core_checks/cc_state_tracker.cpp",
   "layers/core_checks/cc_state_tracker.h",
+  "layers/core_checks/cc_submit.cpp",
+  "layers/core_checks/cc_submit.h",
   "layers/core_checks/cc_synchronization.cpp",
   "layers/core_checks/cc_video.cpp",
   "layers/core_checks/cc_vuid_maps.cpp",

--- a/layers/CMakeLists.txt
+++ b/layers/CMakeLists.txt
@@ -175,6 +175,8 @@ target_sources(vvl PRIVATE
     core_checks/cc_shader_object.cpp
     core_checks/cc_state_tracker.h
     core_checks/cc_state_tracker.cpp
+    core_checks/cc_submit.h
+    core_checks/cc_submit.cpp
     core_checks/cc_synchronization.cpp
     core_checks/cc_video.cpp
     core_checks/cc_vuid_maps.cpp

--- a/layers/core_checks/cc_state_tracker.h
+++ b/layers/core_checks/cc_state_tracker.h
@@ -18,8 +18,10 @@
  * limitations under the License.
  */
 #pragma once
+#include "cc_submit.h"
 #include "state_tracker/state_tracker.h"
 #include "state_tracker/cmd_buffer_state.h"
+#include "state_tracker/queue_state.h"
 
 namespace core {
 
@@ -33,6 +35,20 @@ class CommandBuffer : public vvl::CommandBuffer {
 
     void RecordWaitEvents(vvl::Func command, uint32_t eventCount, const VkEvent* pEvents,
                           VkPipelineStageFlags2KHR src_stage_mask) override;
+};
+
+// Override Retire to validate submissions in the order defined by synchronization
+class Queue : public vvl::Queue {
+  public:
+    Queue(ValidationStateTracker& dev_data, VkQueue handle, uint32_t family_index, uint32_t queue_index,
+          VkDeviceQueueCreateFlags flags, const VkQueueFamilyProperties& queue_family_properties,
+          const ValidationObject& error_logger);
+
+  private:
+    void Retire(vvl::QueueSubmission&) override;
+
+  private:
+    QueueSubmissionValidator queue_submission_validator_;
 };
 
 }  // namespace core

--- a/layers/core_checks/cc_submit.cpp
+++ b/layers/core_checks/cc_submit.cpp
@@ -1,0 +1,47 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "cc_submit.h"
+#include "state_tracker/queue_state.h"
+#include "sync/sync_vuid_maps.h"
+#include "generated/chassis.h"  // ValidationObject
+
+static Location GetSignaledSemaphoreLocation(const Location& submit_loc, uint32_t index) {
+    vvl::Field field = vvl::Field::Empty;
+    if (submit_loc.function == vvl::Func::vkQueueSubmit || submit_loc.function == vvl::Func::vkQueueBindSparse) {
+        field = vvl::Field::pSignalSemaphores;
+    } else if (submit_loc.function == vvl::Func::vkQueueSubmit2 || submit_loc.function == vvl::Func::vkQueueSubmit2KHR) {
+        field = vvl::Field::pSignalSemaphoreInfos;
+    } else {
+        assert(false && "Unhandled signaling function");
+    }
+    return submit_loc.dot(field, index);
+}
+
+void QueueSubmissionValidator::Validate(const vvl::QueueSubmission& submission) const {
+    for (uint32_t i = 0; i < (uint32_t)submission.signal_semaphores.size(); ++i) {
+        const auto& signal = submission.signal_semaphores[i];
+        const uint64_t current_payload = signal.semaphore->CurrentPayload();
+        if (signal.payload < current_payload) {
+            const Location signal_semaphore_loc = GetSignaledSemaphoreLocation(submission.loc.Get(), i);
+            const auto& vuid = GetQueueSubmitVUID(signal_semaphore_loc, sync_vuid_maps::SubmitError::kTimelineSemSmallValue);
+            error_logger.LogError(vuid, signal.semaphore->Handle(), signal_semaphore_loc,
+                                  "(%s) signaled with value %" PRIu64 " which is smaller than the current value %" PRIu64,
+                                  error_logger.FormatHandle(signal.semaphore->VkHandle()).c_str(), signal.payload, current_payload);
+        }
+    }
+}

--- a/layers/core_checks/cc_submit.h
+++ b/layers/core_checks/cc_submit.h
@@ -1,0 +1,39 @@
+/* Copyright (c) 2024 The Khronos Group Inc.
+ * Copyright (c) 2024 Valve Corporation
+ * Copyright (c) 2024 LunarG, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+// About submit time validation module:
+// In some cases validation of the submitted work cannot be done directly during QueueSubmit call.
+// Timeline semaphore's wait-before-signal can reorder batches comparing to the submission order.
+// That's why validation that depends on the final batch order cannot be done immediately in
+// QueueSubmit (it will validate in submission order). This file provides support for submit validation
+// where ordering is important.
+
+class ValidationObject;
+
+namespace vvl {
+struct QueueSubmission;
+}  // namespace vvl
+
+// Performs validationn when QueueSubmision is ready to retire.
+struct QueueSubmissionValidator {
+    const ValidationObject& error_logger;
+
+    QueueSubmissionValidator(const ValidationObject& error_logger) : error_logger(error_logger) {}
+    void Validate(const vvl::QueueSubmission& submission) const;
+};

--- a/layers/core_checks/core_validation.h
+++ b/layers/core_checks/core_validation.h
@@ -2632,4 +2632,8 @@ class CoreChecks : public ValidationStateTracker {
     std::shared_ptr<vvl::CommandBuffer> CreateCmdBufferState(VkCommandBuffer handle,
                                                              const VkCommandBufferAllocateInfo* pAllocateInfo,
                                                              const vvl::CommandPool* pool) final;
+
+    std::shared_ptr<vvl::Queue> CreateQueue(VkQueue handle, uint32_t family_index, uint32_t queue_index,
+                                            VkDeviceQueueCreateFlags flags,
+                                            const VkQueueFamilyProperties& queue_family_properties) final;
 };  // Class CoreChecks

--- a/layers/state_tracker/state_tracker.cpp
+++ b/layers/state_tracker/state_tracker.cpp
@@ -1180,7 +1180,7 @@ void ValidationStateTracker::PreCallRecordQueueSubmit(VkQueue queue, uint32_t su
     }
     // Now process each individual submit
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        Location submit_loc = record_obj.location.dot(vvl::Field::pSubmits, submit_idx);
+        Location submit_loc = record_obj.location.dot(vvl::Struct::VkSubmitInfo, vvl::Field::pSubmits, submit_idx);
         vvl::QueueSubmission submission(submit_loc);
         const VkSubmitInfo *submit = &pSubmits[submit_idx];
         auto *timeline_semaphore_submit = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(submit->pNext);
@@ -1270,7 +1270,7 @@ void ValidationStateTracker::PreCallRecordQueueSubmit2(VkQueue queue, uint32_t s
     }
 
     for (uint32_t submit_idx = 0; submit_idx < submitCount; submit_idx++) {
-        Location submit_loc = record_obj.location.dot(vvl::Field::pSubmits, submit_idx);
+        Location submit_loc = record_obj.location.dot(vvl::Struct::VkSubmitInfo2, vvl::Field::pSubmits, submit_idx);
         vvl::QueueSubmission submission(submit_loc);
         const VkSubmitInfo2KHR *submit = &pSubmits[submit_idx];
         for (uint32_t i = 0; i < submit->waitSemaphoreInfoCount; ++i) {
@@ -1419,7 +1419,7 @@ void ValidationStateTracker::PreCallRecordQueueBindSparse(VkQueue queue, uint32_
             }
         }
         auto timeline_info = vku::FindStructInPNextChain<VkTimelineSemaphoreSubmitInfo>(bind_info.pNext);
-        Location submit_loc = record_obj.location.dot(vvl::Field::pBindInfo, bind_idx);
+        Location submit_loc = record_obj.location.dot(vvl::Struct::VkBindSparseInfo, vvl::Field::pBindInfo, bind_idx);
         vvl::QueueSubmission submission(submit_loc);
         for (uint32_t i = 0; i < bind_info.waitSemaphoreCount; ++i) {
             uint64_t payload = 0;

--- a/tests/unit/sync_object_positive.cpp
+++ b/tests/unit/sync_object_positive.cpp
@@ -2236,44 +2236,6 @@ TEST_F(PositiveSyncObject, TimelineSubmitWaitThenHostSignalLargerValue) {
     m_default_queue->Wait();
 }
 
-// TODO: non-monotonic signaling order, when validation can detect this convert to a negative test
-TEST_F(PositiveSyncObject, ClosestSignalValueDoesNotFinishWait) {
-    TEST_DESCRIPTION("Test that validation selects correct signal");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredFeature(vkt::Feature::timelineSemaphore);
-    RETURN_IF_SKIP(Init());
-
-    if (!m_second_queue) {
-        GTEST_SKIP() << "2 queues are needed";
-    }
-
-    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-
-    m_default_queue->Submit(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
-    m_default_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(semaphore, 2));
-    m_second_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(semaphore, 3));
-    m_default_queue->Wait();
-}
-
-// TODO: non-monotonic signaling order, when validation can detect this convert to a negative test
-TEST_F(PositiveSyncObject, ClosestSignalValueDoesNotFinishWait2) {
-    TEST_DESCRIPTION("Test that validation selects correct signal");
-    SetTargetApiVersion(VK_API_VERSION_1_2);
-    AddRequiredFeature(vkt::Feature::timelineSemaphore);
-    RETURN_IF_SKIP(Init());
-
-    if (!m_second_queue) {
-        GTEST_SKIP() << "2 queues are needed";
-    }
-
-    vkt::Semaphore semaphore(*m_device, VK_SEMAPHORE_TYPE_TIMELINE);
-
-    m_default_queue->Submit(vkt::no_cmd, vkt::TimelineWait(semaphore, 1));
-    m_default_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(semaphore, 1));
-    m_second_queue->Submit(vkt::no_cmd, vkt::TimelineSignal(semaphore, 3));
-    m_default_queue->Wait();
-}
-
 TEST_F(PositiveSyncObject, PollSemaphoreCounter) {
     TEST_DESCRIPTION("Basic semaphore polling test");
     SetTargetApiVersion(VK_API_VERSION_1_2);


### PR DESCRIPTION
This introduces new type of submit validation (will see how it flies) and it is done and reported by the Queue threads. This should be taken into account by the tests. During QueueSubmit call no error might be reported when validation is performed by the Queue thread. `VerifyFound` should be put after device/queue `Wait` which guarantees that Queue thread finished its job.