### PR TITLE
layers: Fix the pNext wording

### DIFF
--- a/layers/best_practices/bp_pipeline.cpp
+++ b/layers/best_practices/bp_pipeline.cpp
@@ -124,8 +124,9 @@ bool BestPractices::ValidateCreateGraphicsPipeline(const VkGraphicsPipelineCreat
         (!graphics_lib_info ||
          (graphics_lib_info->flags & (VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_SHADER_BIT_EXT |
                                       VK_GRAPHICS_PIPELINE_LIBRARY_FRAGMENT_OUTPUT_INTERFACE_BIT_EXT)) != 0)) {
-        skip |= LogWarning("BestPractices-Pipeline-NoRendering", device, create_info_loc,
-                           "renderPass is VK_NULL_HANDLE and pNext chain does not contain VkPipelineRenderingCreateInfoKHR.");
+        skip |= LogWarning(
+            "BestPractices-Pipeline-NoRendering", device, create_info_loc,
+            "renderPass is VK_NULL_HANDLE and pNext chain does not contain an instance of VkPipelineRenderingCreateInfoKHR.");
     }
 
     if (VendorCheckEnabled(kBPVendorArm)) {

--- a/layers/core_checks/cc_android.cpp
+++ b/layers/core_checks/cc_android.cpp
@@ -393,8 +393,9 @@ bool CoreChecks::ValidateAllocateMemoryANDROID(const VkMemoryAllocateInfo &alloc
                                      "is %s but allocationSize is 0.", FormatHandle(mem_ded_alloc_info->buffer).c_str());
                 }
             } else if (0 == allocate_info.allocationSize) {
-                skip |= LogError("VUID-VkMemoryAllocateInfo-pNext-07900", device, allocate_info_loc,
-                                 "pNext chain does not include VkMemoryDedicatedAllocateInfo, but allocationSize is 0.");
+                skip |=
+                    LogError("VUID-VkMemoryAllocateInfo-pNext-07900", device, allocate_info_loc,
+                             "pNext chain does not contain an instance of VkMemoryDedicatedAllocateInfo, but allocationSize is 0.");
             }
         }
     }

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -405,10 +405,11 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
     auto* shader_info = vku::FindStructInPNextChain<VkGeneratedCommandsShaderInfoEXT>(generated_commands_info.pNext);
     if (generated_commands_info.indirectExecutionSet == VK_NULL_HANDLE) {
         if (!pipeline_info && !shader_info) {
-            skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-indirectExecutionSet-11080", cb_state.Handle(),
-                             info_loc.dot(Field::indirectExecutionSet),
-                             "is VK_NULL_HANDLE but the pNext element is missing a VkGeneratedCommandsPipelineInfoEXT or "
-                             "VkGeneratedCommandsShaderInfoEXT.");
+            skip |= LogError(
+                "VUID-VkGeneratedCommandsInfoEXT-indirectExecutionSet-11080", cb_state.Handle(),
+                info_loc.dot(Field::indirectExecutionSet),
+                "is VK_NULL_HANDLE but the pNext chain does not contain an instance of VkGeneratedCommandsPipelineInfoEXT or "
+                "VkGeneratedCommandsShaderInfoEXT.");
             valid_dispatch = false;
         } else if (indirect_commands_layout.has_execution_set_token) {
             skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-indirectCommandsLayout-11083", indirect_commands_layout.Handle(),
@@ -762,10 +763,11 @@ bool CoreChecks::PreCallValidateGetGeneratedCommandsMemoryRequirementsEXT(VkDevi
         auto* pipeline_info = vku::FindStructInPNextChain<VkGeneratedCommandsPipelineInfoEXT>(pInfo->pNext);
         auto* shader_info = vku::FindStructInPNextChain<VkGeneratedCommandsShaderInfoEXT>(pInfo->pNext);
         if (!pipeline_info && !shader_info) {
-            skip |= LogError("VUID-VkGeneratedCommandsMemoryRequirementsInfoEXT-indirectExecutionSet-11012",
-                             indirect_commands_layout->Handle(), info_loc.dot(Field::indirectExecutionSet),
-                             "is VK_NULL_HANDLE but the pNext element is missing a VkGeneratedCommandsPipelineInfoEXT or "
-                             "VkGeneratedCommandsShaderInfoEXT.");
+            skip |= LogError(
+                "VUID-VkGeneratedCommandsMemoryRequirementsInfoEXT-indirectExecutionSet-11012", indirect_commands_layout->Handle(),
+                info_loc.dot(Field::indirectExecutionSet),
+                "is VK_NULL_HANDLE but the pNext chain does not contain an instance of VkGeneratedCommandsPipelineInfoEXT or "
+                "VkGeneratedCommandsShaderInfoEXT.");
         }
     } else {
         if (!indirect_commands_layout->has_execution_set_token) {

--- a/layers/core_checks/cc_device_generated_commands.cpp
+++ b/layers/core_checks/cc_device_generated_commands.cpp
@@ -168,7 +168,7 @@ bool CoreChecks::PreCallValidateCreateIndirectCommandsLayoutEXT(VkDevice device,
                 } else if (!dynamic_layout_create) {
                     skip |= LogError("VUID-VkIndirectCommandsLayoutCreateInfoEXT-pTokens-11102", device, token_loc.dot(Field::type),
                                      "is %s, pipelineLayout is VK_NULL_HANDLE, but no "
-                                     "there is no VkPipelineLayoutCreateInfo structure attached to the pNext.",
+                                     "there is no VkPipelineLayoutCreateInfo structure attached to the pNext chain.",
                                      string_VkIndirectCommandsTokenTypeEXT(token.type));
                 }
             }
@@ -407,7 +407,7 @@ bool CoreChecks::ValidateGeneratedCommandsInfo(const vvl::CommandBuffer& cb_stat
         if (!pipeline_info && !shader_info) {
             skip |= LogError("VUID-VkGeneratedCommandsInfoEXT-indirectExecutionSet-11080", cb_state.Handle(),
                              info_loc.dot(Field::indirectExecutionSet),
-                             "is VK_NULL_HANDLE but the pNext is missing a VkGeneratedCommandsPipelineInfoEXT or "
+                             "is VK_NULL_HANDLE but the pNext element is missing a VkGeneratedCommandsPipelineInfoEXT or "
                              "VkGeneratedCommandsShaderInfoEXT.");
             valid_dispatch = false;
         } else if (indirect_commands_layout.has_execution_set_token) {
@@ -764,7 +764,7 @@ bool CoreChecks::PreCallValidateGetGeneratedCommandsMemoryRequirementsEXT(VkDevi
         if (!pipeline_info && !shader_info) {
             skip |= LogError("VUID-VkGeneratedCommandsMemoryRequirementsInfoEXT-indirectExecutionSet-11012",
                              indirect_commands_layout->Handle(), info_loc.dot(Field::indirectExecutionSet),
-                             "is VK_NULL_HANDLE but the pNext is missing a VkGeneratedCommandsPipelineInfoEXT or "
+                             "is VK_NULL_HANDLE but the pNext element is missing a VkGeneratedCommandsPipelineInfoEXT or "
                              "VkGeneratedCommandsShaderInfoEXT.");
         }
     } else {

--- a/layers/core_checks/cc_external_object.cpp
+++ b/layers/core_checks/cc_external_object.cpp
@@ -51,7 +51,7 @@ bool CoreChecks::PreCallValidateGetMemoryFdKHR(VkDevice device, const VkMemoryGe
         if (!export_info) {
             skip |= LogError("VUID-VkMemoryGetFdInfoKHR-handleType-00671", pGetFdInfo->memory,
                              error_obj.location.dot(Field::pGetFdInfo).dot(Field::memory),
-                             "pNext chain does not include a VkExportMemoryAllocateInfo structure.");
+                             "pNext chain does not contain an instance of VkExportMemoryAllocateInfo.");
         } else if ((export_info->handleTypes & pGetFdInfo->handleType) == 0) {
             skip |= LogError("VUID-VkMemoryGetFdInfoKHR-handleType-00671", pGetFdInfo->memory,
                              error_obj.location.dot(Field::pGetFdInfo).dot(Field::memory),
@@ -195,7 +195,7 @@ bool CoreChecks::PreCallValidateGetMemoryWin32HandleKHR(VkDevice device, const V
         if (!export_info) {
             skip |= LogError("VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00662", pGetWin32HandleInfo->memory,
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::memory),
-                             "pNext chain does not include a VkExportMemoryAllocateInfo structure.");
+                             "pNext chain does not contain an instance of VkExportMemoryAllocateInfo.");
         } else if ((export_info->handleTypes & pGetWin32HandleInfo->handleType) == 0) {
             skip |= LogError("VUID-VkMemoryGetWin32HandleInfoKHR-handleType-00662", pGetWin32HandleInfo->memory,
                              error_obj.location.dot(Field::pGetWin32HandleInfo).dot(Field::memory),

--- a/layers/core_checks/cc_pipeline_graphics.cpp
+++ b/layers/core_checks/cc_pipeline_graphics.cpp
@@ -852,12 +852,12 @@ bool CoreChecks::ValidateGraphicsPipelineLibrary(const vvl::Pipeline &pipeline, 
                 skip |= LogError(
                     vuid, device, create_info_loc,
                     "Fragment Shader has a valid VkPipelineFragmentShadingRateStateCreateInfoKHR, but Pre Rasterization has "
-                    "no VkPipelineFragmentShadingRateStateCreateInfoKHR in the pNext.");
+                    "no VkPipelineFragmentShadingRateStateCreateInfoKHR in the pNext chain.");
             } else if (!frag_shader_info.shading_rate_state) {
                 skip |= LogError(
                     vuid, device, create_info_loc,
                     "Pre Rasterization has a valid VkPipelineFragmentShadingRateStateCreateInfoKHR, but Fragment Shader has "
-                    "no VkPipelineFragmentShadingRateStateCreateInfoKHR in the pNext.");
+                    "no VkPipelineFragmentShadingRateStateCreateInfoKHR in the pNext chain.");
             } else if (!ComparePipelineFragmentShadingRateStateCreateInfo(*frag_shader_info.shading_rate_state,
                                                                           *pre_raster_info.shading_rate_state)) {
                 skip |= LogError(vuid, device, create_info_loc,

--- a/layers/core_checks/cc_ray_tracing.cpp
+++ b/layers/core_checks/cc_ray_tracing.cpp
@@ -2035,7 +2035,6 @@ bool CoreChecks::ValidateRaytracingShaderBindingTable(VkCommandBuffer commandBuf
              [table_loc, &binding_table]() {
                  return "The following buffers have a size inferior to " + table_loc.Fields() + "->stride (" +
                         std::to_string(binding_table.stride) + "):";
-                 ;
              }},
         }}};
 

--- a/layers/core_checks/cc_render_pass.cpp
+++ b/layers/core_checks/cc_render_pass.cpp
@@ -2468,7 +2468,7 @@ bool CoreChecks::PreCallValidateCreateRenderPass(VkDevice device, const VkRender
 bool CoreChecks::ValidateDepthStencilResolve(const VkRenderPassCreateInfo2 *pCreateInfo, const ErrorObject &error_obj) const {
     bool skip = false;
 
-    // If the pNext list of VkSubpassDescription2 includes a VkSubpassDescriptionDepthStencilResolve structure,
+    // If the pNext chain in VkSubpassDescription2 includes a VkSubpassDescriptionDepthStencilResolve structure,
     // then that structure describes depth/stencil resolve operations for the subpass.
     for (uint32_t i = 0; i < pCreateInfo->subpassCount; i++) {
         const Location subpass_loc = error_obj.location.dot(Field::pSubpasses, i);

--- a/layers/state_tracker/device_memory_state.cpp
+++ b/layers/state_tracker/device_memory_state.cpp
@@ -51,7 +51,7 @@ static std::optional<VkExternalMemoryHandleTypeFlagBits> GetImportHandleType(con
         return host_pointer_import->handleType;
     }
 #ifdef VK_USE_PLATFORM_ANDROID_KHR
-    // AHB Import doesn't have handle in the pNext struct
+    // AHB Import doesn't have handle in the pNext chain
     // It should be assumed that all imported AHB can only have the same, single handleType
     auto ahb_import = vku::FindStructInPNextChain<VkImportAndroidHardwareBufferInfoANDROID>(p_alloc_info->pNext);
     if ((ahb_import) && (ahb_import->buffer != nullptr)) {

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -1089,7 +1089,7 @@ bool StatelessValidation::manual_PreCallValidateCreateQueryPool(VkDevice device,
             }
             if (!vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext)) {
                 skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-03222", device, create_info_loc.dot(Field::queryType),
-                                 "is VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR, but the pNext chain does not contain in instance of "
+                                 "is VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR, but the pNext chain does not contain an instance of "
                                  "VkQueryPoolPerformanceCreateInfoKHR.");
             }
             break;

--- a/layers/stateless/sl_descriptor.cpp
+++ b/layers/stateless/sl_descriptor.cpp
@@ -1089,7 +1089,7 @@ bool StatelessValidation::manual_PreCallValidateCreateQueryPool(VkDevice device,
             }
             if (!vku::FindStructInPNextChain<VkQueryPoolPerformanceCreateInfoKHR>(pCreateInfo->pNext)) {
                 skip |= LogError("VUID-VkQueryPoolCreateInfo-queryType-03222", device, create_info_loc.dot(Field::queryType),
-                                 "is VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR, but the pNext does not contain in instance of "
+                                 "is VK_QUERY_TYPE_PERFORMANCE_QUERY_KHR, but the pNext chain does not contain in instance of "
                                  "VkQueryPoolPerformanceCreateInfoKHR.");
             }
             break;

--- a/layers/stateless/sl_instance_device.cpp
+++ b/layers/stateless/sl_instance_device.cpp
@@ -839,7 +839,8 @@ bool StatelessValidation::manual_PreCallValidateGetPhysicalDeviceImageFormatProp
                 skip |= LogError(
                     "VUID-VkPhysicalDeviceImageFormatInfo2-tiling-02313", physicalDevice, format_info_loc,
                     "tiling is VK_IMAGE_TILING_DRM_FORMAT_MODIFIER_EXT and flags contain VK_IMAGE_CREATE_MUTABLE_FORMAT_BIT "
-                    "bit, but the pNext chain does not include VkImageFormatListCreateInfo with non-zero viewFormatCount.");
+                    "bit, but the pNext chain does not contain an instance of VkImageFormatListCreateInfo with non-zero "
+                    "viewFormatCount.");
             }
         }
     }

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -95,7 +95,7 @@ bool StatelessValidation::ValidateSwapchainCreateInfo(const VkSwapchainCreateInf
     if ((create_info.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) != 0) {
         if (format_list_info == nullptr) {
             skip |= LogError("VUID-VkSwapchainCreateInfoKHR-flags-03168", device, loc.dot(Field::flags),
-                             "includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the pNext does not contain "
+                             "includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the pNext chain does not contain "
                              "VkImageFormatListCreateInfo.");
         } else if (format_list_info->viewFormatCount == 0) {
             skip |= LogError("VUID-VkSwapchainCreateInfoKHR-flags-03168", device, loc.dot(Field::flags),

--- a/layers/stateless/sl_wsi.cpp
+++ b/layers/stateless/sl_wsi.cpp
@@ -95,8 +95,8 @@ bool StatelessValidation::ValidateSwapchainCreateInfo(const VkSwapchainCreateInf
     if ((create_info.flags & VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR) != 0) {
         if (format_list_info == nullptr) {
             skip |= LogError("VUID-VkSwapchainCreateInfoKHR-flags-03168", device, loc.dot(Field::flags),
-                             "includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the pNext chain does not contain "
-                             "VkImageFormatListCreateInfo.");
+                             "includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but the pNext chain does not contain an instance "
+                             "of VkImageFormatListCreateInfo.");
         } else if (format_list_info->viewFormatCount == 0) {
             skip |= LogError("VUID-VkSwapchainCreateInfoKHR-flags-03168", device, loc.dot(Field::flags),
                              "includes VK_SWAPCHAIN_CREATE_MUTABLE_FORMAT_BIT_KHR but %s is zero.",

--- a/tests/unit/copy_buffer_image.cpp
+++ b/tests/unit/copy_buffer_image.cpp
@@ -1474,7 +1474,6 @@ TEST_F(NegativeCopyBufferImage, ImageSrcSizeExceeded) {
     copy_region.extent = {32, 32, 8};
     copy_region.srcSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
     copy_region.dstSubresource = {VK_IMAGE_ASPECT_COLOR_BIT, 0, 0, 1};
-    ;
     copy_region.srcOffset = {0, 0, 0};
     copy_region.dstOffset = {0, 0, 0};
 

--- a/tests/unit/image_positive.cpp
+++ b/tests/unit/image_positive.cpp
@@ -463,7 +463,7 @@ TEST_F(PositiveImage, ImagelessLayoutTracking) {
     vk::BindImageMemory2(device(), 1, &bind_info);
 
     const std::vector<VkImage> swapchain_images = m_swapchain.GetImages();
-    
+
     vkt::Semaphore image_acquired(*m_device);
     const uint32_t current_buffer = m_swapchain.AcquireNextImage(image_acquired, kWaitTimeout);
 
@@ -1045,7 +1045,6 @@ TEST_F(PositiveImage, BlitRemainingArrayLayers) {
     AddRequiredExtensions(VK_KHR_MAINTENANCE_5_EXTENSION_NAME);
     AddRequiredFeature(vkt::Feature::maintenance5);
     RETURN_IF_SKIP(Init());
-    ;
 
     VkFormat f_color = VK_FORMAT_R32_SFLOAT;  // Need features ..BLIT_SRC_BIT & ..BLIT_DST_BIT
     if (!FormatFeaturesAreSupported(Gpu(), f_color, VK_IMAGE_TILING_OPTIMAL,

--- a/tests/unit/protected_memory.cpp
+++ b/tests/unit/protected_memory.cpp
@@ -1029,7 +1029,7 @@ TEST_F(NegativeProtectedMemory, MixingProtectedResources) {
     vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);
     m_errorMonitor->VerifyFound();
 
-    // If the VkSubmitInfo::pNext chain does not include this structure, the batch is unprotected.
+    // If the VkSubmitInfo::pNext chain does not contain an instance of this structure, the batch is unprotected.
     submit_info.pNext = nullptr;
     m_errorMonitor->SetDesiredError("VUID-VkSubmitInfo-pNext-04120");
     vk::QueueSubmit(m_default_queue->handle(), 1, &submit_info, VK_NULL_HANDLE);

--- a/tests/unit/ray_tracing_pipeline_nv.cpp
+++ b/tests/unit/ray_tracing_pipeline_nv.cpp
@@ -40,7 +40,6 @@ TEST_F(NegativeRayTracingPipelineNV, BasicUsage) {
     VkPipeline pipeline = VK_NULL_HANDLE;
     VkPipelineShaderStageCreateInfo stage_create_info = vku::InitStructHelper();
     stage_create_info.stage = VK_SHADER_STAGE_RAYGEN_BIT_NV;
-    ;
     stage_create_info.module = rgen_shader.handle();
     stage_create_info.pName = "main";
     VkRayTracingShaderGroupCreateInfoNV group_create_info = vku::InitStructHelper();

--- a/tests/unit/video.cpp
+++ b/tests/unit/video.cpp
@@ -9669,7 +9669,6 @@ TEST_F(NegativeVideo, DecodeInlineQueryUnavailable) {
 
     // Use custom begin info because the default uses VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    ;
 
     cb.begin(&begin_info);
     cb.BeginVideoCoding(context.Begin());
@@ -9943,7 +9942,6 @@ TEST_F(NegativeVideo, EncodeInlineQueryUnavailable) {
 
     // Use custom begin info because the default uses VK_COMMAND_BUFFER_USAGE_ONE_TIME_SUBMIT_BIT
     VkCommandBufferBeginInfo begin_info = vku::InitStructHelper();
-    ;
 
     cb.begin(&begin_info);
     cb.BeginVideoCoding(context.Begin());


### PR DESCRIPTION
as @arno-lunarg pointed out in https://github.com/KhronosGroup/Vulkan-ValidationLayers/pull/8720#discussion_r1808412232

the spec goes `the pNext **element**` or `the pNext **chain**`

when through and found all `the pNext` missing that wording